### PR TITLE
CLDR-13059 move subdivisions into main for Survey Tool

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -793,6 +793,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Onbekende gebied</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Engeland</subdivision>
+			<subdivision type="gbsct">Skotland</subdivision>
+			<subdivision type="gbwls">Wallis</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901" draft="unconfirmed">Duitse ortografie van 1901</variant>
 			<variant type="1996" draft="unconfirmed">Duitse ortografie van 1996</variant>
@@ -6152,11 +6157,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} perdekrag</unitPattern>
 				<unitPattern count="other">{0} perdekrag</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascal</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeter kwik</displayName>
 				<unitPattern count="one">{0} millimeter kwik</unitPattern>
@@ -6181,6 +6181,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfere</displayName>
 				<unitPattern count="one">{0} atmosfeer</unitPattern>
 				<unitPattern count="other">{0} atmosfere</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascal</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascal</displayName>
@@ -6955,11 +6960,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} pk.</unitPattern>
 				<unitPattern count="other">{0} pk.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -6984,6 +6984,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -7356,10 +7361,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}pk.</unitPattern>
 				<unitPattern count="other">{0}pk.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} dm.Hg</unitPattern>
 				<unitPattern count="other">{0} dm.Hg</unitPattern>
@@ -7367,6 +7368,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -870,6 +870,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ዚምቧቤ</territory>
 			<territory type="ZZ">ያልታወቀ ክልል</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">እንግሊዝ</subdivision>
+			<subdivision type="gbsct">ስኮትላንድ</subdivision>
+			<subdivision type="gbwls">ዌልስ</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">የቀን አቆጣጠር</key>
 			<key type="cf">የምንዛሪ ቅርጸት</key>
@@ -6826,11 +6831,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} የፈረስ ጉልበት</unitPattern>
 				<unitPattern count="other">{0} የፈረስ ጉልበት</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ሄክቶፓስካል</displayName>
-				<unitPattern count="one">{0} ሄክቶፓስካል</unitPattern>
-				<unitPattern count="other">{0} ሄክቶፓስካል</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -6855,6 +6855,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ከባቢ አየር</displayName>
 				<unitPattern count="one">{0} ከባቢ አየር</unitPattern>
 				<unitPattern count="other">{0} ከባቢ አየር</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ሄክቶፓስካል</displayName>
+				<unitPattern count="one">{0} ሄክቶፓስካል</unitPattern>
+				<unitPattern count="other">{0} ሄክቶፓስካል</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ኪሎፓስካል</displayName>
@@ -7629,11 +7634,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} የፈጉ</unitPattern>
 				<unitPattern count="other">{0} የፈጉ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ሄክቶፓስካል</displayName>
-				<unitPattern count="one">{0} ሄክቶፓስካል</unitPattern>
-				<unitPattern count="other">{0} ሄክቶፓስካል</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7658,6 +7658,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ከባቢ አየር</displayName>
 				<unitPattern count="one">{0} ከባቢ አየር</unitPattern>
 				<unitPattern count="other">{0} ከባቢ አየር</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ሄክቶፓስካል</displayName>
+				<unitPattern count="one">{0} ሄክቶፓስካል</unitPattern>
+				<unitPattern count="other">{0} ሄክቶፓስካል</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ኪሎፓስካል</displayName>
@@ -8033,10 +8038,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} የፈረስ ኃይል</unitPattern>
 				<unitPattern count="other">{0} የፈረስ ኃይል</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -8044,6 +8045,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} ሚባ</unitPattern>
 				<unitPattern count="other">{0} ሚባ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ኪሎሜትር በሰዓት</displayName>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -986,6 +986,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">زيمبابوي</territory>
 			<territory type="ZZ">منطقة غير معروفة</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">إنجلترا</subdivision>
+			<subdivision type="gbsct">اسكتلندا</subdivision>
+			<subdivision type="gbwls">ويلز</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">التهجئة الألمانية التقليدية</variant>
 			<variant type="1996">التهجئة الألمانية لعام 1996</variant>
@@ -9484,15 +9489,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} قوة حصان</unitPattern>
 				<unitPattern count="other">{0} قوة حصان</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هكتوباسكال</displayName>
-				<unitPattern count="zero">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="one">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="two">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="few">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="many">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="other">{0} هكتوباسكال</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>مليمتر زئبقي</displayName>
 				<unitPattern count="zero">{0} مليمتر زئبقي</unitPattern>
@@ -9537,6 +9533,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ض.ج</unitPattern>
 				<unitPattern count="many">{0} ض.ج</unitPattern>
 				<unitPattern count="other">{0} ضغط جوي</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هكتوباسكال</displayName>
+				<unitPattern count="zero">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="one">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="two">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="few">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="many">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="other">{0} هكتوباسكال</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">كيلوباسكال</displayName>
@@ -10893,15 +10898,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} حصان</unitPattern>
 				<unitPattern count="other">{0} حصان</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هكتوباسكال</displayName>
-				<unitPattern count="zero">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="one">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="two">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="few">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="many">{0} هكتوباسكال</unitPattern>
-				<unitPattern count="other">{0} هكتوباسكال</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ملم زئبقي</displayName>
 				<unitPattern count="zero">{0} ملم زئبقي</unitPattern>
@@ -10946,6 +10942,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ض.ج</unitPattern>
 				<unitPattern count="many">{0} ض.ج</unitPattern>
 				<unitPattern count="other">{0} ض.ج</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هكتوباسكال</displayName>
+				<unitPattern count="zero">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="one">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="two">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="few">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="many">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="other">{0} هكتوباسكال</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -11620,14 +11625,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" draft="contributed">{0} قوة حصان</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} قوة حصان</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="zero">{0} هكب</unitPattern>
-				<unitPattern count="one">{0} هكب</unitPattern>
-				<unitPattern count="two">{0} هكب</unitPattern>
-				<unitPattern count="few">{0} هكب</unitPattern>
-				<unitPattern count="many">{0} هكب</unitPattern>
-				<unitPattern count="other">{0} هكب</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="zero">{0} ب ز</unitPattern>
 				<unitPattern count="one">{0} ب ز</unitPattern>
@@ -11643,6 +11640,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" draft="contributed">{0} مللي بار</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} مللي بار</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} مللي بار</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="zero">{0} هكب</unitPattern>
+				<unitPattern count="one">{0} هكب</unitPattern>
+				<unitPattern count="two">{0} هكب</unitPattern>
+				<unitPattern count="few">{0} هكب</unitPattern>
+				<unitPattern count="many">{0} هكب</unitPattern>
+				<unitPattern count="other">{0} هكب</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>كم/س</displayName>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -772,6 +772,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">জিম্বাবৱে</territory>
 			<territory type="ZZ">অজ্ঞাত ক্ষেত্ৰ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ইংলেণ্ড</subdivision>
+			<subdivision type="gbsct">স্কটলেণ্ড</subdivision>
+			<subdivision type="gbwls">ৱেলছ্</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">কেলেণ্ডাৰ</key>
 			<key type="cf">মুদ্ৰা সজ্জা</key>
@@ -5981,11 +5986,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} অশ্বক্ষমতা</unitPattern>
 				<unitPattern count="other">{0} অশ্বক্ষমতা</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>হেক্টোপাছকল</displayName>
-				<unitPattern count="one">{0} হেক্টোপাছকল</unitPattern>
-				<unitPattern count="other">{0} হেক্টোপাছকল</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>মিলিমিটাৰ মাৰ্কিউৰী</displayName>
 				<unitPattern count="one">{0} মিলিমিটাৰ মাৰ্কিউৰী</unitPattern>
@@ -6010,6 +6010,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>বতৰ</displayName>
 				<unitPattern count="one">{0} বতৰ</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>হেক্টোপাছকল</displayName>
+				<unitPattern count="one">{0} হেক্টোপাছকল</unitPattern>
+				<unitPattern count="other">{0} হেক্টোপাছকল</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>কিল’পাস্কেল</displayName>
@@ -6784,11 +6789,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} অশ্বক্ষমতা</unitPattern>
 				<unitPattern count="other">{0} অশ্বক্ষমতা</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -6813,6 +6813,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>কি. পা.</displayName>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -978,6 +978,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">Naməlum Region</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">İngiltərə</subdivision>
+			<subdivision type="gbsct">Şotlandiya</subdivision>
+			<subdivision type="gbwls">Uels</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Təqvim</key>
 			<key type="cf">Valyuta Formatı</key>
@@ -6788,11 +6793,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} at gücü</unitPattern>
 				<unitPattern count="other">{0} at gücü</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskal</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="other">{0} hektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimetr civə sütunu</displayName>
 				<unitPattern count="one">{0} millimetr civə sütunu</unitPattern>
@@ -6817,6 +6817,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfer</displayName>
 				<unitPattern count="one">{0} atmosfer</unitPattern>
 				<unitPattern count="other">{0} atmosfer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskal</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="other">{0} hektopaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskal</displayName>
@@ -7596,11 +7601,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskal</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7625,6 +7625,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskal</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -8000,10 +8005,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -8011,6 +8012,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilometr/saat</displayName>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -782,6 +782,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зімбабвэ</territory>
 			<territory type="ZZ">Невядомы рэгіён</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англія</subdivision>
+			<subdivision type="gbsct">Шатландыя</subdivision>
+			<subdivision type="gbwls">Уэльс</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">каляндар</key>
 			<key type="cf">фармат валюты</key>
@@ -6801,13 +6806,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} к. с.</unitPattern>
 				<unitPattern count="other">{0} к. с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектапаскалі</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="few">{0} гПа</unitPattern>
-				<unitPattern count="many">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>міліметры ртутнага слупа</displayName>
 				<unitPattern count="one">{0} мм рт. сл.</unitPattern>
@@ -6842,6 +6840,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} атм</unitPattern>
 				<unitPattern count="many">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектапаскалі</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="few">{0} гПа</unitPattern>
+				<unitPattern count="many">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>кілапаскалі</displayName>
@@ -7910,13 +7915,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} к. с.</unitPattern>
 				<unitPattern count="other">{0} к. с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гПа</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="few">{0} гПа</unitPattern>
-				<unitPattern count="many">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>мм рт. сл.</displayName>
 				<unitPattern count="one">{0} мм рт. сл.</unitPattern>
@@ -7951,6 +7949,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} атм</unitPattern>
 				<unitPattern count="many">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гПа</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="few">{0} гПа</unitPattern>
+				<unitPattern count="many">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>кПа</displayName>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -954,6 +954,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">непознат регион</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англия</subdivision>
+			<subdivision type="gbsct">Шотландия</subdivision>
+			<subdivision type="gbwls">Уелс</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Традиционен немски правопис</variant>
 			<variant type="1994">Стандартен резиански правопис</variant>
@@ -6922,11 +6927,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} конска сила</unitPattern>
 				<unitPattern count="other">{0} конски сили</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>хектопаскали</displayName>
-				<unitPattern count="one">{0} хектопаскал</unitPattern>
-				<unitPattern count="other">{0} хектопаскала</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>милиметри живачен стълб</displayName>
 				<unitPattern count="one">{0} мм живачен стълб</unitPattern>
@@ -6951,6 +6951,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атмосфери</displayName>
 				<unitPattern count="one">{0} атмосфера</unitPattern>
 				<unitPattern count="other">{0} атмосфери</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>хектопаскали</displayName>
+				<unitPattern count="one">{0} хектопаскал</unitPattern>
+				<unitPattern count="other">{0} хектопаскала</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>килопаскали</displayName>
@@ -7720,11 +7725,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} к. с.</unitPattern>
 				<unitPattern count="other">{0} к. с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -7749,6 +7749,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -8121,10 +8126,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} к.с.</unitPattern>
 				<unitPattern count="other">{0} к.с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -8132,6 +8133,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -987,6 +987,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">জিম্বাবোয়ে</territory>
 			<territory type="ZZ">অজানা অঞ্চল</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ইংল্যাণ্ড</subdivision>
+			<subdivision type="gbsct">স্কটল্যান্ড</subdivision>
+			<subdivision type="gbwls">ওয়েল্স</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN" draft="provisional">পিনইন রোমানাইজেশন</variant>
 			<variant type="WADEGILE" draft="provisional">ওয়াদে-গিলেস রোমানাইজেশন</variant>
@@ -7650,11 +7655,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} হর্সপাওয়ার</unitPattern>
 				<unitPattern count="other">{0} হর্সপাওয়ার</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>হেক্টোপাসকল</displayName>
-				<unitPattern count="one">{0} হেক্টোপাসকল</unitPattern>
-				<unitPattern count="other">{0} হেক্টোপাসকল</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>মিলিমিটার পারদ</displayName>
 				<unitPattern count="one">{0} মিলিমিটার পারদ</unitPattern>
@@ -7674,6 +7674,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>মিলিবার</displayName>
 				<unitPattern count="one">{0} মিলিবার</unitPattern>
 				<unitPattern count="other">{0} মিলিবার</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>হেক্টোপাসকল</displayName>
+				<unitPattern count="one">{0} হেক্টোপাসকল</unitPattern>
+				<unitPattern count="other">{0} হেক্টোপাসকল</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">কিলোপ্যাসকেল</displayName>
@@ -8451,11 +8456,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8475,6 +8475,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8915,10 +8920,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ওয়াট</unitPattern>
 				<unitPattern count="other">{0} ওয়াট</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -8926,6 +8927,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -951,6 +951,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Rannved dianav</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Bro-Saoz</subdivision>
+			<subdivision type="gbsct">Skos</subdivision>
+			<subdivision type="gbwls">Kembre</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">reizhskrivadur alamanek hengounel</variant>
 			<variant type="1994">reizhskrivadur resianek skoueriekaet</variant>
@@ -11294,14 +11299,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="many">{0} a varc'hadoù nerzh</unitPattern>
 				<unitPattern count="other">{0} marc'had nerzh</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskaloù</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="two">{0} hektopaskal</unitPattern>
-				<unitPattern count="few">{0} hektopaskal</unitPattern>
-				<unitPattern count="many">{0} a hektopaskaloù</unitPattern>
-				<unitPattern count="other">{0} hektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-pound-per-square-inch">
 				<displayName>lurioù dre veutad karrez</displayName>
 				<unitPattern count="one">{0} lur dre veutad karrez</unitPattern>
@@ -11317,6 +11314,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} milibar</unitPattern>
 				<unitPattern count="many">{0} a vilibaroù</unitPattern>
 				<unitPattern count="other">{0} milibar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskaloù</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="two">{0} hektopaskal</unitPattern>
+				<unitPattern count="few">{0} hektopaskal</unitPattern>
+				<unitPattern count="many">{0} a hektopaskaloù</unitPattern>
+				<unitPattern count="other">{0} hektopaskal</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilometroù dre eur</displayName>
@@ -12250,14 +12255,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -12289,6 +12286,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="many">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -12991,14 +12996,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -13030,6 +13027,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="many">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -1007,6 +1007,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">Nepoznata oblast</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Engleska</subdivision>
+			<subdivision type="gbsct">Škotska</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Tradicionalna nemačka ortografija</variant>
 			<variant type="1994">Standardizovana rezijanska ortografija</variant>
@@ -7948,12 +7953,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} konjske snage</unitPattern>
 				<unitPattern count="other">{0} konjskih snaga</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskali</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="few">{0} hektopaskala</unitPattern>
-				<unitPattern count="other">{0} hektopaskala</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetri živinog stuba</displayName>
 				<unitPattern count="one">{0} milimetar živinog stuba</unitPattern>
@@ -7983,6 +7982,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskali</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="few">{0} hektopaskala</unitPattern>
+				<unitPattern count="other">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskali</displayName>
@@ -8904,12 +8909,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ks</unitPattern>
 				<unitPattern count="other">{0} ks</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8939,6 +8938,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -9386,11 +9391,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" draft="provisional">{0} KS</unitPattern>
 				<unitPattern count="other" draft="provisional">{0} KS</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one" draft="provisional">{0} hPa</unitPattern>
-				<unitPattern count="few" draft="provisional">{0} hPa</unitPattern>
-				<unitPattern count="other" draft="provisional">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one" draft="provisional">{0} inHg</unitPattern>
 				<unitPattern count="few" draft="provisional">{0} inHg</unitPattern>
@@ -9400,6 +9400,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" draft="provisional">{0} mb</unitPattern>
 				<unitPattern count="few" draft="provisional">{0} mb</unitPattern>
 				<unitPattern count="other" draft="provisional">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one" draft="provisional">{0} hPa</unitPattern>
+				<unitPattern count="few" draft="provisional">{0} hPa</unitPattern>
+				<unitPattern count="other" draft="provisional">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -1082,6 +1082,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbàbue</territory>
 			<territory type="ZZ">Regió desconeguda</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglaterra</subdivision>
+			<subdivision type="gbsct">Escòcia</subdivision>
+			<subdivision type="gbwls">Gal·les</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ortografia alemanya tradicional</variant>
 			<variant type="1994">ortografia resiana estandarditzada</variant>
@@ -7564,11 +7569,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} cavall de vapor</unitPattern>
 				<unitPattern count="other">{0} cavalls de vapor</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascals</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascals</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mil·límetres de mercuri</displayName>
 				<unitPattern count="one">mil·límetre de mercuri</unitPattern>
@@ -7593,6 +7593,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosferes</displayName>
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="other">{0} atmosferes</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascals</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascals</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>quilopascals</displayName>
@@ -8367,11 +8372,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} CV</unitPattern>
 				<unitPattern count="other">{0} CV</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -8396,6 +8396,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -8793,13 +8798,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}CV</unitPattern>
 				<unitPattern count="other">{0}CV</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="one" draft="contributed">{0} mb</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -975,6 +975,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">𑄎𑄨𑄟𑄴𑄝𑄝𑄪𑄠𑄬</territory>
 			<territory type="ZZ">𑄃𑄨𑄌𑄨𑄚𑄴 𑄎𑄉</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">𑄃𑄨𑄁𑄣𑄳𑄠𑄚𑄳𑄓𑄴</subdivision>
+			<subdivision type="gbsct">𑄌𑄳𑄇𑄧𑄖𑄴𑄣𑄳𑄠𑄚𑄳𑄓𑄴</subdivision>
+			<subdivision type="gbwls">𑄃𑄮𑄠𑄬𑄣𑄴</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN" draft="provisional">𑄛𑄨𑄚𑄴𑄃𑄨𑄚𑄴 𑄟𑄮𑄟𑄚𑄭𑄎𑄬𑄥𑄧𑄚𑄴</variant>
 			<variant type="WADEGILE" draft="provisional">𑄤𑄘𑄬-𑄉𑄨𑄣𑄬𑄌𑄴 𑄢𑄮𑄟𑄚𑄭𑄎𑄬𑄥𑄧𑄚𑄴</variant>
@@ -6689,11 +6694,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} 𑄦𑄧𑄢𑄴𑄥𑄴𑄛𑄤𑄢𑄴</unitPattern>
 				<unitPattern count="other">{0} 𑄦𑄧𑄢𑄴𑄥𑄴𑄛𑄤𑄢𑄴</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>𑄦𑄬𑄇𑄴𑄑𑄮𑄛𑄥𑄴𑄇𑄧𑄣𑄴</displayName>
