### PR TITLE
CLDR-11598 rm, add preposition to format months, update date formats for consistency

### DIFF
--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -961,12 +961,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">EEEE, 'ils' d 'da' MMMM y G</pattern>
+							<pattern draft="contributed">EEEE, 'ils' d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">d 'da' MMMM y G</pattern>
+							<pattern draft="contributed">d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
@@ -976,40 +976,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern draft="contributed">dd-MM-yy GGGGG</pattern>
+							<pattern draft="contributed">dd-MM-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
 						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E d.</dateFormatItem>
-						<dateFormatItem id="H" draft="contributed">H</dateFormatItem>
-						<dateFormatItem id="HHmm" draft="contributed">HH:mm</dateFormatItem>
-						<dateFormatItem id="HHmmss" draft="contributed">HH:mm:ss</dateFormatItem>
-						<dateFormatItem id="Hm" draft="contributed">H:mm</dateFormatItem>
+						<dateFormatItem id="Ehm" draft="contributed">E h:mm a</dateFormatItem>
+						<dateFormatItem id="EHm" draft="contributed">E HH:mm</dateFormatItem>
+						<dateFormatItem id="Ehms" draft="contributed">E h:mm:ss a</dateFormatItem>
+						<dateFormatItem id="EHms" draft="contributed">E HH:mm:ss</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">LLL y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E, dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMMMd" draft="contributed">d MMMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd" draft="contributed">E, d MMMM y G</dateFormatItem>
+						<dateFormatItem id="h">h a</dateFormatItem>
+						<dateFormatItem id="H">HH</dateFormatItem>
+						<dateFormatItem id="hm">h:mm a</dateFormatItem>
+						<dateFormatItem id="Hm">HH:mm</dateFormatItem>
+						<dateFormatItem id="hms">h:mm:ss a</dateFormatItem>
+						<dateFormatItem id="Hms">HH:mm:ss</dateFormatItem>
+						<dateFormatItem id="hmsv">h:mm:ss a v</dateFormatItem>
+						<dateFormatItem id="Hmsv">HH:mm:ss v</dateFormatItem>
+						<dateFormatItem id="hmv">h:mm a v</dateFormatItem>
+						<dateFormatItem id="Hmv">HH:mm v</dateFormatItem>
 						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">d.M.</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">E, d.M.</dateFormatItem>
-						<dateFormatItem id="MMd" draft="contributed">d.MM.</dateFormatItem>
-						<dateFormatItem id="MMdd" draft="contributed">dd.MM.</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">dd-MM</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, dd-MM</dateFormatItem>
 						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">d. MMM</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">E d. MMM</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">d. MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMEd" draft="contributed">E d. MMMM</dateFormatItem>
-						<dateFormatItem id="mmss" draft="contributed">mm:ss</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">dd-MM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, dd-MM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="contributed">E, d MMMM</dateFormatItem>
 						<dateFormatItem id="ms" draft="contributed">mm:ss</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">y</dateFormatItem>
