### PR TITLE
CLDR-13047 add git hash to manifest, show in SurveyTool

### DIFF
--- a/tools/cldr-apps/WebContent/about.jsp
+++ b/tools/cldr-apps/WebContent/about.jsp
@@ -1,4 +1,7 @@
+<%@page import="org.unicode.cldr.util.CldrUtility"%>
+<%@page import="org.unicode.cldr.util.CLDRURLS"%>
 <%@page import="org.unicode.cldr.web.DBUtils"%>
+<%@page import="org.unicode.cldr.util.CLDRConfigImpl"%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <!-- Copyright (C) 2012 IBM and Others. All Rights Reserved --> 
 <html>
@@ -73,10 +76,12 @@
             <th>SurveyMain.BASELINE_LANGUAGE_NAME</th>
             <td> <%= org.unicode.cldr.web.SurveyMain.BASELINE_LANGUAGE_NAME %>  </td>
         </tr>
-        <tr class="row<%= ((i++)%2) %>">
-            <th>SVN Version</th>
-            <td> <%= org.unicode.cldr.util.CldrUtility.getProperty("CLDR_CURREV", null) %>  </td>
-        </tr>
+        <% for(String k : org.unicode.cldr.util.CLDRConfigImpl.ALL_GIT_HASHES) { %>
+	        <tr class="row<%= ((i++)%2) %>">
+	            <th><%= k %></th>
+	            <td> <%= CLDRURLS.gitHashToLink(CLDRConfigImpl.getInstance().getProperty(k)) %>  </td>
+	        </tr>
+        <% } %>
     </table>    
     <%
         }

--- a/tools/cldr-apps/WebContent/index.jsp
+++ b/tools/cldr-apps/WebContent/index.jsp
@@ -73,7 +73,7 @@
         
         <hr />
         <p><a href="http://www.unicode.org">Unicode</a> | <a href="http://www.unicode.org/cldr">CLDR</a></p>
-        <span style='font-size: 60%;'>SVN Version : <%= org.unicode.cldr.util.CldrUtility.getProperty("CLDR_CURREV", null) %></span>
+        <span style='font-size: 60%;'>Code Version : <%= SurveyMain.getCurrev() %></span>
         <div style='float: right; font-size: 60%;'><span class='notselected'>valid <a href='http://jigsaw.w3.org/css-validator/check/referer'>css</a>,
             <a href='http://validator.w3.org/check?uri=referer'>xhtml 1.1</a></span></div>
             

--- a/tools/cldr-apps/WebContent/surveytool.css
+++ b/tools/cldr-apps/WebContent/surveytool.css
@@ -3185,6 +3185,12 @@ td.v-win {
     
 }
 
+
+#revision-info {
+	font-size: x-small;
+	whitespace: nowrap;
+}
+
 #oldVotesAcceptList {
     border-collapse: collapse;
 }

