### PR TITLE
CLDR-13132 synchronize CLDRLocale.getInstance

### DIFF
--- a/tools/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/java/org/unicode/cldr/util/CLDRLocale.java
@@ -368,13 +368,15 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
      * @return
      */
     public static CLDRLocale getInstance(String s) {
-        if (s == null) return null;
-        CLDRLocale loc = stringToLoc.get(s);
-        if (loc == null) {
-            loc = new CLDRLocale(s);
-            loc.register();
+        synchronized(CLDRLocale.class) {
+            if (s == null) return null;
+            CLDRLocale loc = stringToLoc.get(s);
+            if (loc == null) {
+                loc = new CLDRLocale(s);
+                loc.register();
+            }
+            return loc;
         }
-        return loc;
     }
 
     /**
@@ -385,13 +387,15 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
      * @return
      */
     public static CLDRLocale getInstance(ULocale u) {
-        if (u == null) return null;
-        CLDRLocale loc = ulocToLoc.get(u);
-        if (loc == null) {
-            loc = new CLDRLocale(u);
-            loc.register();
+        synchronized(CLDRLocale.class) {
+            if (u == null) return null;
+            CLDRLocale loc = ulocToLoc.get(u);
+            if (loc == null) {
+                loc = new CLDRLocale(u);
+                loc.register();
+            }
+            return loc;
         }
-        return loc;
     }
 
     /**


### PR DESCRIPTION
[CLDR-13132]
- CLDRLocale.getInstance() needs to be synchronized
-  At runtime, CLDRLocale is a singleton, but needs to be
thread safe at construction

##### Checklist

- [x] Issue filed: [CLDR-13132]
- [x] Updated PR title and link in previous line to include Issue number



[CLDR-13132]: https://unicode-org.atlassian.net/browse/CLDR-13132
[CLDR-13132]: https://unicode-org.atlassian.net/browse/CLDR-13132