### PR TITLE
CLDR-13056 Add a GitHub pull-request template for CLDR.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+Thank you for your pull request.
+Please see http://cldr.unicode.org/index/process for general
+information on contributing to CLDR.
+
+You will be automatically asked to sign the contributors license before the PR is accepted.
+- sign: https://cla-assistant.io/unicode-org/cldr
+- license: http://www.unicode.org/copyright.html#License
+-->
+
+##### Checklist
+
+- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-_____
+- [ ] Updated PR title and link in previous line to include Issue number
+


### PR DESCRIPTION
[CLDR-13056]
This change adds a GitHub Pull-Request template for CLDR, similar to the one used by ICU.


[CLDR-13056]: https://unicode-org.atlassian.net/browse/CLDR-13056