### PR TITLE
CLDR-13160 update en tts name and keywords for transgender flag

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -2989,7 +2989,7 @@ annotations.
 		<annotation cp="🪧" type="tts">placard</annotation>
 		<annotation cp="⚧">transgender</annotation> 	<!-- 26A7 -->
 		<annotation cp="⚧" type="tts">transgender symbol</annotation>
-		<annotation cp="🏳‍⚧">flag | transgender</annotation> 	<!-- 1F3F3 200D 26A7 -->
-		<annotation cp="🏳‍⚧" type="tts">blue, pink, and white flag</annotation>
+		<annotation cp="🏳‍⚧">flag | light blue | pink | transgender | white</annotation> 	<!-- 1F3F3 200D 26A7 -->
+		<annotation cp="🏳‍⚧" type="tts">transgender flag</annotation>
 	</annotations>
 </ldml>

--- a/tools/java/org/unicode/cldr/util/data/emoji/emoji-test.txt
+++ b/tools/java/org/unicode/cldr/util/data/emoji/emoji-test.txt
@@ -3986,9 +3986,9 @@
 1F3F3                                      ; unqualified         # 🏳 white flag
 1F3F3 FE0F 200D 1F308                      ; fully-qualified     # 🏳️‍🌈 rainbow flag
 1F3F3 200D 1F308                           ; unqualified         # 🏳‍🌈 rainbow flag
-1F3F3 FE0F 200D 26A7 FE0F                  ; fully-qualified     # 🏳️‍⚧️ blue, pink, and white flag
-1F3F3 FE0F 200D 26A7                       ; minimally-qualified # 🏳️‍⚧ blue, pink, and white flag
-1F3F3 200D 26A7                            ; unqualified         # 🏳‍⚧ blue, pink, and white flag
+1F3F3 FE0F 200D 26A7 FE0F                  ; fully-qualified     # 🏳️‍⚧️ transgender flag
+1F3F3 FE0F 200D 26A7                       ; minimally-qualified # 🏳️‍⚧ transgender flag
+1F3F3 200D 26A7                            ; unqualified         # 🏳‍⚧ transgender flag
 1F3F4 200D 2620 FE0F                       ; fully-qualified     # 🏴‍☠️ pirate flag
 1F3F4 200D 2620                            ; minimally-qualified # 🏴‍☠ pirate flag
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13160
- [x] Updated PR title and link in previous line to include Issue number

For transgender flag emoji sequence, update English tts name and keywords per ESC.
Also needed to update the local copy of emoji-test.txt so tests pass.
