### PR TITLE
CLDR-11049 Improvements to the API for handling (and documenting) inheritance markers.

### DIFF
--- a/tools/java/org/unicode/cldr/api/AbstractDataSource.java
+++ b/tools/java/org/unicode/cldr/api/AbstractDataSource.java
@@ -1,6 +1,10 @@
 package org.unicode.cldr.api;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.Map;
+
+import org.unicode.cldr.util.CldrUtility;
 
 /**
  * Base class for any non-trivial implementation of the CldrData interface. The main benefit of
@@ -19,12 +23,12 @@ abstract class AbstractDataSource implements CldrData {
     }
 
     // Helper to wrap the visit method and report errors that occur.
-    static void safeVisit(CldrValue v, ValueVisitor visitor) {
+    static void safeVisit(CldrValue cldrValue, ValueVisitor visitor) {
         try {
-            visitor.visit(v);
+            visitor.visit(cldrValue);
         } catch (RuntimeException e) {
             // TODO: Throw wrapped exception but ensure it's not rewrapped by parent visitors!
-            System.err.format("Exception thrown by value visitor for value: %s\n", v);
+            System.err.format("Exception thrown by value visitor for value: %s\n", cldrValue);
             System.err.println(e);
             e.printStackTrace(System.err);
         }

--- a/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
@@ -129,11 +129,12 @@ public abstract class CldrDataSupplier {
 
     /**
      * Returns an in-memory supplier for the specified {@link CldrValue}s. This is useful for
-     * testing or handling special case data.
-     * @param values
+     * testing or handling special case data. The default (arbitrary) path or is determined by
+     * the order of values passed to this method.
+     *
+     * @param values the values (and associated paths) to include in the returned data.
      */
-    // Note: This could be made public if necessary.
-    static CldrData forValues(Iterable<CldrValue> values) {
+    public static CldrData forValues(Iterable<CldrValue> values) {
         return new InMemoryData(values);
     }
 

--- a/tools/java/org/unicode/cldr/api/CldrValue.java
+++ b/tools/java/org/unicode/cldr/api/CldrValue.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.api;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.unicode.cldr.api.AttributeKey.AttributeSupplier;
+import org.unicode.cldr.util.CldrUtility;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -70,7 +71,13 @@ public final class CldrValue implements AttributeSupplier {
     private final int hashCode;
 
     private CldrValue(String value, Map<AttributeKey, String> attributes, CldrPath path) {
-        // Empty value strings are permitted (but null is not).
+        // Since early 2019 there's been the possibility of getting the inheritance marker as
+        // a value for a path. This indicates that the value does NOT actually exist for a
+        // locale and would be inherited. However everything that creates a CldrValue instance
+        // is expected to deal with this and we should never see inheritance markers here.
+        // Note: This also serves as a null check for values.
+        checkArgument(!value.equals(CldrUtility.INHERITANCE_MARKER),
+            "unexpected inheritance marker '%s' for path: %s", value, path);
         this.value = checkNotNull(value);
         this.attributes = checkAttributeMap(attributes);
         this.path = checkNotNull(path);


### PR DESCRIPTION
The hopefully last tweak to the API classes for now, which adds a check and fixes some documentation regarding the handling of inheritance markers. Also added a better error message for when the entity resolution isn't supported (an issue for Googlers due to the default JDK setup).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

