### PR TITLE
CLDR-11681 Tailor currency format/symbol for KRW and JPY in ko and ja

### DIFF
--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -7489,7 +7489,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="JPY">
 				<displayName>日本円</displayName>
 				<displayName count="other">円</displayName>
-				<symbol>￥</symbol>
+				<pattern>#,##0.00¤</pattern>
+				<symbol>円</symbol>
 				<symbol alt="narrow" draft="contributed">￥</symbol>
 			</currency>
 			<currency type="KES">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -6648,15 +6648,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">코모르 프랑</displayName>
 			</currency>
 			<currency type="KPW">
-				<displayName>조선 민주주의 인민 공화국 원</displayName>
-				<displayName count="other">조선 민주주의 인민 공화국 원</displayName>
+				<displayName>북한 원</displayName>
+				<displayName count="other">북한 원</displayName>
 			</currency>
 			<currency type="KRH">
-				<displayName draft="contributed">대한민국 환 (1953–1962)</displayName>
+				<displayName draft="contributed">환 (1953~1962)</displayName>
 			</currency>
 			<currency type="KRW">
-				<displayName>대한민국 원</displayName>
-				<displayName count="other">대한민국 원</displayName>
+				<displayName>원</displayName>
+				<displayName count="other">원</displayName>
+				<pattern>#,##0.00¤</pattern>
+				<symbol>원</symbol>
 			</currency>
 			<currency type="KWD">
 				<displayName>쿠웨이트 디나르</displayName>

--- a/common/main/ko_KP.xml
+++ b/common/main/ko_KP.xml
@@ -27,4 +27,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 		</timeZoneNames>
 	</dates>
+	<numbers>
+		<currencies>
+			<currency type="KPW">
+				<displayName>원</displayName>
+				<displayName count="other">원</displayName>
+				<pattern>#,##0.00¤</pattern>
+				<symbol>원</symbol>
+			</currency>
+			<currency type="KRH">
+				<displayName draft="contributed">남조선 환 (1953~1962)</displayName>
+			</currency>
+			<currency type="KRW">
+				<displayName>남조선 원</displayName>
+				<displayName count="other">남조선 원</displayName>
+				<pattern>¤ #,##0.00</pattern>
+				<symbol>KR₩</symbol>
+			</currency>
+		</currencies>
+	</numbers>
 </ldml>


### PR DESCRIPTION
In ko locale, use '#,##0.00¤' for KRW with '원' as the symbol.
In ja locale, do the same for JPY with '円' as the symbol.
In ko-KP locale, do the same for KPW while preserving the current
format for KRW.

Shorten the display names for KRW, KRH, JPY, KPW by dropping the
official (and long in case KPW) country names or replacing
it with colloquial short names.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [V] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11681
- [ ] Updated PR title and link in previous line to include Issue number

