### PR TITLE
CLDR-13065 Country/lang/pop additions for Chickasaw

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1449,6 +1449,7 @@ XXX Code for transations where no currency is involved
 		<language type="chr" scripts="Cher"/>
 		<language type="chy" scripts="Latn"/>
 		<language type="cic" scripts="Latn"/>
+		<language type="cic" territories="US" alt="secondary"/>
 		<language type="cja" scripts="Arab"/>
 		<language type="cja" scripts="Cham" alt="secondary"/>
 		<language type="cjm" scripts="Cham"/>

--- a/tools/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -160,6 +160,8 @@ public class GenerateMaximalLocales {
      */
     // Many of the overrides below can be removed once the language/pop/country data is updated.
     private static final Map<String, String> LANGUAGE_OVERRIDES = CldrUtility.asMap(new String[][] {
+        { "cic", "cic_Latn_US" },
+        { "cic_Latn", "cic_Latn_US" },
         { "eo", "eo_Latn_001" },
         { "eo_Latn", "eo_Latn_001" },
         { "es", "es_Latn_ES" },

--- a/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -1345,6 +1345,7 @@ United States	US	"329,256,465"	99%	"19,490,000,000,000"		Cherokee	chr	"25,300"	5
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Chinese (Traditional)	zh_Hant	"2,260,000"			
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Choctaw	cho	"10,800"			
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Creek	mus	"4,000"			
+United States	US	"329,256,465"	99%	"19,490,000,000,000"		Chickasaw	cic	"75"
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Dakota	dak	"19,500"			
 United States	US	"329,256,465"	99%	"19,490,000,000,000"	de_facto_official	English	en	96%			
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Filipino	fil	"1,370,000"			

--- a/tools/java/org/unicode/cldr/util/data/external/alternate_country_names.txt
+++ b/tools/java/org/unicode/cldr/util/data/external/alternate_country_names.txt
@@ -127,7 +127,7 @@ SK; Slovakia; Slovak Republic
 
 SY; Syria; Syrian Arab Republic
 
-SZ; Swaziland; Eswatini
+SZ; Eswatini; eSwatini; Swaziland 
 
 SH; Saint Helena; Saint Helena, Ascension, and Tristan da Cunha
 

--- a/tools/java/org/unicode/cldr/util/data/external/factbook_literacy.txt
+++ b/tools/java/org/unicode/cldr/util/data/external/factbook_literacy.txt
@@ -142,7 +142,7 @@
 142	Gabon	    89.00
 143	Mauritius	    88.80
 144	Namibia	    88.80
-145	Swaziland	    87.80
+145	Eswatini	    87.80
 146	Kenya	    87.40
 147	Saudi Arabia	    87.20
 148	Jamaica	    87.00

--- a/tools/java/org/unicode/cldr/util/data/language_script_raw.txt
+++ b/tools/java/org/unicode/cldr/util/data/language_script_raw.txt
@@ -138,6 +138,7 @@ chp	Chipewyan	primary	Latn	Latin
 chp	Chipewyan	secondary	Cans	Unified Canadian Aboriginal Syllabics
 chr	Cherokee	primary	Cher	Cherokee
 chy	Cheyenne	primary	Latn	Latin
+cic	Chickasaw	primary	Latn	Latin
 cja	Western Cham	primary	Arab	Arabic
 cja	Western Cham	secondary	Cham	Cham
 cjm	Eastern Cham	primary	Cham	Cham


### PR DESCRIPTION
[CLDR-13065]

The tools were also barfing on the Eswatini vs. Swaziland change, so I changed factbook literacy file ( which will likely never change ) to Eswatini.

[CLDR-13065]: https://unicode-org.atlassian.net/browse/CLDR-13065