### PR TITLE
CLDR-13186 Subdivisions SE, consistency correction

### DIFF
--- a/common/subdivisions/be.xml
+++ b/common/subdivisions/be.xml
@@ -2049,26 +2049,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sc12" draft="contributed">Гласіс</subdivision>
 			<subdivision type="sdkh" draft="contributed">Хартум</subdivision>
 			<subdivision type="seab" draft="contributed">лен Стакгольм</subdivision>
-			<subdivision type="seac" draft="contributed">Лен Вестэрботэн</subdivision>
-			<subdivision type="sebd" draft="contributed">Лен Норботэн</subdivision>
+			<subdivision type="seac" draft="contributed">лен Вестэрботэн</subdivision>
+			<subdivision type="sebd" draft="contributed">лен Норботэн</subdivision>
 			<subdivision type="sec" draft="contributed">лен Упсала</subdivision>
 			<subdivision type="sed" draft="contributed">лен Сёдэрманланд</subdivision>
 			<subdivision type="see" draft="contributed">лен Эстэргётланд</subdivision>
 			<subdivision type="sef" draft="contributed">лен Ёнчэпінг</subdivision>
-			<subdivision type="seg" draft="contributed">Лен Крунуберг</subdivision>
-			<subdivision type="seh" draft="contributed">Лен Кальмар</subdivision>
-			<subdivision type="sei" draft="contributed">Лен Готланд</subdivision>
-			<subdivision type="sek" draft="contributed">Блекінгэ</subdivision>
-			<subdivision type="sem" draft="contributed">Лен Сконэ</subdivision>
+			<subdivision type="seg" draft="contributed">лен Крунуберг</subdivision>
+			<subdivision type="seh" draft="contributed">лен Кальмар</subdivision>
+			<subdivision type="sei" draft="contributed">лен Готланд</subdivision>
+			<subdivision type="sek" draft="contributed">лен Блекінгэ</subdivision>
+			<subdivision type="sem" draft="contributed">лен Сконэ</subdivision>
 			<subdivision type="sen" draft="contributed">лен Халанд</subdivision>
 			<subdivision type="seo" draft="contributed">лен Вестра-Гёталанд</subdivision>
 			<subdivision type="ses" draft="contributed">лен Вермланд</subdivision>
-			<subdivision type="set" draft="contributed">Лен Эрэбру</subdivision>
-			<subdivision type="seu" draft="contributed">Лен Вестманланд</subdivision>
-			<subdivision type="sew" draft="contributed">Лен Даларна</subdivision>
+			<subdivision type="set" draft="contributed">лен Эрэбру</subdivision>
+			<subdivision type="seu" draft="contributed">лен Вестманланд</subdivision>
+			<subdivision type="sew" draft="contributed">лен Даларна</subdivision>
 			<subdivision type="sex" draft="contributed">лен Еўлебарг</subdivision>
-			<subdivision type="sey" draft="contributed">Лен Вестэрнорланд</subdivision>
-			<subdivision type="sez" draft="contributed">Лен Емтланд</subdivision>
+			<subdivision type="sey" draft="contributed">лен Вестэрнорланд</subdivision>
+			<subdivision type="sez" draft="contributed">лен Емтланд</subdivision>
 			<subdivision type="shac" draft="contributed">Востраў Ушэсця</subdivision>
 			<subdivision type="shhl" draft="contributed">Востраў Святой Алены</subdivision>
 			<subdivision type="si011" draft="contributed">Цэле</subdivision>

--- a/common/subdivisions/ca.xml
+++ b/common/subdivisions/ca.xml
@@ -2988,27 +2988,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sdno" draft="contributed">Estat del Nord</subdivision>
 			<subdivision type="sdnr" draft="contributed">Nahr an-Nil</subdivision>
 			<subdivision type="sdrs" draft="contributed">Estat de la Mar Roja</subdivision>
-			<subdivision type="seab" draft="contributed">Comtat d’Estocolm</subdivision>
-			<subdivision type="seac" draft="contributed">Comtat de Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">Comtat de Norrbotten</subdivision>
+			<subdivision type="seab" draft="contributed">comtat d’Estocolm</subdivision>
+			<subdivision type="seac" draft="contributed">comtat de Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">comtat de Norrbotten</subdivision>
 			<subdivision type="sec" draft="contributed">comtat d’Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">comtat de Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">comtat d’Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">comtat de Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">Comtat de Kronoberg</subdivision>
