### PR TITLE
CLDR-13034 kw plurals, fix duplicate samples for 1000.0, 10000.0, 100000.0

### DIFF
--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -228,7 +228,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="two">n % 100 = 2,22,42,62,82 or n%1000 = 0 and n%100000=1000..20000,40000,60000,80000 or n!=0 and n%1000000=100000@integer 2, 22, 42, 62, 82, 102, 122, 142, 1002, … @decimal 2.0, 22.0, 42.0, 62.0, 82.0, 102.0, 122.0, 142.0, 1002.0, …</pluralRule>
             <pluralRule count="few">n % 100 = 3,23,43,63,83 @integer 3, 23, 43, 63, 83, 103, 123, 143, 1003, … @decimal 3.0, 23.0, 43.0, 63.0, 83.0, 103.0, 123.0, 143.0, 1003.0, …</pluralRule>
             <pluralRule count="many">n != 1 and n % 100 = 1,21,41,61,81 @integer 21, 41, 61, 81, 101, 121, 141, 161, 1001, … @decimal 21.0, 41.0, 61.0, 81.0, 101.0, 121.0, 141.0, 161.0, 1001.0, …</pluralRule>
-            <pluralRule count="other"> @integer 4~19, 100, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="other"> @integer 4~19, 100, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000000.0, …</pluralRule>
         </pluralRules>
     </plurals>
 </supplementalData>


### PR DESCRIPTION
[CLDR-13034]

Apologies for not filing an issue about this first, that does not seem possible at the moment?

For now, there's a mismatch between the Cornish (kw) rules and examples, with the decimal numbers 1000.0, 10000.0, and 100000.0 included in the sample list for the `other` category, but being mis-categorised as `two` instead. There is an issue about fixing the rules for this properly ([CLDR-11876](https://unicode.org/cldr/trac/ticket/11876)), but in the interim it would be useful to drop them from the samples, as was done for their integer counterparts in 0481649.

This issue was brought to my attention by @longlho in eemeli/make-plural#13. When parsing the CLDR rules into JavaScript, my code verifies its output using the sample list, and that's currently failing for CLDR v35 Cornish due to this issue.

[CLDR-13034]: https://unicode-org.atlassian.net/browse/CLDR-13034