### PR TITLE
CLDR-11893 Change first day of week from Sunday to Monday for Argentina

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -4675,7 +4675,7 @@ XXX Code for transations where no currency is involved
 		<!-- The first workday of the week (after the weekend) is distinct, and can be determined as the day after the weekendEnd day. -->
           <firstDay day="mon"  territories="
 			001
-			AD AI AL AM AN AT AX AZ
+			AD AI AL AM AN AR AT AX AZ
 			BA BE BG BM BN BY
 			CH CL CM CR CY CZ
 			DE DK
@@ -4699,7 +4699,7 @@ XXX Code for transations where no currency is involved
 		<firstDay day="fri" territories="MV"/>
 		<firstDay day="sat" territories="AE AF BH DJ DZ EG IQ IR JO KW LY OM QA SD SY"/>
           <firstDay day="sun"  territories="
-			AG AR AS AU
+			AG AS AU
 			BD BR BS BT BW BZ
 			CA CN CO
 			DM DO


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11893
- [x] Updated PR title and link in previous line to include Issue number

