### PR TITLE
CLDR-13134 Fix wrong background color for values inherited from root

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -315,7 +315,14 @@ public class DataSection implements JSONString {
                     if (inheritedLocale != null && XMLSource.CODE_FALLBACK_ID.equals(inheritedLocale.getBaseName())) {
                         return "fallback_code";
                     }
-                    if (inheritedLocale == CLDRLocale.ROOT) {
+                    /*
+                     * Formerly the following test was "if (inheritedLocale == CLDRLocale.ROOT)", but that was
+                     * unreliable due to more than one CLDRLocale object having the name "root".
+                     * Reference: https://unicode-org.atlassian.net/browse/CLDR-13134
+                     * Also: https://unicode-org.atlassian.net/browse/CLDR-13132
+                     * If and when CLDR-13132 is fixed, the former test with "==" might be OK here.
+                     */
+                    if (inheritedLocale != null && "root".equals(inheritedLocale.getBaseName())) {
                         return "fallback_root";
                     }
                     return "fallback";


### PR DESCRIPTION
-Avoid == due to multiple CLDRLocale objects with name root

-Note: this might not be needed if and when [CLDR-13132] is fixed

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13134
- [x] Updated PR title and link in previous line to include Issue number



[CLDR-13132]: https://unicode-org.atlassian.net/browse/CLDR-13132