-			<subdivision type="seh" draft="contributed">Comtat de Kalmar</subdivision>
-			<subdivision type="sei" draft="contributed">Comtat de Gotland</subdivision>
-			<subdivision type="sek" draft="contributed">Comtat de Blekinge</subdivision>
-			<subdivision type="sem" draft="contributed">Comtat d’Escània</subdivision>
+			<subdivision type="seg" draft="contributed">comtat de Kronoberg</subdivision>
+			<subdivision type="seh" draft="contributed">comtat de Kalmar</subdivision>
+			<subdivision type="sei" draft="contributed">comtat de Gotland</subdivision>
+			<subdivision type="sek" draft="contributed">comtat de Blekinge</subdivision>
+			<subdivision type="sem" draft="contributed">comtat d’Escània</subdivision>
 			<subdivision type="sen" draft="contributed">comtat de Halland</subdivision>
 			<subdivision type="seo" draft="contributed">comtat de Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">comtat de Värmland</subdivision>
-			<subdivision type="set" draft="contributed">Comtat d’Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">Comtat de Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">Comtat de Dalarna</subdivision>
-			<subdivision type="sex" draft="contributed">Comtat de Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">Comtat de Västernorrland</subdivision>
-			<subdivision type="sez" draft="contributed">Comtat de Jämtland</subdivision>
+			<subdivision type="set" draft="contributed">comtat d’Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">comtat de Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">comtat de Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">comtat de Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">comtat de Västernorrland</subdivision>
+			<subdivision type="sez" draft="contributed">comtat de Jämtland</subdivision>
 			<subdivision type="shac" draft="contributed">Illa de l’Ascensió</subdivision>
 			<subdivision type="shhl" draft="contributed">Santa Helena</subdivision>
 			<subdivision type="si001" draft="contributed">Ajdovščina</subdivision>

--- a/common/subdivisions/ceb.xml
+++ b/common/subdivisions/ceb.xml
@@ -3498,23 +3498,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="seab" draft="contributed">Stockholms län</subdivision>
 			<subdivision type="seac" draft="contributed">Västerbottens län</subdivision>
 			<subdivision type="sebd" draft="contributed">Norrbottens län</subdivision>
-			<subdivision type="sec" draft="contributed">Uppsala (rehyon)</subdivision>
+			<subdivision type="sec" draft="contributed">Uppsala län</subdivision>
 			<subdivision type="sed" draft="contributed">Södermanlands län</subdivision>
 			<subdivision type="see" draft="contributed">Östergötlands län</subdivision>
 			<subdivision type="sef" draft="contributed">Jönköpings län</subdivision>
 			<subdivision type="seg" draft="contributed">Kronoberg</subdivision>
-			<subdivision type="seh" draft="contributed">Blekinge län</subdivision>
+			<subdivision type="seh" draft="contributed">Kalmar län</subdivision>
 			<subdivision type="sei" draft="contributed">Gotlands län</subdivision>
-			<subdivision type="sek" draft="contributed">Blekinge län²</subdivision>
+			<subdivision type="sek" draft="contributed">Blekinge län</subdivision>
 			<subdivision type="sem" draft="contributed">Skåne län</subdivision>
 			<subdivision type="sen" draft="contributed">Hallands län</subdivision>
 			<subdivision type="seo" draft="contributed">Västra Götalands län</subdivision>
 			<subdivision type="ses" draft="contributed">Värmlands län</subdivision>
-			<subdivision type="set" draft="contributed">Örebro Län</subdivision>
-			<subdivision type="seu" draft="contributed">Västmanlands Län</subdivision>
+			<subdivision type="set" draft="contributed">Örebro län</subdivision>
+			<subdivision type="seu" draft="contributed">Västmanlands län</subdivision>
 			<subdivision type="sew" draft="contributed">Dalarnas län</subdivision>
-			<subdivision type="sex" draft="contributed">Gävleborgs Län</subdivision>
-			<subdivision type="sey" draft="contributed">Västernorrlands Län</subdivision>
+			<subdivision type="sex" draft="contributed">Gävleborgs län</subdivision>
+			<subdivision type="sey" draft="contributed">Västernorrlands län</subdivision>
 			<subdivision type="sez" draft="contributed">Jämtlands län</subdivision>
 			<subdivision type="sg01" draft="contributed">Central Singapore Community Development Council</subdivision>
 			<subdivision type="sg02" draft="contributed">North East Community Development Region</subdivision>

