### PR TITLE
CLDR-13042 Remove unnecessary mkdir from cldr-unittest build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ jdk:
 services:
 install: true
 script:
-  mkdir -vp /home/travis/build/unicode-org/cldr/tools/cldr-unittest/libs ; mkdir -vp test/tools/cldr-unittest/libs ; ant all -f tools/java/build.xml ;  ant jar -f tools/java/build.xml ; ant check -f tools/cldr-unittest/build.xml -DCLDR_DIR=$(pwd)
+  ant all -f tools/java/build.xml && ant jar -f tools/java/build.xml && ant check -f tools/cldr-unittest/build.xml -DCLDR_DIR=$(pwd)
   
 # ant -DCLDR_TOOLS=$(pwd)/tools/java -DCATALINA_HOME=cldr.tomcat -f tools/cldr-apps/build.xml


### PR DESCRIPTION
- obviated by b566f5d18f16105b7307b5ebb769c4b95fef513a / #18
- change `;` to `&&` so Travis jobs fail when the build fails