### PR TITLE
CLDR-11799 Extend ST timeout

### DIFF
--- a/tools/cldr-apps/WebContent/AdminAjax.jsp
+++ b/tools/cldr-apps/WebContent/AdminAjax.jsp
@@ -2,8 +2,7 @@
 	import="org.unicode.cldr.web.*,java.util.Map,java.util.Set,java.util.Comparator,java.util.TreeMap,java.util.TreeSet"%><%@ page
 	language="java" contentType="application/json; charset=UTF-8"
 	import="com.ibm.icu.util.ULocale,org.unicode.cldr.util.*,org.json.*"%><%--  Copyright (C) 2012 IBM and Others. All Rights Reserved 
-	 --%><%@ page import="java.lang.management.*"%><%
-	 CLDRConfigImpl.setUrls(request);
+	 --%><%@ page import="java.lang.management.*"%><%CLDRConfigImpl.setUrls(request);
 	String vap = request.getParameter("vap");
 	String action = request.getParameter("do");
 	if (vap == null || action == null
@@ -24,9 +23,9 @@
 			}
 			sess.put("id", cs.id);
 			sess.put("ip", cs.ip);
-            sess.put("last", SurveyMain.timeDiff(cs.last));
-            sess.put("lastAction", SurveyMain.timeDiff(cs.getLastAction()));
-            sess.put("timeTillKick", cs.timeTillKick());
+            sess.put("lastBrowserCallMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastBrowserCallMillisSinceEpoch()));
+            sess.put("lastActionMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastActionMillisSinceEpoch()));
+            sess.put("millisTillKick", cs.millisTillKick());
 			//			sess.put("locales",new JSONArray().put(cs.getLocales().keys()));
 			users.put(cs.id, sess);
 		}
@@ -46,9 +45,9 @@
 			}
 			sess.put("id", cs.id);
 			sess.put("ip", cs.ip);
-            sess.put("last", SurveyMain.timeDiff(cs.last));
-            sess.put("lastAction", SurveyMain.timeDiff(cs.getLastAction()));
-            sess.put("timeTillKick", cs.timeTillKick());
+            sess.put("lastBrowserCallMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastBrowserCallMillisSinceEpoch()));
+            sess.put("lastActionMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastActionMillisSinceEpoch()));
+            sess.put("millisTillKick", cs.millisTillKick());
 
             new JSONWriter(out).object().key("kick").value(s).key("removing").value(sess)
 			.endObject();
@@ -139,5 +138,4 @@
         .endObject();
 	} else {
 		response.sendError(500, "Unknown action.");
-	}
-%>
+	}%>

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -1437,17 +1437,17 @@ function updateStatusBox(json) {
 		}
 
 		if(window.kickMe) {
-			json.timeTillKick = 0;
+			json.millisTillKick = 0;
 		} else if(window.kickMeSoon) {
-			json.timeTillKick = 5000;
+			json.millisTillKick = 5000;
 		}
 
 		// really don't care if guest user gets 'kicked'. Doesn't matter.
