### PR TITLE
CLDR-12038 ignore <version> element for ICU or comparator

### DIFF
--- a/tools/java/org/unicode/cldr/icu/BreakIteratorMapper.java
+++ b/tools/java/org/unicode/cldr/icu/BreakIteratorMapper.java
@@ -110,7 +110,7 @@ class BreakIteratorMapper extends Mapper {
             if (qName.equals("segmentation")) {
                 segPath = "/exceptions/" + attr.getValue("type") + ":array";
             } else if (qName.equals("version")) {
-                icuData.add("/Version", new String[] { MapperUtils.formatVersion(attr.getValue("number")) });
+                icuData.add("/Version", CLDRFile.GEN_VERSION);
             }
         }
 

--- a/tools/java/org/unicode/cldr/icu/CollationMapper.java
+++ b/tools/java/org/unicode/cldr/icu/CollationMapper.java
@@ -145,7 +145,7 @@ public class CollationMapper extends Mapper {
                     subLocales = validSubLocales.split("\\s++");
                 }
             } else if (qName.equals("version")) {
-                icuData.add("/Version", MapperUtils.formatVersion(attr.getValue("number")));
+                icuData.add("/Version", CLDRFile.GEN_VERSION);
             }
             if (collationType == null) return;
 

--- a/tools/java/org/unicode/cldr/icu/LDMLComparator.java
+++ b/tools/java/org/unicode/cldr/icu/LDMLComparator.java
@@ -125,7 +125,6 @@ public class LDMLComparator {
     Hashtable<String, String> optionTable = new Hashtable<String, String>();
     private String destFolder = ".";
     private String localeStr;
-    private String ourCvsVersion = "";
     private Calendar cal = Calendar.getInstance();
     private Hashtable<String, String> colorHash = new Hashtable<String, String>();
     private String goldFileName;
@@ -247,8 +246,6 @@ public class LDMLComparator {
                 if ((m_totalCount == 0) && m_Vetting) { // only optional for vetting.
                     // System.out.println("INFO:  no file created (nothing to write..) " + fileName);
                 } else {
-                    ourCvsVersion = "";
-                    getCVSVersion();
                     OutputStreamWriter os = new OutputStreamWriter(new FileOutputStream(fileName), encoding);
                     System.out.println("INFO: Writing: " + fileName + "\t(" + m_totalCount + " items)");
                     PrintWriter writer = new PrintWriter(os);
@@ -269,8 +266,7 @@ public class LDMLComparator {
                         if (!m_Vetting) {
                             indexwriter.println(" <td>" + m_diffcount + "</td>");
                         }
-                        indexwriter.println(" <td>" + LDMLUtilities.getCVSLink(localeStr, ourCvsVersion)
-                            + ourCvsVersion + "</a></td>");
+                        indexwriter.println("<td></td>"); // TODO: need to calculate full path (i.e. seed/main/ssy.xml) and append to CLDRURLS.something
                         indexwriter.println("</tr>");
                         is.close();
                     }
@@ -735,10 +731,6 @@ public class LDMLComparator {
                 "<a href=\"http://oss.software.ibm.com/cgi-bin/icu/lx/en/?_=" + localeStr + "\">Demo</a>, " +
                 "<a href=\"./index.html\">Main and About</a>, " +
                 "</b></p>\n");
-            if ((ourCvsVersion != null) && (ourCvsVersion.length() > 0)) {
-                writer.println("<h3><tt>" + LDMLUtilities.getCVSLink(localeStr) + localeStr + ".xml</a> version " +
-                    LDMLUtilities.getCVSLink(localeStr, ourCvsVersion) + ourCvsVersion + "</a></tt></h3>");
-            }
             writer.print("        <table>\n");
         }
 
@@ -1692,10 +1684,6 @@ public class LDMLComparator {
         }
 
         writer.print("      </table>\n");
-    }
-
-    private void getCVSVersion() {
-        ourCvsVersion = LDMLUtilities.loadFileRevision(goldFileName);
     }
 
 } // end of class definition/declaration