-				<unitPattern count="one">{0} 𑄦𑄬𑄇𑄴𑄑𑄮𑄛𑄥𑄴𑄇𑄧𑄣𑄴</unitPattern>
-				<unitPattern count="other">{0} 𑄦𑄬𑄇𑄴𑄑𑄮𑄛𑄥𑄴𑄇𑄧𑄣𑄴</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>𑄟𑄨𑄣𑄨𑄟𑄨𑄑𑄢𑄴 𑄛𑄢𑄧𑄖𑄴</displayName>
 				<unitPattern count="one">{0} 𑄟𑄨𑄣𑄨𑄟𑄨𑄑𑄢𑄴 𑄛𑄢𑄧𑄖𑄴</unitPattern>
@@ -6713,6 +6713,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>𑄟𑄨𑄣𑄨𑄝𑄢𑄴</displayName>
 				<unitPattern count="one">{0} 𑄟𑄨𑄣𑄨𑄝𑄢𑄴</unitPattern>
 				<unitPattern count="other">{0}𑄟𑄨𑄣𑄨𑄝𑄢𑄴</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>𑄦𑄬𑄇𑄴𑄑𑄮𑄛𑄥𑄴𑄇𑄧𑄣𑄴</displayName>
+				<unitPattern count="one">{0} 𑄦𑄬𑄇𑄴𑄑𑄮𑄛𑄥𑄴𑄇𑄧𑄣𑄴</unitPattern>
+				<unitPattern count="other">{0} 𑄦𑄬𑄇𑄴𑄑𑄮𑄛𑄥𑄴𑄇𑄧𑄣𑄴</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>𑄊𑄧𑄚𑄳𑄑 𑄛𑄳𑄢𑄧𑄖𑄨 𑄇𑄨𑄣𑄮𑄟𑄨𑄑𑄢𑄴</displayName>
@@ -7376,11 +7381,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7400,6 +7400,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -7736,10 +7741,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -7747,6 +7748,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -75,6 +75,11 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			<territory type="US">Estados Unidos</territory>
 			<territory type="ZZ">Wala-mailhing Rehiyon</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inglatera</subdivision>
+			<subdivision type="gbsct">Scotland</subdivision>
+			<subdivision type="gbwls">Wales (apil sa nasod)</subdivision>
+		</subdivisions>
 		<types>
 			<type key="calendar" type="gregorian">Gregorian nga Kalendaryo</type>
 			<type key="collation" type="standard">Standard nga Paagi sa Pagpihig</type>

--- a/common/main/ckb.xml
+++ b/common/main/ckb.xml
@@ -751,6 +751,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">زیمبابوی</territory>
 			<territory type="ZZ">ناوچەی نەناسراو</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ئینگلاند</subdivision>
+			<subdivision type="gbsct">سکۆتلەندا</subdivision>
+			<subdivision type="gbwls">وەیڵز</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar" draft="unconfirmed">ڕۆژژمێر</key>
 			<key type="collation" draft="unconfirmed">ڕیزبەندی</key>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -1109,6 +1109,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">neznámá oblast</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglie</subdivision>
+			<subdivision type="gbsct">Skotsko</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN" draft="provisional">pinyin</variant>
 			<variant type="SCOTLAND" draft="contributed">angličtina (Skotsko)</variant>
@@ -10385,13 +10390,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} koňské síly</unitPattern>
 				<unitPattern count="other">{0} koňských sil</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascaly</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="few">{0} hektopascaly</unitPattern>
-				<unitPattern count="many">{0} hektopascalu</unitPattern>
-				<unitPattern count="other">{0} hektopascalů</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetry rtuti</displayName>
 				<unitPattern count="one">{0} milimetr rtuti</unitPattern>
@@ -10426,6 +10424,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atmosféry</unitPattern>
 				<unitPattern count="many">{0} atmosféry</unitPattern>
 				<unitPattern count="other">{0} atmosfér</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascaly</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="few">{0} hektopascaly</unitPattern>
+				<unitPattern count="many">{0} hektopascalu</unitPattern>
+				<unitPattern count="other">{0} hektopascalů</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascaly</displayName>
@@ -11522,13 +11527,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -11563,6 +11561,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -12482,13 +12487,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -12516,6 +12514,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} mb</unitPattern>
 				<unitPattern count="many">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -915,6 +915,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Rhanbarth Anhysbys</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Lloegr</subdivision>
+			<subdivision type="gbsct">Yr Alban</subdivision>
+			<subdivision type="gbwls">Cymru</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">orgraff draddodiadol yr Almaeneg</variant>
 			<variant type="1606NICT">Ffrangeg Canol Diweddar hyd at 1606</variant>
@@ -8911,15 +8916,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} marchnerth</unitPattern>
 				<unitPattern count="other">{0} marchnerth</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascalau</displayName>
-				<unitPattern count="zero">{0} hectopascal</unitPattern>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="two">{0} hectopascal</unitPattern>
-				<unitPattern count="few">{0} hectopascal</unitPattern>
-				<unitPattern count="many">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetrau o fercwri</displayName>
 				<unitPattern count="zero">{0} milimetr o fercwri</unitPattern>
@@ -8964,6 +8960,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atmosffer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascalau</displayName>
+				<unitPattern count="zero">{0} hectopascal</unitPattern>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="two">{0} hectopascal</unitPattern>
+				<unitPattern count="few">{0} hectopascal</unitPattern>
+				<unitPattern count="many">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>cilopascalau</displayName>
@@ -10356,15 +10361,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="zero">{0} hPa</unitPattern>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="zero">{0} mmHg</unitPattern>
@@ -10409,6 +10405,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="zero">{0} hPa</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -11479,15 +11484,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="zero">{0}hPa</unitPattern>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="two">{0}hPa</unitPattern>
-				<unitPattern count="few">{0}hPa</unitPattern>
-				<unitPattern count="many">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="zero">{0}mmHg</unitPattern>
@@ -11523,6 +11519,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0}mb</unitPattern>
 				<unitPattern count="many">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="zero">{0}hPa</unitPattern>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="two">{0}hPa</unitPattern>
+				<unitPattern count="few">{0}hPa</unitPattern>
+				<unitPattern count="many">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -1028,6 +1028,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Ukendt område</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Skotland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">traditionel tysk retskrivning</variant>
 			<variant type="1994" draft="contributed">standardiseret Resi-ortografi</variant>
@@ -7504,11 +7509,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hestekraft</unitPattern>
 				<unitPattern count="other">{0} hestekræfter</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascal</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeter kviksølv</displayName>
 				<unitPattern count="one">{0} millimeter kviksølv</unitPattern>
@@ -7533,6 +7533,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">atmosfære</displayName>
 				<unitPattern count="one" draft="contributed">{0} atmosfære</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} atmosfære</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascal</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascal</displayName>
@@ -8307,11 +8312,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hk</unitPattern>
 				<unitPattern count="other">{0} hk</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -8331,6 +8331,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8779,10 +8784,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hk</unitPattern>
 				<unitPattern count="other">{0}hk</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">mmHg</displayName>
 				<unitPattern count="one" draft="contributed">{0} mmHg</unitPattern>
@@ -8796,6 +8797,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/t</displayName>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -1141,6 +1141,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Simbabwe</territory>
 			<territory type="ZZ">Unbekannte Region</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Schottland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Alte deutsche Rechtschreibung</variant>
 			<variant type="1994">Standardisierte Resianische Rechtschreibung</variant>
@@ -7900,11 +7905,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Pferdestärke</unitPattern>
 				<unitPattern count="other">{0} Pferdestärken</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>Hektopascal</displayName>
-				<unitPattern count="one">{0} Hektopascal</unitPattern>
-				<unitPattern count="other">{0} Hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>Millimeter Quecksilbersäule</displayName>
 				<unitPattern count="one">{0} Millimeter Quecksilbersäule</unitPattern>
@@ -7929,6 +7929,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">Atmosphären</displayName>
 				<unitPattern count="one" draft="contributed">{0} Atmosphäre</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} Atmosphären</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>Hektopascal</displayName>
+				<unitPattern count="one">{0} Hektopascal</unitPattern>
+				<unitPattern count="other">{0} Hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8486,11 +8491,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} PS</unitPattern>
 				<unitPattern count="other">{0} PS</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8510,6 +8510,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Millibar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -998,6 +998,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Ζιμπάμπουε</territory>
 			<territory type="ZZ">Άγνωστη περιοχή</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Αγγλία</subdivision>
+			<subdivision type="gbsct">Σκωτία</subdivision>
+			<subdivision type="gbwls">Ουαλία</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Παραδοσιακή γερμανική ορθογραφία</variant>
 			<variant type="1994">Τυποποιημένη ορθογραφία Ρεσιάν</variant>
@@ -7475,11 +7480,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ίππος</unitPattern>
 				<unitPattern count="other">{0} ίπποι</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>εκτοπασκάλ</displayName>
-				<unitPattern count="one">{0} εκτοπασκάλ</unitPattern>
-				<unitPattern count="other">{0} εκτοπασκάλ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>χιλιοστόμετρα στήλης υδραργύρου</displayName>
 				<unitPattern count="one">{0} χιλιοστόμετρα στήλης υδραργύρου</unitPattern>
@@ -7504,6 +7504,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ατμόσφαιρες</displayName>
 				<unitPattern count="one">{0} ατμόσφαιρα</unitPattern>
 				<unitPattern count="other">{0} ατμόσφαιρες</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>εκτοπασκάλ</displayName>
+				<unitPattern count="one">{0} εκτοπασκάλ</unitPattern>
+				<unitPattern count="other">{0} εκτοπασκάλ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>κιλοπασκάλ</displayName>
@@ -8278,11 +8283,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ίπ.</unitPattern>
 				<unitPattern count="other">{0} ίπ.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -8307,6 +8307,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -8679,10 +8684,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -8690,6 +8691,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>χλμ/ώ.</displayName>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -124,8 +124,8 @@ annotations.
 			<language type="chp">Chipewyan</language>
 			<language type="chr">Cherokee</language>
 			<language type="chy">Cheyenne</language>
-			<language type="ckb">Central Kurdish</language>
 			<language type="cic">Chickasaw</language>
+			<language type="ckb">Central Kurdish</language>
 			<language type="co">Corsican</language>
 			<language type="cop">Coptic</language>
 			<language type="cps">Capiznon</language>
@@ -1163,6 +1163,11 @@ annotations.
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Unknown Region</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Scotland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Traditional German orthography</variant>
 			<variant type="1994">Standardized Resian orthography</variant>
@@ -6161,11 +6166,11 @@ annotations.
 				<unitPattern count="one">{0} century</unitPattern>
 				<unitPattern count="other">{0} centuries</unitPattern>
 			</unit>
-            <unit type="duration-decade">
-                <displayName>decades</displayName>
-                <unitPattern count="one">{0} decade</unitPattern>
-                <unitPattern count="other">{0} decades</unitPattern>
-            </unit>
+			<unit type="duration-decade">
+				<displayName>decades</displayName>
+				<unitPattern count="one">{0} decade</unitPattern>
+				<unitPattern count="other">{0} decades</unitPattern>
+			</unit>
 			<unit type="duration-year">
 				<displayName>years</displayName>
 				<unitPattern count="one">{0} year</unitPattern>
@@ -6283,12 +6288,12 @@ annotations.
 				<unitPattern count="one">{0} British thermal unit</unitPattern>
 				<unitPattern count="other">{0} British thermal units</unitPattern>
 			</unit>
-              <unit type="energy-therm-us">
-                <displayName>US therms</displayName>
-                <unitPattern count="one">{0} US therm</unitPattern>
-                <unitPattern count="other">{0} US therms</unitPattern>
-            </unit>
-  			<unit type="force-pound-force">
+			<unit type="energy-therm-us">
+				<displayName>US therms</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therms</unitPattern>
+			</unit>
+			<unit type="force-pound-force">
 				<displayName>pounds of force</displayName>
 				<unitPattern count="one">{0} pound of force</unitPattern>
 				<unitPattern count="other">{0} pounds of force</unitPattern>
@@ -6577,16 +6582,6 @@ annotations.
 				<unitPattern count="one">{0} horsepower</unitPattern>
 				<unitPattern count="other">{0} horsepower</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascals</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascals</unitPattern>
-			</unit>
-            <unit type="pressure-pascal">
-                <displayName>pascals</displayName>
-                <unitPattern count="one">{0} pascal</unitPattern>
-                <unitPattern count="other">{0} pascals</unitPattern>
-            </unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeters of mercury</displayName>
 				<unitPattern count="one">{0} millimeter of mercury</unitPattern>
@@ -6602,11 +6597,11 @@ annotations.
 				<unitPattern count="one">{0} inch of mercury</unitPattern>
 				<unitPattern count="other">{0} inches of mercury</unitPattern>
 			</unit>
-            <unit type="pressure-bar">
-                <displayName>bars</displayName>
-                <unitPattern count="one">{0} bar</unitPattern>
-                <unitPattern count="other">{0} bars</unitPattern>
-            </unit>
+			<unit type="pressure-bar">
+				<displayName>bars</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bars</unitPattern>
+			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibars</displayName>
 				<unitPattern count="one">{0} millibar</unitPattern>
@@ -6616,6 +6611,16 @@ annotations.
 				<displayName>atmospheres</displayName>
 				<unitPattern count="one">{0} atmosphere</unitPattern>
 				<unitPattern count="other">{0} atmospheres</unitPattern>
+			</unit>
+			<unit type="pressure-pascal">
+				<displayName>pascals</displayName>
+				<unitPattern count="one">{0} pascal</unitPattern>
+				<unitPattern count="other">{0} pascals</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascals</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascals</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascals</displayName>
@@ -7034,11 +7039,11 @@ annotations.
 				<unitPattern count="one">{0} c</unitPattern>
 				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
-            <unit type="duration-decade">
-                <displayName>dec</displayName>
-                <unitPattern count="one">{0} dec</unitPattern>
-                <unitPattern count="other">{0} dec</unitPattern>
-            </unit>
+			<unit type="duration-decade">
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
+			</unit>
 			<unit type="duration-year">
 				<displayName>years</displayName>
 				<unitPattern count="one">{0} yr</unitPattern>
@@ -7156,11 +7161,11 @@ annotations.
 				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
-            <unit type="energy-therm-us">
-                <displayName>US therm</displayName>
-                <unitPattern count="one">{0} US therm</unitPattern>
-                <unitPattern count="other">{0} US therms</unitPattern>
-            </unit>
+			<unit type="energy-therm-us">
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therms</unitPattern>
+			</unit>
 			<unit type="force-pound-force">
 				<displayName>pound-force</displayName>
 				<unitPattern count="one">{0} lbf</unitPattern>
@@ -7450,16 +7455,6 @@ annotations.
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
-            <unit type="pressure-pascal">
-                <displayName>Pa</displayName>
-                <unitPattern count="one">{0} Pa</unitPattern>
-                <unitPattern count="other">{0} Pa</unitPattern>
-            </unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -7475,11 +7470,11 @@ annotations.
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
-            <unit type="pressure-bar">
-                <displayName>bar</displayName>
-                <unitPattern count="one">{0} bar</unitPattern>
-                <unitPattern count="other">{0} bars</unitPattern>
-            </unit>
+			<unit type="pressure-bar">
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bars</unitPattern>
+			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
@@ -7489,6 +7484,16 @@ annotations.
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-pascal">
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -7881,11 +7886,11 @@ annotations.
 				<unitPattern count="one">{0}bit</unitPattern>
 				<unitPattern count="other">{0}bit</unitPattern>
 			</unit>
-            <unit type="duration-decade">
-                <displayName>dec</displayName>
-                <unitPattern count="one">{0}dec</unitPattern>
-                <unitPattern count="other">{0}dec</unitPattern>
-            </unit>
+			<unit type="duration-decade">
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0}dec</unitPattern>
+				<unitPattern count="other">{0}dec</unitPattern>
+			</unit>
 			<unit type="duration-year">
 				<displayName>yr</displayName>
 				<unitPattern count="one">{0}y</unitPattern>
@@ -7996,11 +8001,11 @@ annotations.
 				<unitPattern count="one">{0}Btu</unitPattern>
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
-            <unit type="energy-therm-us">
-                <displayName>US therm</displayName>
-                <unitPattern count="one">{0}US therm</unitPattern>
-                <unitPattern count="other">{0}US therms</unitPattern>
-            </unit>
+			<unit type="energy-therm-us">
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0}US therm</unitPattern>
+				<unitPattern count="other">{0}US therms</unitPattern>
+			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
@@ -8281,16 +8286,6 @@ annotations.
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
-            <unit type="pressure-pascal">
-                <displayName>Pa</displayName>
-                <unitPattern count="one">{0}Pa</unitPattern>
-                <unitPattern count="other">{0}Pa</unitPattern>
-            </unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0}mmHg</unitPattern>
@@ -8306,11 +8301,11 @@ annotations.
 				<unitPattern count="one">{0}″ Hg</unitPattern>
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
-            <unit type="pressure-bar">
-                <displayName>bar</displayName>
-                <unitPattern count="one">{0}bar</unitPattern>
-                <unitPattern count="other">{0}bars</unitPattern>
-            </unit>
+			<unit type="pressure-bar">
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0}bar</unitPattern>
+				<unitPattern count="other">{0}bars</unitPattern>
+			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mb</unitPattern>
@@ -8320,6 +8315,16 @@ annotations.
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0}atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
+			</unit>
+			<unit type="pressure-pascal">
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0}Pa</unitPattern>
+				<unitPattern count="other">{0}Pa</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -993,6 +993,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabue</territory>
 			<territory type="ZZ">Región desconocida</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inglaterra</subdivision>
+			<subdivision type="gbsct">Escocia</subdivision>
+			<subdivision type="gbwls">Gales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Ortografía alemana tradicional</variant>
 			<variant type="1994" draft="provisional">Ortografía estandarizada del resiano</variant>
@@ -7640,11 +7645,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} caballo de vapor</unitPattern>
 				<unitPattern count="other">{0} caballos de vapor</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascales</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascales</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milímetros de mercurio</displayName>
 				<unitPattern count="one">{0} milímetro de mercurio</unitPattern>
@@ -7669,6 +7669,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmósferas</displayName>
 				<unitPattern count="one">{0} atmósfera</unitPattern>
 				<unitPattern count="other">{0} atmósferas</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascales</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascales</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascales</displayName>
@@ -8443,11 +8448,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} CV</unitPattern>
 				<unitPattern count="other">{0} CV</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -8472,6 +8472,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8889,10 +8894,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">mmHg</displayName>
 				<unitPattern count="one" draft="contributed">{0}mmHg</unitPattern>
@@ -8909,6 +8910,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -1121,6 +1121,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Tundmatu piirkond</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inglismaa</subdivision>
+			<subdivision type="gbsct">Šotimaa</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">saksa traditsiooniline kirjaviis</variant>
 			<variant type="1994">normitud Resia kirjaviis</variant>
@@ -7248,11 +7253,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hobujõud</unitPattern>
 				<unitPattern count="other">{0} hobujõudu</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskalid</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="other">{0} hektopaskalit</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeetrid elavhõbedasammast</displayName>
 				<unitPattern count="one">{0} millimeeter elavhõbedasammast</unitPattern>