--- a/common/subdivisions/es.xml
+++ b/common/subdivisions/es.xml
@@ -3760,25 +3760,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sdrs" draft="contributed">Mar Rojo</subdivision>
 			<subdivision type="sdsi" draft="contributed">Sennar</subdivision>
 			<subdivision type="seab" draft="contributed">provincia de Estocolmo</subdivision>
-			<subdivision type="seac" draft="contributed">Provincia de Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">Provincia de Norrbotten</subdivision>
-			<subdivision type="sec" draft="contributed">Provincia de Upsala</subdivision>
+			<subdivision type="seac" draft="contributed">provincia de Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">provincia de Norrbotten</subdivision>
+			<subdivision type="sec" draft="contributed">provincia de Upsala</subdivision>
 			<subdivision type="sed" draft="contributed">provincia de Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">provincia de Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">provincia de Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">Provincia de Kronoberg</subdivision>
+			<subdivision type="seg" draft="contributed">provincia de Kronoberg</subdivision>
 			<subdivision type="seh" draft="contributed">provincia de Kalmar</subdivision>
-			<subdivision type="sei" draft="contributed">Provincia de Gotland</subdivision>
+			<subdivision type="sei" draft="contributed">provincia de Gotland</subdivision>
 			<subdivision type="sek" draft="contributed">provincia de Blekinge</subdivision>
 			<subdivision type="sem" draft="contributed">provincia de Escania</subdivision>
-			<subdivision type="sen" draft="contributed">Provincia de Halland</subdivision>
-			<subdivision type="seo" draft="contributed">Provincia de Västra Götaland</subdivision>
+			<subdivision type="sen" draft="contributed">provincia de Halland</subdivision>
+			<subdivision type="seo" draft="contributed">provincia de Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">provincia de Värmland</subdivision>
-			<subdivision type="set" draft="contributed">Provincia de Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">Provincia de Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">Provincia de Dalarna</subdivision>
-			<subdivision type="sex" draft="contributed">Provincia de Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">Provincia de Västernorrland</subdivision>
+			<subdivision type="set" draft="contributed">provincia de Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">provincia de Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">provincia de Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">provincia de Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">provincia de Västernorrland</subdivision>
 			<subdivision type="sez" draft="contributed">provincia de Jämtland</subdivision>
 			<subdivision type="sg01" draft="contributed">Consejo Central (Singapur)</subdivision>
 			<subdivision type="sg02" draft="contributed">Consejo del Noreste (Singapur)</subdivision>

--- a/common/subdivisions/eu.xml
+++ b/common/subdivisions/eu.xml
@@ -2234,7 +2234,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="ses" draft="contributed">Värmlandeko konderria</subdivision>
 			<subdivision type="set" draft="contributed">Örebroko konderria</subdivision>
 			<subdivision type="seu" draft="contributed">Västmanlandeko konderria</subdivision>
-			<subdivision type="sew" draft="contributed">Dalarna</subdivision>
+			<subdivision type="sew" draft="contributed">Dalarna konderria</subdivision>
 			<subdivision type="sex" draft="contributed">Gävleborgeko konderria</subdivision>
 			<subdivision type="sey" draft="contributed">Västernorrlandeko konderria</subdivision>
 			<subdivision type="sez" draft="contributed">Jämtlandeko konderria</subdivision>

--- a/common/subdivisions/eu.xml
+++ b/common/subdivisions/eu.xml
@@ -2234,7 +2234,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="ses" draft="contributed">Värmlandeko konderria</subdivision>
 			<subdivision type="set" draft="contributed">Örebroko konderria</subdivision>
 			<subdivision type="seu" draft="contributed">Västmanlandeko konderria</subdivision>
-			<subdivision type="sew" draft="contributed">Dalarna konderria</subdivision>
+			<subdivision type="sew" draft="contributed">Dalarnako konderria</subdivision>
 			<subdivision type="sex" draft="contributed">Gävleborgeko konderria</subdivision>
 			<subdivision type="sey" draft="contributed">Västernorrlandeko konderria</subdivision>
 			<subdivision type="sez" draft="contributed">Jämtlandeko konderria</subdivision>