-						<dateFormatItem id="yM" draft="contributed">y-M</dateFormatItem>
-						<dateFormatItem id="yMEd" draft="contributed">E, y-M-d</dateFormatItem>
-						<dateFormatItem id="yMM" draft="contributed">MM.y</dateFormatItem>
-						<dateFormatItem id="yMMdd" draft="contributed">dd.MM.y</dateFormatItem>
-						<dateFormatItem id="yMMM" draft="contributed">MMM y</dateFormatItem>
-						<dateFormatItem id="yMMMEd" draft="contributed">E, d. MMM y</dateFormatItem>
-						<dateFormatItem id="yMMMM" draft="contributed">MMMM y</dateFormatItem>
-						<dateFormatItem id="yQQQ" draft="contributed">QQQ y</dateFormatItem>
-						<dateFormatItem id="yQQQQ" draft="contributed">QQQQ y</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yM" draft="contributed">MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yMEd" draft="contributed">E, dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yMMM" draft="contributed">LLL y G</dateFormatItem>
+						<dateFormatItem id="yMMMd" draft="contributed">dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yMMMEd" draft="contributed">E, dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yMMMM" draft="contributed">LLLL y G</dateFormatItem>
+						<dateFormatItem id="yMMMMd" draft="contributed">d MMMM y G</dateFormatItem>
+						<dateFormatItem id="yMMMMEd" draft="contributed">E, d MMMM y G</dateFormatItem>
+						<dateFormatItem id="yQQQ" draft="contributed">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yQQQQ" draft="contributed">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} - {1}</intervalFormatFallback>
@@ -1020,76 +1035,108 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="H">
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hm">
 							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
 							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hm">
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
 							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="Hmv">
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm v</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="Hv">
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">M.–M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LL–LL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">dd.MM. – dd.MM.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM – dd-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM – dd-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM – E, dd-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM – E, dd-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">d.–d. MMM</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. MMM – d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM – dd-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM – dd-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E, d. – E, d. MMM</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E, d. MMM – E, d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM – E, dd-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM – E, dd-MM</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="MMMMd">
+							<greatestDifference id="d" draft="contributed">d.–d MMMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMMM – d MMMM</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="MMMMEd">
+							<greatestDifference id="d" draft="contributed">E, d. – E, d MMMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMMM – E, d MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">y–y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">MM.y – MM.y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">MM.y – MM.y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LL-y – LL-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">LL-y – LL-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">dd.MM.y – dd.MM.y</greatestDifference>
-							<greatestDifference id="M" draft="contributed">dd.MM.y – dd.MM.y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">dd.MM.y – dd.MM.y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">E, dd.MM.y – E, dd.MM.y</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E, dd.MM.y – E, dd.MM.y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">E, dd.MM.y – E, dd.MM.y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">MMM–MMM y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">MMM y – MMM y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LLL–LLL y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">LLL y – LLL y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">d.–d. MMM y</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. MMM – d. MMM y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">d. MMM y – d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E, d. – E, d. MMM y</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E, d. MMM – E, d. MMM y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">E, d. MMM y – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">MM – MM.y</greatestDifference>
-							<greatestDifference id="y" draft="contributed">MM.y – MM.y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LLLL–LLLL y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">LLLL y – LLLL y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="yMMMMd">
+							<greatestDifference id="d" draft="contributed">d.–d MMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMMM – d MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMMM y – d MMMM y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="yMMMMEd">
+							<greatestDifference id="d" draft="contributed">E, d. – E, d MMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMMM – E, d MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMMM y – E, d MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1126,18 +1173,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">schaner</month>
-							<month type="2">favrer</month>
-							<month type="3">mars</month>
-							<month type="4">avrigl</month>
-							<month type="5">matg</month>
-							<month type="6">zercladur</month>
-							<month type="7">fanadur</month>
-							<month type="8">avust</month>
-							<month type="9">settember</month>
-							<month type="10">october</month>
-							<month type="11">november</month>
-							<month type="12">december</month>
+							<month type="1">da schaner</month>
+							<month type="2">da favrer</month>
+							<month type="3">da mars</month>
+							<month type="4">d’avrigl</month>
+							<month type="5">da matg</month>
+							<month type="6">da zercladur</month>
+							<month type="7">da fanadur</month>
+							<month type="8">d’avust</month>
+							<month type="9">da settember</month>
+							<month type="10">d’october</month>
+							<month type="11">da november</month>
+							<month type="12">da december</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1352,12 +1399,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>EEEE, 'ils' d 'da' MMMM y</pattern>
+							<pattern>EEEE, 'ils' d MMMM y</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>d 'da' MMMM y</pattern>
+							<pattern>d MMMM y</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
@@ -1422,14 +1469,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="EHm">E HH:mm</dateFormatItem>
 						<dateFormatItem id="Ehms">E h:mm:ss a</dateFormatItem>
 						<dateFormatItem id="EHms">E HH:mm:ss</dateFormatItem>
-						<dateFormatItem id="Gy">G y</dateFormatItem>
-						<dateFormatItem id="GyMMM">G y MMM</dateFormatItem>
-						<dateFormatItem id="GyMMMd">G y MMM d</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">G y MMM d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">LLL y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMMMd">d MMMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd">E, d MMMM y G</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
-						<dateFormatItem id="HHmm">HH:mm</dateFormatItem>
-						<dateFormatItem id="HHmmss">HH:mm:ss</dateFormatItem>
 						<dateFormatItem id="hm">h:mm a</dateFormatItem>
 						<dateFormatItem id="Hm">HH:mm</dateFormatItem>
 						<dateFormatItem id="hms">h:mm:ss a</dateFormatItem>