@@ -7277,6 +7277,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfäärid</displayName>
 				<unitPattern count="one">{0} atmosfäär</unitPattern>
 				<unitPattern count="other">{0} atmosfääri</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskalid</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="other">{0} hektopaskalit</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskalid</displayName>
@@ -8067,11 +8072,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hj</unitPattern>
 				<unitPattern count="other">{0} hj</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8096,6 +8096,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -8485,10 +8490,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hj</unitPattern>
 				<unitPattern count="other">{0} hj</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8503,6 +8504,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -776,6 +776,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Eskualde ezezaguna</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Ingalaterra</subdivision>
+			<subdivision type="gbsct">Eskozia</subdivision>
+			<subdivision type="gbwls">Gales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="POLYTON">POLITON</variant>
 			<variant type="REVISED">BERRIKUSIA</variant>
@@ -6394,11 +6399,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} zaldi-potentzia</unitPattern>
 				<unitPattern count="other">{0} zaldi-potentzia</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascalak</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>merkurio-milimetroak</displayName>
 				<unitPattern count="one">{0} merkurio-milimetro</unitPattern>
@@ -6423,6 +6423,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascalak</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascalak</displayName>
@@ -7197,11 +7202,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7226,6 +7226,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -7598,10 +7603,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -7609,6 +7610,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -989,6 +989,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">زیمبابوه</territory>
 			<territory type="ZZ">ناحیهٔ نامشخص</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">انگلستان</subdivision>
+			<subdivision type="gbsct">اسکاتلند</subdivision>
+			<subdivision type="gbwls">ویلز</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">رسم‌الخط سنتی آلمانی</variant>
 			<variant type="1996">رسم‌الخط آلمانی ۱۹۹۶ میلادی</variant>
@@ -7442,11 +7447,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} اسب بخار</unitPattern>
 				<unitPattern count="other">{0} اسب بخار</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هکتوپاسکال</displayName>
-				<unitPattern count="one">{0} هکتوپاسکال</unitPattern>
-				<unitPattern count="other">{0} هکتوپاسکال</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>میلی‌متر جیوه</displayName>
 				<unitPattern count="one">{0} میلی‌متر جیوه</unitPattern>
@@ -7471,6 +7471,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>اتمسفر</displayName>
 				<unitPattern count="one">{0} اتمسفر</unitPattern>
 				<unitPattern count="other">{0} اتمسفر</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هکتوپاسکال</displayName>
+				<unitPattern count="one">{0} هکتوپاسکال</unitPattern>
+				<unitPattern count="other">{0} هکتوپاسکال</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>کیلوپاسکال</displayName>
@@ -8225,11 +8230,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} اسب بخار</unitPattern>
 				<unitPattern count="other">{0} اسب بخار</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هکتوپاسکال</displayName>
-				<unitPattern count="one">{0}‎ hPa</unitPattern>
-				<unitPattern count="other">{0}‎ hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>میلی‌متر جیوه</displayName>
 				<unitPattern count="one">{0} م‌م جیوه</unitPattern>
@@ -8252,6 +8252,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>اتمسفر</displayName>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هکتوپاسکال</displayName>
+				<unitPattern count="one">{0}‎ hPa</unitPattern>
+				<unitPattern count="other">{0}‎ hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ک.پاسکال</displayName>
@@ -8723,11 +8728,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">هکتوپاسکال</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">میلی‌متر جیوه</displayName>
 				<unitPattern count="one" draft="contributed">{0} م‌م جیوه</unitPattern>
@@ -8747,6 +8747,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">میلی‌بار</displayName>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">هکتوپاسکال</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>کیلومتر/ساعت</displayName>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -1138,6 +1138,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">tuntematon alue</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Englanti</subdivision>
+			<subdivision type="gbsct">Skotlanti</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">saksan perinteinen oikeinkirjoitus</variant>
 			<variant type="1994">sloveenin resian murteen yhdenmukaistettu oikeinkirjoitus</variant>
@@ -8194,11 +8199,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hevosvoima</unitPattern>
 				<unitPattern count="other">{0} hevosvoimaa</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hehtopascalit</displayName>
-				<unitPattern count="one">{0} hehtopascal</unitPattern>
-				<unitPattern count="other">{0} hehtopascalia</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>elohopeamillimetrit</displayName>
 				<unitPattern count="one">{0} millimetri elohopeaa</unitPattern>
@@ -8223,6 +8223,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">normaali-ilmakehät</displayName>
 				<unitPattern count="one" draft="contributed">{0} normaali-ilmakehä</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} normaali-ilmakehää</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hehtopascalit</displayName>
+				<unitPattern count="one">{0} hehtopascal</unitPattern>
+				<unitPattern count="other">{0} hehtopascalia</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascalit</displayName>
@@ -9015,11 +9020,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hv</unitPattern>
 				<unitPattern count="other">{0} hv</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -9039,6 +9039,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -9758,11 +9763,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hv</unitPattern>
 				<unitPattern count="other">{0}hv</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0}mmHg</unitPattern>
@@ -9782,6 +9782,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -788,6 +788,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Hindi Kilalang Rehiyon</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Scotland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN">Pinyin Romanization</variant>
 			<variant type="WADEGILE">Wade-Giles Romanization</variant>
@@ -7343,11 +7348,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} horsepower</unitPattern>
 				<unitPattern count="other">{0} horsepower</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascals</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} na hectopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetro ng asoge</displayName>
 				<unitPattern count="one">{0} millimetro ng mercury</unitPattern>
@@ -7372,6 +7372,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmospheres</displayName>
 				<unitPattern count="one">{0} atmosphere</unitPattern>
 				<unitPattern count="other">{0} atmospheres</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascals</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} na hectopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascal</displayName>
@@ -8120,11 +8125,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetro ng asoge</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8149,6 +8149,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -8585,10 +8590,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">mmHg</displayName>
 				<unitPattern count="one" draft="contributed">{0}mmHg</unitPattern>
@@ -8606,6 +8607,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -1145,6 +1145,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">région indéterminée</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Angleterre</subdivision>
+			<subdivision type="gbsct">Écosse</subdivision>
+			<subdivision type="gbwls">Pays de Galles</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">orthographe allemande traditionnelle</variant>
 			<variant type="1994">orthographe normalisée de Resia</variant>
@@ -10055,11 +10060,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} cheval-vapeur</unitPattern>
 				<unitPattern count="other">{0} chevaux-vapeur</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascals</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascals</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimètres de mercure</displayName>
 				<unitPattern count="one">{0} millimètre de mercure</unitPattern>
@@ -10084,6 +10084,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosphères</displayName>
 				<unitPattern count="one">{0} atmosphère</unitPattern>
 				<unitPattern count="other">{0} atmosphères</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascals</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascals</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascals</displayName>
@@ -10866,11 +10871,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ch</unitPattern>
 				<unitPattern count="other">{0} ch</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -10895,6 +10895,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -11596,10 +11601,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}ch</unitPattern>
 				<unitPattern count="other">{0}ch</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">mmHg</displayName>
 				<unitPattern count="one" draft="contributed">{0} mmHg</unitPattern>
@@ -11623,6 +11624,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="unconfirmed">atm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}atm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="unconfirmed">kPa</displayName>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -942,6 +942,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">an tSiombáib</territory>
 			<territory type="ZZ">Réigiún Anaithnid</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Sasana</subdivision>
+			<subdivision type="gbsct">Albain</subdivision>
+			<subdivision type="gbwls">an Bhreatain Bheag</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Litriú Traidisiúnta na Gearmáinise</variant>
 			<variant type="1994">1994</variant>
@@ -8859,14 +8864,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} n-each-chumhacht</unitPattern>
 				<unitPattern count="other">{0} each-chumhacht</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>heicteapascail</displayName>
-				<unitPattern count="one">{0} heicteapascal</unitPattern>
-				<unitPattern count="two">{0} heicteapascal</unitPattern>
-				<unitPattern count="few">{0} heicteapascal</unitPattern>
-				<unitPattern count="many">{0} heicteapascal</unitPattern>
-				<unitPattern count="other">{0} heicteapascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milliméadair mhearcair</displayName>
 				<unitPattern count="one">{0} mhilliméadar mearcair</unitPattern>
@@ -8906,6 +8903,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atmaisféar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>heicteapascail</displayName>
+				<unitPattern count="one">{0} heicteapascal</unitPattern>
+				<unitPattern count="two">{0} heicteapascal</unitPattern>
+				<unitPattern count="few">{0} heicteapascal</unitPattern>
+				<unitPattern count="many">{0} heicteapascal</unitPattern>
+				<unitPattern count="other">{0} heicteapascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>cileapascail</displayName>
@@ -10153,14 +10158,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} ec</unitPattern>
 				<unitPattern count="other">{0} ec</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -10200,6 +10197,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -11335,14 +11340,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0}ec</unitPattern>
 				<unitPattern count="other">{0}ec</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="two">{0}hPa</unitPattern>
-				<unitPattern count="few">{0}hPa</unitPattern>
-				<unitPattern count="many">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0}mmHg</unitPattern>
@@ -11374,6 +11371,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0}mb</unitPattern>
 				<unitPattern count="many">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="two">{0}hPa</unitPattern>
+				<unitPattern count="few">{0}hPa</unitPattern>
+				<unitPattern count="many">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/u</displayName>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -1100,6 +1100,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">An t-Sìombab</territory>
 			<territory type="ZZ">Roinn-dùthcha neo-aithnichte</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Sasainn</subdivision>
+			<subdivision type="gbsct">Alba</subdivision>
+			<subdivision type="gbwls">A’ Chuimrigh</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Litreachadh tradaiseanta na Gearmailtise</variant>
 			<variant type="1994">Litreachadh stannardach dual-chainnt Resia</variant>
@@ -10268,13 +10273,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} cumhachdan-eich</unitPattern>
 				<unitPattern count="other">{0} cumhachd-eich</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>heacta pascal</displayName>
-				<unitPattern count="one">{0} heacta pascal</unitPattern>
-				<unitPattern count="two">{0} heacta pascal</unitPattern>
-				<unitPattern count="few">{0} heacta pascal</unitPattern>
-				<unitPattern count="other">{0} heacta pascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mille-mheatair de dh’airgead-beò</displayName>
 				<unitPattern count="one">{0} mhille-mheatair de dh’airgead-beò</unitPattern>
@@ -10309,6 +10307,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} bhrùthadh-àile</unitPattern>
 				<unitPattern count="few">{0} brùthadh-àile</unitPattern>
 				<unitPattern count="other">{0} brùthadh-àile</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>heacta pascal</displayName>
+				<unitPattern count="one">{0} heacta pascal</unitPattern>
+				<unitPattern count="two">{0} heacta pascal</unitPattern>
+				<unitPattern count="few">{0} heacta pascal</unitPattern>
+				<unitPattern count="other">{0} heacta pascal</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>cilemeatair san uair</displayName>
@@ -11279,13 +11284,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -11320,6 +11318,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} àile</unitPattern>
 				<unitPattern count="few">{0} àile</unitPattern>
 				<unitPattern count="other">{0} àile</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/uair</displayName>
@@ -12290,13 +12295,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="two">{0}hPa</unitPattern>
-				<unitPattern count="few">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0}mm Hg</unitPattern>
@@ -12331,6 +12329,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0}atm</unitPattern>
 				<unitPattern count="few">{0}atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="two">{0}hPa</unitPattern>
+				<unitPattern count="few">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -785,6 +785,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Rexión descoñecida</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inglaterra</subdivision>
+			<subdivision type="gbsct">Escocia</subdivision>
+			<subdivision type="gbwls">Gales</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">calendario</key>
 			<key type="cf">formato de moeda</key>
@@ -6339,11 +6344,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} cabalo de potencia</unitPattern>
 				<unitPattern count="other">{0} cabalos de potencia</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascais</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascais</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milímetros de mercurio</displayName>
 				<unitPattern count="one">{0} milímetro de mercurio</unitPattern>
@@ -6368,6 +6368,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosferas</displayName>
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="other">{0} atmosferas</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascais</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascais</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>quilopascais</displayName>
@@ -7142,11 +7147,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7171,6 +7171,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -998,6 +998,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ઝિમ્બાબ્વે</territory>
 			<territory type="ZZ">અજ્ઞાત પ્રદેશ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ઈંગ્લેન્ડ</subdivision>
+			<subdivision type="gbsct">સ્કોટલેન્ડ</subdivision>
+			<subdivision type="gbwls">વોલ્સ</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN">પિનયિન રોમનાઇઝેશન</variant>
 			<variant type="WADEGILE">વેડ-ગિલ્સ રોમનાઇઝેશન</variant>
@@ -6999,11 +7004,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} હોર્સપાવર</unitPattern>
 				<unitPattern count="other">{0} હોર્સપાવર</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>હેક્ટૉપાસ્કલ</displayName>
-				<unitPattern count="one">{0} હેક્ટૉપાસ્કલ</unitPattern>
-				<unitPattern count="other">{0} હેક્ટૉપાસ્કલ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>પારાનું મિલિમીટર</displayName>
 				<unitPattern count="one">{0} પારાનું મિલિમીટર</unitPattern>
@@ -7028,6 +7028,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">વાતાવરણ</displayName>
 				<unitPattern count="one" draft="contributed">{0} વાતાવરણ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} વાતાવરણ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>હેક્ટૉપાસ્કલ</displayName>
+				<unitPattern count="one">{0} હેક્ટૉપાસ્કલ</unitPattern>
+				<unitPattern count="other">{0} હેક્ટૉપાસ્કલ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">કિલોપાસ્કલ</displayName>
@@ -7803,11 +7808,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7827,6 +7827,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -938,6 +938,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">זימבבואה</territory>
 			<territory type="ZZ">אזור לא ידוע</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">אנגליה</subdivision>
+			<subdivision type="gbsct">סקוטלנד</subdivision>
+			<subdivision type="gbwls">וויילס</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">כתיב גרמני מסורתי</variant>
 			<variant type="AREVELA">מזרח ארמנית</variant>
@@ -8198,13 +8203,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} כוח סוס</unitPattern>
 				<unitPattern count="other">{0} כוח סוס</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>הקטופסקל</displayName>
-				<unitPattern count="one">הקטופסקל {0}</unitPattern>
-				<unitPattern count="two">{0} הקטופסקל</unitPattern>
-				<unitPattern count="many">{0} הקטופסקל</unitPattern>
-				<unitPattern count="other">{0} הקטופסקל</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>מילימטר כספית</displayName>
 				<unitPattern count="one">מילימטר כספית אחד</unitPattern>
@@ -8239,6 +8237,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} אטמוספרה</unitPattern>
 				<unitPattern count="many">{0} אטמוספרה</unitPattern>
 				<unitPattern count="other">{0} אטמוספרות</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>הקטופסקל</displayName>
+				<unitPattern count="one">הקטופסקל {0}</unitPattern>
+				<unitPattern count="two">{0} הקטופסקל</unitPattern>
+				<unitPattern count="many">{0} הקטופסקל</unitPattern>
+				<unitPattern count="other">{0} הקטופסקל</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>קילו-פסקל</displayName>
@@ -9314,13 +9319,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} כ״ס</unitPattern>
 				<unitPattern count="other">{0} כ״ס</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -9355,6 +9353,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -9973,12 +9978,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" draft="contributed">{0} כ״ס</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} כ״ס</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<displayName draft="contributed">in Hg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
@@ -9992,6 +9991,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} מיליבר</unitPattern>
 				<unitPattern count="many">{0} מיליבר</unitPattern>
 				<unitPattern count="other">{0} מיליבר</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>קמ״ש</displayName>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -986,6 +986,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ज़िम्बाब्वे</territory>
 			<territory type="ZZ">अज्ञात क्षेत्र</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">इंग्लैंड</subdivision>
+			<subdivision type="gbsct">स्कॉटलैंड</subdivision>
+			<subdivision type="gbwls">वेल्स</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">पारम्पारिक जर्मन वर्तनी</variant>
 			<variant type="1996">जर्मेनी की 1996 वर्तनी</variant>
@@ -6820,11 +6825,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} अश्वशक्ति</unitPattern>
 				<unitPattern count="other">{0} अश्वशक्ति</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>हैक्टोपास्कल</displayName>
-				<unitPattern count="one">{0} हैक्टोपास्कल</unitPattern>
-				<unitPattern count="other">{0} हैक्टोपास्कल</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>मर्क्यूरी मिलीमीटर</displayName>
 				<unitPattern count="one">{0} मर्क्यूरी मिलीमीटर</unitPattern>
@@ -6849,6 +6849,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">वायुमण्डलीय दबाव</displayName>
 				<unitPattern count="one" draft="contributed">{0} वायुमंडलीय दबाव</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} वायुमंडलीय दबाव</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>हैक्टोपास्कल</displayName>
+				<unitPattern count="one">{0} हैक्टोपास्कल</unitPattern>
+				<unitPattern count="other">{0} हैक्टोपास्कल</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">किलोपास्कल</displayName>
@@ -7826,10 +7831,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}एचपी</unitPattern>
 				<unitPattern count="other">{0}एचपी</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0}&quot; Hg</unitPattern>
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
@@ -7837,6 +7838,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>कि॰मी॰/घं॰</displayName>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -1026,6 +1026,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">nepoznato područje</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Engleska</subdivision>
+			<subdivision type="gbsct">Škotska</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">tradicionalan njemački pravopis</variant>
 			<variant type="1994">standardizirani resian pravopis</variant>
@@ -8236,12 +8241,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} konjske snage</unitPattern>
 				<unitPattern count="other">{0} konjskih snaga</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskali</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="few">{0} hektopaskala</unitPattern>
-				<unitPattern count="other">{0} hektopaskala</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetri živina stupca</displayName>
 				<unitPattern count="one">{0} milimetar živina stupca</unitPattern>
@@ -8271,6 +8270,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskali</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="few">{0} hektopaskala</unitPattern>
+				<unitPattern count="other">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskali</displayName>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -1001,6 +1001,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Ismeretlen körzet</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglia</subdivision>
+			<subdivision type="gbsct">Skócia</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Hagyományos német helyesírás</variant>
 			<variant type="1994">Szabványosított reziján helyesírás</variant>
@@ -7562,11 +7567,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} lóerő</unitPattern>
 				<unitPattern count="other">{0} lóerő</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascal</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} higanymilliméter</unitPattern>
@@ -7591,6 +7591,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmoszféra</displayName>
 				<unitPattern count="one">{0} atmoszféra</unitPattern>
 				<unitPattern count="other">{0} atmoszféra</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascal</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascal</displayName>
@@ -8359,11 +8364,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} LE</unitPattern>
 				<unitPattern count="other">{0} LE</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8388,6 +8388,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -8771,10 +8776,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} LE</unitPattern>
 				<unitPattern count="other">{0} LE</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">Hgmm</displayName>
 				<unitPattern count="one" draft="contributed">{0} Hgmm</unitPattern>
@@ -8787,6 +8788,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -849,6 +849,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Զիմբաբվե</territory>
 			<territory type="ZZ">Անհայտ տարածաշրջան</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Անգլիա</subdivision>
+			<subdivision type="gbsct">Շոտլանդիա</subdivision>
+			<subdivision type="gbwls">Ուելս</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="AREVELA" draft="contributed">արևելահայերեն</variant>
 			<variant type="AREVMDA" draft="contributed">արեւմտահայերէն</variant>
