### PR TITLE
CLDR-11912 Add ga_GB locale

### DIFF
--- a/common/main/ga_GB.xml
+++ b/common/main/ga_GB.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2019 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ga"/>
+		<territory type="GB"/>
+	</identity>
+</ldml>


### PR DESCRIPTION
[CLDR-11912] 
Adds UK Irish locale, for Irish spoken in Northern Ireland.

[CLDR-11912]: https://unicode-org.atlassian.net/browse/CLDR-11912