--- a/tools/java/org/unicode/cldr/icu/LocaleMapper.java
+++ b/tools/java/org/unicode/cldr/icu/LocaleMapper.java
@@ -401,7 +401,7 @@ public class LocaleMapper extends Mapper {
 
         // <version number="$Revision: 5806 $"/>
         String version = cldrResolved.getFullXPath("//ldml/identity/version");
-        icuData.add("/Version", MapperUtils.formatVersion(version));
+        icuData.add("/Version", CLDRFile.GEN_VERSION);
 
         // PaperSize:intvector{ 279, 216, } - now in supplemental
         // MeasurementSystem:int{1} - now in supplemental

--- a/tools/java/org/unicode/cldr/icu/MapperUtils.java
+++ b/tools/java/org/unicode/cldr/icu/MapperUtils.java
@@ -6,12 +6,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.unicode.cldr.util.InputStreamFactory;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.RegexUtilities;
 import org.unicode.cldr.util.XMLFileReader;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -25,8 +21,6 @@ import org.xml.sax.XMLReader;
  * @author jchye
  */
 public class MapperUtils {
-    private static final Pattern VERSION_PATTERN = PatternCache.get("\\$Revision:\\s*([\\d.]+)\\s*\\$");
-
     /**
      * Parses an XML file.
      *
@@ -53,32 +47,6 @@ public class MapperUtils {
             System.err.println("Error loading " + inputFile.getAbsolutePath());
             e.printStackTrace();
         }
-    }
-
-    public static String formatVersion(String value) {
-        Matcher versionMatcher = VERSION_PATTERN.matcher(value);
-        int versionNum;
-        if (!versionMatcher.find()) {
-            int failPoint = RegexUtilities.findMismatch(versionMatcher, value);
-            String show = value.substring(0, failPoint) + "☹" + value.substring(failPoint);
-            System.err.println("Warning: no version match with: " + show);
-            versionNum = 0;
-        } else {
-            String rawVersion = versionMatcher.group(1);
-            // No further processing needed, e.g. "1.1"
-            if (rawVersion.contains(".")) {
-                return rawVersion;
-            }
-            versionNum = Integer.parseInt(rawVersion);
-        }
-        String version = "";
-        int numDots = 0;
-        while (versionNum > 0) {
-            version = "." + versionNum % 100 + version;
-            versionNum /= 100;
-            numDots++;
-        }
-        return (numDots > 2 ? "2" : "2.0") + version;
     }
 
     /**

--- a/tools/java/org/unicode/cldr/icu/RbnfMapper.java
+++ b/tools/java/org/unicode/cldr/icu/RbnfMapper.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.icu;
 import java.io.File;
 import java.util.Collection;
 
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -90,7 +91,7 @@ public class RbnfMapper extends Mapper {
                 }
                 value.append(": ");
             } else if (qName.equals("version")) {
-                icuData.replace("/Version", new String[] { MapperUtils.formatVersion(attr.getValue("number")) });
+                icuData.replace("/Version", CLDRFile.GEN_VERSION);
             }
         }
 

--- a/tools/java/org/unicode/cldr/util/LDMLUtilities.java
+++ b/tools/java/org/unicode/cldr/util/LDMLUtilities.java
@@ -9,9 +9,7 @@
  */
 package org.unicode.cldr.util;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -19,8 +17,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -37,7 +33,6 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.unicode.cldr.icu.LDMLConstants;
-import org.unicode.cldr.util.XMLFileReader.SimpleHandler;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -2023,100 +2018,6 @@ public class LDMLUtilities {
 
         // out.close();
     } // printDOMTree(Node, PrintWriter)
-
-    // Utility functions, HTML and such.
-    public static String CVSBASE = "http://www.unicode.org/cldr/trac/browser/trunk";
-
-    public static final String getCVSLink(String locale) {
-        return "<a href=\"" + CVSBASE + "/common/main/" + locale + ".xml\">";
-    }
-
-    public static final String getCVSLink(String locale, String version) {
-        return "<a href=\"" + CVSBASE + "/common/main/" + locale + ".xml?rev=" +
-            version + "\">";
-
-    }
-
-    /**
-     * Load the revision from CVS or from the Identity element.
-     *
-     * @param fileName
-     * @return
-     */
-    static public String loadFileRevision(String fileName) {
-        int index = fileName.lastIndexOf(File.separatorChar);
-        if (index == -1) {
-            return null;
-        }
-        String sourceDir = fileName.substring(0, index);
-        return loadFileRevision(sourceDir, new File(fileName).getName());
-    }
-
-    // //ldml[@version="1.7"]/identity/version[@number="$Revision$"]
-    // private static Pattern VERSION_PATTERN =
-    // PatternCache.get("//ldml[^/]*/identity/version\\[@number=\"[^0-9]*\\([0-9.]+\\).*");
-    private static Pattern VERSION_PATTERN = PatternCache.get(".*identity/version.*Revision[: ]*([0-9.]*).*");
-
-    /**
-     * Load the revision from CVS or from the Identity element.
-     *
-     * @param sourceDir
-     * @param fileName
-     * @return
-     */
-    static public String loadFileRevision(String sourceDir, String fileName) {
-        String aVersion = null;
-        File entriesFile = new File(sourceDir + File.separatorChar + "CVS", "Entries");
-        if (entriesFile.exists() && entriesFile.canRead()) {
-            try {
-                BufferedReader r = new BufferedReader(new FileReader(entriesFile.getPath()));
-                String s;
-                while ((s = r.readLine()) != null) {
-                    String lookFor = "/" + fileName + "/";
-                    if (s.startsWith(lookFor)) {
-                        String ver = s.substring(lookFor.length());
-                        ver = ver.substring(0, ver.indexOf('/'));
-                        aVersion = ver;
-                    }
-                }
-                r.close();
-            } catch (Throwable th) {
-                System.err.println(th.toString() + " trying to read CVS Entries file " + entriesFile.getPath());
-                return null;
-            }
-        } else {
-            // no CVS, use file ident.
-            File xmlFile = new File(sourceDir, fileName);
-            if (!xmlFile.exists()) return null;
-            final String bVersion[] = { "unknown" };
-            try {
-                XMLFileReader xfr = new XMLFileReader().setHandler(new SimpleHandler() {
-                    private boolean done = false;
-
-                    // public void handleAttributeDecl(String eName, String aName, String type, String mode, String
-                    // value) {
-                    public void handlePathValue(String p, String v) {
-                        if (!done) {
-                            Matcher m = VERSION_PATTERN.matcher(p);
-                            if (m.matches()) {
-                                // System.err.println("Matches! "+p+" = "+m.group(1));
-                                bVersion[0] = m.group(1);
-                                done = true;
-                            }
-                        }
-                    }
-                });
-                xfr.read(xmlFile.getPath(), -1, true);
-                aVersion = bVersion[0]; // copy from input param
-            } catch (Throwable t) {
-                t.printStackTrace();
-                aVersion = "err";
-                System.err.println("Error reading version of " + xmlFile.getAbsolutePath() + ": " + t.toString());
-            }
-        }
-        // System.err.println("v="+aVersion);
-        return aVersion;
-    }
 
     // // Caching Resolution
     // private static File getCacheName(String sourceDir, String last, String loc)


### PR DESCRIPTION
[CLDR-12038]
- <version> is useless and should be deprecated (separate ticket)
- $Revision:$ keyword behavior under svn was not what we 'enjoyed' before '06
- remove extremely obsolete code for reading CVS metadata directly
- use CLDRFile.GEN_VERSION for ldml2icu version production

##### Checklist

- [x] [CLDR-12038]
- [x] Updated PR title and link in previous line to include Issue number


[CLDR-12038]: https://unicode-org.atlassian.net/browse/CLDR-12038
[CLDR-12038]: https://unicode-org.atlassian.net/browse/CLDR-12038