--- a/common/subdivisions/fr.xml
+++ b/common/subdivisions/fr.xml
@@ -3800,25 +3800,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sdsi" draft="contributed">Sannar</subdivision>
 			<subdivision type="seab" draft="contributed">comté de Stockholm</subdivision>
 			<subdivision type="seac" draft="contributed">comté de Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">Comté de Norrbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">comté de Norrbotten</subdivision>
 			<subdivision type="sec" draft="contributed">comté d’Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">comté de Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">comté d’Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">comté de Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">Comté de Kronoberg</subdivision>
+			<subdivision type="seg" draft="contributed">comté de Kronoberg</subdivision>
 			<subdivision type="seh" draft="contributed">comté de Kalmar</subdivision>
-			<subdivision type="sei" draft="contributed">Comté de Gotland</subdivision>
+			<subdivision type="sei" draft="contributed">comté de Gotland</subdivision>
 			<subdivision type="sek" draft="contributed">comté de Blekinge</subdivision>
 			<subdivision type="sem" draft="contributed">comté de Scanie</subdivision>
 			<subdivision type="sen" draft="contributed">comté de Halland</subdivision>
 			<subdivision type="seo" draft="contributed">comté de Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">comté de Värmland</subdivision>
-			<subdivision type="set" draft="contributed">Comté d’Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">Comté de Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">Comté de Dalécarlie</subdivision>
-			<subdivision type="sex" draft="contributed">Comté de Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">Comté de Västernorrland</subdivision>
-			<subdivision type="sez" draft="contributed">Comté de Jämtland</subdivision>
+			<subdivision type="set" draft="contributed">comté d’Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">comté de Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">comté de Dalécarlie</subdivision>
+			<subdivision type="sex" draft="contributed">comté de Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">comté de Västernorrland</subdivision>
+			<subdivision type="sez" draft="contributed">comté de Jämtland</subdivision>
 			<subdivision type="sg01" draft="contributed">Singapour central</subdivision>
 			<subdivision type="sg02" draft="contributed">District du Nord-Est</subdivision>
 			<subdivision type="sg03" draft="contributed">District du Nord-Ouest</subdivision>

--- a/common/subdivisions/gl.xml
+++ b/common/subdivisions/gl.xml
@@ -1547,24 +1547,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sbwe" draft="contributed">Occidental, Illas Salomón</subdivision>
 			<subdivision type="sc15" draft="contributed">La Digue</subdivision>
 			<subdivision type="seab" draft="contributed">condado de Estocolmo</subdivision>
-			<subdivision type="seac" draft="contributed">Condado de Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">Condado de Norrbotten</subdivision>
+			<subdivision type="seac" draft="contributed">condado de Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">condado de Norrbotten</subdivision>
 			<subdivision type="sec" draft="contributed">condado de Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">condado de Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">condado de Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">condado de Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">Condado de Kronoberg</subdivision>
+			<subdivision type="seg" draft="contributed">condado de Kronoberg</subdivision>
 			<subdivision type="seh" draft="contributed">condado de Kalmar</subdivision>
 			<subdivision type="sek" draft="contributed">condado de Blekinge</subdivision>
 			<subdivision type="sem" draft="contributed">condado de Escania</subdivision>
 			<subdivision type="sen" draft="contributed">condado de Halland</subdivision>
 			<subdivision type="seo" draft="contributed">condado de Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">condado de Värmland</subdivision>
-			<subdivision type="set" draft="contributed">Condado de Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">Condado de Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">Condado de Dalarna</subdivision>
-			<subdivision type="sex" draft="contributed">Condado de Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">Condado de Västernorrland</subdivision>
+			<subdivision type="set" draft="contributed">condado de Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">condado de Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">condado de Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">condado de Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">condado de Västernorrland</subdivision>
 			<subdivision type="sez" draft="contributed">condado de Jämtland</subdivision>
 			<subdivision type="shac" draft="contributed">Illa de Ascensión</subdivision>
 			<subdivision type="shhl" draft="contributed">Santa Helena</subdivision>

--- a/common/subdivisions/hr.xml
+++ b/common/subdivisions/hr.xml
@@ -1391,10 +1391,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sbrb" draft="contributed">Rennell i Bellona</subdivision>
 			<subdivision type="sbte" draft="contributed">Temotu (provincija)</subdivision>
 			<subdivision type="sbwe" draft="contributed">Zapadna provincija</subdivision>
-			<subdivision type="seab" draft="contributed">Stockholms län</subdivision>
+			<subdivision type="seab" draft="contributed">Županija Stockholm</subdivision>
 			<subdivision type="seac" draft="contributed">Županija Västerbotten</subdivision>
 			<subdivision type="sebd" draft="contributed">Županija Norrbotten</subdivision>