@@ -6119,11 +6124,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ձիաուժ</unitPattern>
 				<unitPattern count="other">{0} ձիաուժ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>հեկտոպասկալ</displayName>
-				<unitPattern count="one">{0} հեկտոպասկալ</unitPattern>
-				<unitPattern count="other">{0} հեկտոպասկալ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>սնդիկի սյան միլիմետրեր</displayName>
 				<unitPattern count="one">{0} միլիմետր սնդիկի սյուն</unitPattern>
@@ -6148,6 +6148,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>մթնոլորտներ</displayName>
 				<unitPattern count="one">{0} մթնոլորտ</unitPattern>
 				<unitPattern count="other">{0} մթնոլորտ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>հեկտոպասկալ</displayName>
+				<unitPattern count="one">{0} հեկտոպասկալ</unitPattern>
+				<unitPattern count="other">{0} հեկտոպասկալ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>կիլոպասկալներ</displayName>
@@ -6922,11 +6927,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ձ․ու․</unitPattern>
 				<unitPattern count="other">{0} ձ․ու․</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>հՊա</displayName>
-				<unitPattern count="one">{0} հՊա</unitPattern>
-				<unitPattern count="other">{0} հՊա</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>մմ ս.ս.</displayName>
 				<unitPattern count="one">{0} մմ ս.ս.</unitPattern>
@@ -6951,6 +6951,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>մթն</displayName>
 				<unitPattern count="one">{0} մթն</unitPattern>
 				<unitPattern count="other">{0} մթն</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>հՊա</displayName>
+				<unitPattern count="one">{0} հՊա</unitPattern>
+				<unitPattern count="other">{0} հՊա</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>կՊա</displayName>
@@ -7323,10 +7328,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}ձ/ու</unitPattern>
 				<unitPattern count="other">{0}ձ/ու</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} հՊա</unitPattern>
-				<unitPattern count="other">{0} հՊա</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0}&quot; ս. ս.</unitPattern>
 				<unitPattern count="other">{0}&quot; ս. ս</unitPattern>
@@ -7334,6 +7335,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} մբ</unitPattern>
 				<unitPattern count="other">{0} մբ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} հՊա</unitPattern>
+				<unitPattern count="other">{0} հՊա</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>կմ/ժ</displayName>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -1047,6 +1047,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Wilayah Tidak Dikenal</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inggris</subdivision>
+			<subdivision type="gbsct">Skotlandia</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Ortografi Jerman Tradisional</variant>
 			<variant type="1994">Ortografi Resia Standar</variant>
@@ -7237,10 +7242,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>daya kuda</displayName>
 				<unitPattern count="other">{0} daya kuda</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskal</displayName>
-				<unitPattern count="other">{0} hektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimeter merkuri</displayName>
 				<unitPattern count="other">{0} milimeter merkuri</unitPattern>
@@ -7260,6 +7261,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atmosfer</displayName>
 				<unitPattern count="other">{0} atmosfer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskal</displayName>
+				<unitPattern count="other">{0} hektopaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascal</displayName>
@@ -7862,10 +7867,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mW</displayName>
 				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -7873,6 +7874,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-inch-hg">
 				<displayName>in Hg</displayName>
 				<unitPattern count="other">{0} inHg</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -954,6 +954,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Simbabve</territory>
 			<territory type="ZZ">Óþekkt svæði</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Skotland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="MONOTON" draft="unconfirmed">monotonísk</variant>
 			<variant type="PINYIN" draft="unconfirmed">pinyin</variant>
@@ -8858,11 +8863,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hestafl</unitPattern>
 				<unitPattern count="other">{0} hestöfl</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektópasköl</displayName>
-				<unitPattern count="one">{0} hektópaskal</unitPattern>
-				<unitPattern count="other">{0} hektópasköl</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimetrar af kvikasilfri</displayName>
 				<unitPattern count="one">{0} millimetrar af kvikasilfri</unitPattern>
@@ -8887,6 +8887,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>loftþyngdir</displayName>
 				<unitPattern count="one">{0} loftþyngd</unitPattern>
 				<unitPattern count="other">{0} loftþyngdir</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektópasköl</displayName>
+				<unitPattern count="one">{0} hektópaskal</unitPattern>
+				<unitPattern count="other">{0} hektópasköl</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kílópasköl</displayName>
@@ -9676,11 +9681,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hö</unitPattern>
 				<unitPattern count="other">{0} hö</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -9705,6 +9705,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -10226,11 +10231,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" draft="contributed">{0} ek</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ek</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -10250,6 +10250,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbör</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/klst.</displayName>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -1109,6 +1109,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Regione sconosciuta</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inghilterra</subdivision>
+			<subdivision type="gbsct">Scozia</subdivision>
+			<subdivision type="gbwls">Galles</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ortografia tradizionale tedesca</variant>
 			<variant type="1994" draft="contributed">ortografia resiana standard</variant>
@@ -7092,11 +7097,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} cavallo vapore</unitPattern>
 				<unitPattern count="other">{0} cavalli vapore</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ettopascal</displayName>
-				<unitPattern count="one">{0} ettopascal</unitPattern>
-				<unitPattern count="other">{0} ettopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimetri di mercurio</displayName>
 				<unitPattern count="one">{0} millimetro di mercurio</unitPattern>
@@ -7121,6 +7121,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfere</displayName>
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="other">{0} atmosfere</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ettopascal</displayName>
+				<unitPattern count="one">{0} ettopascal</unitPattern>
+				<unitPattern count="other">{0} ettopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>chilopascal</displayName>
@@ -7900,11 +7905,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7929,6 +7929,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -8301,10 +8306,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" draft="contributed">{0}hp</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one" draft="contributed">{0}hPa</unitPattern>
-				<unitPattern count="other" draft="contributed">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one" draft="contributed">{0}inHg</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}inHg</unitPattern>
@@ -8312,6 +8313,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one" draft="contributed">{0}mbar</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one" draft="contributed">{0}hPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -1114,6 +1114,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ジンバブエ</territory>
 			<territory type="ZZ">不明な地域</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">イングランド</subdivision>
+			<subdivision type="gbsct">スコットランド</subdivision>
+			<subdivision type="gbwls">ウェールズ</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ドイツ語旧正書法</variant>
 			<variant type="1994" draft="contributed">標準レージア方言正書法</variant>
@@ -8734,10 +8739,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>馬力</displayName>
 				<unitPattern count="other">{0} 馬力</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ヘクトパスカル</displayName>
-				<unitPattern count="other">{0} ヘクトパスカル</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>水銀柱ミリメートル</displayName>
 				<unitPattern count="other">{0} 水銀柱ミリメートル</unitPattern>
@@ -8757,6 +8758,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>気圧</displayName>
 				<unitPattern count="other">{0} 気圧</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ヘクトパスカル</displayName>
+				<unitPattern count="other">{0} ヘクトパスカル</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">キロパスカル</displayName>
@@ -9398,10 +9403,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>馬力</displayName>
 				<unitPattern count="other">{0} 馬力</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>水銀柱ミリメートル</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -9421,6 +9422,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>気圧</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -9901,9 +9906,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">水銀柱ミリメートル</displayName>
 				<unitPattern count="other" draft="contributed">{0}mm Hg</unitPattern>
@@ -9919,6 +9921,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<displayName draft="contributed">ミリバール</displayName>
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -603,6 +603,11 @@ terms of use, see http://www.unicode.org/copyright.html
 			<territory type="ZW">Simbabwe</territory>
 			<territory type="ZZ">Daerah Ora Dikenali</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inggris</subdivision>
+			<subdivision type="gbsct">Skotlandia</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Tanggalan</key>
 			<key type="cf">Format Mata Uang</key>
@@ -5517,10 +5522,6 @@ terms of use, see http://www.unicode.org/copyright.html
 				<displayName>tenogo jaran</displayName>
 				<unitPattern count="other">{0} tenogo jaran</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskal</displayName>
-				<unitPattern count="other">{0} hektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimeter saka raksa</displayName>
 				<unitPattern count="other">{0} milimeter saka raksa</unitPattern>
@@ -5540,6 +5541,10 @@ terms of use, see http://www.unicode.org/copyright.html
 			<unit type="pressure-atmosphere">
 				<displayName>atmosfer</displayName>
 				<unitPattern count="other">{0} atmosfer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskal</displayName>
+				<unitPattern count="other">{0} hektopaskal</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilometer saben jam</displayName>
@@ -6146,10 +6151,6 @@ terms of use, see http://www.unicode.org/copyright.html
 				<displayName>tenogo jaran</displayName>
 				<unitPattern count="other">{0} tenogo jaran</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
@@ -6167,6 +6168,10 @@ terms of use, see http://www.unicode.org/copyright.html
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="other">↑↑↑</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -973,6 +973,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ზიმბაბვე</territory>
 			<territory type="ZZ">უცნობი რეგიონი</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ინგლისი</subdivision>
+			<subdivision type="gbsct">შოტლანდია</subdivision>
+			<subdivision type="gbwls">უელსი</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901" draft="unconfirmed">ტრადიციული გერმანული ორთოგრაფია</variant>
 			<variant type="1994" draft="unconfirmed">სტანდარტული რეზიანული ორთოგრაფია</variant>
@@ -6912,11 +6917,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ცხენის ძალა</unitPattern>
 				<unitPattern count="other">{0} ცხენის ძალა</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ჰექტოპასკალი</displayName>
-				<unitPattern count="one">{0} ჰექტოპასკალი</unitPattern>
-				<unitPattern count="other">{0} ჰექტოპასკალი</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>მილიმეტრი ვერცხლისწყლის სვეტისა</displayName>
 				<unitPattern count="one">{0} მილიმეტრი ვერცხლისწყლის სვეტისა</unitPattern>
@@ -6941,6 +6941,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ატმოსფეროები</displayName>
 				<unitPattern count="one">{0} ატმოსფერო</unitPattern>
 				<unitPattern count="other">{0} ატმოსფერო</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ჰექტოპასკალი</displayName>
+				<unitPattern count="one">{0} ჰექტოპასკალი</unitPattern>
+				<unitPattern count="other">{0} ჰექტოპასკალი</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>კილოპასკალი</displayName>
@@ -7715,11 +7720,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ცხ. ძ.</unitPattern>
 				<unitPattern count="other">{0} ცხ. ძ.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ჰპა</displayName>
-				<unitPattern count="one">{0} ჰპა</unitPattern>
-				<unitPattern count="other">{0} ჰპა</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>მმ ვწყ. სვ.</displayName>
 				<unitPattern count="one">{0} მმ ვწყ. სვ.</unitPattern>
@@ -7744,6 +7744,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ატმ.</displayName>
 				<unitPattern count="one">{0} ატმ.</unitPattern>
 				<unitPattern count="other">{0} ატმ.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ჰპა</displayName>
+				<unitPattern count="one">{0} ჰპა</unitPattern>
+				<unitPattern count="other">{0} ჰპა</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>კპა</displayName>
@@ -8116,10 +8121,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}ცხ.ძ.</unitPattern>
 				<unitPattern count="other">{0}ცხ.ძ.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} ჰპა</unitPattern>
-				<unitPattern count="other">{0} ჰპა</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} ვრც. დმ.</unitPattern>
 				<unitPattern count="other">{0} ვრც. დმ.</unitPattern>
@@ -8127,6 +8128,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} მბრ</unitPattern>
 				<unitPattern count="other">{0} მბრ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} ჰპა</unitPattern>
+				<unitPattern count="other">{0} ჰპა</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>კმ/სთ</displayName>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -779,6 +779,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">Белгісіз аймақ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англия</subdivision>
+			<subdivision type="gbsct">Шотландия</subdivision>
+			<subdivision type="gbwls">Уэльс</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="AREVELA" draft="unconfirmed">Шығыс-армян</variant>
 			<variant type="AREVMDA" draft="unconfirmed">Батыс-армян</variant>
@@ -6322,11 +6327,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ат күші</unitPattern>
 				<unitPattern count="other">{0} ат күші</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектопаскаль</displayName>
-				<unitPattern count="one">{0} гектопаскаль</unitPattern>
-				<unitPattern count="other">{0} гектопаскаль</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>сынап бағанасының миллиметрі</displayName>
 				<unitPattern count="one">сынап бағанасының {0} миллиметрі</unitPattern>
@@ -6351,6 +6351,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атмосфера</displayName>
 				<unitPattern count="one">{0} атмосфера</unitPattern>
 				<unitPattern count="other">{0} атмосфера</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектопаскаль</displayName>
+				<unitPattern count="one">{0} гектопаскаль</unitPattern>
+				<unitPattern count="other">{0} гектопаскаль</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>килопаскаль</displayName>
@@ -7125,11 +7130,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} а. к.</unitPattern>
 				<unitPattern count="other">{0} а. к.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектопаскаль</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>с.б.мм.</displayName>
 				<unitPattern count="one">{0} с.б.мм.</unitPattern>
@@ -7154,6 +7154,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атм</displayName>
 				<unitPattern count="one">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектопаскаль</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>кПа</displayName>
@@ -7526,10 +7531,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ат күші</unitPattern>
 				<unitPattern count="other">{0} ат күші</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -7537,6 +7538,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} мб</unitPattern>
 				<unitPattern count="other">{0} мб</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/сағ</displayName>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -767,6 +767,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ស៊ីមបាវ៉េ</territory>
 			<territory type="ZZ">តំបន់មិនស្គាល់</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">អង់គ្លេស</subdivision>
+			<subdivision type="gbsct">ស្កុតឡែន</subdivision>
+			<subdivision type="gbwls">វ៉ាល់ស៍</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">ប្រតិទិន</key>
 			<key type="cf">ទម្រង់រូបិយប័ណ្ណ</key>
@@ -5804,10 +5809,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>សេះ</displayName>
 				<unitPattern count="other">{0} សេះ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ហិចតូប៉ាស្កាល់</displayName>
-				<unitPattern count="other">{0} ហិចតូប៉ាស្កាល់</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>មិល្លីម៉ែត្រនៃ​បារត</displayName>
 				<unitPattern count="other">{0} មិល្លីម៉ែត្រនៃ​បារត</unitPattern>
@@ -5827,6 +5828,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>បរិយាកាស</displayName>
 				<unitPattern count="other">បរិយាកាស {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ហិចតូប៉ាស្កាល់</displayName>
+				<unitPattern count="other">{0} ហិចតូប៉ាស្កាល់</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -6454,10 +6459,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hp</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -6477,6 +6478,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -6774,14 +6779,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0} សេះ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0} ម.ប.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -988,6 +988,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ಜಿಂಬಾಬ್ವೆ</territory>
 			<territory type="ZZ">ಅಜ್ಞಾತ ಪ್ರದೇಶ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ಇಂಗ್ಲೆಂಡ್‌</subdivision>
+			<subdivision type="gbsct">ಸ್ಕಾಟ್ಲೆಂಡ್</subdivision>
+			<subdivision type="gbwls">ವೇಲ್ಸ್‌</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN" draft="unconfirmed">ಪಿನ್‌ಯಿನ್ ರೋಮನೈಸೇಶನ್</variant>
 			<variant type="WADEGILE" draft="unconfirmed">ವೇಡ್-ಗೈಲ್ಸ್ ರೋಮನೈಸೇಶನ್</variant>
@@ -6940,11 +6945,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ಹಾರ್ಸ್‌ಪವರ್</unitPattern>
 				<unitPattern count="other">{0} ಹಾರ್ಸ್‌ಪವರ್</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ಹೆಕ್ಟೋಪ್ಯಾಸ್ಕಲ್‌ಗಳು</displayName>
-				<unitPattern count="one">{0} ಹೆಕ್ಟೋಪ್ಯಾಸ್ಕಲ್</unitPattern>
-				<unitPattern count="other">{0} ಹೆಕ್ಟೋಪ್ಯಾಸ್ಕಲ್‌ಗಳು</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ಮರ್ಕ್ಯುರಿ ಮಿಲಿಮೀಟರ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0} ಮರ್ಕ್ಯುರಿ ಮಿಲಿಮೀಟರ್‌</unitPattern>
@@ -6969,6 +6969,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">ವಾತಾವರಣಗಳು</displayName>
 				<unitPattern count="one" draft="contributed">{0} ವಾತಾವರಣ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ವಾತಾವರಣಗಳು</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ಹೆಕ್ಟೋಪ್ಯಾಸ್ಕಲ್‌ಗಳು</displayName>
+				<unitPattern count="one">{0} ಹೆಕ್ಟೋಪ್ಯಾಸ್ಕಲ್</unitPattern>
+				<unitPattern count="other">{0} ಹೆಕ್ಟೋಪ್ಯಾಸ್ಕಲ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">ಕಿಲೋಪಾಸ್ಕಲ್‌ಗಳು</displayName>
@@ -7744,11 +7749,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ಹೆಚ್‌ಪಿ</unitPattern>
 				<unitPattern count="other">{0} ಹೆಚ್‌ಪಿ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ಹೆ.ಪ್ಯಾ.</displayName>
-				<unitPattern count="one">{0} ಹೆ.ಪ್ಯಾ</unitPattern>
-				<unitPattern count="other">{0} ಹೆ.ಪ್ಯಾ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ಮರ್ಕ್ಯು.ಮಿ.ಮೀ.</displayName>
 				<unitPattern count="one">{0} ಮರ್ಕ್ಯು ಮಿಮೀ</unitPattern>
@@ -7773,6 +7773,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">ವಾತಾವರಣಗಳು</displayName>
 				<unitPattern count="one" draft="contributed">{0} ವಾತಾವರಣ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ವಾತಾವರಣ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ಹೆ.ಪ್ಯಾ.</displayName>
+				<unitPattern count="one">{0} ಹೆ.ಪ್ಯಾ</unitPattern>
+				<unitPattern count="other">{0} ಹೆ.ಪ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">ಕೆಪಿಎ</displayName>
@@ -8171,11 +8176,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}ಹೆಚ್‌ಪಿ</unitPattern>
 				<unitPattern count="other">{0}ಹೆಚ್‌ಪಿ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">ಹೆ.ಪ್ಯಾ.</displayName>
-				<unitPattern count="one">{0}ಹೆ.ಪ್ಯಾ</unitPattern>
-				<unitPattern count="other">{0}ಹೆ.ಪ್ಯಾ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">ಮರ್ಕ್ಯು.ಮಿ.ಮೀ.</displayName>
 				<unitPattern count="one">{0}mmHg</unitPattern>
@@ -8195,6 +8195,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">ಮಿ.ಬಾರ್‌</displayName>
 				<unitPattern count="one">{0}ಮಿ.ಬಾ.</unitPattern>
 				<unitPattern count="other">{0}ಮಿ.ಬಾ.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">ಹೆ.ಪ್ಯಾ.</displayName>
+				<unitPattern count="one">{0}ಹೆ.ಪ್ಯಾ</unitPattern>
+				<unitPattern count="other">{0}ಹೆ.ಪ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ಕಿ.ಮೀ/ಗಂ</displayName>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -1051,6 +1051,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">짐바브웨</territory>
 			<territory type="ZZ">알려지지 않은 지역</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">잉글랜드</subdivision>
