### PR TITLE
CLDR-13133 fix CLDRLocale.getInstance

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -169,8 +169,10 @@ public class TestCLDRUtils extends TestFmwk {
     }
 
     public void TestCLDRLocaleEquivalence() {
-        assertEquals("root is caseless", CLDRLocale.getInstance("root"), CLDRLocale.getInstance("RoOt"));
-        assertEquals("root = empty", CLDRLocale.getInstance("root"), CLDRLocale.getInstance(""));
+        assertSame("root is caseless", CLDRLocale.getInstance("root"), CLDRLocale.getInstance("RoOt"));
+        assertSame("root = empty", CLDRLocale.getInstance("root"), CLDRLocale.getInstance(""));
+        assertEquals("ROOT.basename = root", "root", CLDRLocale.ROOT.getBaseName());
+        assertSame("instance of root = ROOT", CLDRLocale.getInstance("root"), CLDRLocale.ROOT);
         String test = "zh-TW-u-co-pinyin";
         assertEquals(test, test, CLDRLocale.getInstance(test).toLanguageTag());
     }

--- a/tools/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -202,27 +202,31 @@ public class DisplayAndInputProcessor {
     }
 
     /**
-     * Constructor, taking locale.
+     * Constructor, taking ULocale and boolean.
      *
-     * @param locale
+     * @param locale the ULocale
+     * @param needsCollator true or false
+     *
+     * Called by getProcessor, with locale = SurveyMain.TRANS_HINT_LOCALE
      */
     public DisplayAndInputProcessor(ULocale locale, boolean needsCollator) {
         init(this.locale = CLDRLocale.getInstance(locale), needsCollator);
     }
 
     /**
-     * Constructor, taking locale.
+     * Constructor, taking ULocale.
      *
-     * @param locale
+     * @param locale the ULocale
      */
     public DisplayAndInputProcessor(ULocale locale) {
-        init(this.locale = CLDRLocale.getInstance(locale), true);
+        init(this.locale = CLDRLocale.getInstance(locale), true /* needsCollator */);
     }
 
     /**
-     * Constructor, taking locale.
+     * Constructor, taking CLDRLocale and boolean.
      *
-     * @param locale
+     * @param locale the CLDRLocale
+     * @param needsCollator true or false
      */
     public DisplayAndInputProcessor(CLDRLocale locale, boolean needsCollator) {
         init(this.locale = locale, needsCollator);

--- a/tools/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1312,7 +1312,7 @@ public class ShowLanguages {
             String curLocale = locale;
             while (status == null) {
                 curLocale = LocaleIDParser.getParent(curLocale);
-                if (curLocale.equals("root")) {
+                if ("root".equals(curLocale)) {
                     status = "&nbsp;";
                     break;
                 }

--- a/tools/java/org/unicode/cldr/util/Factory.java
+++ b/tools/java/org/unicode/cldr/util/Factory.java
@@ -123,7 +123,7 @@ public abstract class Factory implements SublocaleProvider {
     public CLDRFile makeWithFallback(String localeID, DraftStatus madeWithMinimalDraftStatus) {
         String currentLocaleID = localeID;
         Set<String> availableLocales = this.getAvailable();
-        while (!availableLocales.contains(currentLocaleID) && currentLocaleID != "root") {
+        while (!availableLocales.contains(currentLocaleID) && !"root".equals(currentLocaleID)) {
             currentLocaleID = LocaleIDParser.getParent(currentLocaleID);
         }
         return make(currentLocaleID, true, madeWithMinimalDraftStatus);


### PR DESCRIPTION
-LocaleIDParser.getParent return root, not empty string, for _VETTING

-LocaleIDParser.getParent remove SUPPLEMENTAL_NAME test

-LocaleIDParser.getParent call SupplementalDataInfo only if needed

-Prevent creation of multiple instances of root locale

-Improve and extend TestCLDRLocaleEquivalence, assertSame not assertEqual

-Normalize strings equivalent to root before checking stringToLoc

-New function rootMatches encapsulates string equivalence to root

-New constant ROOT_NAME = root

-Make getSiblings and getVendorStatus more bomb-proof in case getParent returns null

-Use !equals instead of != to test string inequality in makeWithFallback

-LocaleIDParser.setVariants guard against null parentID

-Comments, clean-up

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13133
- [x] Updated PR title and link in previous line to include Issue number