--- a/tools/cldr-apps/WebContent/v.jsp
+++ b/tools/cldr-apps/WebContent/v.jsp
@@ -83,6 +83,13 @@ if(SurveyMain.isBusted!=null || request.getParameter("_BUSTED")!=null) {
          <%@include file="/WEB-INF/tmpl/ajax_status.jsp" %>
     	<h1>Waiting for the Survey Tool to come online<span id='dots'>...</span></h1>
         <p class="lead">The Survey Tool may be starting up.  </p>
+				  <%
+				  	if(SurveyMain.isUnofficial()) {
+				  %>
+				             <p><span class="glyphicon glyphicon-wrench"></span><%= SurveyMain.getCurrev() %></p>
+				  <%
+				  	}
+				  %>
         
         <%
             // JavaScript based redirect
@@ -257,7 +264,15 @@ surveyUser =  <%= ctx.session.user.toJSONString() %>;
 		            <li>
 			        	<button type="button" class="btn btn-default toggle-right">Toggle Sidebar <span class="glyphicon glyphicon-align-right"></span></button>
 		            </li>
+				  <%
+				  	if(SurveyMain.isUnofficial()) {
+				  %>
+				             <li id="revision-info"><span class="glyphicon glyphicon-wrench"></span><%= SurveyMain.getCurrev() %></li>
+				  <%
+				  	}
+				  %>
 				  </ul>
+				  
 		   </li>
             <li class="dropdown" id='title-coverage' style='display:none'>
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Coverage: <span id="coverage-info"></span></a>
@@ -307,7 +322,7 @@ surveyUser =  <%= ctx.session.user.toJSONString() %>;
            	<p class='navbar-text navbar-right'><a href='https://www.unicode.org/policies/privacy_policy.html'>This site uses cookies.</a>
           	</p>
  
-          	<p class='specialmessage navbar-text navbar-right'><%= sm.getSpecialHeaderText() %><%= SurveyMain.isUnofficial()?("<br/><span class='rolloverspan'>"+SurveyMain.getCurrev()+"</span>"):"" %>
+          	<p class='specialmessage navbar-text navbar-right'><%= sm.getSpecialHeaderText() %>
           	</p>
     	
         </div>

--- a/tools/cldr-apps/build.xml
+++ b/tools/cldr-apps/build.xml
@@ -168,11 +168,12 @@
         <delete dir="${doc.dir}"/>
     </target>
 
-    <target name="jar" depends="web" description="build full 'cldr.jar' jar file">
+    <target name="jar" depends="web" description="build full 'cldr-apps.jar' jar file (Not normally used.)">
         <jar jarfile="${jar.file}"
             compress="true"
             includes="org/unicode/cldr/util/**/*,org/unicode/cldr/tool/**/*,org/unicode/cldr/test/**/*,org/unicode/cldr/posix/**/*,org/unicode/cldr/ooo/**/*,org/unicode/cldr/ant/**/*,org/unicode/cldr/icu/**/*"
             basedir="${build.dir}"/>
+        <!-- does not include git hash. -->
     </target>
   <!-- Docs stuff -->
     <!-- use excludefiles below when we move to ant 1.5 -->
@@ -203,18 +204,16 @@
             bottom="&lt;font size=-1>&lt;a  target='_top' href='http://www.unicode.org/copyright.html'>Copyright &amp;copy; 2004-${current.year} Unicode, Inc. All Rights Reserved.&lt;/a>&lt;/font>"
             source="1.8" />
     </target>
-               <!-- bottom="&lt;font size=-1>Copyright (c) ${current.year} IBM Corporation and others.&lt;/font>" -->
+    <!-- bottom="&lt;font size=-1>Copyright (c) ${current.year} IBM Corporation and others.&lt;/font>" -->
 
-
-  <!-- SurveyTool (web) stuff follows ................. -->
-
+    <!-- SurveyTool (web) stuff follows ................. -->
 
     <!-- build all web related things -->
     <!--
     	// includes="${src.dir}/**/*.java"
     	    excludes="**/.svn/**/*"
     -->
-	<target name="web" depends="all" description="alias for old 'web' target"/>
+    <target name="web" depends="all" description="alias for old 'web' target"/>
 
     <target name="all" depends="init" description="build web classes">
         <javac
@@ -229,10 +228,22 @@
             encoding="UTF-8"/>
     </target>
 
+    <target name="init-githash" depends="init" description="calculate build.githash">
+      <exec executable="git" outputproperty="build.githash" failifexecutionfails="false">
+        <arg value="rev-parse" />
+        <arg value="--short" />
+        <arg value="HEAD" />
+      </exec>
+      <condition property="build.githash" value="(unknown)">
+        <not>
+          <isset property="build.githash" />
+        </not>
+      </condition>
+    </target>
 
     <!-- build as a WAR file -->
     <!-- TODO: include CLDR as a jar? Only include certain classes? -->
-    <target name="war" depends="web" description="Build war">
+    <target name="war" depends="web,init-githash" description="Build war">
         <war destfile="${warfile}" webxml="${webxml}">
             <!-- classes (for now, may want to take cldr utils as a jar later) -->
             <classes dir="${build.dir}" />
@@ -248,7 +259,10 @@
             <lib file="${MYANMAR_TOOLS_JAR}" /> <!-- MYANMAR_TOOLS_JAR jar -->
             <!-- May want this later. -->
             <!--  <pathelement path="${jsp.jar}"/> -->
-
+	    <manifest>
+	      <attribute name="Built-By" value="${user.name}" />
+              <attribute name="CLDR-Apps-Git-Commit" value="${build.githash}" />
+	    </manifest>
         </war>
     </target>
 

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestMisc.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestMisc.java
@@ -5,6 +5,7 @@ package org.unicode.cldr.unittest.web;
  */
 
 import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRConfigImpl;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.web.STFactory;
@@ -78,5 +79,14 @@ public class TestMisc extends TestFmwk {
             return;
         }
         System.out.println("✅");
+    }
+    
+    public void TestGitHash() {
+        String appsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Apps");
+        assertNotNull(appsVersion, "getting CLDR-Apps version");
+//        System.out.println("Apps: " + appsVersion);
+        String toolsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Tools");
+        assertNotNull(toolsVersion, "getting CLDR-Tools version");
+//        System.out.println("Tools: " + toolsVersion);
     }
 }

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyLog.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyLog.java
@@ -87,7 +87,7 @@ public class SurveyLog {
         StringBuilder sb = new StringBuilder();
         sb.append(RECORD_SEP).append(LogField.SURVEY_EXCEPTION).append(' ').append(what).append('\n').append(FIELD_SEP)
             .append(LogField.DATE).append(' ').append(nextTimePost).append(' ').append(new Date()).append('\n')
-            .append(FIELD_SEP).append(LogField.REVISION).append(' ').append(SurveyMain.getCurrevStr()).append(' ').append(SurveyMain.getNewVersion())
+            .append(FIELD_SEP).append(LogField.REVISION).append(' ').append(SurveyMain.getCurrevCldrApps()).append(' ').append(SurveyMain.getNewVersion())
             .append(' ').append(CLDRConfig.getInstance().getPhase()).append(' ').append(CLDRConfig.getInstance().getEnvironment()).append('\n')
             .append(FIELD_SEP).append(LogField.UPTIME).append(' ').append(SurveyMain.uptime).append('\n');
         if (ctx != null) {

--- a/tools/java/build.xml
+++ b/tools/java/build.xml
@@ -136,7 +136,20 @@
 
 	<target name="jars" depends="jar,srcJar,docsJar" description="build all jars"/>
 
-	<target name="jar" depends="all" description="build full 'cldr.jar' jar file">
+        <target name="init-githash" depends="init" description="calculate build.githash">
+          <exec executable="git" outputproperty="build.githash" failifexecutionfails="false">
+            <arg value="rev-parse" />
+            <arg value="--short" />
+            <arg value="HEAD" />
+          </exec>
+          <condition property="build.githash" value="(unknown)">
+            <not>
+              <isset property="build.githash" />
+            </not>
+          </condition>
+        </target>
+
+	<target name="jar" depends="all,init-githash" description="build full 'cldr.jar' jar file">
 		<jar jarfile="${jar.file}" compress="true"
 			includes="org/unicode/cldr/draft/**/*,
         		org/unicode/cldr/util/**/*,
@@ -151,6 +164,7 @@
 			<manifest>
 				<attribute name="Built-By" value="${user.name}" />
 				<attribute name="Main-Class" value="org.unicode.cldr.tool.Main" />
+                                <attribute name="CLDR-Tools-Git-Commit" value="${build.githash}" />
 				<attribute name="Class-Path"
 					value="./libs/${cldr.libs.icu4j} ./libs/${cldr.libs.utilities} ./libs/${cldr.libs.xerces} ./libs/${cldr.libs.guava} ./libs/${cldr.libs.gson} ${cldr.libs.icu4j} ${cldr.libs.utilities} ${cldr.libs.xerces} ${cldr.libs.gson} ./libs/myanmar-tools-1.1.1.jar" />
 			</manifest>

--- a/tools/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/java/org/unicode/cldr/util/CLDRURLS.java
@@ -11,7 +11,7 @@ public abstract class CLDRURLS {
     public static final String DEFAULT_HOST = "st.unicode.org";
     public static final String DEFAULT_PATH = "/cldr-apps";
     public static final String DEFAULT_BASE = "http://" + DEFAULT_HOST + DEFAULT_PATH;
-    public static final String CLDR_NEWTICKET_URL = "http://unicode.org/cldr/trac/newticket";
+    public static final String CLDR_NEWTICKET_URL = "https://unicode.org/cldr/trac/newticket"; // This is an alias to Jira
     /**
      * Override this property if you want to change the absolute URL to the SurveyTool base from DEFAULT_BASE
      */
@@ -59,6 +59,11 @@ public abstract class CLDRURLS {
     }
 
     protected static String VPATH = "/v#";
+    /**
+     * Constant for an unknown git revision.
+     * Use the same in the builders.
+     */
+    public static final String UNKNOWN_REVISION = "(unknown)";
 
     /**
      * Get the relative base URL for the SurveyTool.
@@ -236,5 +241,26 @@ public abstract class CLDRURLS {
      */
     public final String forPathHeader(CLDRLocale locale, PathHeader pathHeader) {
         return forSpecial(Special.Survey, locale, pathHeader.getPageId(), StringId.getHexId(pathHeader.getOriginalPath()));
+    }
+
+    /**
+     * For a given hash, return as a link
+     * @param hash
+     * @return
+     */
+    public static String gitHashToLink(String hash) {
+        if(!isKnownHash(hash)) return "<span class=\"githashLink\">"+hash+"</span>"; // Not linkifiable
+        return "<a class=\"githashLink\" href=\"" + 
+                CldrUtility.getProperty("CLDR_COMMIT_BASE", "https://github.com/unicode-org/cldr/commit/") 
+                + hash + "\">" + hash + "</a>";
+    }
+
+    /**
+     * Is this a 'known' git hash? Or unknown?
+     * @param hash
+     * @return true if known, false if (unknown)
+     */
+    public static boolean isKnownHash(String hash) {
+        return !hash.equals(UNKNOWN_REVISION);
     }
 }


### PR DESCRIPTION
[CLDR-13047] 

- update cldr.jar and cldr-apps.war builds to include git hash in the jar manifest
- update SurveyMain functions and CLDRConfigImpl to handle the possibly 3 different hashes:
   1. cldr.jar (CLDR_TOOLS_HASH)
   2. cldr-apps.war (CLDR_APPS_HASH)
   3. the actual CLDR data (CLDR_DIR_HASH)
- code in CLDRURLS to generate github URLs for the above
- update the UI to show the version number on the loading page, and under the
gear menu (for SmokeTest).
- Update the 'about.jsp' page to show the three version numbers above

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13047
- [x] Updated PR title and link in previous line to include Issue number



[CLDR-13047]: https://unicode-org.atlassian.net/browse/CLDR-13047