+			<subdivision type="gbsct">스코틀랜드</subdivision>
+			<subdivision type="gbwls">웨일즈</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901" draft="contributed">전통 독일어 표기법</variant>
 			<variant type="1994" draft="provisional">표준 레지아어 표기법</variant>
@@ -7691,10 +7696,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>마력</displayName>
 				<unitPattern count="other">{0}마력</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>헥토파스칼</displayName>
-				<unitPattern count="other">{0}헥토파스칼</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>수은주밀리미터</displayName>
 				<unitPattern count="other">{0}수은주밀리미터</unitPattern>
@@ -7713,6 +7714,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-atmosphere">
 				<unitPattern count="other">{0}atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>헥토파스칼</displayName>
+				<unitPattern count="other">{0}헥토파스칼</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">킬로파스칼</displayName>
@@ -8245,9 +8250,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="other">{0}mmHg</unitPattern>
@@ -8263,6 +8265,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-atmosphere">
 				<unitPattern count="other">{0}atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8575,9 +8580,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other" draft="contributed">{0}HP</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other" draft="contributed">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">mmHg</displayName>
 				<unitPattern count="other" draft="contributed">{0}mmHg</unitPattern>
@@ -8590,6 +8592,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other" draft="contributed">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other" draft="contributed">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<unitPattern count="other">{0}km/h</unitPattern>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -772,6 +772,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">Белгисиз чөлкөм</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англия</subdivision>
+			<subdivision type="gbsct">Шотландия</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Жылнаама</key>
 			<key type="cf">Валюта форматы</key>
@@ -6235,11 +6239,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} аттын күчү</unitPattern>
 				<unitPattern count="other">{0} аттын күчү</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектопаскаль</displayName>
-				<unitPattern count="one">{0} гектопаскаль</unitPattern>
-				<unitPattern count="other">{0} гектопаскаль</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>миллиметр сымап мамычасы</displayName>
 				<unitPattern count="one">{0} миллиметр сымап мамычасы</unitPattern>
@@ -6264,6 +6263,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атмосфера</displayName>
 				<unitPattern count="one">{0} атмосфера</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектопаскаль</displayName>
+				<unitPattern count="one">{0} гектопаскаль</unitPattern>
+				<unitPattern count="other">{0} гектопаскаль</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -7038,11 +7042,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} а.к.</unitPattern>
 				<unitPattern count="other">{0} а.к.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гПа</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>мм.с.м.</displayName>
 				<unitPattern count="one">{0} мм.с. м.</unitPattern>
@@ -7067,6 +7066,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атм</displayName>
 				<unitPattern count="one">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атмс</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гПа</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -7439,10 +7443,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ат</unitPattern>
 				<unitPattern count="other">{0} ат</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -7450,6 +7450,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} мб</unitPattern>
 				<unitPattern count="other">{0} мб</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/саат</displayName>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -1019,6 +1019,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ຊິມບັບເວ</territory>
 			<territory type="ZZ">ຂົງເຂດທີ່ບໍ່ຮູ້ຈັກ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ອັງກິດ</subdivision>
+			<subdivision type="gbsct">ສະກັອດແລນ</subdivision>
+			<subdivision type="gbwls">ເວລສ໌</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ເຢຍລະມັນອໍໂທກຣາຟີດັ້ງເດີມ</variant>
 			<variant type="1994">ອັກສອນເຣຊ່ຽນມາດຕະຖານ</variant>
@@ -7745,10 +7750,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ແຮງມ້າ</displayName>
 				<unitPattern count="other">{0} ແຮງມ້າ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascals</displayName>
-				<unitPattern count="other">{0} hectopascals</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -7768,6 +7769,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atmospheres</displayName>
 				<unitPattern count="other">{0} atmospheres</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascals</displayName>
+				<unitPattern count="other">{0} hectopascals</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ກິ​ໂລ​ປາ​ສ​ການ</displayName>
@@ -8395,10 +8400,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ແຮງມ້າ</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPA</displayName>
-				<unitPattern count="other">{0} hPA</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -8418,6 +8419,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPA</displayName>
+				<unitPattern count="other">{0} hPA</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -8720,10 +8725,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPA</displayName>
-				<unitPattern count="other">{0} hPA</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<displayName>in Hg</displayName>
 				<unitPattern count="other">{0} in Hg</unitPattern>
@@ -8731,6 +8732,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPA</displayName>
+				<unitPattern count="other">{0} hPA</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ກມ/ຊມ</displayName>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -1118,6 +1118,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabvė</territory>
 			<territory type="ZZ">nežinoma sritis</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglija</subdivision>
+			<subdivision type="gbsct">Škotija</subdivision>
+			<subdivision type="gbwls">Velsas</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Įprasta vokiečių rašyba</variant>
 			<variant type="1994">Sunorminta Resian rašyba</variant>
@@ -9848,13 +9853,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} arklio galios</unitPattern>
 				<unitPattern count="other">{0} arklio galių</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskaliai</displayName>
-				<unitPattern count="one">{0} hektopaskalis</unitPattern>
-				<unitPattern count="few">{0} hektopaskaliai</unitPattern>
-				<unitPattern count="many">{0} hektopaskalio</unitPattern>
-				<unitPattern count="other">{0} hektopaskalių</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>gysidabrio stulpelio milimetrai</displayName>
 				<unitPattern count="one">{0} gysidabrio stulpelio milimetras</unitPattern>
@@ -9889,6 +9887,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atmosferos</unitPattern>
 				<unitPattern count="many">{0} atmosferos</unitPattern>
 				<unitPattern count="other">{0} atmosferų</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskaliai</displayName>
+				<unitPattern count="one">{0} hektopaskalis</unitPattern>
+				<unitPattern count="few">{0} hektopaskaliai</unitPattern>
+				<unitPattern count="many">{0} hektopaskalio</unitPattern>
+				<unitPattern count="other">{0} hektopaskalių</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskaliai</displayName>
@@ -10978,13 +10983,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} AG</unitPattern>
 				<unitPattern count="other">{0} AG</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -11019,6 +11017,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -11614,13 +11619,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} AG</unitPattern>
 				<unitPattern count="other">{0} AG</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -11648,6 +11646,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="many">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -940,6 +940,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">nezināms reģions</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglija</subdivision>
+			<subdivision type="gbsct">Skotija</subdivision>
+			<subdivision type="gbwls">Velsa</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">tradicionālā vācu ortogrāfija</variant>
 			<variant type="1996">vācu ortogrāfija no 1996. gada</variant>
@@ -7425,12 +7430,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} zirgspēks</unitPattern>
 				<unitPattern count="other">{0} zirgspēki</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskāli</displayName>
-				<unitPattern count="zero">{0} hektopaskālu</unitPattern>
-				<unitPattern count="one">{0} hektopaskāls</unitPattern>
-				<unitPattern count="other">{0} hektopaskāli</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>dzīvsudraba staba milimetri</displayName>
 				<unitPattern count="zero">{0} dzīvsudraba staba milimetru</unitPattern>
@@ -7460,6 +7459,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero" draft="contributed">{0} atm</unitPattern>
 				<unitPattern count="one" draft="contributed">{0} atmosfēra</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} atmosfēras</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskāli</displayName>
+				<unitPattern count="zero">{0} hektopaskālu</unitPattern>
+				<unitPattern count="one">{0} hektopaskāls</unitPattern>
+				<unitPattern count="other">{0} hektopaskāli</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskāli</displayName>
@@ -8387,12 +8392,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ZS</unitPattern>
 				<unitPattern count="other">{0} ZS</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="zero">{0} hPa</unitPattern>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="zero">{0} mmHg</unitPattern>
@@ -8416,6 +8415,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} mbar</unitPattern>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="zero">{0} hPa</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -8943,11 +8948,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ZS</unitPattern>
 				<unitPattern count="other">{0} ZS</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="zero">{0}hPa</unitPattern>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">mmHg</displayName>
 				<unitPattern count="zero" draft="contributed">{0} mmHg</unitPattern>
@@ -8963,6 +8963,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0}mbar</unitPattern>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="zero">{0}hPa</unitPattern>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -1117,6 +1117,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">Непознат регион</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англија</subdivision>
+			<subdivision type="gbsct">Шкотска</subdivision>
+			<subdivision type="gbwls">Велс</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN">Пинјин романизација</variant>
 			<variant type="WADEGILE">Вејд-Џајлс романизација</variant>
@@ -7640,11 +7645,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} коњска сила</unitPattern>
 				<unitPattern count="other">{0} коњски сили</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>хектопаскали</displayName>
-				<unitPattern count="one">{0} хектопаскал</unitPattern>
-				<unitPattern count="other">{0} хектопаскали</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>милиметри жива</displayName>
 				<unitPattern count="one">{0} милиметар жива</unitPattern>
@@ -7669,6 +7669,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атмосфери</displayName>
 				<unitPattern count="one">{0} атмосфера</unitPattern>
 				<unitPattern count="other">{0} атмосфери</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>хектопаскали</displayName>
+				<unitPattern count="one">{0} хектопаскал</unitPattern>
+				<unitPattern count="other">{0} хектопаскали</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>килопаскали</displayName>
@@ -8463,11 +8468,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} кс</unitPattern>
 				<unitPattern count="other">{0} кс</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>мм жива</displayName>
 				<unitPattern count="one">{0} мм жива</unitPattern>
@@ -8492,6 +8492,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>атм</displayName>
 				<unitPattern count="one">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -9058,10 +9063,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} кс</unitPattern>
 				<unitPattern count="other">{0} кс</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} хПа</unitPattern>
-				<unitPattern count="other">{0} хПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">мм жива</displayName>
 				<unitPattern count="one">{0}mm Hg</unitPattern>
@@ -9075,6 +9076,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>мбар</displayName>
 				<unitPattern count="one">{0} мб</unitPattern>
 				<unitPattern count="other">{0} мб</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} хПа</unitPattern>
+				<unitPattern count="other">{0} хПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/ч</displayName>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -1001,6 +1001,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">സിംബാബ്‌വേ</territory>
 			<territory type="ZZ">അജ്ഞാത പ്രദേശം</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ഇംഗ്ലണ്ട്</subdivision>
+			<subdivision type="gbsct">സ്‌കോട്ട്‌ലന്റ്</subdivision>
+			<subdivision type="gbwls">വെയിൽസ്</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1996">1996-ലെ ജർമൻ ലിപി</variant>
 			<variant type="1606NICT">1606 വരെയുള്ള ആധുനികമദ്ധ്യകാല ഫ്രഞ്ച്</variant>
@@ -7818,11 +7823,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} കുതിരശക്തി</unitPattern>
 				<unitPattern count="other">{0} കുതിരശക്തി</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ഹെക്‌ടോപാസ്‌ക്കൽ</displayName>
-				<unitPattern count="one">{0} ഹെക്‌ടോപാസ്‌ക്കൽ</unitPattern>
-				<unitPattern count="other">{0} ഹെക്‌ടോപാസ്‌ക്കൽ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>മില്ലീമീറ്റർ മെർക്കുറി</displayName>
 				<unitPattern count="one">{0} മില്ലീമീറ്റർ മെർക്കുറി</unitPattern>
@@ -7847,6 +7847,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">അറ്റ്‌മോസ്‌ഫിയർ</displayName>
 				<unitPattern count="one" draft="contributed">{0} അറ്റ്‌മോസ്‌ഫിയർ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} അറ്റ്‌മോസ്‌ഫിയർ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ഹെക്‌ടോപാസ്‌ക്കൽ</displayName>
+				<unitPattern count="one">{0} ഹെക്‌ടോപാസ്‌ക്കൽ</unitPattern>
+				<unitPattern count="other">{0} ഹെക്‌ടോപാസ്‌ക്കൽ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">കിലോപാസ്കൽ</displayName>
@@ -8634,11 +8639,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} എച്ച്.പി.</unitPattern>
 				<unitPattern count="other">{0} എച്ച്.പി.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ഹെ.പാ.</displayName>
-				<unitPattern count="one">{0} ഹെ.പാ.</unitPattern>
-				<unitPattern count="other">{0} ഹെ.പാ.</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>മിമീ.മെ.</displayName>
 				<unitPattern count="one">{0} മിമീ.മെ.</unitPattern>
@@ -8663,6 +8663,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ഹെ.പാ.</displayName>
+				<unitPattern count="one">{0} ഹെ.പാ.</unitPattern>
+				<unitPattern count="other">{0} ഹെ.പാ.</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -9155,11 +9160,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} വാ</unitPattern>
 				<unitPattern count="other">{0} വാ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">ഹെ.പാ.</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">മിമീ.മെ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}മിമീ.മെ.</unitPattern>
@@ -9177,6 +9177,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">മി.ബാ</displayName>
 				<unitPattern count="one">{0} മിബാ</unitPattern>
 				<unitPattern count="other">{0} മിബാ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">ഹെ.പാ.</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>കി.മീ/മ.</displayName>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -774,6 +774,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">Тодорхойгүй бүс</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англи</subdivision>
+			<subdivision type="gbsct">Шотланд</subdivision>
+			<subdivision type="gbwls">Уэльс</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">цаглавар</key>
 			<key type="cf">мөнгөн тэмдэгтийн хэлбэр</key>
@@ -6255,11 +6260,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} морины хүч</unitPattern>
 				<unitPattern count="other">{0} морины хүч</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектопаскал</displayName>
-				<unitPattern count="one">{0} гектопаскал</unitPattern>
-				<unitPattern count="other">{0} гектопаскал</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>мөнгөн усны милиметр</displayName>
 				<unitPattern count="one">{0} мөнгөн усны милиметр</unitPattern>
@@ -6284,6 +6284,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>уур амьсгал</displayName>
 				<unitPattern count="one">{0} уур амьсгал</unitPattern>
 				<unitPattern count="other">{0} уур амьсгал</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектопаскал</displayName>
+				<unitPattern count="one">{0} гектопаскал</unitPattern>
+				<unitPattern count="other">{0} гектопаскал</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>килопаскаль</displayName>
@@ -7057,11 +7062,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} мх</unitPattern>
 				<unitPattern count="other">{0} мх</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гПа</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>МөУс мм</displayName>
 				<unitPattern count="one">{0} МөУс мм</unitPattern>
@@ -7086,6 +7086,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гПа</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>кПа</displayName>
@@ -7458,10 +7463,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} м.х.</unitPattern>
 				<unitPattern count="other">{0} м.х.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} муб</unitPattern>
 				<unitPattern count="other">{0} муб</unitPattern>
@@ -7469,6 +7470,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} милбар</unitPattern>
 				<unitPattern count="other">{0} милбар</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/ц</displayName>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -984,6 +984,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">झिम्बाब्वे</territory>
 			<territory type="ZZ">अज्ञात प्रदेश</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">इंग्लंड</subdivision>
+			<subdivision type="gbsct">स्कॉटलंड</subdivision>
+			<subdivision type="gbwls">वेल्स</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN">पिनयिन रोमनायझेशन</variant>
 			<variant type="WADEGILE">वादे-गिलेस रोमनायझेशन</variant>
@@ -7224,11 +7229,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} हॉर्सपॉवर</unitPattern>
 				<unitPattern count="other">{0} हॉर्सपॉवर</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>हेक्टोपास्कल</displayName>
-				<unitPattern count="one">{0} हेक्टोपास्कल</unitPattern>
-				<unitPattern count="other">{0} हेक्टोपास्कल</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>मर्क्यूरी मिलिमीटर</displayName>
 				<unitPattern count="one">{0} मर्क्यूरी मिलिमीटर</unitPattern>
@@ -7253,6 +7253,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>वातावरण</displayName>
 				<unitPattern count="one">{0} वातावरण</unitPattern>
 				<unitPattern count="other">{0} वातावरण</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>हेक्टोपास्कल</displayName>
+				<unitPattern count="one">{0} हेक्टोपास्कल</unitPattern>
+				<unitPattern count="other">{0} हेक्टोपास्कल</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">किलोपास्कल</displayName>
@@ -8032,11 +8037,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8061,6 +8061,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8499,10 +8504,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} हॉपॉ</unitPattern>
 				<unitPattern count="other">{0}हॉपॉ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}हेक्टोपा</unitPattern>
-				<unitPattern count="other">{0}हेक्टोपा</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<unitPattern count="one" draft="contributed">{0}mmHg</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}mmHg</unitPattern>
@@ -8520,6 +8521,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">मिलिबार</displayName>
 				<unitPattern count="one">{0}मिबा</unitPattern>
 				<unitPattern count="other">{0}मिबा</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}हेक्टोपा</unitPattern>
+				<unitPattern count="other">{0}हेक्टोपा</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>किमी/तास</displayName>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -827,6 +827,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Wilayah Tidak Diketahui</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Scotland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="POSIX">Komputer</variant>
 			<variant type="SCOTLAND">Inggeris Standard Scotland</variant>
@@ -6215,10 +6220,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kuasa kuda</displayName>
 				<unitPattern count="other">{0} kuasa kuda</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascal</displayName>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimeter raksa</displayName>
 				<unitPattern count="other">{0} milimeter raksa</unitPattern>
@@ -6238,6 +6239,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atmosfera</displayName>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascal</displayName>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskal</displayName>
@@ -6875,10 +6880,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hp</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -6898,6 +6899,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -7226,14 +7231,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-carat">
 				<displayName draft="contributed">karat</displayName>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/j</displayName>

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -837,6 +837,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">iż-Żimbabwe</territory>
 			<territory type="ZZ">Reġjun Mhux Magħruf</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">l-Ingilterra</subdivision>
+			<subdivision type="gbsct">l-Iskozja</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="REVISED">Ortografija Irriveda</variant>
 		</variants>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -795,6 +795,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ဇင်ဘာဘွေ</territory>
 			<territory type="ZZ">မသိ (သို့) မရှိသော ဒေသ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">အင်္ဂလန်</subdivision>
+			<subdivision type="gbsct">စကော့တလန်</subdivision>
+			<subdivision type="gbwls">ဝေလ</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ရှေးရိုးစဉ်လာ ဂျာမန် ရေးထုံး</variant>
 			<variant type="1996">၁၉၉၆ ဂျာမန် ရေးထုံး</variant>
@@ -5959,10 +5964,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>မြင်းကောင်ရေအား</displayName>
 				<unitPattern count="other">{0} မြင်းကောင်ရေအား</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ဟက်တိုပါစကယ်</displayName>
-				<unitPattern count="other">{0} ဟက်တိုပါစကယ်</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ပြဒါးမီလီမီတာ</displayName>
 				<unitPattern count="other">{0} ပြဒါးမီလီမီတာ</unitPattern>
@@ -5982,6 +5983,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>ကမ္ဘာ့လေထု</displayName>
 				<unitPattern count="other">{0} ကမ္ဘာ့လေထု</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ဟက်တိုပါစကယ်</displayName>
+				<unitPattern count="other">{0} ဟက်တိုပါစကယ်</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ကီလိုပါစကယ်</displayName>
@@ -6609,10 +6614,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hp</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -6632,6 +6633,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -6929,14 +6934,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ကီလိုမီတာ/နာရီ</displayName>

--- a/common/main/nb.xml
+++ b/common/main/nb.xml
@@ -1105,6 +1105,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">ukjent område</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Skottland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">tradisjonell tysk ortografi</variant>
 			<variant type="1994">standardisert resisk ortografi</variant>