-		if( (surveyUser!==null) && json.timeTillKick && (json.timeTillKick>=0) && (json.timeTillKick < (60*1*1000) )) { // show countdown when 1 minute to go
-			var kmsg = "Your session will end if not active in about "+ (parseInt(json.timeTillKick)/1000).toFixed(0) + " seconds.";
+		if( (surveyUser!==null) && json.millisTillKick && (json.millisTillKick>=0) && (json.millisTillKick < (60*1*1000) )) { // show countdown when 1 minute to go
+			var kmsg = "Your session will end if not active in about "+ (parseInt(json.millisTillKick)/1000).toFixed(0) + " seconds.";
 			console.log(kmsg);
 			updateSpecialHeader(standOutMessage(kmsg));
-		} else if((surveyUser!==null) && (( json.timeTillKick === 0) || (json.session_err))) {
+		} else if((surveyUser!==null) && (( json.millisTillKick === 0) || (json.session_err))) {
 			var kmsg  = stui_str("ari_sessiondisconnect_message");
 			console.log(kmsg);
 			updateSpecialHeader(standOutMessage(kmsg));
@@ -3641,8 +3641,17 @@ function loadAdminPanel() {
 					} else {
 						user.appendChild(createChunk("(anonymous)","div","adminUserUser"));
 					}
-					user.appendChild(createChunk("Last: " + cs.last  + "LastAction: " + cs.lastAction + ", IP: " + cs.ip + ", ttk:"
-								+ (parseInt(cs.timeTillKick)/1000).toFixed(1)+"s", "span","adminUserInfo"));
+					/*
+					 * cs.lastBrowserCallMillisSinceEpoch = time elapsed in millis since server heard from client
+					 * cs.lastActionMillisSinceEpoch = time elapsed in millis since user did active action
+					 * cs.millisTillKick = how many millis before user will be kicked if inactive
+					 */
+					user.appendChild(createChunk(
+							"LastCall: " + cs.lastBrowserCallMillisSinceEpoch
+							+ ", LastAction: " + cs.lastActionMillisSinceEpoch
+							+ ", IP: " + cs.ip
+							+ ", ttk:" + (parseInt(cs.millisTillKick)/1000).toFixed(1) + "s",
+						"span","adminUserInfo"));
 
 					var unlinkButton = createChunk(stui.str("admin_users_action_kick"), "button", "admin_users_action_kick");
 					user.appendChild(unlinkButton);

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -486,9 +486,8 @@ public class SurveyAjax extends HttpServlet {
                 if (sess != null && !sess.isEmpty()) {
                     mySession = CookieSession.retrieve(sess); // or peek?
                     if (mySession != null) {
-                        r2.put("timeTillKick", mySession.timeTillKick());
+                        r2.put("millisTillKick", mySession.millisTillKick());
                     } else {
-                        //                        r2.put("err", "You are not logged into the survey tool)
                         r2.put("session_err", "no session");
                     }
                 }

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
@@ -2239,6 +2239,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * List Users
      *
      * @param ctx
+     *
+     * TODO: this function is over 666 lines long. Shorten it with subroutines.
      */
     public void doList(WebContext ctx) {
         int n = 0;
@@ -2737,7 +2739,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                     // are they logged in?
                     if ((theUser != null) && UserRegistry.userCanModifyUsers(ctx.session.user)) {
                         ctx.println("<td>");
-                        ctx.println("<b>active: " + timeDiff(theUser.last) + " ago</b>");
+                        ctx.println("<b>active: " + timeDiff(theUser.getLastBrowserCallMillisSinceEpoch()) + " ago</b>");
                         if (UserRegistry.userIsAdmin(ctx.session.user)) {
                             ctx.print("<br/>");
                             printLiveUserMenu(ctx, theUser);

--- a/tools/cldr-apps/src/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/WebContext.java
@@ -1802,7 +1802,6 @@ public class WebContext implements Cloneable, Appendable {
 
         // store the session id in the HttpSession
         httpSession.setAttribute(SurveyMain.SURVEYTOOL_COOKIE_SESSION, session.id);
-        //httpSession.setMaxInactiveInterval(CookieSession.Params.CLDR_USER_TIMEOUT.value() / 1000);
         httpSession.setMaxInactiveInterval(-1); // never expire
 
         if (user != null) {


### PR DESCRIPTION
-Booleans KICK_IF_ABSENT = false; KICK_IF_INACTIVE = true

-Change hard-coded timeouts to Params-based timeouts

-Rename variables and functions for clarity, include secs or millis

-Make data private, use accessor functions

-Merge CLDR_USER_INACTIVITY/CLDR_GUEST_INACTIVITY with CLDR_USER_TIMEOUT/CLDR_GUEST_TIMEOUT

-Double timeouts if not tooManyUsers/tooManyGuests

-No special timeout for TC

-Make CookieSession.Params private

-Remove dead code; clean up; comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11799
- [x] Updated PR title and link in previous line to include Issue number