@@ -1439,29 +1486,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="hmv">h:mm a v</dateFormatItem>
 						<dateFormatItem id="Hmv">HH:mm v</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
-						<dateFormatItem id="Md">d.M.</dateFormatItem>
-						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
-						<dateFormatItem id="MMd">d.MM.</dateFormatItem>
-						<dateFormatItem id="MMdd">dd.MM.</dateFormatItem>
+						<dateFormatItem id="Md">dd-MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd-MM</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
-						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
-						<dateFormatItem id="MMMEd">E d. MMM</dateFormatItem>
-						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMEd">E d. MMMM</dateFormatItem>
-						<dateFormatItem id="mmss">mm:ss</dateFormatItem>
+						<dateFormatItem id="MMMd">dd-MM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, dd-MM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
-						<dateFormatItem id="yM">y-M</dateFormatItem>
-						<dateFormatItem id="yMd">y-MM-dd</dateFormatItem>
-						<dateFormatItem id="yMEd">E, y-M-d</dateFormatItem>
-						<dateFormatItem id="yMM">MM.y</dateFormatItem>
-						<dateFormatItem id="yMMdd">dd.MM.y</dateFormatItem>
-						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
-						<dateFormatItem id="yMMMd">y MMM d</dateFormatItem>
-						<dateFormatItem id="yMMMEd">y MMM d, E</dateFormatItem>
-						<dateFormatItem id="yMMMM">y MMMM</dateFormatItem>
-						<dateFormatItem id="yQQQ">y QQQ</dateFormatItem>
-						<dateFormatItem id="yQQQQ">y QQQQ</dateFormatItem>
+						<dateFormatItem id="yM">LL-y</dateFormatItem>
+						<dateFormatItem id="yMd">dd-MM-y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, dd-MM-y</dateFormatItem>
+						<dateFormatItem id="yMMM">LLL y</dateFormatItem>
+						<dateFormatItem id="yMMMd">dd-MM-y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, dd-MM-y</dateFormatItem>
+						<dateFormatItem id="yMMMM">LLLL y</dateFormatItem>
+						<dateFormatItem id="yMMMMd">d MMMM y</dateFormatItem>
+						<dateFormatItem id="yMMMMEd">E, d MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Timezone">{0} {1}</appendItem>
@@ -1504,61 +1548,79 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">MM–MM</greatestDifference>
+							<greatestDifference id="M">LL–LL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
-							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="d">dd-MM – dd-MM</greatestDifference>
+							<greatestDifference id="M">dd-MM – dd-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
-							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="d">E, dd-MM – E, dd-MM</greatestDifference>
+							<greatestDifference id="M">E, dd-MM – E, dd-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">MMM d–d</greatestDifference>
-							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
+							<greatestDifference id="d">dd-MM – dd-MM</greatestDifference>
+							<greatestDifference id="M">dd-MM – dd-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
-							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="d">E, dd-MM – E, dd-MM</greatestDifference>
+							<greatestDifference id="M">E, dd-MM – E, dd-MM</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="MMMMd">
+							<greatestDifference id="d">d.–d MMMM</greatestDifference>
+							<greatestDifference id="M">d MMMM – d MMMM</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="MMMMEd">
+							<greatestDifference id="d">E, d. – E, d MMMM</greatestDifference>
+							<greatestDifference id="M">E, d MMMM – E, d MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">y-MM – y-MM</greatestDifference>
-							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
+							<greatestDifference id="M">LL-y – LL-y</greatestDifference>
+							<greatestDifference id="y">LL-y – LL-y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
-							<greatestDifference id="M">y-MM-dd – y-MM-dd</greatestDifference>
-							<greatestDifference id="y">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="d">dd-MM-y – dd-MM-y</greatestDifference>
+							<greatestDifference id="M">dd-MM-y – dd-MM-y</greatestDifference>
+							<greatestDifference id="y">dd-MM-y – dd-MM-y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">y-MM-dd, E – y-MM-dd, E</greatestDifference>
-							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
-							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="d">E, dd-MM-y – E, dd-MM-y</greatestDifference>
+							<greatestDifference id="M">E, dd-MM-y – E, dd-MM-y</greatestDifference>
+							<greatestDifference id="y">E, dd-MM-y – E, dd-MM-y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">y MMM–MMM</greatestDifference>
-							<greatestDifference id="y">y MMM – y MMM</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y</greatestDifference>
+							<greatestDifference id="y">LLL y – LLL y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">y MMM d–d</greatestDifference>
-							<greatestDifference id="M">y MMM d – MMM d</greatestDifference>
-							<greatestDifference id="y">y MMM d – y MMM d</greatestDifference>
+							<greatestDifference id="d">dd-MM-y – dd-MM-y</greatestDifference>
+							<greatestDifference id="M">dd-MM-y – dd-MM-y</greatestDifference>
+							<greatestDifference id="y">dd-MM-y – dd-MM-y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">y MMM d, E – MMM d, E</greatestDifference>
-							<greatestDifference id="M">y MMM d, E – MMM d, E</greatestDifference>
-							<greatestDifference id="y">y MMM d, E – y MMM d, E</greatestDifference>
+							<greatestDifference id="d">E, dd-MM-y – E, dd-MM-y</greatestDifference>
+							<greatestDifference id="M">E, dd-MM-y – E, dd-MM-y</greatestDifference>
+							<greatestDifference id="y">E, dd-MM-y – E, dd-MM-y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">y MMMM–MMMM</greatestDifference>
-							<greatestDifference id="y">y MMMM – y MMMM</greatestDifference>
+							<greatestDifference id="M">LLLL–LLLL y</greatestDifference>
+							<greatestDifference id="y">LLLL y – LLLL y</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="yMMMMd">
+							<greatestDifference id="d">d.–d MMMM y</greatestDifference>
+							<greatestDifference id="M">d MMMM – d MMMM y</greatestDifference>
+							<greatestDifference id="y">d MMMM y – d MMMM y</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="yMMMMEd">
+							<greatestDifference id="d">E, d. – E, d MMMM y</greatestDifference>
+							<greatestDifference id="M">E, d MMMM – E, d MMMM y</greatestDifference>
+							<greatestDifference id="y">E, d MMMM y – E, d MMMM y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>