@@ -10546,11 +10551,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hestekraft</unitPattern>
 				<unitPattern count="other">{0} hestekrefter</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascal</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeter kvikksølv</displayName>
 				<unitPattern count="one">{0} millimeter kvikksølv</unitPattern>
@@ -10575,6 +10575,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfærer</displayName>
 				<unitPattern count="one">{0} atmosfære</unitPattern>
 				<unitPattern count="other">{0} atmosfærer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascal</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascal</displayName>
@@ -11354,11 +11359,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hk</unitPattern>
 				<unitPattern count="other">{0} hk</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -11383,6 +11383,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -11898,10 +11903,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hk</unitPattern>
 				<unitPattern count="other">{0}hk</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<unitPattern count="one" draft="contributed">{0}mmHg</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}mmHg</unitPattern>
@@ -11917,6 +11918,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/t</displayName>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -1018,6 +1018,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">जिम्बाबवे</territory>
 			<territory type="ZZ">अज्ञात क्षेत्र</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">बेलायत</subdivision>
+			<subdivision type="gbsct">स्कटल्याण्ड</subdivision>
+			<subdivision type="gbwls">वेल्स</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="AREVELA" draft="contributed">पूर्वी आर्मेनियाली</variant>
 			<variant type="POSIX" draft="contributed">कम्प्युटर</variant>
@@ -6286,11 +6291,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} हर्सपावर</unitPattern>
 				<unitPattern count="other">{0} हर्सपावर</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>हेक्टो पास्कल</displayName>
-				<unitPattern count="one">{0} हेक्टो पास्कल</unitPattern>
-				<unitPattern count="other">{0} हेक्टो पास्कल</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>मिलिमिटर पारो</displayName>
 				<unitPattern count="one">{0} मिलिमिटर पारो</unitPattern>
@@ -6315,6 +6315,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>वायुमण्डल</displayName>
 				<unitPattern count="one">{0} वायुमण्डल</unitPattern>
 				<unitPattern count="other">{0} वायुमण्डलहरू</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>हेक्टो पास्कल</displayName>
+				<unitPattern count="one">{0} हेक्टो पास्कल</unitPattern>
+				<unitPattern count="other">{0} हेक्टो पास्कल</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>किलोपास्कल</displayName>
@@ -7089,11 +7094,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} हर्सपावर</unitPattern>
 				<unitPattern count="other">{0} हर्सपावर</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>हेक्टो पास्कल</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7118,6 +7118,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>वायु</displayName>
 				<unitPattern count="one">{0} वायु</unitPattern>
 				<unitPattern count="other">{0} वायु</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>हेक्टो पास्कल</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>किलोपास्कल</displayName>
@@ -7492,10 +7497,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} हर्सपावर</unitPattern>
 				<unitPattern count="other">{0} हर्सपावर</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} ईञ्‍च पारो</unitPattern>
 				<unitPattern count="other">{0} ईञ्‍च पारो</unitPattern>
@@ -7503,6 +7504,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} मिलीबार</unitPattern>
 				<unitPattern count="other">{0} मिलीबार</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>किलोमिटर प्रति घण्टा</displayName>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -1141,6 +1141,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">onbekend gebied</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Engeland</subdivision>
+			<subdivision type="gbsct">Schotland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Traditionele Duitse spelling</variant>
 			<variant type="1994">Gestandaardiseerde Resiaanse spelling</variant>
@@ -10919,11 +10924,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} paardenkracht</unitPattern>
 				<unitPattern count="other">{0} paardenkrachten</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascal</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeter-kwikdruk</displayName>
 				<unitPattern count="one">{0} millimeter-kwikdruk</unitPattern>
@@ -10943,6 +10943,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfeer</displayName>
 				<unitPattern count="one">{0} atmosfeer</unitPattern>
 				<unitPattern count="other">{0} atmosfeer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascal</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascal</displayName>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -973,6 +973,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ଜିମ୍ବାୱେ</territory>
 			<territory type="ZZ">ଅଜଣା ଅଞ୍ଚଳ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ଇଂଲଣ୍ଡ</subdivision>
+			<subdivision type="gbsct">ସ୍କଟଲ୍ୟାଣ୍ଡ</subdivision>
+			<subdivision type="gbwls">ୱେଲ୍ସ</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">କ୍ୟାଲେଣ୍ଡର୍</key>
 			<key type="cf">ମୁଦ୍ରା ଫର୍ମାଟ୍‌</key>
@@ -6424,11 +6429,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ହର୍ସପାୱାର୍</unitPattern>
 				<unitPattern count="other">{0} ହର୍ସପାୱାର୍</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ହେକ୍ଟୋପାସ୍କେଲ୍</displayName>
-				<unitPattern count="one">{0} ହେକ୍ଟୋପାସ୍କେଲ୍</unitPattern>
-				<unitPattern count="other">{0} ହେକ୍ଟୋପାସ୍କେଲ୍</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ପାରାର ମିଲିମିଟର୍</displayName>
 				<unitPattern count="one">ପାରାର {0} ମିଲିମିଟର୍</unitPattern>
@@ -6453,6 +6453,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ଆଟମୋସ୍ପିଅର</displayName>
 				<unitPattern count="one">{0} ଆଟମୋସ୍ପିଅର</unitPattern>
 				<unitPattern count="other">{0} ଆଟମୋସ୍ପିଅର</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ହେକ୍ଟୋପାସ୍କେଲ୍</displayName>
+				<unitPattern count="one">{0} ହେକ୍ଟୋପାସ୍କେଲ୍</unitPattern>
+				<unitPattern count="other">{0} ହେକ୍ଟୋପାସ୍କେଲ୍</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>କିଲୋପାସକଲ</displayName>
@@ -7227,11 +7232,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ଏଚପି</unitPattern>
 				<unitPattern count="other">{0} ଏଚପି</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -7256,6 +7256,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -788,6 +788,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ਜ਼ਿੰਬਾਬਵੇ</territory>
 			<territory type="ZZ">ਅਣਪਛਾਤਾ ਇਲਾਕਾ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ਇੰਗਲੈਂਡ</subdivision>
+			<subdivision type="gbsct">ਸਕਾਟਲੈਂਡ</subdivision>
+			<subdivision type="gbwls">ਵੇਲਸ</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">ਕੈਲੰਡਰ</key>
 			<key type="cf">ਮੁਦਰਾ ਬਣਤਰ</key>
@@ -6888,11 +6893,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ਹੌਰਸਪਾਵਰ</unitPattern>
 				<unitPattern count="other">{0} ਹੌਰਸਪਾਵਰ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ਹੈਕਟੋਪਾਸਕਲ</displayName>
-				<unitPattern count="one">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
-				<unitPattern count="other">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ਮਿਲੀਮੀਟਰ ਪਾਰਾ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਮੀਟਰ ਪਾਰਾ</unitPattern>
@@ -6917,6 +6917,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">ਵਾਯੂਮੰਡਲ</displayName>
 				<unitPattern count="one" draft="contributed">{0} ਵਾਯੂਮੰਡਲ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ਵਾਯੂਮੰਡਲ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ਹੈਕਟੋਪਾਸਕਲ</displayName>
+				<unitPattern count="one">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
+				<unitPattern count="other">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ਕਿੱਲੋਪਾਸਕਲ</displayName>
@@ -7623,11 +7628,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ਹੌਰਸਪਾਵਰ</unitPattern>
 				<unitPattern count="other">{0} ਹੌਰਸਪਾਵਰ</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ਹੈ.ਪਾ.</displayName>
-				<unitPattern count="one">{0} ਹੈ.ਪਾ.</unitPattern>
-				<unitPattern count="other">{0} ਹੈ.ਪਾ.</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ਮਿ.ਮੀ. ਪਾਰਾ</displayName>
 				<unitPattern count="one">{0} ਮਿ.ਮੀ. ਪਾਰਾ</unitPattern>
@@ -7652,6 +7652,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">ਵਾ. ਮੰ.</displayName>
 				<unitPattern count="one" draft="contributed">{0} ਵਾ. ਮੰ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ਵਾ. ਮੰ.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ਹੈ.ਪਾ.</displayName>
+				<unitPattern count="one">{0} ਹੈ.ਪਾ.</unitPattern>
+				<unitPattern count="other">{0} ਹੈ.ਪਾ.</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ਕਿ.ਪਾ</displayName>
@@ -8221,11 +8226,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">ਹੈ.ਪਾ.</displayName>
-				<unitPattern count="one">{0} ਹੈ.ਪਾ.</unitPattern>
-				<unitPattern count="other">{0} ਹੈ.ਪਾ.</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">ਮਿ.ਮੀ. ਪਾਰਾ</displayName>
 				<unitPattern count="one">{0} ਮਿ.ਮੀ. ਪਾਰਾ</unitPattern>
@@ -8245,6 +8245,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">ਮਿਲੀਬਾਰ</displayName>
 				<unitPattern count="one">{0} ਮਿ.ਬਾ.</unitPattern>
 				<unitPattern count="other">{0} ਮਿ.ਬਾ.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">ਹੈ.ਪਾ.</displayName>
+				<unitPattern count="one">{0} ਹੈ.ਪਾ.</unitPattern>
+				<unitPattern count="other">{0} ਹੈ.ਪਾ.</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ਕਿ.ਮੀ./ਘੰਟਾ</displayName>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -1111,6 +1111,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Nieznany region</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglia</subdivision>
+			<subdivision type="gbsct">Szkocja</subdivision>
+			<subdivision type="gbwls">Walia</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">tradycyjna ortografia niemiecka</variant>
 			<variant type="1994">standardowa ortografia regionu Resia</variant>
@@ -8272,13 +8277,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} koni mechanicznych</unitPattern>
 				<unitPattern count="other">{0} konia mechanicznego</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">hektopaskale</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="few">{0} hektopaskale</unitPattern>
-				<unitPattern count="many">{0} hektopaskali</unitPattern>
-				<unitPattern count="other">{0} hektopaskala</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">milimetry słupa rtęci</displayName>
 				<unitPattern count="one" draft="contributed">{0} milimetr słupa rtęci</unitPattern>
@@ -8306,6 +8304,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} millibary</unitPattern>
 				<unitPattern count="many">{0} millibarów</unitPattern>
 				<unitPattern count="other">{0} millibara</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">hektopaskale</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="few">{0} hektopaskale</unitPattern>
+				<unitPattern count="many">{0} hektopaskali</unitPattern>
+				<unitPattern count="other">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskale</displayName>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -772,6 +772,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">زیمبابوی</territory>
 			<territory type="ZZ">نامعلومه سيمه</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">انګلېنډ</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">جنتري</key>
 			<key type="cf">اسعارو بڼه</key>
@@ -4872,11 +4875,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} هارس پاور</unitPattern>
 				<unitPattern count="other">{0} هارس پاور</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هيکټو پاسکلز</displayName>
-				<unitPattern count="one">{0} هيکټو پاسکل</unitPattern>
-				<unitPattern count="other">{0} هيکټو پاسکلز</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>د پارې ملي مترز</displayName>
 				<unitPattern count="one">{0} د پارې ملي متر</unitPattern>
@@ -4901,6 +4899,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>اتموسفيرز</displayName>
 				<unitPattern count="one">{0} اتموسفير</unitPattern>
 				<unitPattern count="other">{0} اتموسفيرز</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هيکټو پاسکلز</displayName>
+				<unitPattern count="one">{0} هيکټو پاسکل</unitPattern>
+				<unitPattern count="other">{0} هيکټو پاسکلز</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>کيلو پاسکلز</displayName>
@@ -5646,11 +5649,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -5675,6 +5673,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -1007,6 +1007,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbábue</territory>
 			<territory type="ZZ">Região desconhecida</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Inglaterra</subdivision>
+			<subdivision type="gbsct">Escócia</subdivision>
+			<subdivision type="gbwls">País de Gales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ortografia alemã tradicional</variant>
 			<variant type="1994">ortografia resiana padronizada</variant>
@@ -7048,11 +7053,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} cavalo-vapor</unitPattern>
 				<unitPattern count="other">{0} cavalos-vapor</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascais</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="other">{0} hectopascais</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milímetros de mercúrio</displayName>
 				<unitPattern count="one">{0} milímetro de mercúrio</unitPattern>
@@ -7072,6 +7072,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosferas</displayName>
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="other">{0} atmosferas</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascais</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="other">{0} hectopascais</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">quilopascais</displayName>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -940,6 +940,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Regiune necunoscută</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglia</subdivision>
+			<subdivision type="gbsct">Scoția</subdivision>
+			<subdivision type="gbwls">Țara Galilor</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901" draft="provisional">ortografie germană tradițională</variant>
 			<variant type="1994" draft="provisional">ortografie resiană standardizată</variant>
@@ -7817,12 +7822,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} cai putere</unitPattern>
 				<unitPattern count="other">{0} de cai putere</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hectopascali</displayName>
-				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="few">{0} hectopascali</unitPattern>
-				<unitPattern count="other">{0} de hectopascali</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetri coloană de mercur</displayName>
 				<unitPattern count="one">{0} milimetru coloană de mercur</unitPattern>
@@ -7852,6 +7851,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} atmosferă</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} de atmosfere</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hectopascali</displayName>
+				<unitPattern count="one">{0} hectopascal</unitPattern>
+				<unitPattern count="few">{0} hectopascali</unitPattern>
+				<unitPattern count="other">{0} de hectopascali</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascali</displayName>
@@ -8732,12 +8737,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} CP</unitPattern>
 				<unitPattern count="other">{0} CP</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8761,6 +8760,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -1032,6 +1032,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">неизвестный регион</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англия</subdivision>
+			<subdivision type="gbsct">Шотландия</subdivision>
+			<subdivision type="gbwls">Уэльс</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901" draft="contributed">Традиционная немецкая орфография</variant>
 			<variant type="1994" draft="contributed">Стандартизированная резьянская орфография</variant>
@@ -8713,13 +8718,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} лошадиных сил</unitPattern>
 				<unitPattern count="other">{0} лошадиной силы</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектопаскали</displayName>
-				<unitPattern count="one">{0} гектопаскаль</unitPattern>
-				<unitPattern count="few">{0} гектопаскаля</unitPattern>
-				<unitPattern count="many">{0} гектопаскалей</unitPattern>
-				<unitPattern count="other">{0} гектопаскаля</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>миллиметры ртутного столба</displayName>
 				<unitPattern count="one">{0} миллиметр ртутного столба</unitPattern>
@@ -8754,6 +8752,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} атмосферы</unitPattern>
 				<unitPattern count="many">{0} атмосфер</unitPattern>
 				<unitPattern count="other">{0} атмосферы</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектопаскали</displayName>
+				<unitPattern count="one">{0} гектопаскаль</unitPattern>
+				<unitPattern count="few">{0} гектопаскаля</unitPattern>
+				<unitPattern count="many">{0} гектопаскалей</unitPattern>
+				<unitPattern count="other">{0} гектопаскаля</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>килопаскали</displayName>
@@ -9843,13 +9848,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} л.с.</unitPattern>
 				<unitPattern count="other">{0} л.с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гПа</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="few">{0} гПа</unitPattern>
-				<unitPattern count="many">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>мм рт. ст.</displayName>
 				<unitPattern count="one">{0} мм рт. ст.</unitPattern>
@@ -9884,6 +9882,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} атм</unitPattern>
 				<unitPattern count="many">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гПа</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="few">{0} гПа</unitPattern>
+				<unitPattern count="many">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>кПа</displayName>
@@ -10578,13 +10583,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" draft="contributed">{0} л.с.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} л.с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">гПа</displayName>
-				<unitPattern count="one" draft="contributed">{0} гПа</unitPattern>
-				<unitPattern count="few" draft="contributed">{0} гПа</unitPattern>
-				<unitPattern count="many" draft="contributed">{0} гПа</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">мм рт. ст.</displayName>
 				<unitPattern count="one" draft="contributed">{0} мм рт. ст.</unitPattern>
@@ -10612,6 +10610,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" draft="contributed">{0} мбар</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} мбар</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} мбар</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">гПа</displayName>
+				<unitPattern count="one" draft="contributed">{0} гПа</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} гПа</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} гПа</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/ч</displayName>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -769,6 +769,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">زمبابوي</territory>
 			<territory type="ZZ">اڻڄاتل خطو</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">انگلينڊ</subdivision>
+			<subdivision type="gbsct">اسڪاٽلينڊ</subdivision>
+			<subdivision type="gbwls">ويلز</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">ڪئلينڊر</key>
 			<key type="cf">سڪي جو فارميٽ</key>
@@ -5924,11 +5929,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} هارس پاور</unitPattern>
 				<unitPattern count="other">{0} هارس پاور</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هيڪٽوپاسڪلز</displayName>
-				<unitPattern count="one">{0} هيڪٽوپاسڪلز</unitPattern>
-				<unitPattern count="other">{0} هيڪٽوپاسڪلز</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>مرڪري جو ملي ميٽر</displayName>
 				<unitPattern count="one">مرڪري جو {0} ملي ميٽر</unitPattern>
@@ -5953,6 +5953,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ايٽماس فيئر</displayName>
 				<unitPattern count="one">{0} ايٽماس فيئر</unitPattern>
 				<unitPattern count="other">{0} ايٽماس فيئر</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هيڪٽوپاسڪلز</displayName>
+				<unitPattern count="one">{0} هيڪٽوپاسڪلز</unitPattern>
+				<unitPattern count="other">{0} هيڪٽوپاسڪلز</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ڪلو پاسڪلز</displayName>
@@ -6727,11 +6732,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} هارس پاور</unitPattern>
 				<unitPattern count="other">{0} هارس پاور</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>هيڪٽوپاسڪلز</displayName>
-				<unitPattern count="one">{0} هيڪٽوپاسڪلز</unitPattern>
-				<unitPattern count="other">{0} هيڪٽوپاسڪلز</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>مرڪري جو ملي ميٽر</displayName>
 				<unitPattern count="one">مرڪري جو {0} ملي ميٽر</unitPattern>
@@ -6756,6 +6756,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ايٽماس فيئر</displayName>
 				<unitPattern count="one">{0} ايٽماس فيئر</unitPattern>
 				<unitPattern count="other">{0} ايٽماس فيئر</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>هيڪٽوپاسڪلز</displayName>
+				<unitPattern count="one">{0} هيڪٽوپاسڪلز</unitPattern>
+				<unitPattern count="other">{0} هيڪٽوپاسڪلز</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -780,6 +780,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">සිම්බාබ්වේ</territory>
 			<territory type="ZZ">හඳුනා නොගත් කළාපය</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">එංගලන්තය</subdivision>
+			<subdivision type="gbsct">ස්කොට්ලන්තය</subdivision>
+			<subdivision type="gbwls">වේල්සය</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">දින දර්ශනය</key>
 			<key type="cf">මුදල් ආකෘති</key>
@@ -6097,11 +6102,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">අශ්වබල {0}</unitPattern>
 				<unitPattern count="other">අශ්වබල {0}</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>හෙක්ටොපැස්කල්</displayName>
