### PR TITLE
CLDR-13172 Disallow voting to inherit No Value

### DIFF
--- a/tools/cldr-apps/WebContent/submit.jsp
+++ b/tools/cldr-apps/WebContent/submit.jsp
@@ -274,10 +274,7 @@
 				section.setUserAndFileForVotelist(cs.user, null);
 
 				DataSection.DataRow pvi = section.getDataRow(base);
-				final Level covLev = pvi.getCoverageLevel();
-				//final int coverageValue = covLev.getLevel();
-				CheckCLDR.StatusAction showRowAction = pvi
-						.getStatusAction();
+				CheckCLDR.StatusAction showRowAction = pvi.getStatusAction();
 
 				if (showRowAction.isForbidden()) {
 					result = "Item may not be modified. ("

--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -207,10 +207,9 @@ define({
 		StatusAction_msg:              "Not submitted: ${0}",
 		StatusAction_popupmsg:         "Sorry, your vote for '${1}' could not be submitted: ${0}", // same as StatusAction_msg but with context
 		StatusAction_ALLOW:            "(Actually, it was allowed.)", // shouldn't happen
-		StatusAction_FORBID:           "Forbidden.",
 		StatusAction_FORBID_ERRORS:    "The item had errors.",
 		StatusAction_FORBID_READONLY:  "The item is read-only.",
-		StatusAction_FORBID_COVERAGE:  "The item is not visible by coverage rules.",
+		StatusAction_FORBID_NULL:      "The item has no value.",
 
 		// v.jsp
 		"v-title2_desc": "Locale title",

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -1440,6 +1440,14 @@ public class DataSection implements JSONString {
             // }
             return ballotBox.hadVotesSometimeThisRelease(xpathId);
         }
+
+        /**
+         * Does this DataRow have null for its inherited value?
+         * @return true if inheritedValue is null, else false.
+         */
+        public boolean wouldInheritNull() {
+            return inheritedValue == null;
+        }
     }
 
     /*

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -2468,8 +2468,10 @@ public class SurveyAjax extends HttpServlet {
         section.setUserAndFileForVotelist(mySession.user, null);
 
         DataRow pvi = section.getDataRow(xp);
-        final Level covLev = pvi.getCoverageLevel();
         CheckCLDR.StatusAction showRowAction = pvi.getStatusAction();
+        if (CldrUtility.INHERITANCE_MARKER.equals(val) && pvi.wouldInheritNull()) {
+            showRowAction = CheckCLDR.StatusAction.FORBID_NULL;
+        }
 
         if (otherErr != null) {
             r.put("didNotSubmit", "Did not submit.");
@@ -2524,13 +2526,6 @@ public class SurveyAjax extends HttpServlet {
                 System.err.println("Not voting: ::  " + showRowAction);
             r.put("statusAction", showRowAction);
         }
-        // don't allow adding items if
-        // ALLOW_VOTING_BUT_NO_ADD
-
-        // informational
-        r.put("cPhase", cPhase);
-        r.put("phStatus", phStatus);
-        r.put("covLev", covLev);
     }
 
     /**

--- a/tools/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/CheckCLDR.java
@@ -107,8 +107,7 @@ abstract public class CheckCLDR {
         FORBID_ERRORS(true), 
         FORBID_READONLY(true), 
         FORBID_UNLESS_DATA_SUBMISSION(true), 
-        FORBID_COVERAGE(true), 
-        FORBID_NEEDS_TICKET(true);
+        FORBID_NULL(true);
 
         private final boolean isForbidden;
 
@@ -127,27 +126,6 @@ abstract public class CheckCLDR {
         public boolean canShow() {
             return !isForbidden;
         }
-
-        /**
-         * @deprecated
-         */
-        public static final StatusAction FORBID = FORBID_READONLY;
-        /**
-         * @deprecated
-         */
-        public static final StatusAction SHOW_VOTING_AND_ADD = ALLOW;
-        /**
-         * @deprecated
-         */
-        public static final StatusAction SHOW_VOTING_AND_TICKET = ALLOW_VOTING_AND_TICKET;
-        /**
-         * @deprecated
-         */
-        public static final StatusAction SHOW_VOTING_BUT_NO_ADD = ALLOW_VOTING_BUT_NO_ADD;
-        /**
-         * @deprecated
-         */
-        public static final StatusAction FORBID_HAS_ERROR = FORBID_ERRORS;
     }
 
     private static final HashMap<String, Phase> PHASE_NAMES = new HashMap<String, Phase>();
@@ -206,20 +184,11 @@ abstract public class CheckCLDR {
                 return StatusAction.ALLOW;
             }
 
-            // remove this since we no longer have an 'optional' level
-//            // if the coverage level is optional, disallow everything
-//            if (pathValueInfo.getCoverageLevel().compareTo(Level.COMPREHENSIVE) > 0) {
-//                return StatusAction.FORBID_COVERAGE;
-//            }
-
             if (status == SurveyToolStatus.HIDE) {
                 return StatusAction.FORBID_READONLY;
             }
 
             CandidateInfo winner = pathValueInfo.getCurrentItem();
-//            if (winner != null && "тлусты".equals(winner.getValue())) {
-//                int debug = 0;
-//            }
             ValueStatus valueStatus = getValueStatus(winner, ValueStatus.NONE, null);
 
             // if limited submission, and winner doesn't have an error, limit the values

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -3246,32 +3246,10 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
      */
     public Collection<String> getExtraPaths() {
         Set<String> toAddTo = new HashSet<String>();
-
-        // reverse the order because we're hitting some strange behavior
-
         toAddTo.addAll(getRawExtraPaths());
         for (String path : this) {
             toAddTo.remove(path);
         }
-
-        //        showStars(getLocaleID() + " getExtraPaths", toAddTo);
-        //        for (String path : getRawExtraPaths()) {
-        //            // don't use getStringValue, since it recurses.
-        //            if (!dataSource.hasValueAtDPath(path)) {
-        //                toAddTo.add(path);
-        //            } else {
-        //                if (path.contains("compoundUnit")) {
-        //                    for (String path2 : this) {
-        //                        if (path2.equals(path)) {
-        //                            System.out.println("\t\t" + path);
-        //                        }
-        //                    }
-        //                    System.out.println();
-        //                }
-        //            }
-        //
-        //        }
-        //        showStars(getLocaleID() + " getExtraPaths", toAddTo);
         return toAddTo;
     }
 
@@ -3307,6 +3285,18 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
         return extraPaths;
     }
 