--- a/tools/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/java/org/unicode/cldr/test/CheckDates.java
@@ -281,8 +281,14 @@ public class CheckDates extends FactoryCheckCLDR {
     PathStarrer pathStarrer = new PathStarrer();
 
     private String stripPrefix(String s) {
-        if (s != null && s.lastIndexOf(" ") < 3) {
-            return s.substring(s.lastIndexOf(" ") + 1);
+        if (s != null) {
+            int prefEnd = s.lastIndexOf(" ");
+            if (prefEnd < 0 || prefEnd >= 3) {
+                prefEnd = s.lastIndexOf("\u2019"); // as in d’
+            }
+            if (prefEnd >= 0 && prefEnd < 3) {
+                return s.substring(prefEnd + 1);
+            }
         }
         return s;
     }


### PR DESCRIPTION
This is for [CLDR-11598](https://unicode-org.atlassian.net/browse/CLDR-11598) Change Romansh month names

The main idea was to add prepositions to the Romansh (rm) format wide names, and update date formats to match (use MMMM if d is present, LLLL otherwise). However, I also noticed that there were some inconsistencies, and tried to fix them.
- The standard formats used numeric form for medium style, so I made the availableFormats and intervalFormats consistent in using numeric style with MMM and alphabetic styles with MMMM.
- There were inconsistencies in date order (yMd vs dMy) and numeric style (e.g dd.MM vs dd-MM)

To resolve these, I looked at the Romansh portion of the website for Lia Rumantscha, the Romansh language & culture association, to see the formats used there. I saw examples like these (always using dMy order, for example):
1.-18 d’avust 2019
27-05-2019
10-05-2019 – 12-05-2019
22-05-2019, 20:00

So I tried to make the rm formats consistent in using those styles. I also had to fix a test that checks for consistency in use of periods for abbreviated forms; if some use periods and some do not, it checks that the ones that do not have names that are the same as the wide names, ignoring any prepositional prefix. The test had to be updated to check for prefixes with apostrophe, like "d’" here.