-				<unitPattern count="one">හෙක්ටොපැස්කල් {0}</unitPattern>
-				<unitPattern count="other">හෙක්ටොපැස්කල් {0}</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>රසදිය මිලිමීටර</displayName>
 				<unitPattern count="one">රසදිය මිලිමීටර {0}</unitPattern>
@@ -6126,6 +6126,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>වායුගෝල</displayName>
 				<unitPattern count="one">වායුගෝල {0}</unitPattern>
 				<unitPattern count="other">වායුගෝල {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>හෙක්ටොපැස්කල්</displayName>
+				<unitPattern count="one">හෙක්ටොපැස්කල් {0}</unitPattern>
+				<unitPattern count="other">හෙක්ටොපැස්කල් {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>කිලෝ පැස්කල්</displayName>
@@ -6900,11 +6905,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">අබ {0}</unitPattern>
 				<unitPattern count="other">අබ {0}</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>හෙක්ටොපැස්කල්</displayName>
-				<unitPattern count="one">හෙ.පැ {0}</unitPattern>
-				<unitPattern count="other">හෙ.පැ {0}</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ර මිමී</displayName>
 				<unitPattern count="one">ර මිමී {0}</unitPattern>
@@ -6929,6 +6929,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>වායුගෝ</displayName>
 				<unitPattern count="one">වායුගෝ {0}</unitPattern>
 				<unitPattern count="other">වායුගෝ {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>හෙක්ටොපැස්කල්</displayName>
+				<unitPattern count="one">හෙ.පැ {0}</unitPattern>
+				<unitPattern count="other">හෙ.පැ {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>කිපැස්</displayName>
@@ -7301,10 +7306,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">රසදිය {0}&quot;</unitPattern>
 				<unitPattern count="other">රසදිය {0}&quot;</unitPattern>
@@ -7312,6 +7313,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">මි.බා. {0}</unitPattern>
 				<unitPattern count="other">මි.බා. {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>පැයට කිලෝමීටර්</displayName>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -912,6 +912,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">neznámy región</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglicko</subdivision>
+			<subdivision type="gbsct">Škótsko</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN" draft="provisional">romanizovaná mandarínčina</variant>
 			<variant type="SCOTLAND" draft="contributed">škótska štandardná angličtina</variant>
@@ -8689,13 +8694,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} konskej sily</unitPattern>
 				<unitPattern count="other">{0} konských síl</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascaly</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="few">{0} hektopascaly</unitPattern>
-				<unitPattern count="many">{0} hektopascala</unitPattern>
-				<unitPattern count="other">{0} hektopascalov</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetre ortuťového stĺpca</displayName>
 				<unitPattern count="one">{0} milimeter ortuťového stĺpca</unitPattern>
@@ -8730,6 +8728,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atmosféry</unitPattern>
 				<unitPattern count="many">{0} atmosféry</unitPattern>
 				<unitPattern count="other">{0} atmosfér</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascaly</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="few">{0} hektopascaly</unitPattern>
+				<unitPattern count="many">{0} hektopascala</unitPattern>
+				<unitPattern count="other">{0} hektopascalov</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascaly</displayName>
@@ -9798,13 +9803,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -9839,6 +9837,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -10483,12 +10488,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="many">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0}&quot; Hg</unitPattern>
 				<unitPattern count="few">{0}&quot; Hg</unitPattern>
@@ -10500,6 +10499,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} mb</unitPattern>
 				<unitPattern count="many">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -968,6 +968,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">Neznano ali neveljavno območje</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anglija</subdivision>
+			<subdivision type="gbsct">Škotska</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">tradicionalni nemški pravopis</variant>
 			<variant type="1994">standardizirani rezijanski pravopis (1994)</variant>
@@ -7833,13 +7838,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} konjske moči</unitPattern>
 				<unitPattern count="other">{0} konjskih moči</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskali</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="two">{0} hektopaskala</unitPattern>
-				<unitPattern count="few">{0} hektopaskali</unitPattern>
-				<unitPattern count="other">{0} hektopaskalov</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetri živega srebra</displayName>
 				<unitPattern count="one">{0} milimeter živega srebra</unitPattern>
@@ -7874,6 +7872,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} atmosferi</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} atmosfer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskali</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="two">{0} hektopaskala</unitPattern>
+				<unitPattern count="few">{0} hektopaskali</unitPattern>
+				<unitPattern count="other">{0} hektopaskalov</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskali</displayName>
@@ -8948,13 +8953,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} KM</unitPattern>
 				<unitPattern count="other">{0} KM</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHG</unitPattern>
@@ -8989,6 +8987,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} atm</unitPattern>
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -9490,12 +9495,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" draft="contributed">{0} KM</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} KM</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="two">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="two">{0} inHg</unitPattern>
@@ -9507,6 +9506,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} mbar</unitPattern>
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -620,6 +620,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">Simbaabwe</territory>
 			<territory type="ZZ">Gobol aan la aqoonin amase aan saxnayn</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Ingiriiska</subdivision>
+			<subdivision type="gbsct">Skotland</subdivision>
+			<subdivision type="gbwls">Waalis</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Habeentiris</key>
 			<key type="cf">Habka Lacagta</key>
@@ -6081,11 +6086,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} horasbaawar</unitPattern>
 				<unitPattern count="other">{0} horasbaawar</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektobaskalis</displayName>
-				<unitPattern count="one">{0} hektobaskal</unitPattern>
-				<unitPattern count="other">{0} hektobaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimitir maarkuri</displayName>
 				<unitPattern count="one">{0} milimitir maarkuri</unitPattern>
@@ -6110,6 +6110,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>hawada agagaarka</displayName>
 				<unitPattern count="one">{0} hawada agagaarka</unitPattern>
 				<unitPattern count="other">{0} hawada agagaarka</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektobaskalis</displayName>
+				<unitPattern count="one">{0} hektobaskal</unitPattern>
+				<unitPattern count="other">{0} hektobaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>Kiilobaskalis</displayName>
@@ -6884,11 +6889,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} hb</unitPattern>
 				<unitPattern count="other">{0} hb</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hBa</displayName>
-				<unitPattern count="one">{0} hBa</unitPattern>
-				<unitPattern count="other">{0} hBa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0} mmHg</unitPattern>
@@ -6913,6 +6913,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ha</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hBa</displayName>
+				<unitPattern count="one">{0} hBa</unitPattern>
+				<unitPattern count="other">{0} hBa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kBa</displayName>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -781,6 +781,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">I panjohur</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Angli</subdivision>
+			<subdivision type="gbsct">Skoci</subdivision>
+			<subdivision type="gbwls">Uells</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Kalendari</key>
 			<key type="cf">Formati valutor</key>
@@ -6155,11 +6160,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kalë-fuqi</unitPattern>
 				<unitPattern count="other">{0} kuaj-fuqi</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskal</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="other">{0} hektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetra mërkuri</displayName>
 				<unitPattern count="one">{0} milimetër mërkuri</unitPattern>
@@ -6184,6 +6184,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosferë</displayName>
 				<unitPattern count="one">{0} atmosferë</unitPattern>
 				<unitPattern count="other">{0} atmosferë</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskal</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="other">{0} hektopaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskal</displayName>
@@ -6958,11 +6963,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -6987,6 +6987,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -7368,11 +7373,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7392,6 +7392,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/orë</displayName>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -984,6 +984,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зимбабве</territory>
 			<territory type="ZZ">Непознат регион</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Енглеска</subdivision>
+			<subdivision type="gbsct">Шкотска</subdivision>
+			<subdivision type="gbwls">Велс</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Традиционална немачка ортографија</variant>
 			<variant type="1994">Стандарднизована ресијанска ортографија</variant>
@@ -8202,12 +8207,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} коњске снаге</unitPattern>
 				<unitPattern count="other">{0} коњских снага</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>хектопаскали</displayName>
-				<unitPattern count="one">{0} хектопаскал</unitPattern>
-				<unitPattern count="few">{0} хектопаскала</unitPattern>
-				<unitPattern count="other">{0} хектопаскала</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>милиметри живиног стуба</displayName>
 				<unitPattern count="one">{0} милиметар живиног стуба</unitPattern>
@@ -8237,6 +8236,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} атмосфера</unitPattern>
 				<unitPattern count="few">{0} атмосфере</unitPattern>
 				<unitPattern count="other">{0} атмосфера</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>хектопаскали</displayName>
+				<unitPattern count="one">{0} хектопаскал</unitPattern>
+				<unitPattern count="few">{0} хектопаскала</unitPattern>
+				<unitPattern count="other">{0} хектопаскала</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>килопаскали</displayName>
@@ -9158,12 +9163,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -9193,6 +9192,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -9636,11 +9641,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" draft="contributed">{0} кс</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} кс</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one" draft="contributed">{0} hPa</unitPattern>
-				<unitPattern count="few" draft="contributed">{0} hPa</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one" draft="contributed">{0} inHg</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} inHg</unitPattern>
@@ -9650,6 +9650,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" draft="contributed">{0} mbar</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} mbar</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one" draft="contributed">{0} hPa</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} hPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -975,6 +975,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">Nepoznat region</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Engleska</subdivision>
+			<subdivision type="gbsct">Škotska</subdivision>
+			<subdivision type="gbwls">Vels</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Tradicionalna nemačka ortografija</variant>
 			<variant type="1994">Standardnizovana resijanska ortografija</variant>
@@ -8193,12 +8198,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} konjske snage</unitPattern>
 				<unitPattern count="other">{0} konjskih snaga</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskali</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="few">{0} hektopaskala</unitPattern>
-				<unitPattern count="other">{0} hektopaskala</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetri živinog stuba</displayName>
 				<unitPattern count="one">{0} milimetar živinog stuba</unitPattern>
@@ -8228,6 +8227,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskali</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="few">{0} hektopaskala</unitPattern>
+				<unitPattern count="other">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskali</displayName>
@@ -9149,12 +9154,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="few">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -9184,6 +9183,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="few">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -9627,11 +9632,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few" draft="contributed">{0} ks</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ks</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one" draft="contributed">{0} hPa</unitPattern>
-				<unitPattern count="few" draft="contributed">{0} hPa</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one" draft="contributed">{0} inHg</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} inHg</unitPattern>
@@ -9641,6 +9641,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" draft="contributed">{0} mbar</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} mbar</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one" draft="contributed">{0} hPa</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} hPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -1139,6 +1139,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">okänd region</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">England</subdivision>
+			<subdivision type="gbsct">Skottland</subdivision>
+			<subdivision type="gbwls">Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">traditionell tysk stavning</variant>
 			<variant type="1994">1994 års resisk stavning</variant>
@@ -8099,11 +8104,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hästkraft</unitPattern>
 				<unitPattern count="other">{0} hästkrafter</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopascal</displayName>
-				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="other">{0} hektopascal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimeter kvicksilver</displayName>
 				<unitPattern count="one">{0} millimeter kvicksilver</unitPattern>
@@ -8128,6 +8128,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfärer</displayName>
 				<unitPattern count="one">{0} atmosfär</unitPattern>
 				<unitPattern count="other">{0} atmosfärer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopascal</displayName>
+				<unitPattern count="one">{0} hektopascal</unitPattern>
+				<unitPattern count="other">{0} hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">kilopascal</displayName>
@@ -8922,11 +8927,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hk</unitPattern>
 				<unitPattern count="other">{0} hk</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8951,6 +8951,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -9630,11 +9635,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" draft="contributed">{0}hk</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}hk</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one" draft="contributed">{0}mm Hg</unitPattern>
@@ -9658,6 +9658,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<unitPattern count="one" draft="contributed">{0}atm</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -808,6 +808,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Eneo lisilojulikana</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Uingereza</subdivision>
+			<subdivision type="gbsct">Uskoti</subdivision>
+			<subdivision type="gbwls">Welisi</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Kalenda</key>
 			<key type="cf">Mpangilio wa Sarafu</key>
@@ -6158,11 +6163,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">kipimo cha hospawa {0}</unitPattern>
 				<unitPattern count="other">kipimo cha hospawa {0}</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskali</displayName>
-				<unitPattern count="one">hektopaskali {0}</unitPattern>
-				<unitPattern count="other">hektopaskali {0}</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimita za zebaki</displayName>
 				<unitPattern count="one">milimita {0} ya zebaki</unitPattern>
@@ -6187,6 +6187,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kanieneo ya hewa</displayName>
 				<unitPattern count="one">kanieneo {0}</unitPattern>
 				<unitPattern count="other">kanieneo {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskali</displayName>
+				<unitPattern count="one">hektopaskali {0}</unitPattern>
+				<unitPattern count="other">hektopaskali {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskali</displayName>
@@ -6961,11 +6966,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskali</displayName>
-				<unitPattern count="one">hPa {0}</unitPattern>
-				<unitPattern count="other">hPa {0}</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimita za zebaki</displayName>
 				<unitPattern count="one">milimita {0} ya zebaki</unitPattern>
@@ -6990,6 +6990,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">atm {0}</unitPattern>
 				<unitPattern count="other">atm {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskali</displayName>
+				<unitPattern count="one">hPa {0}</unitPattern>
+				<unitPattern count="other">hPa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -7367,10 +7372,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">hp {0}</unitPattern>
 				<unitPattern count="other">hp {0}</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">hPa {0}</unitPattern>
-				<unitPattern count="other">hPa {0}</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -7378,6 +7379,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">mbar {0}</unitPattern>
 				<unitPattern count="other">mbar {0}</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">hPa {0}</unitPattern>
+				<unitPattern count="other">hPa {0}</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilomita kwa saa</displayName>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -993,6 +993,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ஜிம்பாப்வே</territory>
 			<territory type="ZZ">அறியப்படாத பிரதேசம்</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">இங்கிலாந்து</subdivision>
+			<subdivision type="gbsct">ஸ்காட்லாந்து</subdivision>
+			<subdivision type="gbwls">வேல்ஸ்</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="PINYIN">பின்யின் ரோமானைசெஷன்</variant>
 			<variant type="WADEGILE">வேட்-கைல்ஸ் ரோமனைஷேசன்</variant>
@@ -6978,11 +6983,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} குதிரைத்திறன்</unitPattern>
 				<unitPattern count="other">{0} குதிரைத்திறன்</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ஹெக்டோபாஸ்கல்</displayName>
-				<unitPattern count="one">{0} ஹெக்டோபாஸ்கல்</unitPattern>
-				<unitPattern count="other">{0} ஹெக்டோபாஸ்கல்</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>பாதரச மில்லிமீட்டர்கள்</displayName>
 				<unitPattern count="one">{0} பாதரச மில்லிமீட்டர்</unitPattern>
@@ -7007,6 +7007,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>வளிஅழுத்தம்</displayName>
 				<unitPattern count="one">{0} வளிஅழுத்தம்</unitPattern>
 				<unitPattern count="other">{0} வளிஅழுத்தங்கள்</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ஹெக்டோபாஸ்கல்</displayName>
+				<unitPattern count="one">{0} ஹெக்டோபாஸ்கல்</unitPattern>
+				<unitPattern count="other">{0} ஹெக்டோபாஸ்கல்</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">கிலோபாஸ்கல்ஸ்</displayName>
@@ -7748,11 +7753,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} கு.தி.</unitPattern>
 				<unitPattern count="other">{0} கு.தி.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ஹெ.பாஸ்.</displayName>
-				<unitPattern count="one">{0} ஹெ.பாஸ்.</unitPattern>
-				<unitPattern count="other">{0} ஹெ.பாஸ்.</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>பாத. மி.மீ.</displayName>
 				<unitPattern count="one">{0} பாத. மி.மீ.</unitPattern>
@@ -7767,6 +7767,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>மி.பா.</displayName>
 				<unitPattern count="one">{0} மி.பா.</unitPattern>
 				<unitPattern count="other">{0} மி.பா.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ஹெ.பாஸ்.</displayName>
+				<unitPattern count="one">{0} ஹெ.பாஸ்.</unitPattern>
+				<unitPattern count="other">{0} ஹெ.பாஸ்.</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">கிபா</displayName>
@@ -8160,11 +8165,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} கு.வே.</unitPattern>
 				<unitPattern count="other">{0} கு.வே.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">ஹெ.பாஸ்.</displayName>
-				<unitPattern count="one">{0} ஹெ.பா.</unitPattern>
-				<unitPattern count="other">{0} ஹெ.பா.</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">பாத. மி.மீ.</displayName>
 				<unitPattern count="one" draft="contributed">{0} பாத. மி.மீ.</unitPattern>
@@ -8179,6 +8179,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">மி.பா.</displayName>
 				<unitPattern count="one">{0} மி.பா.</unitPattern>
 				<unitPattern count="other">{0} மி.பா.</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">ஹெ.பாஸ்.</displayName>
+				<unitPattern count="one">{0} ஹெ.பா.</unitPattern>
+				<unitPattern count="other">{0} ஹெ.பா.</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>கி.மீ./ம.</displayName>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -991,6 +991,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">జింబాబ్వే</territory>
 			<territory type="ZZ">తెలియని ప్రాంతం</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">ఇంగ్లండ్</subdivision>
+			<subdivision type="gbsct">స్కాట్లాండ్</subdivision>
+			<subdivision type="gbwls">వేల్స్</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">ప్రాచీన ఙర్మన వర్ణక్రమం</variant>
 			<variant type="1996">1996 ఙర్మన వర్ణక్రమం</variant>
@@ -6974,11 +6979,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} హార్స్‌పవర్</unitPattern>
 				<unitPattern count="other">{0} హార్స్‌పవర్</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>హెక్టోపాస్కల్‌లు</displayName>
-				<unitPattern count="one">{0} హెక్టోపాస్కల్</unitPattern>
-				<unitPattern count="other">{0} హెక్టోపాస్కల్‌లు</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>మిల్లీమీటర్ల పాదరసం</displayName>
 				<unitPattern count="one">{0} మిల్లీమీటర్ పాదరసం</unitPattern>
@@ -7003,6 +7003,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>వాతావరణాలు</displayName>
 				<unitPattern count="one">{0} వాతావరణం</unitPattern>
 				<unitPattern count="other">{0} వాతావరణాలు</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>హెక్టోపాస్కల్‌లు</displayName>
+				<unitPattern count="one">{0} హెక్టోపాస్కల్</unitPattern>
+				<unitPattern count="other">{0} హెక్టోపాస్కల్‌లు</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">కిలోపాస్కెల్స్</displayName>
@@ -7783,11 +7788,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} హా.ప</unitPattern>
 				<unitPattern count="other">{0} హా.ప</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>హె.పా</displayName>
-				<unitPattern count="one">{0} హె.పా</unitPattern>
-				<unitPattern count="other">{0} హె.పా</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>మిమీ. పాద</displayName>
 				<unitPattern count="one">{0} మిమీ. పాద</unitPattern>
@@ -7812,6 +7812,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>వాతావ</displayName>
 				<unitPattern count="one">{0} వాతావ</unitPattern>
 				<unitPattern count="other">{0} వాతావ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>హె.పా</displayName>
+				<unitPattern count="one">{0} హె.పా</unitPattern>
+				<unitPattern count="other">{0} హె.పా</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -8218,11 +8223,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} హా.ప</unitPattern>
 				<unitPattern count="other">{0} హా.ప</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">హె.పా</displayName>
-				<unitPattern count="one">{0} హె.పా</unitPattern>
-				<unitPattern count="other">{0} హె.పా</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">మిమీ. పాద</displayName>
 				<unitPattern count="one" draft="contributed">{0} మిమీ. పాద</unitPattern>
