### PR TITLE
CLDR-13090 Adding a trivial utility method to return whether a path element is ordered.

### DIFF
--- a/tools/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/java/org/unicode/cldr/util/DtdData.java
@@ -530,6 +530,10 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             return isDeprecatedElement;
         }
 
+        public boolean isOrdered() {
+            return isOrderedElement;
+        }
+
         public ElementStatus getElementStatus() {
             return elementStatus;
         }


### PR DESCRIPTION
This is needed for the new API work since ordered elements need slightly different treatment in the code.

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13090
- [x] Updated PR title and link in previous line to include Issue number