### PR TITLE
CLDR-13040 Fix-the-ordering-to-match-emoji-test

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
@@ -29,6 +29,7 @@ import org.unicode.cldr.util.Containment;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdType;
+import org.unicode.cldr.util.Emoji;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
@@ -1049,8 +1050,8 @@ public class TestPathHeader extends TestFmwkPlus {
         logln("\nInternal Counter:\t" + counterData.size());
         for (PathHeader.Factory.CounterData item : counterData.keySet()) {
             logln("\t" + counterData.getCount(item) + "\t" + item.get2() // externals
-                + "\t" + item.get3() + "\t" + item.get0() // internals
-                + "\t" + item.get1());
+            + "\t" + item.get3() + "\t" + item.get0() // internals
+            + "\t" + item.get1());
         }
         logln("\nMenus/Headers:\t" + threeLevel.size());
         for (String item : threeLevel) {
@@ -1254,7 +1255,7 @@ public class TestPathHeader extends TestFmwkPlus {
             assertEquals("flexible formats", test[1] + "|" + test[0], pathHeader.getHeader() + "|" + pathHeader.getCode());
         }
     }
-    
+
     // Moved from TestAnnotations and generalized
     public void testPathHeaderSize() {
         String locale = "ar"; // choose one with lots of plurals
@@ -1299,4 +1300,30 @@ public class TestPathHeader extends TestFmwkPlus {
         assertEquals("Section", century.getSectionId(), decade.getSectionId());
         assertEquals("Page", century.getPageId(), decade.getPageId());
     }
+
+    public void TestEmojiOrder() {
+        PathHeader.Factory phf = PathHeader.getFactory();
+        String[] desiredOrder = {"👨‍⚕", "👩‍⚕", "🧑‍⚕", "👨‍⚖", "👩‍⚖", "🧑‍⚖"};
+        List<PathHeader> pathHeaders = new ArrayList<>();
+        for (String emoji : desiredOrder) {
+            String base = "//ldml/annotations/annotation[@cp=\"" + emoji + "\"]";
+            pathHeaders.add(phf.fromPath(base + "[@type=\"tts\"]"));
+            pathHeaders.add(phf.fromPath(base));
+            logln(emoji
+                + ": getEmojiMinorOrder="+ Emoji.getEmojiMinorOrder(Emoji.getMinorCategory(emoji))
+                + ", getEmojiToOrder="+ Emoji.getEmojiToOrder(emoji)
+                );
+        }
+        PathHeader lastItem = null;
+        for (PathHeader item : pathHeaders) {
+            if (lastItem != null) {
+                assertEquals("Section", lastItem.getSectionId(), item.getSectionId());
+                assertEquals("Page", lastItem.getPageId(), item.getPageId());
+                assertEquals("Header", lastItem.getHeader(), item.getHeader());
+                assertTrue(lastItem + " < " + item, lastItem.compareTo(item) < 0);
+            }
+            lastItem = item;
+        }
+    }
+
 }

