### PR TITLE
CLDR-12016 Verify consistency when generating vxml

### DIFF
--- a/tools/cldr-apps/WebContent/admin-OutputAllFiles.jsp
+++ b/tools/cldr-apps/WebContent/admin-OutputAllFiles.jsp
@@ -13,64 +13,8 @@
 <title>Update All Files</title>
 </head>
 <body>
-
-<% if( (request.getParameter("vap")==null)
-	   || !request.getParameter("vap").equals(CookieSession.sm.vap)) { %>
-	   Not authorized. 
-<% return;
-	} %>
-
 <%
-long start = System.currentTimeMillis();
-ElapsedTimer overallTimer = new ElapsedTimer("overall update started " + new java.util.Date());
-int numupd = 0;
-	OutputFileManager ofm = CookieSession.sm.getOutputFileManager();
-%>
-
-Have OFM=<%= ofm %>
-
-<ol>
-<%
-	Set<CLDRLocale> sortSet = new TreeSet<CLDRLocale>();
-	sortSet.addAll(SurveyMain.getLocalesSet());
-	Connection conn = null;
-	synchronized(OutputFileManager.class) {
-	try {
-		conn = CookieSession.sm.dbUtils.getDBConnection();
-		for (CLDRLocale loc : sortSet) {
-	          Timestamp locTime=ofm.getLocaleTime(conn, loc);
-%>
-			<li><%= loc.getDisplayName() %> - <%= locTime.toLocaleString() %><br/>
-	
- <% 				for(OutputFileManager.Kind kind : OutputFileManager.Kind.values()) {
-		//if(kind!=OutputFileManager.Kind.vxml) continue;
-		boolean nu= ofm.fileNeedsUpdate(locTime,loc,kind.name());   %> 
-					<span style=' background-color: <%= nu?"#ff9999":"green" %>; font-weight: <%= nu?"regular":"bold" %>; color: <%= nu?"silver":"black" %>;'><%= kind %><%
-						if(nu&&(kind==OutputFileManager.Kind.vxml || kind==OutputFileManager.Kind.pxml)) {
-							System.err.println("Writing " + loc.getDisplayName() + ":"+kind);
-							ElapsedTimer et = new ElapsedTimer("to write " + loc +":"+kind);
-							File f = ofm.getOutputFile(conn, loc, kind.name());
-							out.print(" x=" + (f != null && f.exists()));
-							numupd++;
-							System.err.println(et + " - upd " + numupd+"/"+(sortSet.size()+2));
-						}
-					 %></span>  &nbsp;
-	
-	<%  } %>
-			</li>
-<%
-		}
-	} finally {
-		DBUtils.close(conn);
-	}
-}
-%>
-</ol>
-<hr>
-Total upd: <%= numupd+"/"+(sortSet.size()+2) %>
-Total time: <%= overallTimer %> : <%= ((System.currentTimeMillis()-start)/(1000.0*60)) %>min
-<%
-	System.err.println(overallTimer +  " - updated " + numupd+"/"+(sortSet.size()+2) + " in " + (System.currentTimeMillis()-start)/(1000.0*60) + " min");
+	OutputFileManager.outputAndVerifyAllFiles(request, out);
 %>
 </body>
 </html>

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -543,6 +543,16 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
             lastFiltered = temp;
             wroteAtLeastOnePath = true;
         }
+        /*
+         * SKIP_FILE_IF_SKIP_ALL_PATHS may be set by OutputFileManager, maybe for annotations
+         * but not for main. If so, return false without finishing writing; the caller may delete
+         * the file. However, OutputFileManager might instead generate all files (without
+         * SKIP_FILE_IF_SKIP_ALL_PATHS) and then use something like RemoveEmptyCLDR subsequently.
+         * In the latter case, we might do away with SKIP_FILE_IF_SKIP_ALL_PATHS.
+         * It might still be more efficient, though, to check here whether all paths were skipped,
+         * and remember that later instead of checking again from scratch for "remove empty".
+         * Reference: https://unicode-org.atlassian.net/browse/CLDR-12016
+         */
         if (!wroteAtLeastOnePath && options.containsKey("SKIP_FILE_IF_SKIP_ALL_PATHS")) {
             return false;
         }

--- a/tools/java/org/unicode/cldr/util/CLDRPaths.java
+++ b/tools/java/org/unicode/cldr/util/CLDRPaths.java
@@ -11,6 +11,9 @@ import com.google.common.collect.ImmutableList;
  * These must not be used by any code destined for the SurveyTool, as this class will not be included.
  * @author srl
  *
+ * TODO: clarify "this class will not be included" comment above. Why is it necessary and/or preferable
+ * not to include this class in ST? Anyway, note that CLDRConfig.getInstance().getCldrBaseDirectory()
+ * can be used as an alternative to CLDRPaths.BASE_DIRECTORY.
  */
 
 public class CLDRPaths {
@@ -129,16 +132,5 @@ public class CLDRPaths {
         }
     }
 
-    @Deprecated //use DtdType.ldml.directories
-//    public static final Set<String> LDML_DIRECTORIES = ImmutableSet.of(
-//        "main",
-//        "annotations",
-//        "casing",
-//        "collation",
-//        "rbnf",
-//        "segments",
-//        "subdivisions"
-//        );
-    public static final String UNICODE_VERSION = "10.0.0";
     public static final String TEST_DATA = COMMON_DIRECTORY + "testData/";
 }


### PR DESCRIPTION
[CLDR-12016]

-Change jsp notation to java, move java code from jsp to new OutputFileManager.outputAllFiles

-New OutputFileManager.outputAndVerifyAllFiles

-New function verifyAllFiles and its subroutines

-Make isCacheableKind private

-Remove unused getTryCommitWhyNot

-New function removeEmptyFiles; turn off SKIP_FILE_IF_SKIP_ALL_PATHS

-New createNewManualVetdataDir makes folder like vetdata-2019-05-28T12-34-56-789Z

-Copy ldml.dtd where needed

-Enable both "update" and "new folder" in outputAndVerifyAllFiles

-Encapsulate dir names in new DirNames class

-New parameters for output/separate/remove/verify

-Allow parent in common and child in seed, not vice-versa

-New function otherParentExists

-Allow present in vxml but not in baseline, not vice-versa

-Delete dead code; clean-up, comments

[CLDR-12016]: https://unicode-org.atlassian.net/browse/CLDR-12016