### PR TITLE
CLDR-13127 Hira-Kata fixes for U+309B/309C and final NFC; add test

### DIFF
--- a/common/transforms/Hiragana-Katakana.xml
+++ b/common/transforms/Hiragana-Katakana.xml
@@ -11,8 +11,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<transform source="Hira" target="Kana" direction="both" alias="Hiragana-Katakana und-Kana-t-und-hira" backwardAlias="Katakana-Hiragana und-Hira-t-und-kana">
 			<tRule>
 # note: a global filter is more efficient, but MUST include all source chars
-:: [\u0000-\u007E 、。 ゙-゜ ァ-ー ｡-ﾟー[:Hiragana:] [:Katakana:] [:nonspacing mark:]] ;
-:: NFKC ();
+:: [[\u0000-\u007E 、。 ゙-゜ ァ-ー ｡-ﾟー[:Hiragana:] [:Katakana:] [:nonspacing mark:]]-[\u309B \u309C]];
+:: NFKC (NFC);
 # Hiragana-Katakana
 # This is largely a one-to-one mapping, but it has a
 # few kinks:
@@ -183,9 +183,9 @@ $xo = [ \
 う ← $xu {ー};
 え ← $xe {ー};
 お ← $xo {ー};
-:: (NFKC) ;
+:: NFC (NFKC) ;
 # note: a global filter is more efficient, but MUST include all source chars!!
-:: ([\u0000-\u007E 、。 ゙-゜ ァ-ー ｡-ﾟー[:Hiragana:] [:Katakana:] [:nonspacing mark:]]);
+:: ([[\u0000-\u007E 、。 ゙-゜ ァ-ー ｡-ﾟー[:Hiragana:] [:Katakana:] [:nonspacing mark:]]-[\u309B \u309C]]);
 # eof
 			</tRule>
 		</transform>

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestTransforms.java
@@ -623,6 +623,12 @@ public class TestTransforms extends TestFmwkPlus {
         assertEquals("賈 bug", "jiǎ", pinyin.transform("賈"));
     }
 
+    public void TestHiraKata() { // for CLDR-13127 and ...
+        register();
+        Transliterator hiraKata = getTransliterator("Hiragana-Katakana");
+        assertEquals("Hira-Kata", hiraKata.transform("゛゜ わ゙ ゟ"), "゛゜ ヷ ヨリ");
+    }
+
   public void TestZawgyiToUnicode10899() {
     // Some tests for the transformation of Zawgyi font encoding to Unicode Burmese.
     Transliterator z2u = getTransliterator("my-t-my-s0-zawgyi");


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13127
- [x] Updated PR title and link in previous line to include Issue number

Leave \u309B, \u309C  unaffected by transform.
Add final NFC.
Add unit test.