-			<subdivision type="sec" draft="contributed">Uppsala län</subdivision>
+			<subdivision type="sec" draft="contributed">Županija Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">Županija Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">Županija Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">Županija Jönköping</subdivision>
@@ -1405,7 +1405,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sem" draft="contributed">Županija Skåne</subdivision>
 			<subdivision type="sen" draft="contributed">Županija Halland</subdivision>
 			<subdivision type="seo" draft="contributed">Županija Västra Götaland</subdivision>
-			<subdivision type="ses" draft="contributed">Värmlands län</subdivision>
+			<subdivision type="ses" draft="contributed">Županija Värmland</subdivision>
 			<subdivision type="set" draft="contributed">Županija Örebro</subdivision>
 			<subdivision type="seu" draft="contributed">Županija Västmanland</subdivision>
 			<subdivision type="sew" draft="contributed">Županija Dalarna</subdivision>

--- a/common/subdivisions/id.xml
+++ b/common/subdivisions/id.xml
@@ -3236,7 +3236,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="seh" draft="contributed">Daerah Kalmar</subdivision>
 			<subdivision type="sei" draft="contributed">Daerah Gotland</subdivision>
 			<subdivision type="sek" draft="contributed">Daerah Blekinge</subdivision>
-			<subdivision type="sem" draft="contributed">County Skåne</subdivision>
+			<subdivision type="sem" draft="contributed">Daerah Skåne</subdivision>
 			<subdivision type="sen" draft="contributed">Daerah Halland</subdivision>
 			<subdivision type="seo" draft="contributed">Daerah Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">Daerah Värmland</subdivision>

--- a/common/subdivisions/pt.xml
+++ b/common/subdivisions/pt.xml
@@ -3523,25 +3523,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sdrs" draft="contributed">Mar Vermelho</subdivision>
 			<subdivision type="sdsi" draft="contributed">Sennar</subdivision>
 			<subdivision type="seab" draft="contributed">condado de Estocolmo</subdivision>
-			<subdivision type="seac" draft="contributed">Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">Norrbotten</subdivision>
+			<subdivision type="seac" draft="contributed">condado de Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">condado de Norrbotten</subdivision>
 			<subdivision type="sec" draft="contributed">condado da Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">condado da Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">condado da Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">condado da Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">Kronoberg</subdivision>
+			<subdivision type="seg" draft="contributed">condado de Kronoberg</subdivision>
 			<subdivision type="seh" draft="contributed">condado da Kalmar</subdivision>
-			<subdivision type="sei" draft="contributed">Gotland</subdivision>
-			<subdivision type="sek" draft="contributed">Blekinge</subdivision>
-			<subdivision type="sem" draft="contributed">Escânia</subdivision>
+			<subdivision type="sei" draft="contributed">condado de Gotland</subdivision>
+			<subdivision type="sek" draft="contributed">condado de Blekinge</subdivision>
+			<subdivision type="sem" draft="contributed">condado de Escânia</subdivision>
 			<subdivision type="sen" draft="contributed">condado da Halland</subdivision>
 			<subdivision type="seo" draft="contributed">condado da Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">condado da Värmland</subdivision>
-			<subdivision type="set" draft="contributed">Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">Dalarna</subdivision>
-			<subdivision type="sex" draft="contributed">Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">Västernorrland</subdivision>
+			<subdivision type="set" draft="contributed">condado de Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">condado de Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">condado de Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">condado de Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">condado de Västernorrland</subdivision>
 			<subdivision type="sez" draft="contributed">condado da Jämtland</subdivision>
 			<subdivision type="shac" draft="contributed">Ilha de Ascensão</subdivision>
 			<subdivision type="shhl" draft="contributed">Santa Helena</subdivision>

--- a/common/subdivisions/pt.xml
+++ b/common/subdivisions/pt.xml
@@ -3523,25 +3523,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sdrs" draft="contributed">Mar Vermelho</subdivision>
 			<subdivision type="sdsi" draft="contributed">Sennar</subdivision>
 			<subdivision type="seab" draft="contributed">condado de Estocolmo</subdivision>
-			<subdivision type="seac" draft="contributed">condado de Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">condado de Norrbotten</subdivision>
+			<subdivision type="seac" draft="contributed">Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">Norrbotten</subdivision>
 			<subdivision type="sec" draft="contributed">condado da Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">condado da Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">condado da Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">condado da Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">condado de Kronoberg</subdivision>