@@ -8242,6 +8242,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">మి.బార్</displayName>
 				<unitPattern count="one">{0} మి.బార్</unitPattern>
 				<unitPattern count="other">{0} మి.బార్</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">హె.పా</displayName>
+				<unitPattern count="one">{0} హె.పా</unitPattern>
+				<unitPattern count="other">{0} హె.పా</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>కి.మీ/గం</displayName>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -1119,6 +1119,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">ซิมบับเว</territory>
 			<territory type="ZZ">ภูมิภาคที่ไม่รู้จัก</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">อังกฤษ</subdivision>
+			<subdivision type="gbsct">สกอตแลนด์</subdivision>
+			<subdivision type="gbwls">เวลส์</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">เยอรมันออร์โธกราฟีดั้งเดิม</variant>
 			<variant type="1994" draft="contributed">อักขระเรเซียนมาตราฐาน</variant>
@@ -8045,10 +8050,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>แรงม้า</displayName>
 				<unitPattern count="other">{0} แรงม้า</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>เฮกโตปาสกาล</displayName>
-				<unitPattern count="other">{0} เฮกโตปาสกาล</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>มิลลิเมตรปรอท</displayName>
 				<unitPattern count="other">{0} มิลลิเมตรปรอท</unitPattern>
@@ -8068,6 +8069,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>บรรยากาศ</displayName>
 				<unitPattern count="other">{0} บรรยากาศ</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>เฮกโตปาสกาล</displayName>
+				<unitPattern count="other">{0} เฮกโตปาสกาล</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">กิโลปาสกาล</displayName>
@@ -8686,10 +8691,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>แรงม้า</displayName>
 				<unitPattern count="other">{0} แรงม้า</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>เฮกโตปาสกาล</displayName>
-				<unitPattern count="other">{0} เฮกโตปาสกาล</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>มม. ปรอท</displayName>
 				<unitPattern count="other">{0} มม. ปรอท</unitPattern>
@@ -8708,6 +8709,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName draft="contributed">บรรยากาศ</displayName>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>เฮกโตปาสกาล</displayName>
+				<unitPattern count="other">{0} เฮกโตปาสกาล</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>
@@ -9010,15 +9015,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}แรงม้า</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">เฮกโตปาสกาล</displayName>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0}มิลลิบาร์</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">เฮกโตปาสกาล</displayName>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>กม./ชม.</displayName>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -767,6 +767,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Näbelli sebit</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Angliýa</subdivision>
+			<subdivision type="gbsct">Şotlandiýa</subdivision>
+			<subdivision type="gbwls">Uels</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Senenama</key>
 			<key type="cf">Pul birliginiň formaty</key>
@@ -6246,11 +6251,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} at güýji</unitPattern>
 				<unitPattern count="other">{0} at güýji</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>gektopaskal</displayName>
-				<unitPattern count="one">{0} gektopaskal</unitPattern>
-				<unitPattern count="other">{0} gektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>millimetr simap sütüni</displayName>
 				<unitPattern count="one">{0} millimetr simap sütüni</unitPattern>
@@ -6275,6 +6275,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>gektopaskal</displayName>
+				<unitPattern count="one">{0} gektopaskal</unitPattern>
+				<unitPattern count="other">{0} gektopaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskal</displayName>
@@ -7049,11 +7054,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} a.g.</unitPattern>
 				<unitPattern count="other">{0} a.g.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>gPa</displayName>
-				<unitPattern count="one">{0} gPa</unitPattern>
-				<unitPattern count="other">{0} gPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm sim.süt.</displayName>
 				<unitPattern count="one">{0} mm sim.süt.</unitPattern>
@@ -7078,6 +7078,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>gPa</displayName>
+				<unitPattern count="one">{0} gPa</unitPattern>
+				<unitPattern count="other">{0} gPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -1116,6 +1116,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">Bilinmeyen Bölge</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">İngiltere</subdivision>
+			<subdivision type="gbsct">İskoçya</subdivision>
+			<subdivision type="gbwls">Galler</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Geleneksel Almanca Yazım Kuralları</variant>
 			<variant type="1994">Standart Resia Yazım Kuralları</variant>
@@ -7658,11 +7663,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} beygir gücü</unitPattern>
 				<unitPattern count="other">{0} beygir gücü</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hektopaskal</displayName>
-				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="other">{0} hektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>milimetre cıva</displayName>
 				<unitPattern count="one">{0} milimetre cıva</unitPattern>
@@ -7687,6 +7687,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfer</displayName>
 				<unitPattern count="one">{0} atmosfer</unitPattern>
 				<unitPattern count="other">{0} atmosfer</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hektopaskal</displayName>
+				<unitPattern count="one">{0} hektopaskal</unitPattern>
+				<unitPattern count="other">{0} hektopaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskal</displayName>
@@ -8467,11 +8472,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} bg</unitPattern>
 				<unitPattern count="other">{0} bg</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -8496,6 +8496,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -1028,6 +1028,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Зімбабве</territory>
 			<territory type="ZZ">Невідомий регіон</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Англія</subdivision>
+			<subdivision type="gbsct">Шотландія</subdivision>
+			<subdivision type="gbwls">Уельс</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">Традиційна німецька орфографія</variant>
 			<variant type="1994">Стандартизована резьянська орфографія</variant>
@@ -8309,13 +8314,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} кінських сил</unitPattern>
 				<unitPattern count="other">{0} кінської сили</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гектопаскалі</displayName>
-				<unitPattern count="one">{0} гектопаскаль</unitPattern>
-				<unitPattern count="few">{0} гектопаскалі</unitPattern>
-				<unitPattern count="many">{0} гектопаскалів</unitPattern>
-				<unitPattern count="other">{0} гектопаскаля</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>міліметри ртутного стовпа</displayName>
 				<unitPattern count="one">{0} міліметр ртутного стовпа</unitPattern>
@@ -8350,6 +8348,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} атмосфери</unitPattern>
 				<unitPattern count="many">{0} атмосфер</unitPattern>
 				<unitPattern count="other">{0} атмосфери</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гектопаскалі</displayName>
+				<unitPattern count="one">{0} гектопаскаль</unitPattern>
+				<unitPattern count="few">{0} гектопаскалі</unitPattern>
+				<unitPattern count="many">{0} гектопаскалів</unitPattern>
+				<unitPattern count="other">{0} гектопаскаля</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>кілопаскалі</displayName>
@@ -9403,13 +9408,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} к. с.</unitPattern>
 				<unitPattern count="other">{0} к. с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>гПа</displayName>
-				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="few">{0} гПа</unitPattern>
-				<unitPattern count="many">{0} гПа</unitPattern>
-				<unitPattern count="other">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>мм рт. ст.</displayName>
 				<unitPattern count="one">{0} мм рт. ст.</unitPattern>
@@ -9444,6 +9442,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} атм</unitPattern>
 				<unitPattern count="many">{0} атм</unitPattern>
 				<unitPattern count="other">{0} атм</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>гПа</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="few">{0} гПа</unitPattern>
+				<unitPattern count="many">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">кПа</displayName>
@@ -10152,13 +10157,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" draft="contributed">{0} к.с.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} к.с.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">гПа</displayName>
-				<unitPattern count="one" draft="contributed">{0} гПа</unitPattern>
-				<unitPattern count="few" draft="contributed">{0} гПа</unitPattern>
-				<unitPattern count="many" draft="contributed">{0} гПа</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} гПа</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">ммрс</displayName>
 				<unitPattern count="one" draft="contributed">{0}ммрс</unitPattern>
@@ -10178,6 +10176,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" draft="contributed">{0} мбари</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} мбарів</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} мбара</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">гПа</displayName>
+				<unitPattern count="one" draft="contributed">{0} гПа</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} гПа</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} гПа</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/год</displayName>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -792,6 +792,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">زمبابوے</territory>
 			<territory type="ZZ">نامعلوم علاقہ</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">انگلستان</subdivision>
+			<subdivision type="gbsct">اسکاٹ لینڈ</subdivision>
+			<subdivision type="gbwls">ویلز</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">کیلنڈر</key>
 			<key type="cf">کرنسی فارمیٹ</key>
@@ -6765,11 +6770,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ہارس پاور</unitPattern>
 				<unitPattern count="other">{0} ہارس پاور</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>ہیکٹو پاسکل</displayName>
-				<unitPattern count="one">{0} ہیکٹو پاسکل</unitPattern>
-				<unitPattern count="other">{0} ہیکٹو پاسکل</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>ملی میٹر مرکری</displayName>
 				<unitPattern count="one">{0} ملی میٹر مرکری</unitPattern>
@@ -6794,6 +6794,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ماحول</displayName>
 				<unitPattern count="one">{0} ماحول</unitPattern>
 				<unitPattern count="other">{0} ماحول</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>ہیکٹو پاسکل</displayName>
+				<unitPattern count="one">{0} ہیکٹو پاسکل</unitPattern>
+				<unitPattern count="other">{0} ہیکٹو پاسکل</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>کلو پاسکلز</displayName>
@@ -7563,11 +7568,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -7592,6 +7592,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -7976,10 +7981,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<displayName draft="contributed">″ Hg</displayName>
 				<unitPattern count="one">{0} انچ مرکری</unitPattern>
@@ -7988,6 +7989,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0}hPa</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -778,6 +778,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabve</territory>
 			<territory type="ZZ">Noma’lum mintaqa</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Angliya</subdivision>
+			<subdivision type="gbsct">Shotlandiya</subdivision>
+			<subdivision type="gbwls">Uels</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">taqvim</key>
 			<key type="cf">valyuta formati</key>
@@ -6026,11 +6031,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ot kuchi</unitPattern>
 				<unitPattern count="other">{0} ot kuchi</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>gektopaskal</displayName>
-				<unitPattern count="one">{0} gektopaskal</unitPattern>
-				<unitPattern count="other">{0} gektopaskal</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm simob ustuni</displayName>
 				<unitPattern count="one">{0} mm simob ustuni</unitPattern>
@@ -6055,6 +6055,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atmosfera</displayName>
 				<unitPattern count="one">{0} atmosfera</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>gektopaskal</displayName>
+				<unitPattern count="one">{0} gektopaskal</unitPattern>
+				<unitPattern count="other">{0} gektopaskal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopaskal</displayName>
@@ -6829,11 +6834,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} o.k.</unitPattern>
 				<unitPattern count="other">{0} o.k.</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>gPa</displayName>
-				<unitPattern count="one">{0} gPa</unitPattern>
-				<unitPattern count="other">{0} gPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm sim.ust</displayName>
 				<unitPattern count="one">{0} mm sim.ust</unitPattern>
@@ -6858,6 +6858,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>gPa</displayName>
+				<unitPattern count="one">{0} gPa</unitPattern>
+				<unitPattern count="other">{0} gPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -7230,10 +7235,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
@@ -7241,6 +7242,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/soat</displayName>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -1080,6 +1080,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">Zimbabwe</territory>
 			<territory type="ZZ">Vùng không xác định</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Anh Quốc</subdivision>
+			<subdivision type="gbsct">Scotland</subdivision>
+			<subdivision type="gbwls">Xứ Wales</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901" draft="contributed">Phép chính tả Tiếng Đức Truyền thống</variant>
 			<variant type="1994" draft="contributed">Phép chính tả Resian Chuẩn hóa</variant>
@@ -9099,10 +9104,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mã lực</displayName>
 				<unitPattern count="other">{0} mã lực</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>héctô pascal</displayName>
-				<unitPattern count="other">{0} héctô pascal</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<displayName>inch thủy ngân</displayName>
 				<unitPattern count="other">{0} inch thủy ngân</unitPattern>
@@ -9113,6 +9114,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-atmosphere">
 				<unitPattern count="other">{0} átmốtphe</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>héctô pascal</displayName>
+				<unitPattern count="other">{0} héctô pascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -9546,9 +9551,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<displayName>hp</displayName>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
@@ -9565,6 +9567,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -9838,14 +9843,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -370,6 +370,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">Orílẹ́ède ṣimibabe</territory>
 			<territory type="ZZ">Àgbègbè àìmọ̀</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Ilẹ̀gẹ̀ẹ́sì</subdivision>
+			<subdivision type="gbsct">Skọ́tlándì</subdivision>
+			<subdivision type="gbwls">Wélsì</subdivision>
+		</subdivisions>
 		<types>
 			<type key="calendar" type="gregorian">Kàlẹ́ńdà Gregory</type>
 			<type key="collation" type="standard">Ìlànà Onírúurú Ètò</type>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -371,6 +371,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">Orílɛ́ède shimibabe</territory>
 			<territory type="ZZ">Àgbègbè àìmɔ̀</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">Ilɛ̀gɛ̀ɛ́sì</subdivision>
+			<subdivision type="gbsct">Skɔ́tlándì</subdivision>
+		</subdivisions>
 		<types>
 			<type key="calendar" type="gregorian">Kàlɛ́ńdà Gregory</type>
 			<type key="collation" type="standard">Ìlànà Onírúurú Ètò</type>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -1109,6 +1109,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">辛巴威</territory>
 			<territory type="ZZ">未知區域</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">英倫</subdivision>
+			<subdivision type="gbsct">蘇格蘭</subdivision>
+			<subdivision type="gbwls">威爾斯</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">傳統德語拼字學</variant>
 			<variant type="1994" draft="contributed">標準雷西亞拼字</variant>
@@ -8625,10 +8630,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>匹</displayName>
 				<unitPattern count="other">{0} 匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0} 百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
@@ -8648,6 +8649,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>千帕</displayName>
@@ -9291,10 +9296,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>匹</displayName>
 				<unitPattern count="other">{0} 匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0} 百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
@@ -9314,6 +9315,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>千帕</displayName>
@@ -9777,9 +9782,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0}百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<unitPattern count="other" draft="contributed">{0}mmHg</unitPattern>
 			</unit>
@@ -9791,6 +9793,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0}毫巴</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0}百帕</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>公里/小時</displayName>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -1096,6 +1096,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="ZW">辛巴威</territory>
 			<territory type="ZZ">未知区域</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">英伦</subdivision>
+			<subdivision type="gbsct">苏格兰</subdivision>
+			<subdivision type="gbwls">威尔斯</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">传统德语拼字学</variant>
 			<variant type="1994" draft="contributed">标准雷西亚拼字</variant>
@@ -8613,10 +8618,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>马力</displayName>
 				<unitPattern count="other">{0} 匹马力</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0} 百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
@@ -8636,6 +8637,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>千帕</displayName>
@@ -9279,10 +9284,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>匹</displayName>
 				<unitPattern count="other">{0} 匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0} 百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
@@ -9302,6 +9303,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>千帕</displayName>
@@ -9765,9 +9770,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0}百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<unitPattern count="other" draft="contributed">{0}mmHg</unitPattern>
 			</unit>
@@ -9779,6 +9781,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0}毫巴</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0}百帕</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>公里/小时</displayName>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -1053,6 +1053,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">津巴布韦</territory>
 			<territory type="ZZ">未知地区</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">英格兰</subdivision>
+			<subdivision type="gbsct">苏格兰</subdivision>
+			<subdivision type="gbwls">威尔士</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">传统德文拼字</variant>
 			<variant type="1994">标准雷西亚拼字</variant>
@@ -10421,10 +10426,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>马力</displayName>
 				<unitPattern count="other">{0}马力</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕斯卡</displayName>
-				<unitPattern count="other">{0}百帕斯卡</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0}毫米汞柱</unitPattern>
@@ -10444,6 +10445,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName draft="contributed">标准大气压</displayName>
 				<unitPattern count="other" draft="contributed">{0}个标准大气压</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕斯卡</displayName>
+				<unitPattern count="other">{0}百帕斯卡</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>千帕斯卡</displayName>
@@ -11075,10 +11080,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>马力</displayName>
 				<unitPattern count="other">{0}马力</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0}百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0}毫米汞柱</unitPattern>
@@ -11098,6 +11099,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName draft="contributed">大气压</displayName>
 				<unitPattern count="other" draft="contributed">{0}个大气压</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0}百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>千帕</displayName>
@@ -11553,14 +11558,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-horsepower">
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<unitPattern count="other">{0}hPa</unitPattern>
-			</unit>
 			<unit type="pressure-inch-hg">
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<unitPattern count="other">{0}mb</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="contributed">↑↑↑</displayName>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -1131,6 +1131,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">辛巴威</territory>
 			<territory type="ZZ">未知區域</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">英格蘭</subdivision>
+			<subdivision type="gbsct">蘇格蘭</subdivision>
+			<subdivision type="gbwls">威爾斯</subdivision>
+		</subdivisions>
 		<variants>
 			<variant type="1901">傳統德語拼字學</variant>
 			<variant type="1994" draft="contributed">標準雷西亞拼字</variant>
@@ -12284,10 +12289,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>馬力</displayName>
 				<unitPattern count="other">{0} 匹馬力</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0} 百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
@@ -12307,6 +12308,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>氣壓</displayName>
 				<unitPattern count="other">{0} 大氣壓</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>帕斯卡</displayName>
@@ -12948,10 +12953,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>匹</displayName>
 				<unitPattern count="other">{0} 匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>百帕</displayName>
-				<unitPattern count="other">{0} 百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>毫米汞柱</displayName>
 				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
@@ -12971,6 +12972,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
@@ -13538,10 +13543,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">匹</displayName>
 				<unitPattern count="other">{0}匹</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">百帕</displayName>
-				<unitPattern count="other">{0}百帕</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName draft="contributed">毫米汞柱</displayName>
 				<unitPattern count="other" draft="contributed">{0}mmHg</unitPattern>
@@ -13557,6 +13558,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-millibar">
 				<displayName draft="contributed">毫巴</displayName>
 				<unitPattern count="other">{0}毫巴</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName draft="contributed">百帕</displayName>
+				<unitPattern count="other">{0}百帕</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>公里/小時</displayName>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -791,6 +791,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="ZW">iZimbabwe</territory>
 			<territory type="ZZ">iSifunda esingaziwa</territory>
 		</territories>
+		<subdivisions>
+			<subdivision type="gbeng">I-England</subdivision>
+			<subdivision type="gbsct">I-Scotland</subdivision>
+			<subdivision type="gbwls">I-Wales</subdivision>
+		</subdivisions>
 		<keys>
 			<key type="calendar">Ikhalenda</key>
 			<key type="cf">Ifomethi yemali</key>
@@ -6127,11 +6132,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -6156,6 +6156,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
@@ -6930,11 +6935,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>hPa</displayName>
-				<unitPattern count="one">{0} hPa</unitPattern>
-				<unitPattern count="other">{0} hPa</unitPattern>
-			</unit>
 			<unit type="pressure-millimeter-of-mercury">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
@@ -6959,6 +6959,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>atm</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
+			</unit>
+			<unit type="pressure-hectopascal">
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>


### PR DESCRIPTION
[CLDR-13059]
This moves the 3 subdivisions we use the ST for into /main/ files (from the corresponding /subdivisions/ files).

Note: ignore the changes to pressure-hectopascal. It was not in the right place (alphabetically) so it switched positions when the file was written out.

[CLDR-13059]: https://unicode-org.atlassian.net/browse/CLDR-13059