### PR TITLE
CLDR-11238 INHERITANCE_MARKER without inheritedValue

### DIFF
--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -513,10 +513,11 @@ const cldrSurveyTable = (function() {
 			if (item.value === INHERITANCE_MARKER) {
 				if (!theRow.inheritedValue) {
 					/*
-					 * In earlier implementation, essentially the same error was reported as "... there is no Bailey Target item!")
-					 * Reference: https://unicode.org/cldr/trac/ticket/11238
+					 * In earlier implementation, essentially the same error was reported as "... there is no Bailey Target item!").
 					 */
-					console.error('For ' + theRow.xpstrid + ' - there is INHERITANCE_MARKER without inheritedValue');
+					if (!extraPathAllowsNullValue(theRow.xpath)) {
+						console.error('For ' + theRow.xpstrid + ' - there is INHERITANCE_MARKER without inheritedValue');
+					}
 				} else if (!theRow.inheritedLocale && !theRow.inheritedXpid) {
 					/*
 					 * It is probably a bug if item.value === INHERITANCE_MARKER but theRow.inheritedLocale and
@@ -528,6 +529,33 @@ const cldrSurveyTable = (function() {
 				}
 			}
 		}
+	}
+
+    /**
+     * Is the given path exceptional in the sense that null value is allowed?
+     *
+     * @param path the path
+     * @return true if null value is allowed for path, else false
+     *
+     * This function is nearly identical to the Java function with the same name in TestPaths.java.
+     * Keep it consistent with that function. It would be more ideal if this knowledge were encapsulated
+     * on the server and the client didn't need to know about it. The server could send the client special
+     * fallback values instead of null.
+     *
+     * Unlike the Java version on the server, here on the client we don't actually check that the path is an "extra" path.
+     *
+     * Example: http://localhost:8080/cldr-apps/v#/pa_Arab/Gregorian/35b886c9d25c9cb7
+     * //ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="midnight"]
+     *
+     * Reference: https://unicode-org.atlassian.net/browse/CLDR-11238
+     */
+	function extraPathAllowsNullValue(path) {
+		if (path.includes('timeZoneNames/metazone') ||
+			path.includes('timeZoneNames/zone') ||
+			path.includes('dayPeriods/dayPeriodContext')) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
@@ -100,62 +100,120 @@ public class TestPaths extends TestFmwkPlus {
         return b.toString();
     }
 
-    public void TestGetFullPath() {
-        Status status = new Status();
-
-        for (String locale : getLocalesToTest()) {
-            CLDRFile file = testInfo.getCLDRFile(locale, true);
-            logln(locale);
-
-            for (Iterator<String> it = file.iterator(); it.hasNext();) {
-                String path = it.next();
-                String fullPath = file.getFullXPath(path);
-                String value = file.getStringValue(path);
-                String source = file.getSourceLocaleID(path, status);
-                if (fullPath == null) {
-                    errln("Locale: " + locale + ",\t FullPath: " + path);
-                }
-                if (value == null) {
-                    errln("Locale: " + locale + ",\t Value: " + path);
-                }
-                if (source == null) {
-                    errln("Locale: " + locale + ",\t Source: " + path);
-                }
-                if (status.pathWhereFound == null) {
-                    errln("Locale: " + locale + ",\t Found Path: " + path);
-                }
-            }
-        }
-    }
-
-    public void TestPathHeaders() {
-
+    /**
+     * For each locale to test, loop through all the paths, including "extra" paths,
+     * checking for each path: checkFullpathValue; checkPrettyPaths
+     */
+    public void TestPathHeadersAndValues() {
+        /*
+         * Use the pathsSeen hash to keep track of which paths have
+         * already been seen. Since the test checkPrettyPaths isn't really
+         * locale-dependent, run it only once for each path, for the first
+         * locale in which the path occurs.
+         */
         Set<String> pathsSeen = new HashSet<String>();
         CLDRFile englishFile = testInfo.getCldrFactory().make("en", true);
         PathHeader.Factory phf = PathHeader.getFactory(englishFile);
-
+        Status status = new Status();
         for (String locale : getLocalesToTest()) {
-            CLDRFile file = testInfo.getCldrFactory().make(locale, true);
-            logln("Testing path headers for locale => " + locale);
-
+            CLDRFile file = testInfo.getCLDRFile(locale, true);
+            logln("Testing path headers and values for locale => " + locale);
             for (Iterator<String> it = file.iterator(); it.hasNext();) {
-                checkPaths(it.next(), pathsSeen, phf, locale);
+                String path = it.next();
+                checkFullpathValue(path, file, locale, status, false /* not extra path */);
+                if (!pathsSeen.contains(path)) {
+                    pathsSeen.add(path);
+                    checkPrettyPaths(path, phf);
+                }
             }
             for (String path : file.getExtraPaths()) {
-                checkPaths(path, pathsSeen, phf, locale);
+                checkFullpathValue(path, file, locale, status, true /* extra path */);
+                if (!pathsSeen.contains(path)) {
+                    pathsSeen.add(path);
+                    checkPrettyPaths(path, phf);
+                }
             }
         }
     }
 
-    private void checkPaths(String path, Set<String> pathsSeen,
-        PathHeader.Factory phf, String locale) {
+    /**
+     * For the given path and CLDRFile, check that fullPath, value, and source are all non-null.
+     *
+     * Allow null value for some exceptional extra paths.
+     *
+     * @param path the path, such as '//ldml/dates/fields/field[@type="tue"]/relative[@type="1"]'
+     * @param file the CLDRFile
+     * @param locale the locale string
+     * @param status the Status to be used/set by getSourceLocaleID
+     * @param isExtraPath true if the path is an "extra" path, else false
+     */
+    private void checkFullpathValue(String path, CLDRFile file, String locale, Status status, boolean isExtraPath) {
+        String fullPath = file.getFullXPath(path);
+        String value = file.getStringValue(path);
+        String source = file.getSourceLocaleID(path, status);
+        if (fullPath == null) {
+            errln("Locale: " + locale + ",\t FullPath: " + path);
+        }
+        if (value == null) {
+            /*
+             * Allow null value for some exceptional extra paths.
+             */
+            if (!isExtraPath || !extraPathAllowsNullValue(path)) {
+                errln("Locale: " + locale + ",\t Value: " + path);
+            }
+        }
+        if (source == null) {
+            errln("Locale: " + locale + ",\t Source: " + path);
+        }
+        if (status.pathWhereFound == null) {
+            errln("Locale: " + locale + ",\t Found Path: " + path);
+        }
+    }
+
+    /**
+     * Is the given extra path exceptional in the sense that null value is allowed?
+     *
+     * @param path the extra path
+     * @return true if null value is allowed for path, else false
+     *
+     * As of 2019-08-09, null values are found for many "metazone" paths like:
+     * //ldml/dates/timeZoneNames/metazone[@type="Galapagos"]/long/standard
+     * for many locales. Also for some "zone" paths like:
+     * //ldml/dates/timeZoneNames/zone[@type="Pacific/Honolulu"]/short/generic
+     * for locales including root, ja, and ar. Also for some "dayPeriods" paths like
+     * //ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="midnight"]
+     * only for these six locales: bs_Cyrl, bs_Cyrl_BA, pa_Arab, pa_Arab_PK, uz_Arab, uz_Arab_AF.
+     *
+     * This function is nearly identical to the JavaScript function with the same name.
+     * Keep the two functions consistent with each other. It would be more ideal if this
+     * knowledge were encapsulated on the server and the client didn't need to know about it.
+     * The server could send the client special fallback values instead of null.
+     *
+     * Extra paths are generated by CLDRFile.getRawExtraPathsPrivate; this function may need
+     * updating (to allow null for other paths) if that function changes.
+     *
+     * Reference: https://unicode-org.atlassian.net/browse/CLDR-11238
+     */
+    private boolean extraPathAllowsNullValue(String path) {
+        if (path.contains("timeZoneNames/metazone") ||
+            path.contains("timeZoneNames/zone") ||
+            path.contains("dayPeriods/dayPeriodContext")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check that the given path and PathHeader.Factory undergo correct
+     * roundtrip conversion between original and pretty paths.
+     *
+     * @param path the path string
+     * @param phf the PathHeader.Factory
+     */
+    private void checkPrettyPaths(String path, PathHeader.Factory phf) {
         if (path.endsWith("/alias")) {
             return;
         }
-        if (pathsSeen.contains(path)) {
-            return;
-        }
-        pathsSeen.add(path);
         logln("Testing ==> " + path);
         String prettied = phf.fromPath(path).toString();
         String unprettied = phf.fromPath(path).getOriginalPath();

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -3296,6 +3296,15 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
      * "Raw" refers to the fact that some of the paths may duplicate paths that are
      * already in this CLDRFile (in the xml and/or votes), in which case they will
      * later get filtered by getExtraPaths (removed from toAddTo) rather than re-added.
+     *
+     * NOTE: values may be null for some "extra" paths in locales for which no explicit
+     * values have been submitted. Both unit tests and Survey Tool client code generate
+     * errors or warnings for null value, but allow null value for certain exceptional
+     * extra paths. See the functions named extraPathAllowsNullValue in TestPaths.java
+     * and in the JavaScript client code. Make sure that updates here are reflected there
+     * and vice versa.
+     *
+     * Reference: https://unicode-org.atlassian.net/browse/CLDR-11238
      */
     private Collection<String> getRawExtraPathsPrivate(Collection<String> toAddTo) {
         SupplementalDataInfo supplementalData = CLDRConfig.getInstance().getSupplementalDataInfo();


### PR DESCRIPTION
-Enhance unit test to check extra path null value

-New TestPathHeadersAndValues combines old TestGetFullPath and TestPathHeaders, for speed

-Check extra paths as well as regular paths

-Allow null value for exceptional extra paths, both unit test and client

-Exceptional extra paths are like timeZoneNames/(meta)zone or dayPeriods/dayPeriodContext

-Use getCLDRFile instead of getCldrFactory().make, for speed

-Rename checkPaths to checkPrettyPaths

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11238
- [x] Updated PR title and link in previous line to include Issue number

