### PR TITLE
CLDR-11049 Fixes and improvements for the CLDR API classes.

### DIFF
--- a/tools/java/org/unicode/cldr/api/AbstractDataSource.java
+++ b/tools/java/org/unicode/cldr/api/AbstractDataSource.java
@@ -18,26 +18,6 @@ abstract class AbstractDataSource implements CldrData {
         PrefixVisitorHost.accept(this::accept, order, visitor);
     }
 
-    void safeVisit(
-        CldrPath cldrPath, String value, Map<AttributeKey, String> valueAttributes, ValueVisitor visitor) {
-
-        if (shouldEmit(cldrPath)) {
-            CldrValue cldrValue = CldrValue.create(value, valueAttributes, cldrPath);
-            safeVisit(cldrValue, visitor);
-        }
-    }
-
-    private boolean shouldEmit(CldrPath path) {
-        // Hacky way to detect the version declaration in LDML files (which must always be
-        // skipped since they are duplicate paths and reveal XML file boundaries). The path is
-        // always "//ldmlXxxx/version" for some DTD type.
-        if (path.getLength() == 2 && path.getName().equals("version")) {
-            return false;
-        }
-        // Other tests can go here if we need to skip other paths/values.
-        return true;
-    }
-
     // Helper to wrap the visit method and report errors that occur.
     static void safeVisit(CldrValue v, ValueVisitor visitor) {
         try {

--- a/tools/java/org/unicode/cldr/api/AttributeKey.java
+++ b/tools/java/org/unicode/cldr/api/AttributeKey.java
@@ -218,7 +218,7 @@ public final class AttributeKey {
      * @param enumType the enum class type of the result.
      * @return an enum value instance from the underlying attribute value by name.
      */
-    // TODO: Handler optional enumerations (e.g. PluralRange#start/end).
+    // TODO: Handle optional enumerations (e.g. PluralRange#start/end).
     public <T extends Enum<T>> T valueFrom(AttributeSupplier src, Class<T> enumType) {
         return Enum.valueOf(enumType, valueFrom(src));
     }

--- a/tools/java/org/unicode/cldr/api/CldrDataType.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataType.java
@@ -46,13 +46,23 @@ public enum CldrDataType {
      */
     LDML(DtdType.ldml, true, true, DtdType.ldmlICU);
 
-    private static final ImmutableMap<DtdType, CldrDataType> RAW_TYPE_MAP =
-        Arrays.stream(values()).collect(toImmutableMap(t -> t.mainType, identity()));
+    private static final ImmutableMap<String, CldrDataType> NAME_MAP =
+        Arrays.stream(values()).collect(toImmutableMap(t -> t.mainType.name(), identity()));
+
+    /**
+     * Returns a CLDR data type given its XML name (the root element name in a CLDR path).
+     *
+     * @param name the XML path root (e.g. "ldml" or "supplementalData").
+     * @return the associated data type instance.
+     */
+    public static CldrDataType forXmlName(String name) {
+        CldrDataType type = NAME_MAP.get(name);
+        checkArgument(type != null, "unsupported DTD type: %s", name);
+        return type;
+    }
 
     static CldrDataType forRawType(DtdType rawType) {
-        CldrDataType type = RAW_TYPE_MAP.get(rawType);
-        checkArgument(type != null, "unknown DTD type: %s", rawType);
-        return type;
+        return forXmlName(rawType.name());
     }
 
     private final DtdType mainType;

--- a/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
+++ b/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
@@ -130,7 +130,8 @@ final class CldrFileDataSource extends AbstractDataSource {
                 src.getFullXPath(dPath), previousElements, valueAttributes::put);
 
             if (CldrPaths.isLeafPath(cldrPath) && CldrPaths.shouldEmit(cldrPath)) {
-                safeVisit(cldrPath, value, valueAttributes, visitor);
+
+                safeVisit(CldrValue.create(value, valueAttributes, cldrPath), visitor);
             }
 
             // Prepare the element stack for next time by pushing the current path onto it.

--- a/tools/java/org/unicode/cldr/api/CldrPath.java
+++ b/tools/java/org/unicode/cldr/api/CldrPath.java
@@ -388,8 +388,23 @@ public final class CldrPath implements AttributeSupplier, Comparable<CldrPath> {
             return false;
         }
         CldrPath other = (CldrPath) obj;
-        // Test our own fields first, since paths will tend to differ at the ends.
-        return localEquals(other) && Objects.equals(this.parent, other.parent);
+        // Check type and length first (checking length catches most non-equal paths).
+        if (!getDataType().equals(other.getDataType()) || length != other.length) {
+            return false;
+        }
+        // Do (n - 1) comparisons since we already know the root element is the same (the root
+        // element never has value attributes on it and is uniquely defined by the DTD type).
+        // Working up from the "leaf" of the path works well because different paths will almost
+        // always be different in the leaf element (i.e. we will fail almost immediately).
+        CldrPath pthis = this;
+        for (int n = length - 1; n > 0; n--) {
+            if (!pthis.localEquals(other)) {
+                return false;
+            }
+            pthis = pthis.getParent();
+            other = other.getParent();
+        }
+        return true;
     }
 
     /** {@inheritDoc} */
@@ -407,8 +422,7 @@ public final class CldrPath implements AttributeSupplier, Comparable<CldrPath> {
     private boolean localEquals(CldrPath other) {
         // In _theory_ only length and localToString need to be checked (since the localToString is
         // an unambiguous representation of the data, but it seems a bit hacky to rely on that.
-        return this.length == other.length
-            && this.elementName.equals(other.elementName)
+        return this.elementName.equals(other.elementName)
             && this.sortIndex == other.sortIndex
             && this.attributeKeyValuePairs.equals(other.attributeKeyValuePairs);
     }

--- a/tools/java/org/unicode/cldr/api/LocaleIds.java
+++ b/tools/java/org/unicode/cldr/api/LocaleIds.java
@@ -1,0 +1,84 @@
+package org.unicode.cldr.api;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for working with locale IDs as strings.
+ */
+// TODO: Consider making this public when moving "SupplementalData" into the API.
+final class LocaleIds {
+    // From: https://unicode.org/reports/tr35/#Identifiers
+    // Locale ID is:
+    //   (<language>(_<script>)?|<script>)(_<region>)?(_<variant>)*
+    //
+    // However in CLDR data, there's always a language (even if it's "und"), and never more
+    // than one variant, so this can be simplified to:
+    //   <language>(_<script>)?(_<region>)?(_<variant>)?
+    //
+    // * Required language is lowercase 2 or 3 letter language ID (e.g. "en", "gsw").
+    //   Note that the specification allows for languages 5-8 characters long, but in reality
+    //   this has never occurred yet, so it's ignored in this code.
+    //
+    // * Script is 4-letter Xxxx script identifier (e.g. "Latn").
+    //   The specification permits any casing for script subtags, but since all the data uses
+    //   the capitalized "Xxxx" form, that's what this code expects.
+    //
+    // * Region is the uppercase 2-letter CLDR region code ("GB") or the 3-digit numeric
+    //   identifier (e.g. "001").
+    //
+    // * Variants are a bit complex; either 5-8 length alphanumerics, or length 4 but starting
+    //   with a digit (this avoids any ambiguity with script subtags). However because ICU
+    //   violates this rule by using "TRADITIONAL" (11-letters) the length restriction is
+    //   merely "longer than 5".
+    //
+    // Finaly, CLDR data only uses an '_' as the separator, whereas the specification allows
+    // for either '-' or '_').
+    //
+    // The regex for unambiguously matching a valid locale ID (other than "root") for CLDR data is:
+    private static final Pattern LOCALE_ID =
+        Pattern.compile("(?:[a-z]{2,3})"
+            + "(?:_(?:[A-Z][a-z]{3}))?"
+            + "(?:_(?:[A-Z]{2}|[0-9]{3}))?"
+            + "(?:_(?:[A-Z]{5,}|[0-9][A-Z0-9]{3}))?");
+
+    /**
+     * Checks whether the given ID is valid for CLDR use (including case). Locale IDs for use in
+     * CLDR APIs are a subset of all possible locale IDs and, unlike general locale IDs, they
+     * are case sensitive. The rules are:
+     * <ul>
+     *     <li>A locale ID is up to four subtags {@code
+     *         <language>(_<script>)?(_<region>)?(_<variant>)?}
+     *     <li>The allowed subtag separator is only ASCII underscore (not hyphen).
+     *     <li>The language subtag must exist (though it is permitted to be {@code "und"}).
+     *     <li>All other subtags are optional and are separated by a single underscore.
+     *     <li>Language subtag is lower-case, and is either 2 or 3 letters (i.e. "[a-z]{2,3}").
+     *     <li>Script subtag is mixed-case and must match {@code "[A-Z][a-z]{3}"}.
+     *     <li>Region subtag is upper-case and must match {@code "[A-Z]{2}} or {@code "[0-9]{3}"}.
+     *     <li>Variant subtag is upper-case and must match {@code "[A-Z]{5,}} or
+     *         {@code "[0-9][A-Z0-9]{3}"}.
+     *     <li>The special locale ID {@code "root"} is also permitted.
+     * <ul>
+     *
+     * <p>Note that this check does don't enforce validity in terms of checking for deprecated
+     * languages, regions or script, so things like {@code "sh_YU"} (deprecated language and/or
+     * region) are accepted.
+     *
+     * <p>Examples of valid locale IDs are {@code "en"}, {@code "zh_Hant"}, {@code "fr_CA"},
+     * {@code "sr_Latn_RS"} and {@code "ja_JP_TRADITIONAL"}.
+     *
+     * <p>Examples of invalid locale IDs are {@code ""}, {@code "en_"}, {@code "Latn"} and
+     * {@code "de__TRADITIONAL"}.
+     *
+     * @param localeId the ID the check.
+     * @throws IllegalArgumentException is the ID is invalid.
+     */
+    public static void checkCldrLocaleId(String localeId) {
+        // This check runs on a lot of locales, so make it as minimal as possible. If normalization
+        // is ever needed, do it in a separate method.
+        checkArgument(LOCALE_ID.matcher(localeId).matches() || localeId.equals("root"),
+            "bad locale ID: %s", localeId);
+    }
+
+}

--- a/tools/java/org/unicode/cldr/api/XmlDataSource.java
+++ b/tools/java/org/unicode/cldr/api/XmlDataSource.java
@@ -22,6 +22,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -138,7 +139,7 @@ final class XmlDataSource extends AbstractDataSource {
         try {
             return Files.newBufferedReader(p);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -157,7 +158,7 @@ final class XmlDataSource extends AbstractDataSource {
                 src.setSystemId(p.toString());
                 parseXml(xmlReader, src, p);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException(e);
             }
         }
     }
@@ -261,7 +262,7 @@ final class XmlDataSource extends AbstractDataSource {
                             value = value + Strings.repeat(" ", (elementText.length() - 1) - n);
                         }
                     }
-                    safeVisit(path, value, valueAttributes, visitor);
+                    safeVisit(CldrValue.create(value, valueAttributes, path), visitor);
                 }
             } else {
                 checkState(whitespace().matchesAllOf(elementText),
@@ -299,7 +300,7 @@ final class XmlDataSource extends AbstractDataSource {
      * @param parent parent path (or null if this is the root element).
      * @param elementName qualified element name as provided by the SAX parser.
      * @param xmlAttributes attributes as provided by the SAX parser.
-     * @param dtd the DTD information to allow attributes to be filtered and sorted correctly.
+     * @param dataType the DTD information to allow attributes to be filtered and sorted correctly.
      * @param valueAttributeCollector a collector for any non-distinguishing value attributes
      *     encountered during processing (they get "saved up" to go on the CldrValue).
      */


### PR DESCRIPTION
A handful of bug fixes:
* not walking subdirs for XML files
* improve local-equality checking in paths (it was inefficient)
* have only one bit of logic to check if a path should be emitted rather than 3!
* add alias as a "leaf" element so it doesn't skip all those paths (oops)

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

