### PR TITLE
CLDR-11049 First version of the new lightweight data access API for ICU data conversion.

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/api/AllTests.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/AllTests.java
@@ -1,0 +1,32 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableList;
+import com.ibm.icu.dev.test.TestFmwk.TestGroup;
+
+import java.io.PrintWriter;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class AllTests extends TestGroup {
+    private static final ImmutableList<Class<?>> TEST_CLASSES = ImmutableList.of(
+        CldrFileDataSourceTest.class,
+        CldrPathTest.class,
+        CldrValueTest.class,
+        PrefixVisitorTest.class,
+        XmlDataSourceTest.class);
+    
+    public static void main(String[] args) {
+        System.setProperty("CLDR_ENVIRONMENT", "UNITTEST");
+        new AllTests().run(args, new PrintWriter(System.out));
+    }
+
+    private static String[] getTestClassNames() {
+        return TEST_CLASSES.stream()
+            .map(Class::getName)
+            .collect(toImmutableList()).toArray(new String[0]);
+    }
+    
+    public AllTests() {
+        super("org.unicode.cldr.api", getTestClassNames(), "API unit tests");
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/CldrFileDataSourceTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/CldrFileDataSourceTest.java
@@ -1,0 +1,64 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.ibm.icu.dev.test.TestFmwk;
+import org.unicode.cldr.util.CLDRConfig;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
+
+public class CldrFileDataSourceTest extends TestFmwk {
+    // The config knows if it's being run as part of a test. This is NOT immutable (but this test
+    // won't mutate it anyway).
+    private static final CLDRConfig testInfo = CLDRConfig.getInstance();
+
+    public void TestRootPathsAndValues() {
+        CldrFileDataSource src = new CldrFileDataSource(testInfo.getRoot());
+        Map<CldrPath, CldrValue> arbitraryOrderMap = new LinkedHashMap<>();
+        src.accept(ARBITRARY, value -> arbitraryOrderMap.put(value.getPath(), value));
+
+        Map<CldrPath, CldrValue> dtdOrderMap = new LinkedHashMap<>();
+        src.accept(DTD, value -> dtdOrderMap.put(value.getPath(), value));
+
+        // Map equality doesn't care about key order.
+        assertEquals("maps are equal", arbitraryOrderMap, dtdOrderMap);
+
+        // This could give a false negative if the DTD order ever miraculously matched hash order,
+        // and if it ever did, it should be sufficient to just change any aspect of the test data.
+        List<CldrPath> arbitraryKeyList = new ArrayList<>(arbitraryOrderMap.keySet());
+        List<CldrPath> dtdKeyList = new ArrayList<>(dtdOrderMap.keySet());
+        assertNotEquals("dtd order differs", arbitraryKeyList, dtdKeyList);
+
+        arbitraryKeyList.sort(Comparator.naturalOrder());
+        assertEquals("sorted order same", arbitraryKeyList, dtdKeyList);
+    }
+
+    public void TestUnresolvedVsResolved() {
+        CldrFileDataSource unresolved = new CldrFileDataSource(testInfo.getCLDRFile("en_GB", false));
+        Map<CldrPath, CldrValue> unresolvedMap = new LinkedHashMap<>();
+        unresolved.accept(DTD, value -> unresolvedMap.put(value.getPath(), value));
+
+        CldrFileDataSource resolved = new CldrFileDataSource(testInfo.getCLDRFile("en_GB", true));
+        Map<CldrPath, CldrValue> resolvedMap = new LinkedHashMap<>();
+        resolved.accept(DTD, value -> resolvedMap.put(value.getPath(), value));
+
+        assertTrue("unresolved is subset", unresolvedMap.size() < resolvedMap.size());
+        Set<CldrPath> onlyUnresolved = Sets.difference(unresolvedMap.keySet(), resolvedMap.keySet());
+        assertEquals("unresolved is subset", ImmutableSet.of(), onlyUnresolved);
+    }
+
+    public void TestNoDtdVersionPath() {
+        CldrFileDataSource unresolved = new CldrFileDataSource(testInfo.getCLDRFile("en_GB", false));
+        unresolved.accept(DTD, v ->
+            assertFalse("is DTD version string",
+                v.getPath().toString().startsWith("//ldml/version")));
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/CldrPathTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/CldrPathTest.java
@@ -1,0 +1,178 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.dev.test.TestFmwk;
+
+import java.util.Comparator;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * Tests for the core CLDR path representation. Since this is an immutable value type, the tests
+ * largely focus on things like parsing and validity checking. 
+ */
+// TODO(dbeaumont): Add more tests for the details of DTD ordering.
+public final class CldrPathTest extends TestFmwk {
+    // An arbitrary set of full path strings (must have value elements) and their corresponding
+    // distinguishing paths.
+    private static final ImmutableMap<String, String> FULL_PATHS =
+        ImmutableMap.<String, String>builder()
+            .put(
+                "//ldmlBCP47/keyword"
+                    + "/key[@name=\"tz\"][@description=\"Time zone key\"][@alias=\"timezone\"]"
+                    + "/type[@name=\"adalv\"][@description=\"Andorra\"][@alias=\"Europe/Andorra\"]",
+                "//ldmlBCP47/keyword/key[@name=\"tz\"]/type[@name=\"adalv\"]")
+            .put("//supplementalData/info[@iso4217=\"AMD\"][@digits=\"2\"]"
+                    + "[@rounding=\"0\"][@cashDigits=\"0\"][@cashRounding=\"0\"]",
+                "//supplementalData/info[@iso4217=\"AMD\"]")
+            .build();
+
+    // An arbitrary set of distinguishing path strings (no value elements).
+    private static final ImmutableList<String> DISTINGUISHING_PATHS =
+        ImmutableList.<String>builder()
+            .addAll(FULL_PATHS.values())
+            .add("//ldml/localeDisplayNames/territories/territory[@type=\"US\"]")
+            .add("//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]")
+            .add("//ldml/dates/fields/field[@type=\"era\"]/displayName")
+            .add("//ldml/rbnf/rulesetGrouping[@type=\"NumberingSystemRules\"]"
+                + "/ruleset#0[@type=\"armenian-lower\"]/rbnfrule#10")
+            .build();
+
+    public void TestSimple() {
+        CldrPath p = CldrPath.parseDistinguishingPath(
+            "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]");
+        assertEquals("path length", 4, p.getLength());
+        assertEquals("element name", "territory", p.getName());
+        assertEquals("sort index", -1, p.getSortIndex());
+        assertEquals("attribute count", 1, p.getAttributeCount());
+        assertEquals("parent name", "territories", p.getParent().getName());
+        assertEquals("parent attribute count", 0, p.getParent().getAttributeCount());
+    }
+
+    public void TestSortIndex() {
+        CldrPath p = CldrPath.parseDistinguishingPath(
+            "//ldml/rbnf/rulesetGrouping[@type=\"NumberingSystemRules\"]"
+                + "/ruleset#0[@type=\"armenian-lower\"]/rbnfrule#10");
+        assertEquals("path length", 5, p.getLength());
+
+        assertEquals("element name", "rbnfrule", p.getName());
+        assertEquals("sort index", 10, p.getSortIndex());
+        assertEquals("element name", "ruleset", p.getParent().getName());
+        assertEquals("sort index", 0, p.getParent().getSortIndex());
+    }
+
+    public void TestInvalid() {
+        try {
+            CldrPath.parseDistinguishingPath("");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message", "path must not be empty", e.getMessage());
+        }
+        try {
+            CldrPath.parseDistinguishingPath("//");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message", "invalid path: //", e.getMessage());
+        }
+        try {
+            CldrPath.parseDistinguishingPath("Hello World");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message", "invalid path: Hello World", e.getMessage());
+        }
+    }
+
+    public void TestInvalidDtd() {
+        try {
+            CldrPath.parseDistinguishingPath("//foo");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message", "unknown DTD type: //foo", e.getMessage());
+        }
+    }
+
+    public void TestInvalidElementName() {
+        try {
+            CldrPath.parseDistinguishingPath("//ldml/foo");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message", "invalid path: //ldml/foo", e.getMessage());
+        }
+    }
+
+    public void TestInvalidAtributeName() {
+        try {
+            CldrPath.parseDistinguishingPath(
+                "//ldml/localeDisplayNames/territories/territory[@foo=\"CH\"]");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message",
+                "invalid path: //ldml/localeDisplayNames/territories/territory[@foo=\"CH\"]",
+                e.getMessage());
+        }
+    }
+
+    public void TestDistinguishingPathParsing() {
+        for (String s : DISTINGUISHING_PATHS) {
+            CldrPath.parseDistinguishingPath(s);
+        }
+        // Paths with value attributes should not parse. 
+        for (String s : FULL_PATHS.keySet()) {
+            try {
+                CldrPath.parseDistinguishingPath(s);
+                fail("expected IllegalArgumentException");
+            } catch (IllegalArgumentException e) {
+                assertTrue("error message matches",
+                    e.getMessage().matches(
+                        "unexpected value attribute '.*' in distinguishing path: .*"));
+            }
+        }
+    }
+
+    public void TestFullPathParsing() {
+        for (String s : FULL_PATHS.keySet()) {
+            // The parsed path should be only the distinguishing path.
+            CldrPath p = CldrValue.parseValue(s, "").getPath();
+            assertEquals("distinguishing paths", FULL_PATHS.get(s), p.toString());
+        }
+    }
+
+    public void TestDistinguishingPathRoundTrip() {
+        for (String s1 : DISTINGUISHING_PATHS) {
+            CldrPath p1 = CldrPath.parseDistinguishingPath(s1);
+            String s2 = p1.toString();
+            assertEquals("path string", s1, s2);
+            CldrPath p2 = CldrPath.parseDistinguishingPath(p1.toString());
+            assertEquals("paths", p1, p2);
+        }
+    }
+
+    public void TestDtdOrder() {
+        ImmutableList<String> sorted =
+            DISTINGUISHING_PATHS.stream()
+                .map(CldrPath::parseDistinguishingPath)
+                .sorted(Comparator.naturalOrder())
+                .map(Object::toString)
+                .collect(toImmutableList());
+        assertEquals("sorted paths", ImmutableList.of(
+            "//ldmlBCP47/keyword/key[@name=\"tz\"]/type[@name=\"adalv\"]",
+            "//supplementalData/info[@iso4217=\"AMD\"]",
+            "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]",
+            "//ldml/localeDisplayNames/territories/territory[@type=\"US\"]",
+            "//ldml/dates/fields/field[@type=\"era\"]/displayName",
+            "//ldml/rbnf/rulesetGrouping[@type=\"NumberingSystemRules\"]"
+                + "/ruleset#0[@type=\"armenian-lower\"]/rbnfrule#10"),
+            sorted);
+    }
+
+    public void TestDraftStatus() {
+        CldrPath p = CldrPath.parseDistinguishingPath(
+            "//ldml/numbers/currencies/currency[@type=\"MGA\"]"
+                + "/displayName[@count=\"one\"][@draft=\"contributed\"]");
+        assertEquals("path string",
+            "//ldml/numbers/currencies/currency[@type=\"MGA\"]/displayName[@count=\"one\"]",
+            p.toString());
+        assertEquals("draft status", CldrDraftStatus.CONTRIBUTED, p.getDraftStatus().get());
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/CldrValueTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/CldrValueTest.java
@@ -1,0 +1,81 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.dev.test.TestFmwk;
+
+/**
+ * Tests for the core CLDR value representation. Since this is an immutable value type, the tests
+ * largely focus on things like parsing and validity checking. 
+ */
+public class CldrValueTest extends TestFmwk {
+
+    public void TestNoValueAttributes() {
+        String dpath = "//ldml/localeDisplayNames/territories/territory[@type=\"US\"]";
+        CldrValue value = CldrValue.parseValue(dpath, "Hello World");
+        assertEquals("value", "Hello World", value.getValue());
+        assertTrue("no attributes", value.getValueAttributes().isEmpty());
+        assertEquals("path", dpath, value.getPath().toString());
+    }
+
+    public void TestValueAttributes() {
+        CldrValue v = CldrValue.parseValue("//supplementalData/info[@digits=\"2\"][@iso4217=\"AMD\"]"
+            + "[@cashRounding=\"0\"][@rounding=\"0\"][@cashDigits=\"0\"]", "");
+        assertEquals("value", "", v.getValue());
+        // The map contains only the value attributes (no "iso4217") and in DTD order. 
+        ImmutableMap<AttributeKey, String> expected = ImmutableMap.of(
+            AttributeKey.keyOf("info", "digits"), "2",
+            AttributeKey.keyOf("info", "rounding"), "0",
+            AttributeKey.keyOf("info", "cashDigits"), "0",
+            AttributeKey.keyOf("info", "cashRounding"), "0");
+        assertEquals("attributes", expected, v.getValueAttributes());
+        // Attribute order is normalized to DTD order.
+        assertEquals("attribute order",
+            expected.keySet().asList(), v.getValueAttributes().keySet().asList());
+    }
+
+    public void TestRetainExplicitNonDefault() {
+        // The "deprecated" attribute has a default value of "false" and should be ignored, even if
+        // explicitly present.
+        CldrValue v = CldrValue.parseValue(
+            "//ldmlBCP47/keyword"
+                + "/key[@name=\"cu\"][@description=\"Currency type key\"][@alias=\"currency\"]"
+                + "/type[@name=\"xau\"][@description=\"Gold\"][@deprecated=\"true\"]",
+            "");
+        assertEquals("path string",
+            "//ldmlBCP47/keyword/key[@name=\"cu\"]/type[@name=\"xau\"]", v.getPath().toString());
+        AttributeKey key = AttributeKey.keyOf("type", "deprecated");
+        assertTrue("deprecated", v.getValueAttributes().containsKey(key));
+    }
+
+    public void TestValueEquality() {
+        CldrValue v = CldrValue.parseValue(
+            "//supplementalData/info[@iso4217=\"AMD\"][@digits=\"2\"]"
+                + "[@rounding=\"0\"][@cashDigits=\"0\"][@cashRounding=\"0\"]", "value");
+        // Same value, but attributes in a different order in the string (does not matter).
+        CldrValue vDiffOrder = CldrValue.parseValue(
+            "//supplementalData/info[@iso4217=\"AMD\"][@cashRounding=\"0\"]"
+                + "[@cashDigits=\"0\"][@rounding=\"0\"][@digits=\"2\"]", "value");
+        // Different value does matter.
+        CldrValue vDiffValue = CldrValue.parseValue(
+            "//supplementalData/info[@iso4217=\"AMD\"][@digits=\"2\"]"
+                + "[@rounding=\"0\"][@cashDigits=\"0\"][@cashRounding=\"0\"]", "different");
+        // Different "value" attribute value does matter.
+        CldrValue vDiffAttr = CldrValue.parseValue(
+            "//supplementalData/info[@iso4217=\"AMD\"][@digits=\"3\"]"
+                + "[@rounding=\"0\"][@cashDigits=\"0\"][@cashRounding=\"0\"]", "value");
+        // Differing "distinguishing" attribute does matter (that's part of the CldrPath).
+        CldrValue vSameDiffPath = CldrValue.parseValue(
+            "//supplementalData/info[@iso4217=\"XXX\"][@digits=\"2\"]"
+                + "[@rounding=\"0\"][@cashDigits=\"0\"][@cashRounding=\"0\"]", "value");
+        assertEquals("equal instances", v, vDiffOrder);
+        assertNotEquals("unequal path", v, vSameDiffPath);
+        assertNotEquals("unequal values", v, vDiffValue);
+        assertNotEquals("unequal attributes", v, vDiffAttr);
+
+        // Also do some hashcode checking (not all combinations).
+        assertEquals("equal hashcode", v.hashCode(), vDiffOrder.hashCode());
+        // Clash is technically possible but effectively impossible.
+        assertNotEquals("unequal hashcode", v.hashCode(), vDiffValue.hashCode());
+        assertNotEquals("unequal hashcode", v.hashCode(), vDiffAttr.hashCode());
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/PrefixVisitorTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/PrefixVisitorTest.java
@@ -1,0 +1,193 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.dev.test.TestFmwk;
+import org.unicode.cldr.api.CldrData.PrefixVisitor;
+
+import java.util.ArrayList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
+
+/**
+ * Tests for the code which converts a sequence of path/value pairs into a nested sequence of path
+ * prefixes (this is necessary when using prefix visitors for data obtained via CLDRFile). 
+ */
+public final class PrefixVisitorTest extends TestFmwk {
+
+    public void TestEmptyData() {
+        CldrData testData = CldrDataSupplier.forValues(ImmutableList.of());
+        PrefixVisitor v = new PrefixVisitor() {
+            @Override
+            public void visitPrefixStart(CldrPath prefix, Context ctx) {
+                fail("no visitation should occur");
+            }
+
+            @Override
+            public void visitPrefixEnd(CldrPath prefix) {
+                fail("no visitation should occur");
+            }
+        };
+        testData.accept(ARBITRARY, v);
+    }
+
+    public void TestSinglePathProcessing() {
+        List<CldrValue> values = new ArrayList<>();
+        addTo(values, "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]", "Switzerland");
+
+        CldrData testData = CldrDataSupplier.forValues(values);
+        List<String> prefixes = new ArrayList<>();
+        PrefixVisitor v = new PrefixVisitor() {
+            @Override
+            public void visitPrefixStart(CldrPath prefix, Context ctx) {
+                prefixes.add("+" + prefix);
+            }
+
+            @Override
+            public void visitPrefixEnd(CldrPath prefix) {
+                prefixes.add("-" + prefix);
+            }
+        };
+        testData.accept(ARBITRARY, v);
+        List<String> expected = ImmutableList.of(
+            "+//ldml",
+            "+//ldml/localeDisplayNames",
+            "+//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames",
+            "-//ldml");
+        assertEquals("cldr path prefixes", expected, prefixes);
+    }
+
+    public void TestSameParentPathProcessing() {
+        List<CldrValue> values = new ArrayList<>();
+        addTo(values, "//ldml/localeDisplayNames/territories/territory[@type=\"BE\"]", "Belgium");
+        addTo(values, "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]", "Switzerland");
+        addTo(values, "//ldml/localeDisplayNames/territories/territory[@type=\"IN\"]", "India");
+
+        CldrData testData = CldrDataSupplier.forValues(values);
+        List<String> prefixes = new ArrayList<>();
+        PrefixVisitor v = new PrefixVisitor() {
+            @Override
+            public void visitPrefixStart(CldrPath prefix, Context ctx) {
+                prefixes.add("+" + prefix);
+            }
+
+            @Override
+            public void visitPrefixEnd(CldrPath prefix) {
+                prefixes.add("-" + prefix);
+            }
+        };
+        testData.accept(ARBITRARY, v);
+        // Same as above since the transition to sibling paths does not trigger start/end events.
+        List<String> expected = ImmutableList.of(
+            "+//ldml",
+            "+//ldml/localeDisplayNames",
+            "+//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames",
+            "-//ldml");
+        assertEquals("cldr path prefixes", expected, prefixes);
+    }
+
+    public void TestMultiplePathProcessing() {
+        List<CldrValue> values = new ArrayList<>();
+        // Note that the order is deliberately "bad" (since the prefixes are not grouped) but this
+        // should be corrected for, even when path order is specified as "ARBITRARY".
+        addTo(values, "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]", "Switzerland");
+        addTo(values,
+            "//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras/eraAbbr/era[@type=\"0\"]",
+            "BE");
+        addTo(values, "//ldml/dates/fields/field[@type=\"era\"]/displayName", "era");
+        addTo(values, "//ldml/localeDisplayNames/languages/language[@type=\"fr\"]", "French");
+
+        CldrData testData = CldrDataSupplier.forValues(values);
+        List<String> prefixes = new ArrayList<>();
+        PrefixVisitor v = new PrefixVisitor() {
+            @Override
+            public void visitPrefixStart(CldrPath prefix, Context ctx) {
+                prefixes.add("+" + prefix);
+            }
+
+            @Override
+            public void visitPrefixEnd(CldrPath prefix) {
+                prefixes.add("-" + prefix);
+            }
+        };
+        testData.accept(ARBITRARY, v);
+        List<String> expectedNested = ImmutableList.of(
+            "+//ldml",
+            "+//ldml/dates",
+            "+//ldml/dates/calendars",
+            "+//ldml/dates/calendars/calendar[@type=\"buddhist\"]",
+            "+//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras",
+            "+//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras/eraAbbr",
+            "-//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras/eraAbbr",
+            "-//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras",
+            "-//ldml/dates/calendars/calendar[@type=\"buddhist\"]",
+            "-//ldml/dates/calendars",
+            "+//ldml/dates/fields",
+            "+//ldml/dates/fields/field[@type=\"era\"]",
+            "-//ldml/dates/fields/field[@type=\"era\"]",
+            "-//ldml/dates/fields",
+            "-//ldml/dates",
+            "+//ldml/localeDisplayNames",
+            "+//ldml/localeDisplayNames/languages",
+            "-//ldml/localeDisplayNames/languages",
+            "+//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames",
+            "-//ldml");
+        assertEquals("cldr path prefixes", expectedNested, prefixes);
+
+        prefixes.clear();
+        testData.accept(DTD, v);
+        List<String> expectedDtd = ImmutableList.of(
+            "+//ldml",
+            "+//ldml/localeDisplayNames",
+            "+//ldml/localeDisplayNames/languages",
+            "-//ldml/localeDisplayNames/languages",
+            "+//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames/territories",
+            "-//ldml/localeDisplayNames",
+            "+//ldml/dates",
+            "+//ldml/dates/calendars",
+            "+//ldml/dates/calendars/calendar[@type=\"buddhist\"]",
+            "+//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras",
+            "+//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras/eraAbbr",
+            "-//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras/eraAbbr",
+            "-//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras",
+            "-//ldml/dates/calendars/calendar[@type=\"buddhist\"]",
+            "-//ldml/dates/calendars",
+            "+//ldml/dates/fields",
+            "+//ldml/dates/fields/field[@type=\"era\"]",
+            "-//ldml/dates/fields/field[@type=\"era\"]",
+            "-//ldml/dates/fields",
+            "-//ldml/dates",
+            "-//ldml");
+        assertEquals("cldr path prefixes", expectedDtd, prefixes);
+    }
+
+    // Note: Just testing the test supplier, not the real suppliers (their tests are elsewhere).
+    public void TestParentPathsNotAllowed() {
+        List<CldrValue> values = new ArrayList<>();
+        addTo(values, "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]", "Switzerland");
+        addTo(values, "//ldml/localeDisplayNames/territories", "Invalid Parent Path");
+
+        try {
+            CldrDataSupplier.forValues(values);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue("exception message contains",
+                e.getMessage().contains("//ldml/localeDisplayNames/territories"));
+        }
+    }
+
+    private static void addTo(List<CldrValue> values, String fullPath, String value) {
+        values.add(CldrValue.parseValue(fullPath, value));
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/XmlDataSourceTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/XmlDataSourceTest.java
@@ -1,0 +1,208 @@
+package org.unicode.cldr.api;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.ibm.icu.dev.test.TestFmwk;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
+import static org.unicode.cldr.api.CldrDataType.BCP47;
+import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
+import static org.unicode.cldr.api.CldrDraftStatus.UNCONFIRMED;
+
+/**
+ * Tests XML file parsing and path/value generation. These focus on end-to-end parsing of fake data
+ * into expected sequences of path/value pairs. In particular this tests that unwanted attributes
+ * are not generated in the final paths and the output ordering is as expected.
+ */
+public class XmlDataSourceTest extends TestFmwk {
+
+    // Note that the XML paths specified for the dummy XML data must still represent the expected
+    // local file structure, since they are used to resolve relative references to the DTDs.
+
+    public void TestSimple() {
+        ListMultimap<Path, String> files = ArrayListMultimap.create();
+        addFile(files, "common/bcp47/foo.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
+            "<!DOCTYPE ldmlBCP47 SYSTEM \"../../common/dtd/ldmlBCP47.dtd\">",
+            "<ldmlBCP47>",
+            "  <version number=\"42\"/>",
+            "  <keyword>",
+            "    <key name=\"cf\" description=\"Currency format key\" since=\"28\">",
+            "      <type name=\"standard\" description=\"Standard format\" since=\"28\"/>",
+            "      <type name=\"account\" description=\"Accounting format\" since=\"28\"/>",
+            "    </key>",
+            "    <key name=\"cu\" description=\"Currency type key\" alias=\"currency\">",
+            "      <type name=\"adp\" description=\"Andorran Peseta\" since=\"1.9\"/>",
+            "      <type name=\"zar\" description=\"South African Rand\"/>",
+            "    </key>",
+            "  </keyword>",
+            "</ldmlBCP47>");
+        addFile(files, "common/bcp47/bar.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
+            "<!DOCTYPE ldmlBCP47 SYSTEM \"../../common/dtd/ldmlBCP47.dtd\">",
+            "<ldmlBCP47>",
+            "  <version number=\"42\"/>",
+            "  <keyword>",
+            "    <key name=\"tz\" description=\"Time zone key\" alias=\"timezone\">",
+            "      <type name=\"adalv\" description=\"Andorra\" alias=\"Europe/Andorra\"/>",
+            "      <type name=\"fjsuv\" description=\"Fiji\" alias=\"Pacific/Fiji\"/>",
+            "    </key>",
+            "  </keyword>",
+            "</ldmlBCP47>");
+        XmlDataSource xmlDataSource =
+            new XmlDataSource(BCP47, files.keySet(), UNCONFIRMED, openFileFn(files));
+
+        Map<CldrPath, CldrValue> expected = new LinkedHashMap<>();
+        addTo(expected, "//ldmlBCP47/keyword"
+            + "/key[@name=\"cf\"][@description=\"Currency format key\"][@since=\"28\"][@deprecated=\"false\"]"
+            + "/type[@name=\"standard\"][@description=\"Standard format\"][@since=\"28\"][@deprecated=\"false\"]");
+        addTo(expected, "//ldmlBCP47/keyword"
+            + "/key[@name=\"cf\"][@description=\"Currency format key\"][@since=\"28\"][@deprecated=\"false\"]"
+            + "/type[@name=\"account\"][@description=\"Accounting format\"][@since=\"28\"][@deprecated=\"false\"]");
+        addTo(expected, "//ldmlBCP47/keyword"
+            + "/key[@name=\"cu\"][@description=\"Currency type key\"][@alias=\"currency\"][@deprecated=\"false\"]"
+            + "/type[@name=\"adp\"][@description=\"Andorran Peseta\"][@since=\"1.9\"][@deprecated=\"false\"]");
+        addTo(expected, "//ldmlBCP47/keyword"
+            + "/key[@name=\"cu\"][@description=\"Currency type key\"][@alias=\"currency\"][@deprecated=\"false\"]"
+            + "/type[@name=\"zar\"][@description=\"South African Rand\"][@deprecated=\"false\"]");
+        addTo(expected, "//ldmlBCP47/keyword"
+            + "/key[@name=\"tz\"][@description=\"Time zone key\"][@alias=\"timezone\"][@deprecated=\"false\"]"
+            + "/type[@name=\"adalv\"][@description=\"Andorra\"][@alias=\"Europe/Andorra\"][@deprecated=\"false\"]");
+        addTo(expected, "//ldmlBCP47/keyword"
+            + "/key[@name=\"tz\"][@description=\"Time zone key\"][@alias=\"timezone\"][@deprecated=\"false\"]"
+            + "/type[@name=\"fjsuv\"][@description=\"Fiji\"][@alias=\"Pacific/Fiji\"][@deprecated=\"false\"]");
+        ImmutableList<CldrPath> naturalOrderedPaths = ImmutableList.copyOf(expected.keySet());
+        ImmutableList<CldrPath> dtdOrderedPaths = ImmutableList.sortedCopyOf(expected.keySet());
+        // We want to check that DTD ordering will typically differ from "natural" order.
+        assertNotEquals("check expectations", naturalOrderedPaths, dtdOrderedPaths);
+
+        Map<CldrPath, CldrValue> out = new LinkedHashMap<>();
+        xmlDataSource.accept(ARBITRARY, value -> out.put(value.getPath(), value));
+        assertEquals("paths and values", expected, out);
+        assertEquals("paths order", naturalOrderedPaths, ImmutableList.copyOf(out.keySet()));
+
+        out.clear();
+        xmlDataSource.accept(NESTED_GROUPING, value -> out.put(value.getPath(), value));
+        assertEquals("paths and values", expected, out);
+        assertEquals("paths order", naturalOrderedPaths, ImmutableList.copyOf(out.keySet()));
+
+        out.clear();
+        xmlDataSource.accept(DTD, value -> out.put(value.getPath(), value));
+        assertEquals("paths and values", expected, out);
+        assertEquals("paths order", dtdOrderedPaths, ImmutableList.copyOf(out.keySet()));
+    }
+    
+    public void TestBadElementNesting() {
+        ListMultimap<Path, String> files = ArrayListMultimap.create();
+        addFile(files, "common/supplemental/bad.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
+            "<!DOCTYPE supplementalData SYSTEM \"../../common/dtd/ldmlSupplemental.dtd\">",
+            "<supplementalData>",
+            "  <version number=\"42\"/>",
+            "  <currencyData>",
+            "    <fractions>",
+            "      <info iso4217=\"ADP\" digits=\"0\" rounding=\"0\"/>",
+            "    </fractions>",
+            "    <region iso3166=\"AC\">",
+            "      <currency iso4217=\"SHP\" from=\"1976-01-01\"/>",
+            "    </region>",
+            "    <fractions>",
+            "      <info iso4217=\"AFN\" digits=\"0\" rounding=\"0\"/>",
+            "    </fractions>",
+            "    <region iso3166=\"AE\">",
+            "      <currency iso4217=\"AED\" from=\"1973-05-19\"/>",
+            "    </region>",
+            "  </currencyData>",
+            "</supplementalData>");
+        XmlDataSource badDataSource =
+            new XmlDataSource(SUPPLEMENTAL, files.keySet(), UNCONFIRMED, openFileFn(files));
+        try {
+            badDataSource.accept(ARBITRARY, v -> {});
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message", "error reading common/supplemental/bad.xml (line 18)", e.getMessage());
+        }
+    }
+
+    // This is an important restriction based on the observation that a lot of the existing path
+    // and regex based transformation logic implicitly relies on " not being allowed in attribute
+    // values. If it were, then the path string representation would have to change, path parsing
+    // would need to be changed and a lot of the regex transformation logic would need to be
+    // re-thought.
+    public void TestDoubleQuotesDisallowedAsAttributeValue() {
+        ListMultimap<Path, String> files = ArrayListMultimap.create();
+        addFile(files, "common/supplemental/bad.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
+            "<!DOCTYPE supplementalData SYSTEM \"../../common/dtd/ldmlSupplemental.dtd\">",
+            "<supplementalData>",
+            "  <version number=\"42\"/>",
+            "  <characters>",
+            "    <character-fallback>",
+            "      <character value=\"'\">",
+            "        <substitute>single-quote</substitute>",
+            "      </character>",
+            "      <character value='\"'>",
+            "        <substitute>double-quote</substitute>",
+            "      </character>",
+            "    </character-fallback>",
+            "  </characters>",
+            "</supplementalData>");
+        XmlDataSource badDataSource =
+            new XmlDataSource(SUPPLEMENTAL, files.keySet(), UNCONFIRMED, openFileFn(files));
+        try {
+            badDataSource.accept(ARBITRARY, v -> {});
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("error message",
+                "unsupported '\"' in attribute value: \"", e.getMessage());
+        }
+    }
+
+    public void TestNoDtdVersionPath() {
+        ListMultimap<Path, String> files = ArrayListMultimap.create();
+        addFile(files, "common/supplemental/bad.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>",
+            "<!DOCTYPE supplementalData SYSTEM \"../../common/dtd/ldmlSupplemental.dtd\">",
+            "<supplementalData>",
+            "  <version number=\"42\"/>",
+            "  <characters>",
+            "    <character-fallback>",
+            "      <character value=\"'\">",
+            "        <substitute>single-quote</substitute>",
+            "      </character>",
+            "    </character-fallback>",
+            "  </characters>",
+            "</supplementalData>");
+        XmlDataSource src =
+            new XmlDataSource(SUPPLEMENTAL, files.keySet(), UNCONFIRMED, openFileFn(files));
+        src.accept(DTD, v ->
+            assertFalse("is DTD version string",
+                v.getPath().toString().startsWith("//supplementalData/version")));
+    }
+
+    private static void addFile(ListMultimap<Path, String> files, String path, String... lines) {
+        files.putAll(Paths.get(path), Arrays.asList(lines));
+    }
+
+    private static Function<Path, Reader> openFileFn(ListMultimap<Path, String> files) {
+        return p -> new StringReader(Joiner.on('\n').join(files.get(p)));
+    }
+
+    private static void addTo(Map<CldrPath, CldrValue> map, String fullPath) {
+        CldrValue v = CldrValue.parseValue(fullPath, "");
+        map.put(v.getPath(), v);
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAll.java
@@ -226,6 +226,7 @@ public class TestAll extends TestGroup {
             "org.unicode.cldr.unittest.TestCldrFactory",
             "org.unicode.cldr.unittest.TestUnContainment",
             //            "org.unicode.cldr.unittest.TestCollators" See Ticket #8288
+            "org.unicode.cldr.api.AllTests",
         },
             "All tests in CLDR");
     }

--- a/tools/java/org/unicode/cldr/api/AbstractDataSource.java
+++ b/tools/java/org/unicode/cldr/api/AbstractDataSource.java
@@ -1,0 +1,52 @@
+package org.unicode.cldr.api;
+
+import java.util.Map;
+
+/**
+ * Base class for any non-trivial implementation of the CldrData interface. The main benefit of
+ * using this class is that it implements prefix visitation automatically using {@link
+ * PrefixVisitorHost} to reconstruct path hierarchy visitation from a sequence of leaf paths and
+ * values. It also enforces policy checks to avoid emitting potentially duplicate paths.
+ */
+abstract class AbstractDataSource implements CldrData {
+    AbstractDataSource() {}
+
+    // Implements prefix visitation by accepting values in nested grouping order to reconstruct
+    // intermediate prefix paths.
+    @Override
+    public final void accept(PathOrder order, PrefixVisitor visitor) {
+        PrefixVisitorHost.accept(this::accept, order, visitor);
+    }
+
+    void safeVisit(
+        CldrPath cldrPath, String value, Map<AttributeKey, String> valueAttributes, ValueVisitor visitor) {
+
+        if (shouldEmit(cldrPath)) {
+            CldrValue cldrValue = CldrValue.create(value, valueAttributes, cldrPath);
+            safeVisit(cldrValue, visitor);
+        }
+    }
+
+    private boolean shouldEmit(CldrPath path) {
+        // Hacky way to detect the version declaration in LDML files (which must always be
+        // skipped since they are duplicate paths and reveal XML file boundaries). The path is
+        // always "//ldmlXxxx/version" for some DTD type.
+        if (path.getLength() == 2 && path.getName().equals("version")) {
+            return false;
+        }
+        // Other tests can go here if we need to skip other paths/values.
+        return true;
+    }
+
+    // Helper to wrap the visit method and report errors that occur.
+    static void safeVisit(CldrValue v, ValueVisitor visitor) {
+        try {
+            visitor.visit(v);
+        } catch (RuntimeException e) {
+            // TODO: Throw wrapped exception but ensure it's not rewrapped by parent visitors!
+            System.err.format("Exception thrown by value visitor for value: %s\n", v);
+            System.err.println(e);
+            e.printStackTrace(System.err);
+        }
+    }
+}

--- a/tools/java/org/unicode/cldr/api/AttributeKey.java
+++ b/tools/java/org/unicode/cldr/api/AttributeKey.java
@@ -1,0 +1,260 @@
+package org.unicode.cldr.api;
+
+import com.google.common.base.Ascii;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableTable;
+import org.unicode.cldr.util.DtdData.Attribute;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableTable.toImmutableTable;
+import static java.util.function.Function.identity;
+import static org.unicode.cldr.util.DtdData.AttributeStatus.distinguished;
+import static org.unicode.cldr.util.DtdData.AttributeStatus.value;
+
+/**
+ * Immutable identifier which holds both an attribute's name and the path element it is associated
+ * with. It is expected that key instances will be created as static constants in code rather than
+ * being generated each time they are used.
+ *
+ * <p>As well as providing a key for looking up attribute values from {@link CldrPath} or {@link
+ * CldrValue}, this class offers accessor methods to provide additional common semantics. This
+ * includes checking and parsing boolean values, and splitting lists. It is generally preferred to
+ * use the methods from this class rather than accessing the raw attribute value.
+ *
+ * <p>For example, prefer:
+ * <pre>{@code
+ *   // The attribute value cannot be null.
+ *   String attribute = REQUIRED_ATTRIBUTE_KEY.valueFrom(path);
+ * }</pre>
+ * to:
+ * <pre>{@code
+ *   // This could be null.
+ *   String attribute = path.get(REQUIRED_ATTRIBUTE_KEY);
+ * }</pre>
+ *
+ */
+// Note: Using Guava's @AutoValue library would remove all this boiler-plate.
+public final class AttributeKey {
+    // Unsorted cache of all possible known attribute keys (not including keys for elements in
+    // external namespaces (e.g. "icu:").
+    private static final ImmutableTable<String, String, AttributeKey> KNOWN_KEYS =
+        Arrays.stream(CldrDataType.values())
+            .flatMap(CldrDataType::getElements)
+            .flatMap(e -> e.getAttributes().keySet().stream()
+                .filter(AttributeKey::isKnownAttribute)
+                .map(a -> new AttributeKey(e.getName(), a.getName())))
+            .distinct()
+            .collect(toImmutableTable(
+                AttributeKey::getElementName, AttributeKey::getAttributeName, identity()));
+
+    private static boolean isKnownAttribute(Attribute attr) {
+        return !attr.isDeprecated() &&
+            (attr.attributeStatus == distinguished || attr.attributeStatus == value);
+    }
+
+    private static final Splitter LIST_SPLITTER =
+        Splitter.on(CharMatcher.whitespace()).omitEmptyStrings();
+
+    /**
+     * Common interface to permit both {@link CldrPath} and {@link CldrValue} to have attributes
+     * processed by the methods in this class.
+     */
+    interface AttributeSupplier {
+        /** Returns the raw attribute value, or null. */
+        /* @Nullable */ String get(AttributeKey k);
+
+        /** Returns the data type of this supplier. */
+        CldrDataType getDataType();
+    }
+
+    /**
+     * Returns a key which identifies an attribute in either {@link CldrValue} or {@link CldrPath}.
+     *
+     * <p>It is expected that callers will typically store the keys for desired attributes as
+     * constant static fields rather than creating new keys each time they are needed.
+     *
+     * @param elementName the CLDR path element name.
+     * @param attributeName the CLDR attribute name in the specified element.
+     * @return a key to uniquely identify the specified attribute.
+     */
+    public static AttributeKey keyOf(String elementName, String attributeName) {
+        // No namespace for the element means that:
+        // 1) we don't expect the attribute name to have a namespace either,
+        // 2) the attribute key should be in our cache of known instances.
+        if (elementName.indexOf(':') == -1) {
+            checkArgument(attributeName.indexOf(':') == -1,
+                "attributes in an external namespace cannot be present in elements in the default"
+                    + " namespace: %s:%s",
+                elementName, attributeName);
+            return checkNotNull(KNOWN_KEYS.get(elementName, attributeName),
+                "unknown attribute (was it deprecated?): %s:%s",
+                elementName, attributeName);
+        }
+        // An element in an external namespace _can_ have an attribute in the default namespace!
+        // (e.g. <icu:dictionary type="Thai" icu:dependency="thaidict.dict"/>)
+        return new AttributeKey(elementName, attributeName);
+    }
+
+    private final String elementName;
+    private final String attributeName;
+
+    private AttributeKey(String elementName, String attributeName) {
+        this.elementName = checkValidLabel(elementName, "element name");
+        this.attributeName = checkValidLabel(attributeName, "attribute name");
+    }
+
+    /** @return the non-empty element name of this key. */
+    public String getElementName() {
+        return elementName;
+    }
+
+    /** @return the non-empty attribute name of this key. */
+    public String getAttributeName() {
+        return attributeName;
+    }
+
+    /**
+     * Accessor for required attribute values on a {@link CldrPath} or {@link CldrValue}. Use this
+     * method in preference to the instance's own {@code get()} method in cases where the value is
+     * required or takes an implicit value.
+     *
+     * @param src the {@link CldrPath} or {@link CldrValue} from which the value is to be obtained.
+     * @return the attribute value or, if not present, the specified default.
+     * @throws IllegalStateException if this attribute is optional for the given supplier.
+     */
+    public String valueFrom(AttributeSupplier src) {
+        checkState(!src.getDataType().isOptionalAttribute(this),
+            "attribute %s is optional in %s, it should be accessed by an optional accessor",
+            this, src.getDataType());
+        // If this fails, it's a sign of an issue in the DTD and/or parser.
+        return checkNotNull(src.get(this), "missing required attribute: %s", this);
+    }
+
+    /**
+     * Accessor for optional attribute values on a {@link CldrPath} or {@link CldrValue}. Use this
+     * method in preference to the instance's own {@code get()} method, unless efficiency is vital.
+     *
+     * @param src the {@link CldrPath} or {@link CldrValue} from which the value is to be obtained.
+     * @return the attribute value or, if not present, the specified default.
+     * @throws IllegalStateException if this attribute is not optional for the given supplier.
+     */
+    public Optional<String> optionalValueFrom(AttributeSupplier src) {
+        checkState(src.getDataType().isOptionalAttribute(this),
+            "attribute %s is not optional in %s, it should not be accessed by an optional accessor",
+            this, src.getDataType());
+        return Optional.ofNullable(src.get(this));
+    }
+
+    /**
+     * Accessor for attribute values on a {@link CldrPath} or {@link CldrValue}. Use this method
+     * in preference to the instance's own {@code get()} method in cases where a non-null value is
+     * required.
+     *
+     * @param src the {@link CldrPath} or {@link CldrValue} from which the value is to be obtained.
+     * @param defaultValue a non-null default returned if the value is not present.
+     * @return the attribute value or, if not present, the specified default.
+     * @throws IllegalStateException if this attribute is not optional for the given supplier.
+     */
+    public String valueFrom(AttributeSupplier src, String defaultValue) {
+        checkState(src.getDataType().isOptionalAttribute(this),
+            "attribute %s is not optional in %s, it should not be accessed by an optional accessor",
+            this, src.getDataType());
+        checkNotNull(defaultValue, "default value must not be null");
+        String v = src.get(this);
+        return v != null ? v : defaultValue;
+    }
+
+    /**
+     * Accessor for attribute values on a {@link CldrPath} or {@link CldrValue}. Use this method
+     * in preference to the instance's own {@code get()} method when an attribute is expected to
+     * only contain a legitimate boolean value.
+     *
+     * @param src the {@link CldrPath} or {@link CldrValue} from which the value is to be obtained.
+     * @param defaultValue a default returned if the value is not present.
+     * @return the attribute value or, if not present, the specified default.
+     */
+    // TODO: Enforce that this is only called for #ENUMERATION attributes with boolean values.
+    public boolean booleanValueFrom(AttributeSupplier src, boolean defaultValue) {
+        String v = src.get(this);
+        if (v == null) {
+            return defaultValue;
+        } else if (Ascii.equalsIgnoreCase(v, "true")) {
+            return true;
+        } else if (Ascii.equalsIgnoreCase(v, "false")) {
+            return false;
+        }
+        throw new IllegalArgumentException("value of attribute " + this + " is not boolean: " + v);
+    }
+
+    /**
+     * Accessor for attribute values on a {@link CldrPath} or {@link CldrValue}. Use this method
+     * in preference to the instance's own {@code get()} method when an attribute is expected to
+     * contain a whitespace separated list of values.
+     *
+     * @param src the {@link CldrPath} or {@link CldrValue} from which values are to be obtained.
+     * @return a list of split attribute values, possible empty if the attribute does not exist.
+     */
+    // TODO: Perhaps extend this if non-whitespace separated lists need to be handled.
+    public List<String> listOfValuesFrom(AttributeSupplier src) {
+        String v = src.get(this);
+        return v != null ? LIST_SPLITTER.splitToList(v) : ImmutableList.of();
+    }
+
+    /**
+     * Accessor for attribute values on a {@link CldrPath} or {@link CldrValue} which map to a known
+     * enum. Use this method in preference to the instance's own {@code get()} method in cases where
+     * a non-null value is required.
+     *
+     * @param src the {@link CldrPath} or {@link CldrValue} from which the value is to be obtained.
+     * @param enumType the enum class type of the result.
+     * @return an enum value instance from the underlying attribute value by name.
+     */
+    // TODO: Handler optional enumerations (e.g. PluralRange#start/end).
+    public <T extends Enum<T>> T valueFrom(AttributeSupplier src, Class<T> enumType) {
+        return Enum.valueOf(enumType, valueFrom(src));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof AttributeKey)) {
+            return false;
+        }
+        AttributeKey other = (AttributeKey) obj;
+        return this.elementName.equals(other.elementName)
+            && this.attributeName.equals(other.attributeName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(elementName, attributeName);
+    }
+
+    /** Returns a debug-only representation of the qualified attribute key. */
+    @Override
+    public String toString() {
+        return elementName + ":" + attributeName;
+    }
+
+    // Note: This can be modified if necessary but care must be taken to never allow various
+    // meta-characters in element or attribute names (see CldrPath for the full list).
+    private static String checkValidLabel(String value, String description) {
+        checkArgument(!value.isEmpty(), "%s cannot be empty", description);
+        checkArgument(CharMatcher.ascii().matchesAllOf(value),
+            "non-ascii character in %s: %s", description, value);
+        return value;
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrData.java
+++ b/tools/java/org/unicode/cldr/api/CldrData.java
@@ -1,0 +1,190 @@
+package org.unicode.cldr.api;
+
+import java.util.function.Consumer;
+
+/**
+ * An immutable, reusable CLDR data instance on which visitors can be accepted to process paths
+ * and values, or for which values can be looked up by their corresponding distinguishing path.
+ */
+public interface CldrData {
+    /**
+     * Accepts the given visitor over all path/value pairs of this CLDR data instance. Note
+     * that value visitors only visit complete "leaf" paths which have associated values, and
+     * never see partial prefix paths.
+     *
+     * <p>Since a value visitor never sees partial path prefixes, a value visitor can never
+     * defer to a prefix visitor (since there's nothing "below" the paths that a value
+     * visitor visits).
+     *
+     * @param order the order in which visitation should occur.
+     * @param visitor the visitor to process CLDR data.
+     */
+    void accept(PathOrder order, ValueVisitor visitor);
+
+    /**
+     * Accepts the given visitor over all partial path prefixes of this CLDR data instance.
+     * Note that, on its own, this visitor will never see CDLR values, or even complete paths.
+     * It only sees the prefix paths under which values can exist.
+     *
+     * <p>Typically an instance of a {@link PrefixVisitor} would by used to identify a specific
+     * sub-hierarchy of data based on the prefix path, and then defer to a {@link ValueVisitor
+     * value visitor} or another {@link PrefixVisitor prefix visitor} to handle it.
+     *
+     * <p>Since {@link PrefixVisitor} requires that paths are visited in at least {@link
+     * PathOrder#NESTED_GROUPING nested grouping} order, the actual order of visitation may be
+     * more strict than the specified value.
+     *
+     * @param order the order in which visitation should occur.
+     * @param visitor the visitor to process CLDR data.
+     */
+    void accept(PathOrder order, PrefixVisitor visitor);
+
+    /**
+     * Returns a {@link CldrValue} for a given distinguishing path.
+     *
+     * @param path the complete distinguishing path associated with a CLDR value.
+     * @return the CldrValue for the given path, if it exists, or else {@code null}.
+     */
+    /* @Nullable */ CldrValue get(CldrPath path);
+
+    /** Ordering options for path visitation. */
+    // Note more orderings can be added if needed (e.g. a fully stable lexicographical ordering).
+    enum PathOrder {
+        /**
+         * Visits {@code CldrPath}s in an arbitrary, potentially unstable, order. Only use this
+         * ordering if your visitation code is completely robust against changes to visitation
+         * ordering. This is expected to be the fastest ordering option, but may change over time.
+         *
+         * <p>Note that if this value is specified for a method which requires a stricter ordering
+         * for correctness, then the stricter ordering will be used. Note also that the ordering of
+         * visitation may change between visitations if a more strictly ordered visitation was
+         * required in the meantime (since paths may be re-ordered and cached).
+         */
+        ARBITRARY,
+
+        /**
+         * Visits {@code CldrPath}s in an order which enforces the grouping of nested sub-paths.
+         * With this ordering, all common "parent" path prefixes will be visited consecutively,
+         * grouping together all "child" paths. However it is important to note that no other
+         * promises are made and this ordering is still unstable and can change over time.
+         *
+         * <p>This ordering is useful for constructing nested visitors over some subset of paths
+         * (e.g. processing all paths with a certain prefix consecutively).
+         *
+         * <p>For example, using {@code NESTED_GROUPING} the paths {@code //a/b/c/d},
+         * {@code //a/b/e/f}, {@code //a/x/y/z} could be ordered like any of the following:
+         * <ul>
+         * <li>{@code //a/b/c/d} &lt; {@code //a/b/e/f} &lt; {@code //a/x/y/z}
+         * <li>{@code //a/b/e/f} &lt; {@code //a/b/c/d} &lt; {@code //a/x/y/z}
+         * <li>{@code //a/x/y/z} &lt; {@code //a/b/c/d} &lt; {@code //a/b/e/f}
+         * <li>{@code //a/x/y/z} &lt; {@code //a/b/e/f} &lt; {@code //a/b/c/d}
+         * </ul>
+         * The only disallowed ordering here is one in which {@code //a/x/y/z} lies between the
+         * other paths.
+         */
+        NESTED_GROUPING,
+
+        /**
+         * Visits {@code CldrPath}s in the order defined by the CLDR DTD declaration. This ordering
+         * naturally enforces "nested grouping" of paths but additionally sorts paths so they are
+         * visited in the order defined by the DTD of the {@link CldrDataType}.
+         *
+         * <p>This ordering is more stable than {@link PathOrder#NESTED_GROUPING}, but may still
+         * change between different DTD versions.
+         */
+        DTD;
+    }
+
+    /** A visitor for complete "leaf" paths and their associated values. */
+    interface ValueVisitor {
+        /** Callback method invoked for each value encountered by this visitor. */
+        void visit(CldrValue value);
+    }
+
+    /** A visitor for partial path prefixes. */
+    @SuppressWarnings("unused") // For unused arguments in no-op default methods.
+    interface PrefixVisitor {
+        /**
+         * A controller API for allow prefix visitors to delegate sub-hierarchy visitation. A
+         * context is passed into the {@link #visitPrefixStart(CldrPath, Context)} method in order
+         * to allow the visitor to "install" a new visitor to handle the sub-hierarchy root at the
+         * current path prefix.
+         */
+        interface Context {
+            /**
+             * Installs a value visitor at the current point in the visitation. The given visitor
+             * will be called for all the values below this point in the path hierarchy, and the
+             * current visitor will be automatically restored once visitation is complete.
+             *
+             * @param visitor a visitor to process the CLDR data sub-hierarchy rooted at the
+             *                current path prefix.
+             */
+            default void install(ValueVisitor visitor) {
+                install(visitor, v -> {});
+            }
+
+            /**
+             * Installs a value visitor at the current point in the visitation. The given visitor
+             * will be called for all the values below this point in the path hierarchy, and the
+             * current visitor will be automatically restored once visitation is complete.
+             *
+             * @param visitor a visitor to process the CLDR data sub-hierarchy rooted at the
+             *                current path prefix.
+             * @param doneHandler a handler invoked just before the visitor is uninstalled.
+             */
+            <T extends ValueVisitor> void install(T visitor, Consumer<T> doneHandler);
+
+            /**
+             * Installs a prefix visitor at the current point in the visitation. The given visitor
+             * will be called for all the start/end events below this point in the path hierarchy,
+             * and the current visitor will be automatically restored once visitation is complete.
+             *
+             * @param visitor a visitor to process the CLDR data sub-hierarchy rooted at the
+             *                current path prefix.
+             */
+            default void install(PrefixVisitor visitor) {
+                install(visitor, v -> {});
+            }
+
+            /**
+             * Installs a prefix visitor at the current point in the visitation. The given visitor
+             * will be called for all the start/end events below this point in the path hierarchy,
+             * and the current visitor will be automatically restored once visitation is complete.
+             *
+             * @param visitor a visitor to process the CLDR data sub-hierarchy rooted at the
+             *                current path prefix.
+             * @param doneHandler a handler invoked just before the visitor is uninstalled.
+             */
+            <T extends PrefixVisitor> void install(T visitor, Consumer<T> doneHandler);
+        }
+
+        /**
+         * Callback method invoked for each partial path prefix encountered by this visitor.
+         *
+         * <p>A typical implementation of this method would test the given path to see if it's the
+         * root of a desired sub-hierarchy and (if it matches) begin some sub-hierarchy processing,
+         * which would often include installing a new visitor via the given context.
+         *
+         * @param prefix a path prefix processed as part of some visitation over CLDR data.
+         * @param context a mechanism for installing sub-hierarchy visitors rooted at this point in
+         *                the visitation.
+         */
+        default void visitPrefixStart(CldrPath prefix, Context context) {}
+
+        /**
+         * Callback method invoked to signal the end of some sub-hierarchy visitation. This method
+         * is invoked exactly once for each call to {@link #visitPrefixStart(CldrPath, Context)},
+         * in the opposite "stack" order with the same path prefix. This means that if this visitor
+         * installs a sub-visitor during a call to {@code visitPrefixStart()} then the next
+         * callback made to this visitor will be a call to {@code visitPrefixEnd()} with the same
+         * path prefix.
+         *
+         * <p>A typical implementation of this method would detect the end of some expected
+         * sub-visitation and do post-processing on the data.
+         *
+         * @param prefix a path prefix corresponding to the end of some previously started
+         *               sub-hierarchy visitation.
+         */
+        default void visitPrefixEnd(CldrPath prefix) {}
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
@@ -1,0 +1,256 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import org.unicode.cldr.api.CldrData.PrefixVisitor;
+import org.unicode.cldr.api.CldrData.ValueVisitor;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.SimpleFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.unicode.cldr.api.CldrDataType.LDML;
+
+/**
+ * The main API for accessing {@link CldrPath} and {@link CldrValue} instances for CLDR data. This
+ * API abstracts the data sources, file names and other implementation details of CLDR to provide
+ * a clean way to access CLDR data.
+ *
+ * <p>{@code CldrData} instances are obtained from an appropriate {@code CldrDataSupplier}, and
+ * accept a {@link ValueVisitor} or {@link PrefixVisitor} to iterate over the data.
+ *
+ * <p>For example the following code prints every value (including its associated distinguishing
+ * path) in the BCP-47 data in DTD order:
+ * <pre>{@code
+ *   CldrDataSupplier supplier = CldrDataSupplier.forFilesIn(rootDir);
+ *   CldrData bcp47Data = supplier.getDataForType(CldrDataType.BCP47);
+ *   bcp47Data.accept(PathOrder.DTD, System.out::println);
+ * }</pre>
+ *
+ * <p>Note that while the paths of values visited in a single {@link CldrData} instance are unique,
+ * there is nothing to prevent duplication between multiple data sources. This is particularly
+ * important when considering "ordered" elements with a sort index, since it represents "encounter
+ * order" and so any merging of values would have to track and rewrite sort indices carefully. It
+ * is recommended that if multiple {@code CldrData} instances are to be processed, users ensure
+ * that no path prefixes be shared between them. See also {@link CldrPath#getSortIndex()}.
+ *
+ * <p>Note that because the distinguishing paths associated with a {@link CldrValue} are unique per
+ * visitation, the special "version" path/value must be omitted (e.g. "//ldml/version") since it
+ * would otherwise appear multiple times. This should be fine, since the version is always available
+ * via {@link #getCldrVersionString()} and this mechanism is scheduled for deprecation anyway.
+ */
+public abstract class CldrDataSupplier {
+    // The set of top level directories could be more than these, but the API should not require
+    // callers to know about directory names or structure itself, so if this is to be configurable
+    // then it should be via methods like "withSeedFiles()" or similar. For now the "seed" directory
+    // is included, but others, such as "exemplars" and "keyboards" are not. This is sufficient for
+    // the API's current use, but will ultimately need addressing.
+    //
+    // TODO: Extend the API to allow source roots to be specified (but not via directory name).
+    private static final ImmutableSet<String> ROOT_DIRECTORIES =
+        ImmutableSet.of("common", "seed");
+
+    /**
+     * Returns the current CLDR version string (e.g. {@code "36"}). This is just wrapping the
+     * underlying CLDR version string to avoid callers needing to import anything from outside the
+     * "icu" API package.
+     */
+    public static String getCldrVersionString() {
+        return CLDRFile.GEN_VERSION;
+    }
+
+    /** Options for controlling how locale-based LDML data is processed. */
+    public enum CldrResolution {
+        /**
+         * Locale-based CLDR data should include resolved values from other "parent" locales
+         * according to the CLDR specification.
+         */
+        RESOLVED,
+
+        /**
+         * Locale-based CLDR data should only include values specified directly in the specified
+         * locale.
+         */
+        UNRESOLVED;
+    }
+
+    /**
+     * Returns a supplier for CLDR data in the specified CLDR project root directory. This must be
+     * a directory which contains the standard CLDR {@code "common"} directory file hierarchy.
+     *
+     * @param cldrRootDir the root directory of a CLDR project containing the data to be read.
+     * @return a supplier for CLDR data in the given path.
+     */
+    public static CldrDataSupplier forCldrFilesIn(Path cldrRootDir) {
+        return new FileBasedDataSupplier(
+            createCldrDirectoryMap(cldrRootDir), CldrDraftStatus.UNCONFIRMED);
+    }
+
+    /**
+     * Returns an unresolved CLDR data instance of a single XML file. This is typically only used
+     * for accessing additional CLDR data outside the CLDR project directories.
+     *
+     * @param type the expected CLDR type of the data in the XML file.
+     * @param xmlFile the CLDR XML file.
+     * @param draftStatus the desired status for filtering paths/values.
+     * @return a data instance for the paths/values in the specified XML file.
+     */
+    public static CldrData forCldrFile(CldrDataType type, Path xmlFile, CldrDraftStatus draftStatus) {
+        return new XmlDataSource(type, ImmutableSet.of(xmlFile), draftStatus);
+    }
+
+    private static Multimap<CldrDataType, Path> createCldrDirectoryMap(Path cldrRootDir) {
+        LinkedHashMultimap<CldrDataType, Path> multimap = LinkedHashMultimap.create();
+        for (CldrDataType type : CldrDataType.values()) {
+            type.getSourceDirectories()
+                .flatMap(d -> ROOT_DIRECTORIES.stream().map(r -> cldrRootDir.resolve(r).resolve(d)))
+                .filter(Files::isDirectory)
+                .forEach(p -> multimap.put(type, p));
+        }
+        return multimap;
+    }
+
+    /**
+     * Returns an in-memory supplier for the specified {@link CldrValue}s. This is useful for
+     * testing or handling special case data.
+     * @param values
+     */
+    // Note: This could be made public if necessary.
+    static CldrData forValues(Iterable<CldrValue> values) {
+        return new InMemoryData(values);
+    }
+
+    // Package protected to keep suppliers in a closed type hierarchy.
+    CldrDataSupplier() {}
+
+    /**
+     * Returns a modified data supplier which only provides paths/values with a draft status at or
+     * above the specified value. To create a supplier that will process all CLDR paths/values, use
+     * {@link CldrDraftStatus#UNCONFIRMED UNCONFIRMED}.
+     *
+     * @param draftStatus the desired status for filtering paths/values.
+     * @return a modified supplier which filters by the specified status.
+     */
+    public abstract CldrDataSupplier withDraftStatusAtLeast(CldrDraftStatus draftStatus);
+
+    /**
+     * Returns an LDML data supplier for the specified locale ID.
+     *
+     * <p>If {@code resolution} is set to {@link CldrResolution#RESOLVED RESOLVED} then values
+     * inferred from parent locales and aliases will be produced by the supplier.
+     *
+     * @param localeId the locale ID (e.g. "en_GB") for the returned data.
+     * @param resolution whether to resolve CLDR values for the given locale ID according to the
+     *                   CLDR specification.
+     * @return the specified locale based CLDR data.
+     */
+    public abstract CldrData getDataForLocale(String localeId, CldrResolution resolution);
+
+    /**
+     * Returns an unmodifiable set of available locale IDs that this supplier can provide.
+     *
+     * @return the set of available locale IDs.
+     */
+    public abstract Set<String> getAvailableLocaleIds();
+
+    /**
+     * Returns a data supplier for non-locale specific CLDR data of the given type.
+     *
+     * @param type the required non-{@link CldrDataType#LDML LDML} data type.
+     * @return the specified non-locale based CLDR data.
+     * @throws IllegalArgumentException if {@link CldrDataType#LDML} is given.
+     */
+    public abstract CldrData getDataForType(CldrDataType type);
+
+    private static final class FileBasedDataSupplier extends CldrDataSupplier {
+        private final ImmutableSetMultimap<CldrDataType, Path> directoryMap;
+        private final CldrDraftStatus draftStatus;
+
+        // Created on-demand to keep constructor simple (in a fluent API you might create several
+        // variants of a supplier but only get data from one, or only use non-LDML XML data).
+        private Factory factory = null;
+
+        private FileBasedDataSupplier(
+            Multimap<CldrDataType, Path> directoryMap, CldrDraftStatus draftStatus) {
+            this.directoryMap = ImmutableSetMultimap.copyOf(directoryMap);
+            this.draftStatus = checkNotNull(draftStatus);
+        }
+
+        // Locking should be no issue, since contention on these supplier instance is expected to
+        // be minimal.
+        private synchronized Factory getFactory() {
+            if (factory == null) {
+                File[] dirArray =
+                    getDirectoriesForType(LDML).map(Path::toFile).toArray(File[]::new);
+                checkArgument(dirArray.length > 0,
+                    "no LDML directories exist: %s", directoryMap.get(LDML));
+                factory = SimpleFactory.make(dirArray, ".*", draftStatus.getRawStatus());
+            }
+            return factory;
+        }
+
+        @Override
+        public CldrDataSupplier withDraftStatusAtLeast(CldrDraftStatus draftStatus) {
+            return new FileBasedDataSupplier(directoryMap, draftStatus);
+        }
+
+        @Override
+        public CldrData getDataForLocale(String localeId, CldrResolution resolution) {
+            return new CldrFileDataSource(
+                getFactory().make(localeId, resolution == CldrResolution.RESOLVED));
+        }
+
+        @Override
+        public Set<String> getAvailableLocaleIds() {
+            return getFactory().getAvailable();
+        }
+
+        @Override
+        public CldrData getDataForType(CldrDataType type) {
+            return new XmlDataSource(type, listXmlFilesForType(type), draftStatus);
+        }
+
+        private Stream<Path> getDirectoriesForType(CldrDataType type) {
+            return directoryMap.get(type).stream().filter(Files::exists);
+        }
+
+        private ImmutableSet<Path> listXmlFilesForType(CldrDataType type) {
+            ImmutableSet<Path> xmlFiles = getDirectoriesForType(type)
+                .flatMap(FileBasedDataSupplier::listXmlFiles)
+                .collect(toImmutableSet());
+            checkArgument(!xmlFiles.isEmpty(),
+                "no XML files exist within directories: %s", directoryMap.get(type));
+            return xmlFiles;
+        }
+
+        // This is a separate function because stream functions cannot throw checked exceptions.
+        //
+        // Note: "Files.list()" warns about closing resources and suggests "try-with-resources" to
+        // ensure closure, "flatMap()" (which is what calls this method) is defined to call close()
+        // on each stream as it's added into the result, so in normal use this should all be fine.
+        //
+        // https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#flatMap-java.util.function.Function-
+        private static Stream<Path> listXmlFiles(Path dir) {
+            try {
+                return Files.list(dir).filter(IS_XML_FILE);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static final Predicate<Path> IS_XML_FILE =
+            p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".xml");
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrDataType.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataType.java
@@ -1,0 +1,209 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.unicode.cldr.util.DtdData;
+import org.unicode.cldr.util.DtdData.Attribute;
+import org.unicode.cldr.util.DtdData.Element;
+import org.unicode.cldr.util.DtdType;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.function.Function.identity;
+import static org.unicode.cldr.util.DtdData.AttributeStatus.distinguished;
+import static org.unicode.cldr.util.DtdData.AttributeStatus.value;
+import static org.unicode.cldr.util.DtdData.Mode.OPTIONAL;
+
+/**
+ * Data types for non-locale based CLDR data. For the canonical specification for LDML data can
+ * be found at <a href="https://unicode.org/reports/tr35">Unicode Locale Data Markup Language<\a>.
+ *
+ * <p>This enum is largely a wrapper for functionality found in the underlying CLDR classes, but
+ * repackaged for convenience and to minimize surface area (and to avoid anyone needing to import
+ * classes from outside the "api" package).
+ */
+public enum CldrDataType {
+    /**
+     * Non-locale based BCP47 data, typically associated with international identifiers such as
+     * currency symbols, timezone identifiers etc.
+     */
+    BCP47(DtdType.ldmlBCP47, false, false),
+    /**
+     * Non-locale based supplemental data, typically associated with character tables (e.g. for
+     * break iterator).
+     */
+    SUPPLEMENTAL(DtdType.supplementalData, false, false),
+    /**
+     * Locale based LDML data consisting of internationalization information and translations on a
+     * per locale basis. LDML data for one locale may be inherited from other locales.
+     */
+    LDML(DtdType.ldml, true, true, DtdType.ldmlICU);
+
+    private static final ImmutableMap<DtdType, CldrDataType> RAW_TYPE_MAP =
+        Arrays.stream(values()).collect(toImmutableMap(t -> t.mainType, identity()));
+
+    static CldrDataType forRawType(DtdType rawType) {
+        CldrDataType type = RAW_TYPE_MAP.get(rawType);
+        checkArgument(type != null, "unknown DTD type: %s", rawType);
+        return type;
+    }
+
+    private final DtdType mainType;
+    private final ImmutableList<DtdType> extraTypes;
+    private final boolean isLdml;
+    private final boolean canResolve;
+    private final Comparator<String> elementComparator;
+    private final Comparator<String> attributeComparator;
+
+    CldrDataType(DtdType mainType, boolean isLdml, boolean canResolve, DtdType... extraTypes) {
+        this.mainType = mainType;
+        this.extraTypes = ImmutableList.copyOf(extraTypes);
+        checkArgument(!canResolve || isLdml, "inconsistent flags");
+        this.isLdml = isLdml;
+        this.canResolve = canResolve;
+        // There's no need to cache the DtdData instance since getInstance() already does that.
+        DtdData dtd = DtdData.getInstance(mainType);
+        // Note that the function passed in to the wrapped comparators needs to be fast, since it's
+        // called for each comparison. We assume getElementFromName() and getAttributesFromName()
+        // are efficient, and if not we'll need to cache.
+        this.elementComparator =
+            wrapToHandleUnknownNames(
+                dtd.getElementComparator(),
+                dtd.getElementFromName()::containsKey);
+        this.attributeComparator =
+            wrapToHandleUnknownNames(
+                dtd.getAttributeComparator(),
+                dtd.getAttributesFromName()::containsKey);
+    }
+
+    String getLdmlName() {
+        return mainType.name();
+    }
+
+    Stream<Path> getSourceDirectories() {
+        return mainType.directories.stream().map(Paths::get);
+    }
+
+    boolean isLocaleBasedData() {
+        return isLdml;
+    }
+
+    boolean canResolve() { return canResolve; }
+
+    /**
+     * Returns all elements known for this DTD type in undefined order. This can include elements
+     * in external namespaces (e.g. "icu:xxx").
+     */
+    Stream<Element> getElements() {
+        Stream<Element> elements = elementsFrom(mainType);
+        if (!extraTypes.isEmpty()) {
+            elements =
+                Stream.concat(elements, extraTypes.stream().flatMap(CldrDataType::elementsFrom));
+        }
+        return elements;
+    }
+
+    /**
+     * Returns all attributes known for this DTD type in undefined order. This can include
+     * attributes in external namespaces (e.g. "icu:xxx").
+     */
+    Stream<Attribute> getAttributes() {
+        // NOTE: DO NOT call getAttributes() here because it makes a new set every time!! This code
+        // just streams the existing collections
+        return getElements().flatMap(e -> e.getAttributes().keySet().stream());
+    }
+
+    private static Stream<Element> elementsFrom(DtdType dataType) {
+        // NOTE: DO NOT call getElements() here because it makes a new set every time!!
+        return DtdData.getInstance(dataType).getElementFromName().values().stream();
+    }
+
+    Attribute getAttribute(String elementName, String attributeName) {
+        Attribute attr = DtdData.getInstance(mainType).getAttribute(elementName, attributeName);
+        if (attr == null) {
+            for (DtdType t : extraTypes) {
+                attr = DtdData.getInstance(t).getAttribute(elementName, attributeName);
+                if (attr != null) {
+                    break;
+                }
+            }
+        }
+        return attr;
+    }
+
+    Comparator<String> getElementComparator() {
+        return elementComparator;
+    }
+
+    Comparator<String> getAttributeComparator() {
+        return attributeComparator;
+    }
+
+    // Unknown elements outside the DTD (such as "//ldml/special" icu:xxx elements) are not
+    // handled properly by the underlying element/attribute name comparators (they throw an
+    // exception) so we have to detect these cases first and handle them manually (even though
+    // they are very rare). Assume that:
+    // * known DTD elements come before any unknown ones, and
+    // * unknown element names can be sorted lexicographically using their qualified name.
+    private static Comparator<String> wrapToHandleUnknownNames(
+        Comparator<String> compare, Predicate<String> isKnown) {
+        // This code should only return "signum" values for ordering (i.e. {-1, 0, 1}).
+        return (lname, rname) -> {
+            if (isKnown.test(lname)) {
+                return isKnown.test(rname) ? compare.compare(lname, rname) : -1;
+            } else {
+                return isKnown.test(rname) ? 1 : lname.compareTo(rname);
+            }
+        };
+    }
+
+    Comparator<String> getAttributeComparator(String elementName, String attributeName) {
+        return DtdData.getAttributeValueComparator(elementName, attributeName);
+    }
+
+    // We shouldn't need to check special cases (e.g. "_q") here because this should only be being
+    // called _after_ those have been filtered out.
+    // The only time that both these methods return false should be for known attributes that are
+    // either marked as deprecated or as metatadata attributes.
+    boolean isDistinguishingAttribute(String elementName, String attributeName) {
+        Attribute attribute = getAttribute(elementName, attributeName);
+        if (attribute != null) {
+            return attribute.attributeStatus == distinguished && !attribute.isDeprecated();
+        }
+        // This can happen if attribute keys are speculatively generated, which sometimes happens
+        // in transformation logic. Ideally this would end up being an error.
+        return false;
+    }
+
+    /** Returns whether the specified attribute is a "value" attribute. */
+    boolean isValueAttribute(String elementName, String attributeName) {
+        Attribute attribute = getAttribute(elementName, attributeName);
+        if (attribute != null) {
+            return attribute.attributeStatus == value && !attribute.isDeprecated();
+        }
+        return true;
+    }
+
+    /** Returns whether the specified attribute is a "value" attribute.  */
+    boolean isValueAttribute(AttributeKey key) {
+        return isValueAttribute(key.getElementName(), key.getAttributeName());
+    }
+
+    /**
+     * Returns whether the specified attribute is optional. Attributes unknown to the DTD are
+     * considered optional, which can happen if attribute keys are speculatively generated, which
+     * sometimes happens in transformation logic.
+     */
+    // TODO: Perhaps we need an isValidAttribute() method as well?
+    boolean isOptionalAttribute(AttributeKey key) {
+        Attribute attribute = getAttribute(key.getElementName(), key.getAttributeName());
+        return attribute == null || attribute.mode == OPTIONAL;
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrDraftStatus.java
+++ b/tools/java/org/unicode/cldr/api/CldrDraftStatus.java
@@ -1,0 +1,46 @@
+package org.unicode.cldr.api;
+
+import com.google.common.base.Ascii;
+import org.unicode.cldr.util.CLDRFile.DraftStatus;
+
+import java.util.Optional;
+
+/**
+ * Draft status for controlling which values to visit. Draft statuses are ordered by ordinal value,
+ * with {@code UNCONFIRMED} being the most lenient status (include everything) and {@code APPROVED}
+ * being the strictest.
+ *
+ * <p>This enum is largely a wrapper for functionality found in the underlying CLDR classes, but
+ * repackaged for convenience and to minimize surface area (and to avoid anyone needing to import
+ * classes from outside the "api" package).
+ */
+public enum CldrDraftStatus {
+    /** Include all values during visitation, performing no filtering. */
+    UNCONFIRMED(DraftStatus.unconfirmed),
+    /** Include only values with "provisional" status or higher during visitation. */
+    PROVISIONAL(DraftStatus.provisional),
+    /** Include only values with "contributed" status or higher during visitation. */
+    CONTRIBUTED(DraftStatus.contributed),
+    /** Include only "approved" values. */
+    APPROVED(DraftStatus.approved);
+
+    private final DraftStatus rawStatus;
+    private final Optional<CldrDraftStatus> optStatus;
+
+    CldrDraftStatus(DraftStatus rawType) {
+        this.rawStatus = rawType;
+        this.optStatus = Optional.of(this);
+    }
+
+    DraftStatus getRawStatus() {
+        return rawStatus;
+    }
+
+    Optional<CldrDraftStatus> asOptional() {
+        return optStatus;
+    }
+
+    static /* @Nullable */ CldrDraftStatus forString(/* @Nullable */ String name) {
+        return name != null ? CldrDraftStatus.valueOf(Ascii.toUpperCase(name)) : null;
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
+++ b/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
@@ -1,0 +1,154 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.Lists;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.XPathParts;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Serializes a CLDRFile as a sequence of {@code (CldrPath, CldrValue)} pairs.
+ *
+ * <p>Ordering affects the cost of processing the CLDRFile, but not excessively. In testing, the
+ * resolved paths for "en_GB" took ~65ms to process in ARBITRARY order, and ~340ms for DTD order.
+ * It's expected that compared to producing these paths, any matching and processing of path
+ * elements will be the most significant issue.
+ */
+final class CldrFileDataSource extends AbstractDataSource {
+    private static final Pattern CAPTURE_SORT_INDEX = Pattern.compile("#[0-9]+");
+
+    private final CLDRFile source;
+
+    CldrFileDataSource(CLDRFile source) {
+        this.source = checkNotNull(source);
+    }
+
+    @Override
+    public void accept(PathOrder order, ValueVisitor visitor) {
+        Iterator<String> paths;
+        switch (order) {
+        case ARBITRARY:
+            paths = source.iterator();
+            break;
+
+        case NESTED_GROUPING:
+            // Distinguishing paths when sorted by string order should yield "nested grouping".
+            // This is because lexicographical order is determined by the earliest character
+            // difference, which either occurs in the element name or the attribute declaration.
+            // Either way, the string before the first difference will agree on zero or more
+            // complete path elements and order is always decided by a change to the lowest path
+            // element. This should therefore result in common parent prefixes always being visited
+            // consecutively. It also (like DTD ordering) greatly improves the performance when
+            // parsing paths because consecutive paths share common parent elements.
+            paths = source.iterator(null, Comparator.naturalOrder());
+            break;
+
+        case DTD:
+            paths = source.iterator(null, source.getComparator());
+            break;
+
+        default:
+            throw new AssertionError("Unknown path ordering: " + order);
+        }
+        read(paths, source, visitor);
+    }
+
+    @Override
+    /* @Nullable */
+    public CldrValue get(CldrPath path) {
+        String xpath = getInternalPathString(path);
+        XPathParts fullPath = XPathParts.getFrozenInstance(source.getFullXPath(xpath));
+        int length = fullPath.size();
+        Map<AttributeKey, String> attributes = new LinkedHashMap<>();
+        for (int n = 0; n < length; n++) {
+            CldrPaths.processPathAttributes(
+                fullPath.getElement(n),
+                fullPath.getAttributes(n),
+                path.getDataType(),
+                e -> {},
+                attributes::put);
+        }
+        // This is MUCH faster if you pass the distinguishing path in.
+        return CldrValue.create(source.getStringValue(xpath), attributes, path);
+    }
+
+    private static String getInternalPathString(CldrPath p) {
+        // This is the distinguishing xpath, but possibly with a sort index present (e.g.
+        // foo#42[@bar="x"]). So to get the internal path as used by CLDRFile, we must convert '#N'
+        // into '[@_q="N"]'
+        String dpath = p.toString();
+        if (dpath.indexOf('#') != -1) {
+            dpath = CAPTURE_SORT_INDEX.matcher(dpath).replaceAll("[@_q=\"$1\"]");
+        }
+        return dpath;
+    }
+
+    private void read(Iterator<String> paths, CLDRFile src, ValueVisitor visitor) {
+        Map<AttributeKey, String> valueAttributes = new LinkedHashMap<>();
+
+        // This is a bit fiddly since we add path elements in reverse order to the 'stack' but want
+        // to access them using the path element index. E.g. if we add the path a->b->c->d to the
+        // stack we get "(d,c,b,a)" in the array, but really want "(a,b,c,d)" to avoid having to
+        // use recursion or other tricks to reverse the order of addition, we can just create a
+        // reversed _view_ onto the list and pass that around. We could just insert the elements at
+        // the front of the array (rather than adding them at the end) but that means repeated
+        // copying of existing elements to make room, so it's slower.
+        //
+        // This has the path elements pushed into it in reverse order.
+        List<CldrPath> previousElementStack = new ArrayList<>();
+        // This views the path elements in forward order.
+        List<CldrPath> previousElements = Lists.reverse(previousElementStack);
+
+        while (paths.hasNext()) {
+            String dPath = paths.next();
+            // This is MUCH faster if you pass the distinguishing path in.
+            String value = src.getStringValue(dPath);
+
+            // Since early 2019 there's been the possibility of getting the inheritance marker as
+            // a value for a path. This indicates that the value does NOT actually exist for a
+            // locale and would be inherited. According to the CldrUtility class:
+            // ""If CLDRFile ever finds this value in a data field, writing of the field should be
+            // suppressed.""
+            // TODO: Remove this null check once everything is settled (null should not be possible)
+            if (value == null || value.equals(CldrUtility.INHERITANCE_MARKER)) {
+                continue;
+            }
+
+            // There's a cache behind XPathParts which probably makes it faster to lookup these
+            // instances rather than parse them each time (it all depends on whether this is the
+            // first time the full paths are used).
+            CldrPath cldrPath = CldrPaths.processXPath(
+                src.getFullXPath(dPath), previousElements, valueAttributes::put);
+
+            if (CldrPaths.isLeafPath(cldrPath) && CldrPaths.shouldEmit(cldrPath)) {
+                safeVisit(cldrPath, value, valueAttributes, visitor);
+            }
+
+            // Prepare the element stack for next time by pushing the current path onto it.
+            pushPathElements(cldrPath, previousElementStack);
+
+            valueAttributes.clear();
+        }
+    }
+
+    /**
+     * Pushes the elements of the given path into the list. This is efficient but results in the
+     * list order being reversed (e.g. path "a->b->c->d" results in "(d,c,b,a)". A reversed view
+     * of this stack is used to present the path elements in "forward order".
+     */
+    private static void pushPathElements(CldrPath cldrPath, List<CldrPath> stack) {
+        stack.clear();
+        for (CldrPath p = cldrPath; p != null; p = p.getParent()) {
+            stack.add(p);
+        }
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrPath.java
+++ b/tools/java/org/unicode/cldr/api/CldrPath.java
@@ -1,0 +1,503 @@
+package org.unicode.cldr.api;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.unicode.cldr.api.AttributeKey.AttributeSupplier;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.CharMatcher.anyOf;
+import static com.google.common.base.CharMatcher.inRange;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.toCollection;
+
+/**
+ * A sequence of CLDR path elements and "distinguishing" attributes.
+ *
+ * <p>In CLDR, a path is composed of a series of elements and associated attributes, where the
+ * attributes can be one of three types; "distinguishing", "value" and "metadata".
+ *
+ * <p>CldrPath instances hold only "distinguishing" attributes, with "value" attributes being held
+ * by the associated {@link CldrValue} instance, and "metadata" attributes being ignored completely
+ * since they are internal to the core CLDR classes. This approach ensures that {@code CldrPath}
+ * instances uniquely identify values and can be used as keys in maps.
+ *
+ * <p>When viewing {@code CldrPath} as strings, it is sometimes necessary to introduce an suffix to
+ * the path element name to indicate the "sort order". This is necessary to represent "ordered"
+ * elements which can appear in the LDML data (though these are rare). This suffix takes the form of
+ * {@code "{element-name}#{sort-index}"} where {@code {sort-index}} is a non-negative index which
+ * corresponds to the value returned from {@link #getSortIndex()} for that path element. The natural
+ * ordering of {@code CldrPath} handles the correctly, but you cannot sort paths properly by just
+ * comparing their string representation.
+ *
+ * <p>CldrPath is an immutable value type with efficient equality semantics.
+ *
+ * <p>See <a href="https://www.unicode.org/reports/tr35/#Definitions">the LDML specification</a>
+ * for more details.
+ */
+public final class CldrPath implements AttributeSupplier, Comparable<CldrPath> {
+    // This is approximate and DOES NOT promise correctness, it's mainly there to catch unexpected
+    // changes in the data and it can be updated or removed if needed. At the very least element
+    // names must not contain '/', '[', ']', '@', '=', '#' or '"' to permit re-parsing of paths.
+    private static final CharMatcher NAME_CHARACTERS =
+        inRange('a', 'z').or(inRange('A', 'Z')).or(inRange('0', '9')).or(anyOf(":-_"));
+
+    /**
+     * Parses a distinguishing CLDR path string, including "distinguishing" and private "metadata"
+     * attributes into a normalized {@link CldrPath} instance. Attributes will be parsed and handled
+     * according to their type:
+     * <ul>
+     * <li>Distinguishing attributes will be added to the returned CldrPath instance.
+     * <li>Non-public metadata attributes will be ignored.
+     * <li>Value attributes are not permitted in distinguishing paths and will cause an error.
+     * </ul>
+     *
+     * <p>The path string must be structured correctly (e.g. "//ldml/foo[@bar="baz]") and must
+     * represent a known DTD type, based on the first path element (e.g. "ldml" or
+     * "supplementalData").
+     *
+     * @param path the distinguishing path string, containing only distinguishing attributes.
+     * @return the parsed distinguishing path instance.
+     * @throws IllegalArgumentException if the path is not well formed (e.g. contains unexpected
+     *      value or metadata attributes).
+     */
+    public static CldrPath parseDistinguishingPath(String path) {
+        return CldrPaths.processXPath(path, ImmutableList.of(), (k, v) -> {
+            throw new IllegalArgumentException(String.format(
+                "unexpected value attribute '%s' in distinguishing path: %s", k, path));
+        });
+    }
+
+    /**
+     * Returns the number of common path elements from the root. This is useful when determining
+     * the last common ancestor during visitation. A {@code null} path is treated as having zero
+     * length (and will always result in zero being returned).
+     *
+     * <p>Note: This is only currently use by PrefixVisitorHost, but could be made public if needed.
+     * It's only here (rather than in PrefixVisitorHost) because it depends on private methods of
+     * this class.
+     */
+    static int getCommonPrefixLength(/* @Nullable */ CldrPath a, /* @Nullable */ CldrPath b) {
+        // Null paths are sentinels with zero length.
+        if (a == null || b == null) {
+            return 0;
+        }
+
+        // Trim whichever path is longer until both are same length.
+        int minLength = Math.min(a.getLength(), b.getLength());
+        while (a.getLength() > minLength)
+            a = a.getParent();
+        while (b.getLength() > minLength)
+            b = b.getParent();
+
+        // Work up the paths, resetting the common length every time the elements differ.
+        int commonLength = minLength;
+        for (int length = minLength; length > 0; length--) {
+            if (!a.localEquals(b)) {
+                // Elements differ, so shortest possible common length is that of our parent path.
+                commonLength = length - 1;
+            }
+            // Parents will both be null on the last iteration, but never used.
+            a = a.getParent();
+            b = b.getParent();
+        }
+        return commonLength;
+    }
+
+    // If the parent is null then this path element is the top level LDML descriptor.
+    /* @Nullable */ private final CldrPath parent;
+    // The number of elements (including this one) in this path.
+    private final int length;
+    private final String elementName;
+    // The attribute keys and values in an alternating list.
+    private final ImmutableList<String> attributeKeyValuePairs;
+    // Inherits the top-most draft status in a path (which matches what CLDRFile appears to do.
+    private final Optional<CldrDraftStatus> draftStatus;
+    // The sort index for "ORDERED" path elements or (more commonly) -1 for non-ORDERED elements.
+    private final int sortIndex;
+    // The DTD type of the path (which is the same for all path elements).
+    private final CldrDataType dtdType;
+    // The proper DTD ordering for this path (based on the DTD type).
+    private final Comparator<CldrPath> ordering;
+    // Cached since ImmutableList recalculates its hash codes every time.
+    private final int hashCode;
+    // Cached on demand (it's useful during equality checking as well as toString() itself).
+    // However for elements with attributes, it's at least as large as the name and all attribute
+    // keys/values combined, so will typically double the in-memory size of the instance. We don't
+    // care about making assignment atomic however, since all values would be equal anyway.
+    private String localToString = null;
+
+    CldrPath(CldrPath parent,
+        String name,
+        List<String> attributeKeyValuePairs,
+        CldrDataType dtdType,
+        /* @Nullable */ CldrDraftStatus localDraftStatus, int sortIndex) {
+        checkState(parent != null || dtdType.getLdmlName().equals(name),
+            "unexpected root element: expected %s, but got %s", dtdType.getLdmlName(), name);
+        this.parent = parent;
+        this.length = (parent != null ? parent.getLength() : 0) + 1;
+        this.elementName = checkValidName(name, "element");
+        this.attributeKeyValuePairs = checkKeyValuePairs(attributeKeyValuePairs);
+        this.draftStatus = resolveDraftStatus(parent, localDraftStatus);
+        // TODO: Maybe check via the DTD data that it's only not -1 for ORDERED elements ?
+        checkArgument(sortIndex >= -1, "invalid sort index: %s", sortIndex);
+        this.sortIndex = sortIndex;
+        this.dtdType = checkNotNull(dtdType);
+        this.ordering = CldrPaths.getPathComparator(dtdType);
+        this.hashCode = Objects.hash(length, name, this.attributeKeyValuePairs, parent);
+    }
+
+    private static String checkValidName(String value, String description) {
+        checkArgument(!value.isEmpty(), "%s name cannot be empty", description);
+        checkArgument(NAME_CHARACTERS.matchesAllOf(value),
+            "invalid character in %s name: %s", description, value);
+        return value;
+    }
+
+    private static ImmutableList<String> checkKeyValuePairs(List<String> keyValuePairs) {
+        // Ensure attribute values never have double-quote in them (since current we don't escape
+        // value when putting into toString().
+        checkArgument((keyValuePairs.size() & 1) == 0,
+            "key/value pairs must have an even number of elements: %s", keyValuePairs);
+        for (int n = 0; n < keyValuePairs.size(); n += 2) {
+            checkValidName(keyValuePairs.get(n), "attribute");
+            String v = keyValuePairs.get(n + 1);
+            checkArgument(!v.contains("\""), "unsupported '\"' in attribute value: %s", v);
+        }
+        return ImmutableList.copyOf(keyValuePairs);
+    }
+
+    /**
+     * Helper method used to test for equivalent path element content. Used to help avoid
+     * unnecessary allocations during processing (see {@link CldrFileDataSource}).
+     */
+    boolean matchesContent(
+        String name,
+        int sortIndex,
+        List<String> keyValuePairs, /* Nullable */ CldrDraftStatus draftStatus) {
+        return this.elementName.equals(name)
+            && this.sortIndex == sortIndex
+            && this.attributeKeyValuePairs.equals(keyValuePairs)
+            && this.draftStatus.equals(resolveDraftStatus(this.parent, draftStatus));
+    }
+
+    // Helper to resolve the current draft status of a path based on any local draft status
+    // attributes and any existing parent status.
+    //
+    // Note that this behaviour currently matches CLDRFile behaviour as of May 2019. CLDRFile
+    // does a regex match over the full path and finds the first draft status attribute that's
+    // present, ignoring any later declarations (even if they are more restrictive). It seems
+    // likely that the implicit expectation in CLDRFile is that there's only ever one draft
+    // status attributes in any given path (see the pop() method in MyDeclHandler).
+    private static Optional<CldrDraftStatus> resolveDraftStatus(
+        /* @Nullable */ CldrPath parent, /* @Nullable */ CldrDraftStatus localStatus) {
+        if (parent != null && parent.draftStatus.isPresent()) {
+            return parent.draftStatus;
+        }
+        return localStatus != null ? localStatus.asOptional() : Optional.empty();
+    }
+
+    /**
+     * Returns the parent path element.
+     *
+     * @return the parent path element (or {@code null} if this was the root element).
+     */
+    /* @Nullable */
+    public CldrPath getParent() {
+        return parent;
+    }
+
+    /**
+     * Returns the non-zero length of this path (i.e. the number of elements it is made up of).
+     *
+     * @return the number of elements in this path.
+     */
+    public int getLength() {
+        return length;
+    }
+
+    /**
+     * Returns the name of this path element. This is the qualified XML name as it appears in the
+     * CLDR XML files, including namespace (e.g. "icu:transforms") though most attributes are not
+     * part of an explicit namespace.
+     *
+     * @return the ASCII-only name of the "lowest" element in this path.
+     */
+    // TODO: This method name is weak - perhaps getElementName() ?
+    public String getName() {
+        return elementName;
+    }
+
+    /**
+     * Returns the sort index of an "ordered" path element, or {@code -1} for non-ordered elements.
+     *
+     * <p>The sort index is used to disambiguate and sort otherwise identical distinguishing paths.
+     * The feature allows a series of values to be processed reliably in an ordered sequence. It is
+     * recommended that if your data includes "ordered" elements, they are always processed in
+     * {@link org.unicode.cldr.api.CldrData.PathOrder#DTD DTD} order.
+     *
+     * @return the element's sort index (which takes priority for element ordering over any
+     *     attribute values).
+     */
+    public int getSortIndex() {
+        return sortIndex;
+    }
+
+    /**
+     * Returns the raw value of an attribute associated with this CLDR path, or null if not present.
+     * For almost all use cases it is preferable to use the accessor methods on the {@link
+     * AttributeKey} class, which provide additional useful semantic checking and common type
+     * conversion. You should only use this method directly if there's a strong performance
+     * requirement.
+     *
+     * @param key the key identifying an attribute.
+     * @return the attribute value or {@code null} if not present.
+     * @see AttributeKey
+     */
+    @Override
+    /* @Nullable */ public String get(AttributeKey key) {
+        checkArgument(!getDataType().isValueAttribute(key),
+            "cannot get 'value attribute' values from a distinguishing path: %s", key);
+        String v = null;
+        for (CldrPath p = this; v == null && p != null; p = p.getParent()) {
+            if (p.getName().equals(key.getElementName())) {
+                v = p.getLocalAttributeValue(key.getAttributeName());
+            }
+        }
+        return v;
+    }
+
+    /**
+     * Returns the data type for this path, as defined by the top most element.
+     *
+     * @return the path's data type.
+     */
+    @Override
+    public CldrDataType getDataType() {
+        return dtdType;
+    }
+
+    /**
+     * Returns whether the given element name is in this path.
+     *
+     * @param elementName the element name to check.
+     * @return true if the name of this path element or any of its parents is equal to the given
+     *     element name.
+     */
+    boolean containsElement(String elementName) {
+        return getName().equals(elementName)
+            || (parent != null && parent.containsElement(elementName));
+    }
+
+    /**
+     * Returns the number of distinguishing attributes for this path element.
+     *
+     * @return the number of distinguishing attributes for the "lowest" element in this path.
+     */
+    int getAttributeCount() {
+        return attributeKeyValuePairs.size() / 2;
+    }
+
+    /**
+     * Returns the (non empty) name of the Nth distinguishing attribute in the leaf path element.
+     *
+     * @param n the index of a distinguishing attribute for the "lowest" element in this path.
+     * @return the name of the Nth attribute on this path element.
+     */
+    String getLocalAttributeName(int n) {
+        checkElementIndex(n, getAttributeCount());
+        return attributeKeyValuePairs.get(2 * n);
+    }
+
+    /**
+     * Returns the value of the Nth distinguishing attribute in the leaf path element.
+     *
+     * @param n the index of a distinguishing attribute for the "lowest" element in this path.
+     * @return the value of the Nth attribute on this path element.
+     */
+    String getLocalAttributeValue(int n) {
+        checkElementIndex(n, getAttributeCount());
+        return attributeKeyValuePairs.get((2 * n) + 1);
+    }
+
+    // Helper to get an attribute by name from this path element.
+    private String getLocalAttributeValue(String attributeName) {
+        checkNotNull(attributeName);
+        for (int i = 0; i < attributeKeyValuePairs.size(); i += 2) {
+            if (attributeName.equals(attributeKeyValuePairs.get(i))) {
+                return attributeKeyValuePairs.get(i + 1);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the draft status for this path, which is inherited from parent path elements. Note
+     * that where multiple (possibly conflicting) draft statuses are defined in a path, the "top
+     * most" (i.e. closest to the root element) value is used.
+     *
+     * @return the potentially inherited draft status.
+     */
+    Optional<CldrDraftStatus> getDraftStatus() {
+        return draftStatus;
+    }
+
+    /**
+     * Returns a combined full path string in the XPath style {@code //foo/bar[@x="y"]/baz},
+     * with value attributes inserted in correct DTD order for each path element.
+     *
+     * <p>Note that while in most cases the values attributes simply follow the path attributes on
+     * each element, this is not necessarily always true, and DTD ordering can place value
+     * attributes before path attributes in an element.
+     *
+     * @param value a value to be associated with this path (from which value attributes will be
+     *              obtained).
+     * @return the full XPath representation containing both distinguishing and value attributes.
+     */
+    String getFullPath(CldrValue value) {
+        checkNotNull(value);
+        return appendToString(new StringBuilder(), value.getValueAttributes()).toString();
+    }
+
+    /** Compares two paths in DTD order. */
+    @Override
+    public int compareTo(CldrPath other) {
+        if (dtdType == other.dtdType) {
+            return ordering.compare(this, other);
+        }
+        return dtdType.compareTo(other.dtdType);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof CldrPath)) {
+            return false;
+        }
+        CldrPath other = (CldrPath) obj;
+        // Test our own fields first, since paths will tend to differ at the ends.
+        return localEquals(other) && Objects.equals(this.parent, other.parent);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    /** @return the distinguishing path string in the XPath style {@code //foo/bar[@x="y"]/baz}. */
+    @Override
+    public String toString() {
+        return appendToString(new StringBuilder(), ImmutableMap.of()).toString();
+    }
+
+    private boolean localEquals(CldrPath other) {
+        // In _theory_ only length and localToString need to be checked (since the localToString is
+        // an unambiguous representation of the data, but it seems a bit hacky to rely on that.
+        return this.length == other.length
+            && this.elementName.equals(other.elementName)
+            && this.sortIndex == other.sortIndex
+            && this.attributeKeyValuePairs.equals(other.attributeKeyValuePairs);
+    }
+
+    // XPath like toString() representation of a path element (e.g. foo[@bar="x"][@baz="y"]).
+    // When a sort index is present, it's appended to the element name (e.g. "foo#42[@bar="x"]").
+    private String getLocalToString() {
+        if (localToString == null) {
+            String str = getName();
+            if (sortIndex != -1) {
+                // This is very rare so it's almost certainly better to not make a StringBuilder
+                // above just for this possibility.
+                str += "#" + sortIndex;
+            }
+            if (getAttributeCount() > 0) {
+                str = IntStream.range(0, getAttributeCount())
+                    .mapToObj(n ->
+                        String.format("[@%s=\"%s\"]", getLocalAttributeName(n), getLocalAttributeValue(n)))
+                    .collect(Collectors.joining("", str, ""));
+            }
+            // Overwrite only once the local string is completed (this is idempotent so we don't
+            // have to care about locking etc.).
+            localToString = str;
+        }
+        return localToString;
+    }
+
+    // Recursive helper for toString().
+    private StringBuilder appendToString(
+        StringBuilder out, ImmutableMap<AttributeKey, String> valueAttributes) {
+        CldrPath parent = getParent();
+        if (parent != null) {
+            parent.appendToString(out, valueAttributes).append('/');
+        } else {
+            out.append("//");
+        }
+        if (valueAttributes.isEmpty()) {
+            return out.append(getLocalToString());
+        }
+        List<String> attributeNames =
+            valueAttributes.keySet().stream()
+                .filter(k -> k.getElementName().equals(getName()))
+                .map(AttributeKey::getAttributeName)
+                .collect(toCollection(ArrayList::new));
+        if (attributeNames.isEmpty()) {
+            // No value attributes for _this_ element so can use just the local toString().
+            return out.append(getLocalToString());
+        }
+        if (getAttributeCount() > 0) {
+            String lastPathAttributeName = getLocalAttributeName(getAttributeCount() - 1);
+            if (dtdType.getAttributeComparator()
+                .compare(lastPathAttributeName, attributeNames.get(0)) > 0) {
+                // Oops, order is not as expected, so must reorder all attributes.
+                appendResortedValueAttributesTo(out, attributeNames, valueAttributes);
+                return out;
+            }
+        }
+        // Value attributes all come after path attributes.
+        return appendValueAttributesTo(out.append(getLocalToString()), attributeNames, valueAttributes);
+    }
+
+    private void appendResortedValueAttributesTo(
+        StringBuilder out,
+        List<String> attributeNames,
+        ImmutableMap<AttributeKey, String> valueAttributes) {
+        out.append(elementName);
+        for (int n = 0; n < attributeKeyValuePairs.size(); n += 2) {
+            attributeNames.add(attributeKeyValuePairs.get(n));
+        }
+        attributeNames.sort(dtdType.getAttributeComparator());
+        for (String attrName : attributeNames) {
+            String value = getLocalAttributeValue(attrName);
+            if (value == null) {
+                value = valueAttributes.get(AttributeKey.keyOf(elementName, attrName));
+                checkState(value != null, "missing value %s:%s", elementName, attrName);
+            }
+            out.append(String.format("[@%s=\"%s\"]", attrName, value));
+        }
+    }
+
+    private StringBuilder appendValueAttributesTo(
+        StringBuilder out,
+        List<String> attributeNames,
+        ImmutableMap<AttributeKey, String> valueAttributes) {
+        for (String attrName : attributeNames) {
+            String value = valueAttributes.get(AttributeKey.keyOf(elementName, attrName));
+            checkState(value != null, "missing value %s:%s", elementName, attrName);
+            out.append(String.format("[@%s=\"%s\"]", attrName, value));
+        }
+        return out;
+    }
+}

--- a/tools/java/org/unicode/cldr/api/CldrPaths.java
+++ b/tools/java/org/unicode/cldr/api/CldrPaths.java
@@ -1,0 +1,413 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
+import org.unicode.cldr.util.DtdData;
+import org.unicode.cldr.util.XPathParts;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Integer.signum;
+
+/**
+ * Utilities related to CLDR paths. It's possible that one day we might wish to expose the path
+ * comparator from this class, but if so we should key it off something other than {@code DtdType}.
+ */
+final class CldrPaths {
+    // Constants to make comparator logic a bit more readable (i.e. LHS < RHS ==> return -1).
+    private static final int LHS_FIRST = -1;
+    private static final int RHS_FIRST = 1;
+
+    // A synthetic attribute used by CLDR code to apply an explicit ordering to otherwise identical
+    // paths (this only happens for "ORDERED" elements). We handle this differently and have the
+    // sort index as an explicit field in CldrPath rather than treating it as an attribute.
+    private static final String HIDDEN_SORT_INDEX_ATTRIBUTE = "_q";
+
+    // When calculating things about elements we need to ignore deprecated ones, especially when
+    // looking for "leaf" elements, since CLDR data used to allow mixed content and the DTD still
+    // has elements with both data and (deprecated) child elements present.
+    private static final Predicate<DtdData.Element> IS_NOT_DEPRECATED = e -> !e.isDeprecated();
+
+    // TODO: Consider moving these basic (string/name) maps to CldrDataType.
+    // TODO: Maybe change to have explict Element and Attribute classes with metadata?
+
+    // A map of the leaf element names for each supported DTD.
+    private static final ImmutableSetMultimap<CldrDataType, String> LEAF_ELEMENTS_MAP;
+    // A map of the ordered element names for each supported DTD.
+    private static final ImmutableSetMultimap<CldrDataType, String> ORDERED_ELEMENTS_MAP;
+    static {
+        ImmutableSetMultimap.Builder<CldrDataType, String> leafElementsMap =
+            ImmutableSetMultimap.builder();
+        ImmutableSetMultimap.Builder<CldrDataType, String> orderedElementsMap =
+            ImmutableSetMultimap.builder();
+        for (CldrDataType type : CldrDataType.values()) {
+            // While at happened to be true (at the time of writing) that the getElements() method
+            // returns a new, mutable set, this is completely undocumented so we cannot rely on it
+            // (otherwise we could just do "removeIf(...)").
+            //
+            // Note that while the "specials" element has no children in the DTD, it is not
+            // considered a "leaf" element as it is expected to contain any additional elements
+            // from unknown namespaces (e.g. "icu:").
+            //
+            // We know that Guava's collection classes have a policy of never iterating over a
+            // collection more than once, so it's safe to use the ::iterator trick to convert a
+            // stream into a one-shot iterable (saves have to make temporary collections).
+            leafElementsMap.putAll(
+                type,
+                type.getElements()
+                    .filter(IS_NOT_DEPRECATED)
+                    // NOTE: Some leaf elements still have deprecated children (from when mixed
+                    // data was permitted).
+                    .filter(e -> e.getChildren().keySet().stream().noneMatch(IS_NOT_DEPRECATED))
+                    .map(DtdData.Element::getName)
+                    .filter(e -> !e.equals("special"))
+                    ::iterator);
+            orderedElementsMap.putAll(
+                type,
+                type.getElements()
+                    .filter(IS_NOT_DEPRECATED)
+                    .filter(DtdData.Element::isOrdered)
+                    .map(DtdData.Element::getName)
+                    ::iterator);
+        }
+        LEAF_ELEMENTS_MAP = leafElementsMap.build();
+        ORDERED_ELEMENTS_MAP = orderedElementsMap.build();
+    }
+
+    // A map of path comparators for each supported DTD.
+    private static final ImmutableMap<CldrDataType, DtdPathComparator> PATH_COMPARATOR_MAP;
+
+    // This static block must come after the attribute map is created since it uses it.
+    static {
+        ImmutableMap.Builder<CldrDataType, DtdPathComparator> pathMap = ImmutableMap.builder();
+        for (CldrDataType type : CldrDataType.values()) {
+            pathMap.put(type, new DtdPathComparator(type));
+        }
+        PATH_COMPARATOR_MAP = pathMap.build();
+    }
+
+    /**
+     * Returns a comparator for {@link CldrPath}s which is compatible with the canonical path
+     * ordering for the given DTD instance (e.g. {@link DtdData#getDtdComparator}()).
+     */
+    // TODO: Add tests to ensure it continues to agree to DTD ordering.
+    static Comparator<CldrPath> getPathComparator(CldrDataType type) {
+        return PATH_COMPARATOR_MAP.get(type);
+    }
+
+    private static final class DtdPathComparator implements Comparator<CldrPath> {
+        private final Comparator<String> elementNameComparator;
+        private final Comparator<String> attributeNameComparator;
+
+        private DtdPathComparator(CldrDataType dataType) {
+            this.elementNameComparator = dataType.getElementComparator();
+            this.attributeNameComparator = dataType.getAttributeComparator();
+        }
+
+        // This code should only return "signum" values for ordering (i.e. {-1, 0, 1}).
+        @Override
+        public int compare(CldrPath lhs, CldrPath rhs) {
+            int length = lhs.getLength();
+            if (length == rhs.getLength()) {
+                if (length == 1) {
+                    // Root nodes are special as they define the DTD type and must always be equal.
+                    // Paths with different types can be compared, but not via this comparator.
+                    checkState(lhs.getName().equals(rhs.getName()),
+                        "cannot compare paths with different DTD type: %s / %s", lhs, rhs);
+                    return 0;
+                }
+                // Compare parent paths first and return if they give an ordering.
+                int signum = compare(lhs.getParent(), rhs.getParent());
+                return (signum != 0) ? signum : compareCurrentElement(lhs, rhs);
+            } else if (length < rhs.getLength()) {
+                // Recursively shorten the RHS path until it's the same length.
+                int signum = compare(lhs, rhs.getParent());
+                // If the LHS is equal to the RHS parent, then the (shorter) LHS path comes first.
+                // Note this this can only happen if we are comparing non-leaf node paths.
+                return signum != 0 ? signum : LHS_FIRST;
+            } else {
+                // Flip the comparison if LHS was longer (we do this at most once per comparison).
+                return -compare(rhs,  lhs);
+            }
+        }
+
+        private int compareCurrentElement(CldrPath lhs, CldrPath rhs) {
+            String elementName = lhs.getName();
+            int signum = signum(elementNameComparator.compare(elementName, rhs.getName()));
+            if (signum != 0) {
+                return signum;
+            }
+            // Primary order within a path element is defined by the element index (this is a
+            // bit of a special value used only for "ORDERED" elements in the DTD. This always
+            // trumps any attribute ordering but is almost always -1.
+            signum = Integer.compare(lhs.getSortIndex(), rhs.getSortIndex());
+            if (signum != 0) {
+                return signum;
+            }
+            // Element name is the same, so test attributes. Attributes are already known to be
+            // ordered by the element's DTD order, so we only need to find and compare the first
+            // difference.
+            int minAttributeCount =
+                Math.min(lhs.getAttributeCount(), rhs.getAttributeCount());
+            for (int n = 0; n < minAttributeCount && signum == 0; n++) {
+                String attributeName = lhs.getLocalAttributeName(n);
+                // Important: We negate the comparison result here because we want elements with
+                // "missing" attributes to sort earlier.
+                //
+                // E.g. for two elements LHS="foo[a=x][b=y]" and RHS="foo[b=y]" we want to say
+                // that "RHS < LHS" because RHS is "missing" the attribute "[a=x]". But when we
+                // compare the first attributes we find "a" (LHS) < "b" (RHS), which is the
+                // opposite of what we want. This is because while LHS has a lower ordered
+                // attribute, that indicates that RHS is missing that attribute in the same
+                // position, which should make RHS sort first.
+                signum = -signum(
+                    attributeNameComparator.compare(attributeName, rhs.getLocalAttributeName(n)));
+                if (signum == 0) {
+                    // Attribute names equal, so test attribute value.
+                    signum = signum(
+                        DtdData.getAttributeValueComparator(elementName, attributeName)
+                            .compare(lhs.getLocalAttributeValue(n), rhs.getLocalAttributeValue(n)));
+                }
+            }
+            if (signum == 0) {
+                // Attributes match up to the minimum length, but one element might have more.
+                // Elements with more attributes sort _after_ those without.
+                if (lhs.getAttributeCount() > minAttributeCount) {
+                    signum = RHS_FIRST;
+                } else if (rhs.getAttributeCount() > minAttributeCount) {
+                    signum = LHS_FIRST;
+                }
+            }
+            return signum;
+        }
+    }
+
+    /** Returns whether this path is a full path ending in a "leaf" element. */
+    static boolean isLeafPath(CldrPath path) {
+        String lastElementName = path.getName();
+        return lastElementName.indexOf(':') != -1
+            || LEAF_ELEMENTS_MAP.get(path.getDataType()).contains(lastElementName);
+    }
+
+    /**
+     * Returns whether an element is "ORDERED" in the specified DTD (and should have an explicit
+     * sort index).
+     */
+    static boolean isOrdered(CldrDataType dtdType, String elementName) {
+        // Elements with namespaces unknown the the DTD are never ordered.
+        if (elementName.indexOf(':') != -1) {
+            return false;
+        }
+        // Returns empty set if DTD unknown, but it might also be the case that a valid DTD has no
+        // ordered elements, so we can't reasonable check for anything here.
+        return ORDERED_ELEMENTS_MAP.get(dtdType).contains(elementName);
+    }
+
+    // This can't go further up due to static initialization ordering issues.
+    // TODO: Move all reading of DTDs and setup for paths into a lazy holder.
+    private static final CldrPath LDML_VERSION =
+        CldrPath.parseDistinguishingPath("//ldml/identity/version");
+
+    /**
+     * Returns whether this path should be emitted by a data supplier. New cases can be added
+     * as needed.
+     */
+    static boolean shouldEmit(CldrPath path) {
+        // CLDRFile seems to do some interesting things with the version based on the DTD in
+        // which we see:
+        //
+        // <!ATTLIST version number CDATA #REQUIRED >
+        //    <!--@MATCH:regex/\$Revision.*\$-->
+        //    <!--@METADATA-->
+        //
+        // <!ATTLIST version cldrVersion CDATA #FIXED "36" >
+        //    <!--@MATCH:any-->
+        //    <!--@VALUE-->
+        //
+        // This results in conflict between values obtained via CLDRFile and those obtained
+        // directly by parsing an LDML XML file (which happens for "special" XML files in ICU).
+        //
+        // So for now I've decided to just ignore the version (since it's hardly used in the
+        // ICU converter code and always available via CldrDataSupplier#getCldrVersionString().
+        //
+        // Note that there is a need for some kind of versioning for some bits of data (since
+        // changes to things like collation can invalidate database search indexes) but this should
+        // be handled directly in the logic which builds the ICU data and isn't strictly the same
+        // as the LDML version anyway.
+        //
+        // TODO: Remove this code if and when LDML version strings are removed.
+        switch (path.getDataType()) {
+        case LDML:
+            return !path.equals(LDML_VERSION);
+        default:
+            return true;
+        }
+    }
+
+    /**
+     * Processes a full path to extract a distinguishing CldrPath and handle any value attributes
+     * present. This is designed for iterating over successive paths from CLDRFile, but can be used
+     * to create paths in isolation if necessary.
+     *
+     * @param fullPath a parsed full path.
+     * @param previousElements an optional list of previous CldrPath elements which will be used
+     *     as the prefix to the new path wherever possible (e.g. if previousElements="(a,b,c,d)"
+     *     and "fullPath=a/b/x/y/z", then the new path will share the path prefix up to and
+     *     including 'b'). When processing sorted paths, this will greatly reduce allocations.
+     * @param valueAttributeCollector a collector into which value attributes will be added (in
+     *     DTD order).
+     * @return a new CldrPath corresponding to the distinguishing path of {@code fullPath}.
+     * @throws IllegalArgumentException if the path string is invalid.
+     */
+    static CldrPath processXPath(
+        String fullPath,
+        List<CldrPath> previousElements,
+        BiConsumer<AttributeKey, String> valueAttributeCollector) {
+        checkArgument(!fullPath.isEmpty(), "path must not be empty");
+        // This fails if attribute names are invalid, but not if element names are invalid, and we
+        // want to control/stabalize the error messages in this API.
+        XPathParts pathParts;
+        try {
+            pathParts = XPathParts.getFrozenInstance(fullPath);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("invalid path: " + fullPath);
+        }
+        int length = pathParts.size();
+        checkArgument(length > 0, "cldr path must not be empty: %s", pathParts);
+        DtdData dtd = pathParts.getDtdData();
+        checkArgument(dtd != null, "unknown DTD type: %s", pathParts);
+        CldrDataType dtdType = CldrDataType.forRawType(dtd.dtdType);
+
+        // The path we're returning, constructed from top-to-bottom.
+        CldrPath path = null;
+        // Reusable key/value attributes list.
+        List<String> keyValuePairs = new ArrayList<>();
+        Consumer<Entry<String, String>> collectElementAttribute = e -> {
+            keyValuePairs.add(e.getKey());
+            keyValuePairs.add(e.getValue());
+        };
+        // True once we've started to create a new path rather than reusing previous elements.
+        boolean diverged = false;
+        for (int n = 0; n < length; n++) {
+            String elementName = pathParts.getElement(n);
+
+            // If this path is from CldrPath.toString() then the sort index is encoded in the
+            // element name suffix (e.g. foo#42[@bar="x"]), otherwise it's in the synthetic "_q"
+            // attribute. Most often there is no sort index however, so this code should optimize
+            // to the null case.
+            int sortIndex = -1;
+            Map<String, String> attributes = pathParts.getAttributes(n);
+            int nameEnd = elementName.indexOf('#');
+            if (nameEnd != -1) {
+                sortIndex = Integer.parseUnsignedInt(elementName.substring(nameEnd + 1));
+                elementName = elementName.substring(0, nameEnd);
+            } else {
+                String sortIndexStr = attributes.get(HIDDEN_SORT_INDEX_ATTRIBUTE);
+                if (sortIndexStr != null) {
+                    sortIndex = Integer.parseUnsignedInt(sortIndexStr);
+                }
+            }
+
+            // Note that element names need not be known to the DTD. If an element's name is
+            // prefixed with an unknown namespace (e.g. "icu:") then it is always permitted.
+            // Similarly, we never filter out attributes in unknown namespaces. For now we assume
+            // that any explicit namespace is unknown.
+            boolean hasNamespace = elementName.indexOf(':') != -1;
+            checkArgument(hasNamespace || dtd.getElementFromName().containsKey(elementName),
+                "invalid path: %s", fullPath);
+
+            // The keyValuePairs list is used by the collectElementAttribute callback but we don't
+            // want/need to make a new callback each time, so just clear the underlying list.
+            keyValuePairs.clear();
+            processPathAttributes(
+                elementName, attributes, dtdType, collectElementAttribute, valueAttributeCollector);
+
+            // WARNING: We cannot just get the draft attribute value from the attributes map (as
+            // would be expected) because it throws an exception. This is because you can only
+            // "get()" values from the attributes map if they are potentially valid attributes for
+            // that element. Unfortunately this is due to a deliberate choice in the implementation
+            // of MapComparator, which explicitly throws an exception if an unknown attribute is
+            // encountered. Thus we have to check that "draft" is a possible attribute before
+            // asking for its value.
+            //
+            // TODO(dbeaumont): Fix this properly, ideally by fixing the comparator to not throw.
+            CldrDraftStatus draftStatus = dtd.getAttribute(elementName, "draft") != null
+                ? CldrDraftStatus.forString(attributes.get("draft")) : null;
+
+            if (!diverged && n < previousElements.size()) {
+                CldrPath p = previousElements.get(n);
+                if (p.matchesContent(elementName, sortIndex, keyValuePairs, draftStatus)) {
+                    // The previous path we processed was the same at least down to this depth, so
+                    // we can just reuse that element instead of creating a new one.
+                    //
+                    // In tests over the resolved paths for "en_GB" in DTD order, there are ~128k
+                    // path elements processed, with ~103k being reused here and ~25k being newly
+                    // allocated (a > 80% reuse rate). However this works best when the incoming
+                    // paths are sorted, since otherwise the "previous" path is random.
+                    //
+                    // For unsorted paths, the reuse rate is reduced to approximately 25%. This is
+                    // still saving ~32k allocations for the "en_GB" example, and it still saved
+                    // about 35% in terms of measured time to process the paths.
+                    path = p;
+                    continue;
+                }
+            }
+            // This path has diverged from the previous path, so we must start making new elements.
+            path = new CldrPath(path, elementName, keyValuePairs, dtdType, draftStatus, sortIndex);
+            diverged = true;
+        }
+        return path;
+    }
+
+    // Returns the element's sort index (or -1 if not present).
+    static void processPathAttributes(
+        String elementName,
+        /* @Nullable */ Map<String, String> attributeMap,
+        CldrDataType dtdType,
+        Consumer<Entry<String, String>> collectElementAttribute,
+        BiConsumer<AttributeKey, String> collectValueAttribute) {
+
+        // Why not just a Map? Maps don't efficiently handle "get the Nth element" which is
+        // something that's used a lot in the ICU conversion code. Distinguishing attributes in
+        // paths are used more as a "list of pairs" than a map with key/value lookup. Even
+        // extensions like "NavigableMap" don't give you what you want.
+        //
+        // This does mean that lookup-by-name is a linear search (unless you want to pay the cost
+        // of also having a map here) but the average number of attributes is very small (<3).
+        if (attributeMap != null && !attributeMap.isEmpty()) {
+            processAttributes(
+                attributeMap.entrySet().stream(), elementName, collectValueAttribute, dtdType)
+                .forEach(collectElementAttribute);
+        }
+    }
+
+    static Stream<Entry<String, String>> processAttributes(
+        Stream<Entry<String, String>> in,
+        String elementName,
+        BiConsumer<AttributeKey, String> collectValueAttribute,
+        CldrDataType dtdType) {
+        Consumer<Entry<String, String>> collectValueAttributes = e -> {
+            if (dtdType.isValueAttribute(elementName, e.getKey())) {
+                collectValueAttribute.accept(AttributeKey.keyOf(elementName, e.getKey()), e.getValue());
+            }
+        };
+        return in
+            // Special case of a synthetic distinguishing attribute that's _not_ in the DTD, and
+            // should be ignored.
+            .filter(e -> !e.getKey().equals(HIDDEN_SORT_INDEX_ATTRIBUTE))
+            .peek(collectValueAttributes)
+            .filter(e -> dtdType.isDistinguishingAttribute(elementName, e.getKey()));
+    }
+
+    private CldrPaths() {}
+}

--- a/tools/java/org/unicode/cldr/api/CldrValue.java
+++ b/tools/java/org/unicode/cldr/api/CldrValue.java
@@ -1,0 +1,195 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.unicode.cldr.api.AttributeKey.AttributeSupplier;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A CLDR element value and associated "value" attributes, along with its distinguishing {@link
+ * CldrPath}.
+ *
+ * <p>In CLDR, a path contains attributes that are one of three types; "distinguishing", "value"
+ * and "metadata", and a path can be parsed to extract value attributes.
+ *
+ * <p>CldrValue instance hold only the "value" attributes, with "distinguishing" attributes being
+ * held by the associated {@link CldrPath}, and "metadata" attributes being ignored completely
+ * since they are synthetic and internal to the core CLDR classes.
+ *
+ * <p>Note that while the ordering of "value" attributes is stable, it should not be relied upon.
+ * Unlike "distinguishing" attributes in CldrPath, "value" attributes don't conceptually form a
+ * sequence. It is expected that users will only lookup attribute values directly by their keys and
+ * never care about their order.
+ *
+ * <p>CldrValue is an immutable value type with efficient equality semantics.
+ *
+ * <p>See <a href="https://www.unicode.org/reports/tr35/#Definitions">the LDML specification</a>
+ * for more details.
+ */
+public final class CldrValue implements AttributeSupplier {
+    /**
+     * Parses a full CLDR path string, possibly containing "distinguishing", "value" and even
+     * private "metadata" attributes into a normalized CldrValue instance. Attributes will be parsed
+     * and handled according to their type:
+     * <ul>
+     * <li>Value attributes will be added to the returned CldrValue instance.
+     * <li>Distinguishing attributes will be added to the associated CldrPath instance.
+     * <li>Other non-public attributes will be ignored.
+     * </ul>
+     *
+     * <p>The path string must be structured correctly (e.g. "//ldml/foo[@bar="baz]") and must
+     * represent a known DTD type, based on the first path element (e.g. "//ldml/...").
+     *
+     * @param fullPath the full path string, possibly containing all types of attribute.
+     * @param value the primary leaf value associated with the path (possibly empty).
+     * @return the parsed value instance, referencing the associated distinguishing path.
+     * @throws IllegalArgumentException if the path is not well formed.
+     */
+    public static CldrValue parseValue(String fullPath, String value) {
+        LinkedHashMap<AttributeKey, String> valueAttributes = new LinkedHashMap<>();
+        CldrPath path = CldrPaths.processXPath(fullPath, ImmutableList.of(), valueAttributes::put);
+        return new CldrValue(value, valueAttributes, path);
+    }
+
+    // Note: If this is ever made public, it should be modified to enforce attribute order
+    // according to the DTD. It works now because the code calling it handles ordering correctly.
+    static CldrValue create(String value, Map<AttributeKey, String> valueAttributes, CldrPath path) {
+        return new CldrValue(value, valueAttributes, path);
+    }
+
+    private final String value;
+    private final ImmutableMap<AttributeKey, String> attributes;
+    private final CldrPath path;
+    // Cached to avoid repeated recalculation from the map (which cannot cache its hash code).
+    private final int hashCode;
+
+    private CldrValue(String value, Map<AttributeKey, String> attributes, CldrPath path) {
+        // Empty value strings are permitted (but null is not).
+        this.value = checkNotNull(value);
+        this.attributes = checkAttributeMap(attributes);
+        this.path = checkNotNull(path);
+        this.hashCode = Objects.hash(value, this.attributes, path);
+    }
+
+    private static ImmutableMap<AttributeKey, String> checkAttributeMap(
+        Map<AttributeKey, String> attributes) {
+        // Keys are checked on creation, but values need to be checked.
+        for (String v : attributes.values()) {
+            checkArgument(!v.contains("\""), "unsupported '\"' in attribute value: %s", v);
+        }
+        return ImmutableMap.copyOf(attributes);
+    }
+
+    /**
+     * Returns the primary (non-attribute) CLDR value associated with a distinguishing path. For a
+     * CLDR element with no explicitly associated value, an empty string is returned.
+     *
+     * @return the primary value of this CLDR value instance.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the raw value of an attribute associated with this CLDR value or distinguishing
+     * path, or null if not present. For almost all use cases it is preferable to use the accessor
+     * methods on the {@link AttributeKey} class, which provide additional useful semantic checking
+     * and common type conversion. You should only use this method directly if there's a strong
+     * performance requirement.
+     *
+     * @param key the key identifying an attribute.
+     * @return the attribute value or {@code null} if not present.
+     * @see AttributeKey
+     */
+    @Override
+    /* @Nullable */ public String get(AttributeKey key) {
+        if (getPath().getDataType().isValueAttribute(key)) {
+            return attributes.get(key);
+        }
+        return getPath().get(key);
+    }
+
+    /**
+     * Returns the data type for this value, as defined by its path.
+     *
+     * @return the value's data type.
+     */
+    @Override
+    public CldrDataType getDataType() {
+        return getPath().getDataType();
+    }
+
+    /**
+     * Returns the "value" attributes associated with this value. Attribute ordering is stable,
+     * with attributes from earlier path elements preceding attributes for later ones. However it
+     * is recommended that callers avoid relying on specific ordering semantics and always look up
+     * attribute values by key if possible.
+     *
+     * @return a map of the value attributes for this CLDR value instance.
+     */
+    // TODO: This is used in only two places outside this package, so consider making it non-public.
+    public ImmutableMap<AttributeKey, String> getValueAttributes() {
+        return attributes;
+    }
+
+    /**
+     * Returns the CldrPath associated with this value. All value instances are associated with
+     * a distinguishing path.
+     */
+    public CldrPath getPath() {
+        return path;
+    }
+
+    /**
+     * Returns a combined full path string in the XPath style {@code //foo/bar[@x="y"]/baz},
+     * with value attributes inserted in correct DTD order for each path element.
+     *
+     * <p>Note that while in most cases the values attributes simply follow the path attributes on
+     * each element, this is not necessarily always true, and DTD ordering can place value
+     * attributes before path attributes in an element.
+     *
+     * @return the full XPath representation containing both distinguishing and value attributes.
+     */
+    public String getFullPath() {
+        return getPath().getFullPath(this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof CldrValue)) {
+            return false;
+        }
+        CldrValue other = (CldrValue) obj;
+        return this.path.equals(other.path)
+            && this.value.equals(other.value)
+            && this.attributes.equals(other.attributes);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    /** @return a debug-only representation of this CLDR value. */
+    @Override
+    public String toString() {
+        if (value.isEmpty()) {
+            return String.format("attributes=%s, path=%s", attributes, path);
+        } else if (attributes.isEmpty()) {
+            return String.format("value=\"%s\", path=%s", value, path);
+        } else {
+            return String.format("value=\"%s\", attributes=%s, path=%s", value, attributes, path);
+        }
+    }
+}

--- a/tools/java/org/unicode/cldr/api/InMemoryData.java
+++ b/tools/java/org/unicode/cldr/api/InMemoryData.java
@@ -1,0 +1,58 @@
+package org.unicode.cldr.api;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+
+/** An in-memory representation of CldrData based on a simple map. */
+final class InMemoryData extends AbstractDataSource implements CldrData {
+    // Allow arbitrary ordering of specified path/value pairs (possibly not even NESTED_GROUPING).
+    private final ImmutableMap<CldrPath, CldrValue> pathValuePairs;
+
+    InMemoryData(Iterable<CldrValue> values) {
+        this.pathValuePairs = Maps.uniqueIndex(values, CldrValue::getPath);
+        // Test that none of the paths in the map are prefixes of any other paths. This is a
+        // requirement for distinguishing paths.
+        Set<CldrPath> pathPrefixes = new HashSet<>();
+        for (CldrPath p : pathValuePairs.keySet()) {
+            checkArgument(pathPrefixes.add(p),
+                "distinguishing paths must not be prefixes of other paths: %s", p);
+            // Add the rest of the path prefixes for this path (until we hit existing values).
+            for (p = p.getParent(); p != null && pathPrefixes.add(p); p = p.getParent()) {}
+        }
+    }
+
+    @Override
+    public void accept(PathOrder order, ValueVisitor visitor) {
+        sortKeys(order).forEach(p -> safeVisit(pathValuePairs.get(p), visitor));
+    }
+
+    @Override
+    public CldrValue get(CldrPath path) {
+        return pathValuePairs.get(path);
+    }
+
+    private Stream<CldrPath> sortKeys(PathOrder order) {
+        Stream<CldrPath> rawOrder = pathValuePairs.keySet().stream();
+        switch (order) {
+        case ARBITRARY:
+            return rawOrder;
+        case NESTED_GROUPING:
+            // toString() will give nested grouping if no paths are prefixes of each other.
+            // More importantly for testing, this is NOT DTD order.
+            return rawOrder.sorted(comparing(Object::toString));
+        case DTD:
+            // Paths are naturally DTD order.
+            return rawOrder.sorted(naturalOrder());
+        default:
+            throw new AssertionError("Unknown path order!!: " + order);
+        }
+    }
+}

--- a/tools/java/org/unicode/cldr/api/PrefixVisitorHost.java
+++ b/tools/java/org/unicode/cldr/api/PrefixVisitorHost.java
@@ -1,0 +1,228 @@
+package org.unicode.cldr.api;
+
+import org.unicode.cldr.api.CldrData.PathOrder;
+import org.unicode.cldr.api.CldrData.PrefixVisitor;
+import org.unicode.cldr.api.CldrData.PrefixVisitor.Context;
+import org.unicode.cldr.api.CldrData.ValueVisitor;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
+
+/**
+ * Utility class for reconstructing nested path visitation from a sequence of path/value pairs. See
+ * {@link PrefixVisitor} for more information.
+ */
+final class PrefixVisitorHost {
+    /**
+     * Accepts a prefix visitor over a nested sequence of prefix paths derived from the given data
+     * instance. This method synthesizes a sequence of start/end events for all the sub-trees
+     * implied by the sequence of CLDR paths produced by the data supplier.
+     *
+     * <p>For example, given the sequence:
+     *
+     * <pre>{@code
+     * //ldml/foo/bar/first
+     * //ldml/foo/bar/second
+     * //ldml/foo/bar/third
+     * //ldml/foo/baz/first
+     * //ldml/foo/baz/second
+     * //ldml/quux
+     * }</pre>
+     *
+     * the following start, end and value visitation events will be derived:
+     *
+     * <pre>{@code
+     * start: //ldml
+     * start: //ldml/foo
+     * start: //ldml/foo/bar
+     * value: //ldml/foo/bar/first
+     * value: //ldml/foo/bar/second
+     * value: //ldml/foo/bar/third
+     * end:   //ldml/foo/bar
+     * start: //ldml/foo/baz
+     * value: //ldml/foo/baz/first
+     * value: //ldml/foo/baz/second
+     * end:   //ldml/foo/baz
+     * end:   //ldml/foo
+     * value: //ldml/quux
+     * end:   //ldml
+     * }</pre>
+     *
+     * <p>Note that deriving the proper sequence of start/end events can only occur if the data is
+     * provided in at least {@link PathOrder#NESTED_GROUPING NESTED_GROUPING} order. If a lower
+     * path order (e.g. {@link PathOrder#ARBITRARY ARBITRARY}) is given then {@code NESTED_GROUPING}
+     * will be used.
+     */
+    static void accept(
+        BiConsumer<PathOrder, ValueVisitor> acceptFn, PathOrder order, PrefixVisitor v) {
+        PrefixVisitorHost host = new PrefixVisitorHost(v);
+        if (order.ordinal() < NESTED_GROUPING.ordinal()) {
+            order = NESTED_GROUPING;
+        }
+        acceptFn.accept(order, host.visitor);
+        host.endVisitation();
+    }
+
+    /**
+     * Represents the root of a sub hierarchy visitation rooted at some path prefix. VisitorState
+     * instances are kept in a stack; they are added when a new visitor is installed to begin a
+     * sub hierarchy visitation and removed automatically once the visitation is complete.
+     */
+    @SuppressWarnings("unused")  // For unused arguments in no-op default methods.
+    private static abstract class VisitorState {
+        /** Creates a visitor state from the given visitor for the specified leaf value. */
+        static <T extends ValueVisitor> VisitorState of(
+            T visitor, Consumer<T> doneHandler, CldrPath prefix) {
+            return new VisitorState(prefix, () -> doneHandler.accept(visitor)) {
+                @Override
+                public void visit(CldrValue value) {
+                    AbstractDataSource.safeVisit(value, visitor);
+                }
+            };
+        }
+
+        /** Creates a visitor state from the given visitor rooted at the specified path prefix. */
+        static <T extends PrefixVisitor> VisitorState of(
+            T visitor, Consumer<T> doneHandler, CldrPath prefix) {
+            return new VisitorState(prefix, () -> doneHandler.accept(visitor)) {
+                @Override
+                public void visitPrefixStart(CldrPath prefix, Context ctx) {
+                    safeVisitPrefix(prefix, p -> visitor.visitPrefixStart(p, ctx));
+                }
+
+                @Override
+                public void visitPrefixEnd(CldrPath prefix) {
+                    safeVisitPrefix(prefix, visitor::visitPrefixEnd);
+                }
+            };
+        }
+
+        // The root of the sub hierarchy visitation.
+        /* @Nullable */ private final CldrPath prefix;
+        private final Runnable doneCallback;
+
+        private VisitorState(CldrPath prefix, Runnable doneCallback) {
+            this.prefix = prefix;
+            this.doneCallback = doneCallback;
+        }
+
+        // These methods are the union of the public visitor methods and are used to dispatch
+        // the events triggered by path processing to the currently installed visitor.
+        void visit(CldrValue value) { }
+
+        void visitPrefixStart(CldrPath prefix, Context ctx) { }
+
+        void visitPrefixEnd(CldrPath prefix) { }
+
+        // Helper to ensure that we don't fail the entire visitation when a single visitor fails.
+        // NOTE: This could be removed once a more coherent error handling strategy is defined.
+        private static void safeVisitPrefix(CldrPath prefix, Consumer<CldrPath> fn) {
+            try {
+                fn.accept(prefix);
+            } catch (RuntimeException e) {
+                System.err.format("Exception thrown by prefix visitor for path '%s'\n", prefix);
+                System.err.println(e);
+                e.printStackTrace(System.err);
+            }
+        }
+    }
+
+    // Stack of currently installed visitor.
+    private final Deque<VisitorState> visitorStack = new ArrayDeque<>();
+    /* @Nullable */ private CldrPath lastValuePath = null;
+
+    // Visits a single value (with its path) and synthesizes prefix start/end calls according
+    // to the state of the visitor stack.
+    // This is a private field to avoid anyone accidentally calling the visit method directly.
+    private final ValueVisitor visitor = value -> {
+        CldrPath path = value.getPath();
+        int commonLength = 0;
+        if (lastValuePath != null) {
+            commonLength = CldrPath.getCommonPrefixLength(lastValuePath, path);
+            checkState(commonLength <= lastValuePath.getLength(),
+                "unexpected child path encountered: %s is child of %s", path, lastValuePath);
+            handleLastPath(commonLength);
+        }
+        // ... then down to the new path (which cannot be a parent of the old path either).
+        checkState(commonLength <= path.getLength(),
+            "unexpected parent path encountered: %s is parent of %s", path, lastValuePath);
+        recursiveStartVisit(path.getParent(), commonLength, new PrefixContext());
+        // This is a no-op if the head of the stack is a prefix visitor.
+        visitorStack.peek().visit(value);
+        lastValuePath = path;
+    };
+
+    private PrefixVisitorHost(PrefixVisitor visitor) {
+        this.visitorStack.push(VisitorState.of(visitor, v -> {}, null));
+    }
+
+    // Called after visitation is complete to close out the last visited value path.
+    private void endVisitation() {
+        if (lastValuePath != null) {
+            handleLastPath(0);
+        }
+    }
+
+    // Recursively visits new prefix path elements (from top-to-bottom) for a new sub hierarchy.
+    private void recursiveStartVisit(
+        /* @Nullable */ CldrPath prefix, int commonLength, PrefixContext ctx) {
+        if (prefix != null && prefix.getLength() > commonLength) {
+            recursiveStartVisit(prefix.getParent(), commonLength, ctx);
+            // Get the current visitor here (it could have been modified by the call above).
+            // This is a no-op if the head of the stack is a value visitor.
+            visitorStack.peek().visitPrefixStart(prefix, ctx.setPrefix(prefix));
+        }
+    }
+
+    // Go up from the previous path to the common length (we _have_ already visited the leaf
+    // node of the previous path and we do not allow the new path to be a sub-path) ...
+    private void handleLastPath(int length) {
+        for (CldrPath prefix = lastValuePath.getParent();
+             prefix != null && prefix.getLength() > length;
+             prefix = prefix.getParent()) {
+            // Get the current visitor here (it could have been modified by the last iteration).
+            //
+            // Note: e.prefix can be null for the top-most entry in the stack, but that's fine
+            // since it will never match "prefix" and we never want to remove it anyway.
+            VisitorState e = visitorStack.peek();
+            if (prefix.equals(e.prefix)) {
+                e.doneCallback.run();
+                visitorStack.pop();
+                e = visitorStack.peek();
+            }
+            // This is a no-op if the head of the stack is a value visitor.
+            e.visitPrefixEnd(prefix);
+        }
+    }
+
+    /**
+     * Implements a reusable context which captures the current prefix being processed. This is
+     * used if a visitor wants to install a sub-visitor at a particular point during visitation.
+     */
+    private final class PrefixContext implements Context {
+        // Only null until first use.
+        private CldrPath prefix = null;
+
+        // Must be called immediately prior to visiting a prefix visitor.
+        private PrefixContext setPrefix(CldrPath prefix) {
+            this.prefix = checkNotNull(prefix);
+            return this;
+        }
+
+        @Override
+        public <T extends PrefixVisitor> void install(T visitor, Consumer<T> doneHandler) {
+            visitorStack.push(VisitorState.of(visitor, doneHandler, prefix));
+        }
+
+        @Override
+        public <T extends ValueVisitor> void install(T visitor, Consumer<T> doneHandler) {
+            visitorStack.push(VisitorState.of(visitor, doneHandler, prefix));
+        }
+    }
+}

--- a/tools/java/org/unicode/cldr/api/XmlDataSource.java
+++ b/tools/java/org/unicode/cldr/api/XmlDataSource.java
@@ -1,0 +1,366 @@
+package org.unicode.cldr.api;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multiset;
+import org.unicode.cldr.util.CachingEntityResolver;
+import org.xml.sax.Attributes;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.base.CharMatcher.whitespace;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.joining;
+
+/** Serializes a set of LDML XML files as a sequence of {@code CldrValue}s. */
+final class XmlDataSource extends AbstractDataSource {
+    private static final Splitter TRIMMING_LINE_SPLITTER =
+        Splitter.on('\n').trimResults().omitEmptyStrings();
+    private static final CharMatcher NOT_WHITESPACE = whitespace().negate();
+
+    private final CldrDataType dtdType;
+    private final ImmutableSet<Path> xmlFiles;
+    private final CldrDraftStatus minimalDraftStatus;
+    private final Function<Path, Reader> openFn;
+
+    // Memoized data map to avoid loading/parsing files more than once.
+    private volatile ImmutableMap<CldrPath, CldrValue> pathValueMap = null;
+    // Whether the memoized map is in DTD order (we re-sort after it's cached).
+    private volatile boolean isDtdOrder = false;
+    // Lock to protect state of memoized map and ordering flag. These fields are volatile because
+    // we're using "double checked locking" to read the cached map.
+    // See: https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
+    private final Object cacheLock = new Object();
+
+    // TODO: Handle draft status properly (it's a METADATA attribute).
+    //
+    // It LOOKS like the current code (see XMLSource and SimpleXMLSource) will handle multiple
+    // equivalent distinguishing paths with draft status by preserving the _last_ one found into
+    // the CLDRFile. This is awkward if we just want to stream the paths directly from the XML,
+    // since we are not keeping track of the paths already seen (maybe we should).
+    //
+    // However in practice, there's only ever one path with draft status present in the non-LDML
+    // files, so it should be enough to simply include/exclude based on the status (and maybe
+    // ignore the possibility of the same distinguishing path appearing twice??)
+    //
+    // It terms of having multiple draft status attributes on a path, it seems that the current
+    // CLDRFile code has a "top-most one wins" strategy, which can be affected in this code by
+    // simply setting draft status the first time it's present on an element.
+    XmlDataSource(CldrDataType dtdType, Set<Path> xmlFiles, CldrDraftStatus draftStatus) {
+        this(dtdType, xmlFiles, draftStatus, XmlDataSource::openFile);
+    }
+
+    // @VisibleForTesting
+    XmlDataSource(
+        CldrDataType dtdType, Set<Path> xmlFiles, CldrDraftStatus draftStatus, Function<Path, Reader> openFn) {
+        this.xmlFiles = ImmutableSet.copyOf(xmlFiles);
+        this.dtdType = dtdType;
+        this.minimalDraftStatus = checkNotNull(draftStatus);
+        this.openFn = checkNotNull(openFn);
+    }
+
+    private Map<CldrPath, CldrValue> getPathValueMap(PathOrder order) {
+        // XML is always at least using nested grouping, so the only question is whether to sort it
+        // into DTD order or not. Obviously this changes if there's ever another ordering possible.
+        boolean mustSort = (order == PathOrder.DTD);
+        ImmutableMap<CldrPath, CldrValue> localMapRef = pathValueMap;
+        if (localMapRef == null) {
+            Map<CldrPath, CldrValue> map = mustSort ? new TreeMap<>() : new LinkedHashMap<>();
+            read(value -> map.put(value.getPath(), value), dtdType, true);
+            // Avoid work with the lock held...
+            localMapRef = ImmutableMap.copyOf(map);
+            // There's a race condition here whereby two threads can decide to create the map
+            // but in different orders and then the flags get out of sync with the map contents.
+            synchronized (cacheLock) {
+                if (pathValueMap == null) {
+                    this.pathValueMap = localMapRef;
+                    this.isDtdOrder = mustSort;
+                    return localMapRef;
+                }
+            }
+        }
+        // Path value map exists, but might need resorting (don't read the dtd order earlier since
+        // it could have just been modified by another thread).
+        if (mustSort && !isDtdOrder) {
+            ImmutableMap.Builder<CldrPath, CldrValue> map = ImmutableSortedMap.naturalOrder();
+            localMapRef = map.putAll(pathValueMap).build();
+            synchronized (cacheLock) {
+                if (!isDtdOrder) {
+                    this.pathValueMap = localMapRef;
+                    this.isDtdOrder = true;
+                }
+            }
+        }
+        return localMapRef;
+    }
+
+    @Override
+    public void accept(PathOrder order, ValueVisitor visitor) {
+        getPathValueMap(order).values().forEach(v -> safeVisit(v, visitor));
+    }
+
+    @Override
+    public CldrValue get(CldrPath path) {
+        return getPathValueMap(PathOrder.ARBITRARY).get(path);
+    }
+
+    // Helper used to open files but which allows alternate implementation for in-memory testing.
+    private static Reader openFile(Path p) {
+        try {
+            return Files.newBufferedReader(p);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void read(ValueVisitor visitor, CldrDataType dtdType, boolean validating) {
+        XMLReader xmlReader = createXmlReader(validating);
+        xmlReader.setErrorHandler(ERROR_HANDLER);
+        xmlReader.setContentHandler(new PathValueHandler(visitor, dtdType));
+        for (Path p : xmlFiles) {
+            try (Reader r = openFn.apply(p)) {
+                InputSource src = new InputSource(r);
+                // Important: The system ID is a URI or path which should identify the XML file so
+                // that a relative path to the DTD can be resolved. Thus if the XML contains
+                // <!DOCTYPE ldmlBCP47 SYSTEM "../../common/dtd/ldmlBCP47.dtd">
+                // then the location of "ldmlBCP47.dtd" can be properly determined. Thus even for
+                // testing, a suitable path from which the DTD can be determined must be used.
+                src.setSystemId(p.toString());
+                parseXml(xmlReader, src, p);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static void parseXml(XMLReader xmlReader, InputSource src, Path path) {
+        try {
+            xmlReader.parse(src);
+        } catch (IncompatibleDtdException e) {
+            // Do nothing and just exit if the root element is not for our expected DTD. This is
+            // fine, since we currently look for an XML files to parse, so cannot have strong
+            // expectations.
+        } catch (SAXParseException e) {
+            throw new IllegalArgumentException(
+                "error reading " + path + " (line " + e.getLineNumber() + ")", e);
+        } catch (SAXException | IOException e) {
+            throw new IllegalArgumentException("error reading " + path, e);
+        }
+    }
+
+    private static XMLReader createXmlReader(boolean validating) {
+        XMLReader xmlReader;
+        try {
+            xmlReader = XMLReaderFactory.createXMLReader();
+            xmlReader.setFeature("http://xml.org/sax/features/validation", validating);
+            xmlReader.setEntityResolver(new CachingEntityResolver());
+        } catch (SAXException e) {
+            throw new RuntimeException(e);
+        }
+        return xmlReader;
+    }
+
+    private final class PathValueHandler extends DefaultHandler {
+        private final ValueVisitor visitor;
+        private final CldrDataType dataType;
+        private final Multiset<String> orderedElementIndices = HashMultiset.create();
+
+        private final Map<AttributeKey, String> valueAttributes = new LinkedHashMap<>();
+        private CldrPath path = null;
+        // You can get multiple calls to "characters()" for a single element.
+        private StringBuilder elementText = new StringBuilder();
+        private boolean wasLeafElement = true;
+
+        private PathValueHandler(ValueVisitor visitor, CldrDataType dataType) {
+            this.visitor = visitor;
+            this.dataType = dataType;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes) {
+            if (path == null && !qName.equals(dataType.getLdmlName())) {
+                throw new IncompatibleDtdException();
+            }
+            int sortIndex = -1;
+            if (CldrPaths.isOrdered(dataType, qName)) {
+                // Zero first time we hit an ordered element.
+                sortIndex = orderedElementIndices.size();
+                orderedElementIndices.add(qName);
+            }
+            path = extendPath(path, qName, attributes, sortIndex, dataType, valueAttributes::put);
+            elementText.setLength(0);
+            wasLeafElement = true;
+        }
+
+        // Note: This is not invoked for self-closing elements (e.g. "<foo/>").
+        @Override
+        public void characters(char[] ch, int start, int length) {
+            elementText.append(ch, start, length);
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) {
+            // False if we have, since starting this element, entered and exited a child element.
+            if (wasLeafElement) {
+                if (hasAllowedDraftStatus(path) && CldrPaths.shouldEmit(path)) {
+                    // IMPORTANT: The CldrFile class doesn't just trim whitespace at the start and
+                    // end of values, it also removes any blank lines (unconditionally) on the
+                    // apparent assumption that it is never important. However it doesn't remove
+                    // leading whitespace if there isn't a newline in it.
+                    //
+                    // Thus: "  foo  \n  bar  " becomes "  foo\nbar  ", and not "foo\nbar".
+                    //
+                    // This is duplicated here but could be adapted or modified if necessary. In
+                    // particular this is not the same as trimAndCollapseFrom() in CharMatcher.
+                    //
+                    // See "addPath()" and "trimWhitespaceSpecial()" in CLDRFile.
+                    //
+                    // The least hacky way to do this is to trim and remove all whitespace, and
+                    // then add back any leading/trailing whitespace (providing it doesn't contain
+                    // a newline).
+                    String value = String.join("\n", TRIMMING_LINE_SPLITTER.split(elementText));
+                    if (!value.isEmpty()) {
+                        // Not empty means there's at least one non-whitespace character in the
+                        // original value, so the code below has something to anchor to. We also
+                        // normalise any leading/trailing whitespace to a single ASCII space.
+                        int n = NOT_WHITESPACE.indexIn(elementText);
+                        if (n > 0 && elementText.charAt(n) != '\n') {
+                            value = Strings.repeat(" ", n) + value;
+                        }
+                        n = NOT_WHITESPACE.lastIndexIn(elementText);
+                        if (n < elementText.length() - 1 && elementText.charAt(n) != '\n') {
+                            value = value + Strings.repeat(" ", (elementText.length() - 1) - n);
+                        }
+                    }
+                    safeVisit(path, value, valueAttributes, visitor);
+                }
+            } else {
+                checkState(whitespace().matchesAllOf(elementText),
+                    "mixed content found in XML file: %s", path);
+            }
+            elementText.setLength(0);
+
+            // Slightly subtle way to ensure that we reset the sort index for any _child_ elements
+            // of the path we are leaving (we do not reset the sort index of the current path).
+            // This is technically optional since the only requirement of the source index is that
+            // it's monotonically increasing in "encounter" order. In fact the whole idea of having
+            // a sort index is weird when considering that CLDR data can be split over multiple XML
+            // files which are not necessarily processed together (consider two data instances,
+            // both with the same ordered elements which are then merged).
+            // TODO: Figure out how to protect against duplicate paths with equal sort indices!!
+            orderedElementIndices.elementSet().removeIf(s -> !path.containsElement(s));
+            path = path.getParent();
+
+            // We just want to remove the attributes which share the name of the element we are
+            // leaving. Since element names are never repeated in a CLDR path, this is safe.
+            valueAttributes.keySet().removeIf(k -> k.getElementName().equals(qName));
+            wasLeafElement = false;
+        }
+    }
+
+    private boolean hasAllowedDraftStatus(CldrPath path) {
+        return path.getDraftStatus().map(s -> s.compareTo(minimalDraftStatus) >= 0).orElse(true);
+    }
+
+    /**
+     * Extends an existing path (or null) according to the currently visited XML element
+     * information. This is designed to only be called by SAX parser handlers and must not be made
+     * public in this class.
+     *
+     * @param parent parent path (or null if this is the root element).
+     * @param elementName qualified element name as provided by the SAX parser.
+     * @param xmlAttributes attributes as provided by the SAX parser.
+     * @param dtd the DTD information to allow attributes to be filtered and sorted correctly.
+     * @param valueAttributeCollector a collector for any non-distinguishing value attributes
+     *     encountered during processing (they get "saved up" to go on the CldrValue).
+     */
+    private static CldrPath extendPath(
+        /* @Nullable */ CldrPath parent,
+        String elementName,
+        Attributes xmlAttributes,
+        int sortIndex,
+        CldrDataType dataType,
+        BiConsumer<AttributeKey, String> valueAttributeCollector) {
+        List<String> attributeKeyValuePairs = ImmutableList.of();
+        CldrDraftStatus draftStatus = null;
+        if (xmlAttributes.getLength() > 0) {
+            draftStatus = CldrDraftStatus.forString(xmlAttributes.getValue("draft"));
+
+            // XML attributes are NOT necessarily ordered by DTD ordering, so we must fix that.
+            Stream<Entry<String, String>> sortedAttributes =
+                IntStream.range(0, xmlAttributes.getLength())
+                    .mapToObj(xmlAttributes::getQName)
+                    .sorted(dataType.getAttributeComparator())
+                    .map(s -> Maps.immutableEntry(s, xmlAttributes.getValue(s)));
+
+            // New variable needed because of lambdas needing "effectively final" instances.
+            List<String> valueAttributes = new ArrayList<>();
+            CldrPaths
+                .processAttributes(sortedAttributes, elementName, valueAttributeCollector, dataType)
+                .forEach(e -> {
+                    valueAttributes.add(e.getKey());
+                    valueAttributes.add(e.getValue());
+                });
+            attributeKeyValuePairs = valueAttributes;
+        }
+        // IMPORTANT: XML based CLDR data currently invents sort indices based on "encounter order"
+        // in the XML, but this doesn't prevent duplicate sort indices if several data sources with
+        // the same path structure are created and then merged. At the moment there are no cases
+        // where paths from different XML files could share sort indices on the same element, but
+        // there should probably be code to handle it one way or another.
+        // TODO: Figure out how to handle sort indices split over multiple files (possibly error).
+        return new CldrPath(
+            parent, elementName, attributeKeyValuePairs, dataType, draftStatus, sortIndex);
+    }
+
+    // Handler used by the XML SAX parser to handle various events during parsing.
+    private static ErrorHandler ERROR_HANDLER = new ErrorHandler() {
+        @Override
+        public void warning(SAXParseException exception) {
+            // TODO: Maybe log a warning here?
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+    };
+
+    // A private exception used to allow non-matching DTDs to be ignored.
+    private static final class IncompatibleDtdException extends RuntimeException {
+    }
+}


### PR DESCRIPTION
Note that this CL includes basic tests, but coverage for these will be improved later (with the aim of getting close to 100% coverage, including error handling and exceptions). The new code soon to be in the ICU project will also have a suite of end-to-end tests in the actual ICU data conversion logic.

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

