### PR TITLE
CLDR-13090 Added a helper function to obtain Attribute instances efficiently.

### DIFF
--- a/tools/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/java/org/unicode/cldr/util/DtdData.java
@@ -1580,15 +1580,13 @@ public class DtdData extends XMLFileReader.SimpleHandler {
     }
 
     public AttributeType getAttributeType(String elementName, String attributeName) {
+        Attribute attr = getAttribute(elementName, attributeName);
+        return (attr != null) ? attr.type : null;
+    }
+
+    public Attribute getAttribute(String elementName, String attributeName) {
         Element element = nameToElement.get(elementName);
-        if (element == null) {
-            return null;
-        }
-        Attribute attr = element.getAttributeNamed(attributeName);
-        if (attr == null) {
-            return null;
-        }
-        return attr.type;
+        return (element != null) ? element.getAttributeNamed(attributeName) : null;
     }
 
     // TODO: add support for following to DTD annotations, and rework API


### PR DESCRIPTION
This should be one of only a small number of changes to existing code required to support the new CLDR data API.

I'm not necessarily seeking a merge at this stage, but just putting the expected changes out for discussion. The prototype API and some unit tests will be added separately (or if people want I can combine into a single pull request).

It turned out to be effectively impossible to simply isolate existing methods and classes to move/expose for a public API, and what I've ended up doing is create a very minimal new API in a new package (but using lots of the existing CLDR classes behind the scenes). This means that there won't be much changing with existing code, which is nice because it removes any risk of breaking things while the new API and ICU tools are being converted to the new API.