+			<subdivision type="seg" draft="contributed">Kronoberg</subdivision>
 			<subdivision type="seh" draft="contributed">condado da Kalmar</subdivision>
-			<subdivision type="sei" draft="contributed">condado de Gotland</subdivision>
-			<subdivision type="sek" draft="contributed">condado de Blekinge</subdivision>
-			<subdivision type="sem" draft="contributed">condado de Escânia</subdivision>
+			<subdivision type="sei" draft="contributed">Gotland</subdivision>
+			<subdivision type="sek" draft="contributed">Blekinge</subdivision>
+			<subdivision type="sem" draft="contributed">Escânia</subdivision>
 			<subdivision type="sen" draft="contributed">condado da Halland</subdivision>
 			<subdivision type="seo" draft="contributed">condado da Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">condado da Värmland</subdivision>
-			<subdivision type="set" draft="contributed">condado de Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">condado de Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">condado de Dalarna</subdivision>
-			<subdivision type="sex" draft="contributed">condado de Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">condado de Västernorrland</subdivision>
+			<subdivision type="set" draft="contributed">Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">Västernorrland</subdivision>
 			<subdivision type="sez" draft="contributed">condado da Jämtland</subdivision>
 			<subdivision type="shac" draft="contributed">Ilha de Ascensão</subdivision>
 			<subdivision type="shhl" draft="contributed">Santa Helena</subdivision>

--- a/common/subdivisions/vi.xml
+++ b/common/subdivisions/vi.xml
@@ -3371,25 +3371,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="sdrs" draft="contributed">Biển Đỏ</subdivision>
 			<subdivision type="sdsi" draft="contributed">Sennar</subdivision>
 			<subdivision type="seab" draft="contributed">hạt Stockholm</subdivision>
-			<subdivision type="seac" draft="contributed">Västerbotten</subdivision>
-			<subdivision type="sebd" draft="contributed">Norrbotten</subdivision>
+			<subdivision type="seac" draft="contributed">hạt Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">hạt Norrbotten</subdivision>
 			<subdivision type="sec" draft="contributed">hạt Uppsala</subdivision>
 			<subdivision type="sed" draft="contributed">hạt Södermanland</subdivision>
 			<subdivision type="see" draft="contributed">hạt Östergötland</subdivision>
 			<subdivision type="sef" draft="contributed">hạt Jönköping</subdivision>
-			<subdivision type="seg" draft="contributed">Kronoberg</subdivision>
+			<subdivision type="seg" draft="contributed">hạt Kronoberg</subdivision>
 			<subdivision type="seh" draft="contributed">hạt Kalmar</subdivision>
-			<subdivision type="sei" draft="contributed">Gotland</subdivision>
+			<subdivision type="sei" draft="contributed">hạt Gotland</subdivision>
 			<subdivision type="sek" draft="contributed">hạt Blekinge</subdivision>
 			<subdivision type="sem" draft="contributed">hạt Skåne</subdivision>
 			<subdivision type="sen" draft="contributed">hạt Halland</subdivision>
 			<subdivision type="seo" draft="contributed">hạt Västra Götaland</subdivision>
 			<subdivision type="ses" draft="contributed">hạt Värmland</subdivision>
-			<subdivision type="set" draft="contributed">Örebro</subdivision>
-			<subdivision type="seu" draft="contributed">Västmanland</subdivision>
-			<subdivision type="sew" draft="contributed">Dalarna</subdivision>
-			<subdivision type="sex" draft="contributed">Gävleborg</subdivision>
-			<subdivision type="sey" draft="contributed">Västernorrland</subdivision>
+			<subdivision type="set" draft="contributed">hạt Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">hạt Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">hạt Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">hạt Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">hạt Västernorrland</subdivision>
 			<subdivision type="sez" draft="contributed">hạt Jämtland</subdivision>
 			<subdivision type="shac" draft="contributed">Đảo Ascension</subdivision>
 			<subdivision type="shhl" draft="contributed">Saint Helena</subdivision>


### PR DESCRIPTION
Split from pull request #89; correcting translations for consistency.
Applied to languages: be, ca, ceb, es, eu, fr, gl, hr, id, vi

From filed issue: https://unicode-org.atlassian.net/browse/CLDR-13186
