### PR TITLE
CLDR-11454 b put decade in right header (not other units)

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
@@ -1292,4 +1292,11 @@ public class TestPathHeader extends TestFmwkPlus {
             }
         }
     }
+    public void TestCLDR_11454() {
+        PathHeader.Factory phf = PathHeader.getFactory();
+        PathHeader century = phf.fromPath("//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-century\"]/displayName");
+        PathHeader decade =  phf.fromPath("//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-decade\"]/displayName");
+        assertEquals("Section", century.getSectionId(), decade.getSectionId());
+        assertEquals("Page", century.getPageId(), decade.getPageId());
+    }
 }

--- a/tools/java/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/java/org/unicode/cldr/util/data/PathHeader.txt
@@ -22,7 +22,6 @@
 %P = (future|past)
 %R = (gregorian|buddhist|coptic|ethiopic|ethiopic-amete-alem|hebrew|indian|islamic|japanese|persian|roc)
 %S = ([^/]*+)
-%T = (nanosecond|microsecond|millisecond|second|minute|hour|day|week|month|year|century)
 %V = (speed|acceleration)
 %W = (temperature|pressure)
 %X = (energy|power)
@@ -175,9 +174,9 @@
 
 //ldml/localeDisplayNames/measurementSystemNames/measurementSystemName[@type="%A"] ; Units ; Measurement Systems ; null ; $1
 
-//ldml/units/unitLength[@type="%L"]/unit[@type="duration-%T%A"]/displayName                             ; Units ; Duration ; &datefield($2$3) ; &unitCount($1-displayName)
-//ldml/units/unitLength[@type="%L"]/unit[@type="duration-%T%A"]/unitPattern[@count="%A"]                ; Units ; Duration ; &datefield($2$3) ; &unitCount($1-$4)
-//ldml/units/unitLength[@type="%L"]/unit[@type="duration-%T%A"]/perUnitPattern                          ; Units ; Duration ; &datefield($2$3) ; &unitCount($1-per)
+//ldml/units/unitLength[@type="%L"]/unit[@type="duration-%A"]/displayName                             ; Units ; Duration ; &datefield($2) ; &unitCount($1-displayName)
+//ldml/units/unitLength[@type="%L"]/unit[@type="duration-%A"]/unitPattern[@count="%A"]                ; Units ; Duration ; &datefield($2) ; &unitCount($1-$3)
+//ldml/units/unitLength[@type="%L"]/unit[@type="duration-%A"]/perUnitPattern                          ; Units ; Duration ; &datefield($2) ; &unitCount($1-per)
 
 //ldml/units/unitLength[@type="%L"]/unit[@type="graphics-%A"]/displayName                               ; Units ; Graphics ; &unit(length-$2) ; &unitCount($1-displayName)
 //ldml/units/unitLength[@type="%L"]/unit[@type="graphics-%A"]/unitPattern[@count="%A"]                  ; Units ; Graphics ; &unit(length-$2) ; &unitCount($1-$3)


### PR DESCRIPTION
CLDR-11454 There was a spurious test on the possible duration values that forced decade into Other Units.