--- a/tools/java/org/unicode/cldr/util/Emoji.java
+++ b/tools/java/org/unicode/cldr/util/Emoji.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.unicode.cldr.draft.FileUtilities;
@@ -12,8 +11,6 @@ import org.unicode.cldr.draft.FileUtilities;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
@@ -66,7 +63,7 @@ public class Emoji {
         String minorCategory = null;
         int majorOrder = 0;
         int minorOrder = 0;
-        Multimap<Pair<Integer,Integer>,String> majorPlusMinorToEmoji = TreeMultimap.create();
+        //Multimap<Pair<Integer,Integer>,String> majorPlusMinorToEmoji = TreeMultimap.create();
         for (String line : FileUtilities.in(Emoji.class, "data/emoji/emoji-test.txt")) {
             if (line.startsWith("#")) {
                 line = line.substring(1).trim();
@@ -78,7 +75,7 @@ public class Emoji {
                     } else {
                         majorOrder = oldMajorOrder;
                     }
-               } else if (line.startsWith("subgroup:")) {
+                } else if (line.startsWith("subgroup:")) {
                     minorCategory = line.substring("subgroup:".length()).trim();
                     Integer oldMinorOrder = minorToOrder.get(minorCategory);
                     if (oldMinorOrder == null) {
@@ -111,8 +108,16 @@ public class Emoji {
             // add all the non-constructed values to a set for annotations
 
             String minimal = original.replace(EMOJI_VARIANT, "");
+
+            // Add the order. If it is not minimal, add that also.
+            if (!emojiToOrder.containsKey(original)) {
+                emojiToOrder.put(original, emojiToOrder.size());
+            }
+            if (!emojiToOrder.containsKey(minimal)) {
+                emojiToOrder.put(original, emojiToOrder.size());
+            }
             // 
-            majorPlusMinorToEmoji.put(Pair.of(majorOrder, minorOrder), minimal);
+            // majorPlusMinorToEmoji.put(Pair.of(majorOrder, minorOrder), minimal);
 
             boolean singleton = CharSequences.getSingleCodePoint(minimal) != Integer.MAX_VALUE;
 //            if (!emojiToOrder.containsKey(minimal)) {
@@ -136,10 +141,10 @@ public class Emoji {
                 nonConstructed.add(minimal);
             }
         }
-        for (Entry<Pair<Integer,Integer>, String> entry : majorPlusMinorToEmoji.entries()) {
-            String minimal = entry.getValue();
-            emojiToOrder.put(minimal, emojiToOrder.size());
-        }
+//        for (Entry<Pair<Integer,Integer>, String> entry : majorPlusMinorToEmoji.entries()) {
+//            String minimal = entry.getValue();
+//            emojiToOrder.put(minimal, emojiToOrder.size());
+//        }
         emojiToMajorCategory.freeze();
         emojiToMinorCategory.freeze();
         nonConstructed.add(MODIFIERS); // needed for names
@@ -165,7 +170,7 @@ public class Emoji {
         }
         return minorCat;
     }
-    
+
     public static String getName(String emoji) {
         return toName.get(emoji);
     }
@@ -175,9 +180,14 @@ public class Emoji {
 //        Integer result = minorToOrder.get(minor);
 //        return result == null ? Integer.MAX_VALUE : result;
 //    }
-    
-    public static int getEmojiToOrder(String minor) {
-        Integer result = emojiToOrder.get(minor);
+
+    public static int getEmojiToOrder(String emoji) {
+        Integer result = emojiToOrder.get(emoji);
+        return result == null ? Integer.MAX_VALUE : result;
+    }
+
+    public static int getEmojiMinorOrder(String minor) {
+        Integer result = minorToOrder.get(minor);
         return result == null ? Integer.MAX_VALUE : result;
     }
 

--- a/tools/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/java/org/unicode/cldr/util/PathHeader.java
@@ -1765,8 +1765,21 @@ public class PathHeader implements Comparable<PathHeader> {
                 @Override
                 public String transform(String source) {
                     String minorCat = Emoji.getMinorCategory(source);
-                    order = Emoji.getEmojiToOrder(source);
+                    order = Emoji.getEmojiMinorOrder(source);
                     return minorCat;
+                }
+            });
+            /**
+             * Use the ordering of the emoji in getEmojiToOrder rather than alphabetic,
+             * since the collator data won't be ready until the candidates are final. 
+             */
+            functionMap.put("emoji", new Transform<String, String>() {
+                @Override
+                public String transform(String source) {
+                    int dashPos = source.indexOf(' ');
+                    String emoji = source.substring(0, dashPos);
+                    order = (Emoji.getEmojiToOrder(emoji) << 1) + (source.endsWith("name") ? 0 : 1);
+                    return source;
                 }
             });
 

--- a/tools/java/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/java/org/unicode/cldr/util/data/PathHeader.txt
@@ -255,8 +255,8 @@
 //ldml/localeDisplayNames/annotationPatterns/annotationPattern[@type="%A"] ; Characters ; Category ; Link ; $1
 
 # Use special hyphens
-//ldml/annotations/annotation[@cp="%A"][@type="tts"]	; Characters ; &major($1) ; &minor($1) ; &alphaOrder($1 -name)
-//ldml/annotations/annotation[@cp="%A"]					; Characters ; &major($1) ; &minor($1) ; &alphaOrder($1 –keywords)
+//ldml/annotations/annotation[@cp="%A"][@type="tts"]	; Characters ; &major($1) ; &minor($1) ; &emoji($1 -name)
+//ldml/annotations/annotation[@cp="%A"]					; Characters ; &major($1) ; &minor($1) ; &emoji($1 –keywords)
 
 #OLD
 //ldml/annotations/annotation_[@cp="%A"]/_tts			; Characters ; Annotation ; $1 ; TTS ; HIDE


### PR DESCRIPTION
The ordering still wasn't right. The root problem is that the collation sequence isn't updated until later in the Unicode process, once we have beta of Unicode.

So reworked the ordering in the Survey Tool (via PathHeader) to follow the emoji-test.txt file, instead of using an alphabetic sort for the Code values.