### PR TITLE
CLDR-11685 ST performance, fix delayed display of submitted values

### DIFF
--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
@@ -932,7 +932,7 @@ function showV() {
 					if(surveyCurrentLocale!=null&&surveyCurrentLocale!='') {
 						var needLocTable = false;
 
-						var url = contextPath + "/SurveyAjax?_="+surveyCurrentLocale+"&s="+surveySessionId+"&what=menus&locmap="+needLocTable+cacheKill();
+						var url = contextPath + "/SurveyAjax?what=menus&_="+surveyCurrentLocale+"&locmap="+needLocTable+"&s="+surveySessionId+cacheKill();
 						myLoad(url, "menus", function(json) {
 							if(!verifyJson(json, "menus")) {
 								return; // busted?
@@ -1194,10 +1194,14 @@ function showV() {
 							hideLoader(null);
 							isLoading=false;
 
-						} else {
+						} else if (!isInputBusy()) {
+							/*
+							 * Make “all rows” requests only when !isInputBusy, to avoid wasted requests
+							 * if the user leaves the input box open for an extended time.
+							 */
 							// (common case) this is an actual locale data page.
 							itemLoadInfo.appendChild(document.createTextNode(locmap.getLocaleName(surveyCurrentLocale) + '/' + surveyCurrentPage + '/' + surveyCurrentId));
-							var url = contextPath + "/SurveyAjax?what="+WHAT_GETROW+"&_="+surveyCurrentLocale+"&s="+surveySessionId+"&x="+surveyCurrentPage+"&strid="+surveyCurrentId+cacheKill();
+							var url = contextPath + "/SurveyAjax?what="+WHAT_GETROW+"&_="+surveyCurrentLocale+"&x="+surveyCurrentPage+"&strid="+surveyCurrentId+"&s="+surveySessionId+cacheKill();
 							$('#nav-page').show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
 							myLoad(url, "section", function(json) {
 								isLoading=false;
@@ -1234,7 +1238,7 @@ function showV() {
 									} else {
 										showInPop2(stui.str("dataPageInitialGuidance"), null, null, null, true); /* show the box the first time */
 									}
-									doUpdate(theDiv.id, function() {
+									if (!isInputBusy()) {
 										showLoader(theDiv.loader,stui.loading3);
 										cldrSurveyTable.insertRows(theDiv,json.pageId,surveySessionId,json); // pageid is the xpath..
 										updateCoverage(flipper.get(pages.data)); // make sure cov is set right before we show.
@@ -1242,7 +1246,7 @@ function showV() {
 										window.showCurrentId(); // already calls scroll
 										refreshCounterVetting();
 										$('#nav-page-footer').show(); // make bottom "Prev/Next" buttons visible after building table
-									});
+									}
 								}
 							});
 						}
@@ -1678,7 +1682,7 @@ function showV() {
 				if(surveyCurrentLocale===null || surveyCurrentLocale=='') {
 					theLocale = 'und';
 				}
-				var xurl = contextPath + "/SurveyAjax?_="+theLocale+"&s="+surveySessionId+"&what=menus&locmap="+true+cacheKill();
+				var xurl = contextPath + "/SurveyAjax?what=menus&_="+theLocale+"&locmap="+true+"&s="+surveySessionId+cacheKill();
 				myLoad(xurl, "initial menus for " + surveyCurrentLocale, function(json) {
 					if(!verifyJson(json,'locmap')) {
 						return;
@@ -1817,7 +1821,7 @@ function showV() {
 								console.log('No change in user cov: ' + setUserCovTo);
 							} else {
 								window.surveyUserCov = setUserCovTo;
-								var updurl  = contextPath + "/SurveyAjax?_="+theLocale+"&s="+surveySessionId+"&what=pref&pref=p_covlev&_v="+window.surveyUserCov+cacheKill(); // SurveyMain.PREF_COVLEV
+								var updurl  = contextPath + "/SurveyAjax?what=pref&_="+theLocale+"&pref=p_covlev&_v="+window.surveyUserCov+"&s="+surveySessionId+cacheKill(); // SurveyMain.PREF_COVLEV
 								myLoad(updurl, "updating covlev to  " + surveyUserCov, function(json) {
 									if(!verifyJson(json,'pref')) {
 										return;
@@ -1857,7 +1861,7 @@ function showV() {
 							/*
 							 * See WHAT_AUTO_IMPORT = "auto_import" in SurveyAjax.java
 							 */
-							var url = contextPath + "/SurveyAjax?s=" + surveySessionId + "&what=auto_import" + cacheKill();
+							var url = contextPath + "/SurveyAjax?what=auto_import&s=" + surveySessionId + cacheKill();
 							myLoad(url, "auto-importing votes", function(json) {
 								autoImportProgressDialog.hide();
 								window.haveDialog = false;

--- a/tools/cldr-apps/WebContent/js/review.js
+++ b/tools/cldr-apps/WebContent/js/review.js
@@ -175,7 +175,7 @@ function getUrlReview(id) {
 
 //save the hide line 
 function toggleReview() {
-	 var url = contextPath + "/SurveyAjax?&s="+surveySessionId+"&what=review_hide";
+	 var url = contextPath + "/SurveyAjax?what=review_hide&s="+surveySessionId;
 	 var path = $(this).parents('tr').data('path');
 	 var choice = $(this).parents('.table-wrapper').data('type');
 	 url += "&path="+path+"&choice="+choice+"&locale="+surveyCurrentLocale;
@@ -495,7 +495,7 @@ function openPost() {
 	var choice = $(this).closest(".table-wrapper").data('type');
 	var postModal = $('#post-modal');
 	var locale = surveyCurrentLocale;
-	var url = contextPath + "/SurveyAjax?&s="+surveySessionId+"&what=forum_fetch&xpath="+$(this).closest('tr').data('path')+"&voteinfo&_="+locale;
+	var url = contextPath + "/SurveyAjax?what=forum_fetch&s="+surveySessionId+"&xpath="+$(this).closest('tr').data('path')+"&voteinfo&_="+locale;
 	showPost(postModal, null);
 
 	$.get(url, function(data){

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -2534,7 +2534,7 @@ public class SurveyAjax extends HttpServlet {
     }
 
     /**
-     * Get data associated with a particular row (xpath).
+     * Get data associated with a particular row (xpath) or section (x, set of rows).
      *
      * @param request
      * @param response
@@ -2568,6 +2568,10 @@ public class SurveyAjax extends HttpServlet {
         if (strid != null && strid.isEmpty()) {
             strid = null;
         }
+        /*
+         * When the "x" parameter is used to specify a sectionName, we're getting all the rows for one page (or section).
+         * Otherwise there is an "xpath" parameter and we're only getting one row.
+         */
         String sectionName = WebContext.decodeFieldString(request.getParameter("x"));
         if (sectionName != null && sectionName.isEmpty()) {
             sectionName = null;
@@ -2652,6 +2656,10 @@ public class SurveyAjax extends HttpServlet {
                         /*
                          * We arrive here normally when loading a page, invoked by request from CldrSurveyVettingLoader.js
                          * var url = contextPath + "/SurveyAjax?what="+WHAT_GETROW+"&_="+surveyCurrentLocale+"&s="+surveySessionId+"&x="+surveyCurrentPage+"&strid="+surveyCurrentId+cacheKill();
+                         *
+                         * This is for getting all the rows for one page (or section).
+                         * There is an "x" parameter for the section/pageId, and also a "strid" parameter.
+                         * There is no "xpath" parameter.
                          */
                         section = ctx.getDataSection(null /* prefix */, null /* matcher */, pageId);
                         section.setUserAndFileForVotelist(mySession.user, null); // TODO: what effect does null cldrFile here have on DataSection.getExampleBuilder??
@@ -2662,6 +2670,9 @@ public class SurveyAjax extends HttpServlet {
                          * 
                          * We also arrive here when a user selects a "Fix" button in the Dashboard, invoked by request from review.js
                          * var url = contextPath + "/SurveyAjax?what="+WHAT_GETROW+"&_="+surveyCurrentLocale+"&s="+surveySessionId+"&xpath="+tr.data('path')+"&strid="+surveyCurrentId+cacheKill()+"&dashboard=true";
+                         *
+                         * This is for getting a single row only.
+                         * There is an "xpath" parameter, and also a "strid" parameter.
                          */
                         baseXp = XPathTable.xpathToBaseXpath(xp);
                         section = ctx.getDataSection(baseXp /* prefix */, matcher, null /* pageId */);


### PR DESCRIPTION
-Do not replace newer data from one-row request with older data from all-row request

-Do not defer all-row update until after one-row update

-Avoid making all-row request if isInputBusy

-Order SurveyAjax parameters more consistently, start with what=...

-Comments

[CLDR-11685]

[CLDR-11685]: https://unicode-org.atlassian.net/browse/CLDR-11685