### PR TITLE
CLDR-13088 Add English name for Qaag=Zawgyi, and translation hint

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -793,6 +793,7 @@ annotations.
 			<script type="Phnx">Phoenician</script>
 			<script type="Plrd">Pollard Phonetic</script>
 			<script type="Prti">Inscriptional Parthian</script>
+			<script type="Qaag">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
 			<script type="Rohg">Hanifi Rohingya</script>
 			<script type="Roro">Rongorongo</script>

--- a/seed/main/en_ZZ.xml
+++ b/seed/main/en_ZZ.xml
@@ -13,8 +13,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</identity>
 	<localeDisplayNames>
 		<languages>
-			<language type="zh">Chinese (translation hint: specifically, Mandarin Chinese.)&quot;</language>
+			<language type="zh">Chinese (translation hint: specifically, Mandarin Chinese.)</language>
 		</languages>
+		<scripts>
+			<script type="Qaag">Zawgyi (translation hint: Special code identifies non-standard Myanmar encoding for use with Zawgyi font.)</script>
+		</scripts>
 		<territories>
 			<territory type="003">North America (translation hint: Warning, see info panel on right.)</territory>
 			<territory type="018">Southern Africa (translation hint: Warning, see info panel on right.)</territory>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13088
- [x] Updated PR title and link in previous line to include Issue number

Added English name for Zawgyi, and translation hint. Should show up in Survey Tool with Comprehensive coverage in Locale Display Names > Scripts, subsection "Other".