### PR TITLE
CLDR-13151 show alternate message for constructed values

### DIFF
--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -2696,6 +2696,7 @@ function showItemInfoFn(theRow, item) {
 function addJumpToOriginal(theRow, el) {
 	if (theRow.inheritedLocale || theRow.inheritedXpid) {
 		var loc = theRow.inheritedLocale;
+		var xpstrid = theRow.inheritedXpid || theRow.xpstrid;
 		if (!loc) {
 			loc = surveyCurrentLocale;
 		} else if (loc === 'code-fallback') {
@@ -2706,10 +2707,16 @@ function addJumpToOriginal(theRow, el) {
 			 */
 			loc = 'root';
 		}
-		var clickyLink = createChunk(stui.str('followAlias'), "a", 'followAlias');
-		clickyLink.href = '#/'+ loc + '//'+ (theRow.inheritedXpid || theRow.xpstrid);
-		el.appendChild(clickyLink);
-	}	
+		if((xpstrid === theRow.xpstrid) && // current hash
+				(loc === window.surveyCurrentLocale)) { // current locale
+			// i.e., following the alias would come back to the current item
+			el.appendChild(createChunk(stui.str('noFollowAlias'), "span", 'followAlias'));
+		} else {
+			var clickyLink = createChunk(stui.str('followAlias'), "a", 'followAlias');
+			clickyLink.href = '#/'+ loc + '//'+ xpstrid;
+			el.appendChild(clickyLink);
+		}
+	}
 }
 
 function appendExample(parent, text, loc) {

--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -155,6 +155,7 @@ define({
 		pClass_fallback: "This item is inherited.", //  ${inheritFromDisplay}.", - removed in r8801
 		pClassExplain_desc: "This area shows the item's status.",
 		followAlias: "Jump to Original ⇒",
+		noFollowAlias: "This item is constructed from other values.",
 		
 		override_explain_msg: "You have voted for this item with ${overrideVotes} votes instead of the usual ${votes}",
 		voteInfo_overrideExplain_desc: "",


### PR DESCRIPTION
- [CLDR-13151]

Do not show 'Jump to Original' if it would be a useless link.

![Captura de Pantalla 2019-07-12 a la(s) 5 17 02 p  m](https://user-images.githubusercontent.com/855219/61164368-58ff0300-a4c9-11e9-9273-5e2bda232cce.png)

Compare to current behavior: https://st.unicode.org/cldr-apps/v#/yo/Languages_E_J/7bbb0dfa5b2ebec9

[CLDR-13151]: https://unicode-org.atlassian.net/browse/CLDR-13151