+    /**
+     * Add (possibly over four thousand) extra paths to the given collection.
+     *
+     * @param toAddTo the (initially empty) collection to which the paths should be added
+     * @return toAddTo (the collection)
+     *
+     * Called only by getRawExtraPaths.
+     *
+     * "Raw" refers to the fact that some of the paths may duplicate paths that are
+     * already in this CLDRFile (in the xml and/or votes), in which case they will
+     * later get filtered by getExtraPaths (removed from toAddTo) rather than re-added.
+     */
     private Collection<String> getRawExtraPathsPrivate(Collection<String> toAddTo) {
         SupplementalDataInfo supplementalData = CLDRConfig.getInstance().getSupplementalDataInfo();
         // units
@@ -3383,20 +3373,6 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
         return toAddTo;
     }
 
-    private void showStars(String title, Iterable<String> source) {
-        PathStarrer ps = new PathStarrer();
-        Relation<String, String> stars = Relation.of(new TreeMap<String, Set<String>>(), TreeSet.class);
-        for (String path : source) {
-            String skeleton = ps.set(path);
-            stars.put(skeleton, ps.getAttributesString("|"));
-
-        }
-        System.out.println(title);
-        for (Entry<String, Set<String>> s : stars.keyValuesSet()) {
-            System.out.println("\t" + s.getKey() + "\t" + s.getValue());
-        }
-    }
-
     private void addPluralCounts(Collection<String> toAddTo,
         final Set<Count> pluralCounts,
         Iterable<String> file) {
@@ -3413,58 +3389,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
                     continue;
                 }
                 toAddTo.add(start + count + end);
-
-                //                for (String unit : new String[] { "year", "month", "week", "day", "hour", "minute", "second" }) {
-                //                    for (String when : new String[] { "", "-past", "-future" }) {
-                //                        toAddTo.add("//ldml/units/unit[@type=\"" + unit + when + "\"]/unitPattern[@count=\""
-                //                            + count + "\"]");
-                //                    }
-                //                    for (String alt : new String[] { "", "[@alt=\"short\"]" }) {
-                //                        toAddTo.add("//ldml/units/unit[@type=\"" + unit + "\"]/unitPattern[@count=\"" + count
-                //                            + "\"]" + alt);
-                //                    }
-                //                }
-
-                //                    for (String unit : codes) {
-                //                        toAddTo.add("//ldml/numbers/currencies/currency[@type=\"" + unit + "\"]/displayName[@count=\""
-                //                                + count + "\"]");
-                //                    }
-                //
-                //                    for (String numberSystem : supplementalData.getNumericNumberingSystems()) {
-                //                        String numberSystemString = "[@numberSystem=\"" + numberSystem + "\"]";
-                //                        final String currencyPattern = "//ldml/numbers/currencyFormats" + numberSystemString +
-                //                                "/unitPattern[@count=\"" + count + "\"]";
-                //                        toAddTo.add(currencyPattern);
-                //                        if (DEBUG) {
-                //                            System.out.println(getLocaleID() + "\t" + currencyPattern);
-                //                        }
-                //
-                //                        for (String type : new String[] {
-                //                                "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000",
-                //                                "10000000000", "100000000000", "1000000000000", "10000000000000", "100000000000000" }) {
-                //                            for (String width : new String[] { "short", "long" }) {
-                //                                toAddTo.add("//ldml/numbers/decimalFormats" +
-                //                                        numberSystemString + "/decimalFormatLength[@type=\"" +
-                //                                        width + "\"]/decimalFormat[@type=\"standard\"]/pattern[@type=\"" +
-                //                                        type + "\"][@count=\"" +
-                //                                        count + "\"]");
-                //                            }
-                //                        }
-                //                    }
             }
         }
     }
-
-    // This code never worked right, since extraPaths is static.
-    // private boolean addUnlessValueEmpty(final String path, Collection<String> toAddTo) {
-    // String value = getWinningValue(path);
-    // if (value != null && value.length() == 0) {
-    // return false;
-    // } else {
-    // toAddTo.add(path);
-    // return true;
-    // }
-    // }
 
     private Matcher typeValueMatcher = PatternCache.get("\\[@type=\"([^\"]*)\"\\]").matcher("");
 


### PR DESCRIPTION
-New StatusAction.FORBID_NULL and message: The item has no value.

-New function DataRow.wouldInheritNull

-Delete unused StatusAction values FORBID_COVERAGE, FORBID_NEEDS_TICKET, ...

-Do not send cPhase, phStatus, or covLev to client since client does not use them

-Delete some dead code

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13172
- [x] Updated PR title and link in previous line to include Issue number

