### PR TITLE
CLDR-11049 Breaking an unnecessary inter-package dependency for API jar.

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLdml2ICU.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLdml2ICU.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.unittest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -10,7 +11,6 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CldrUtility.VariableReplacer;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.RegexFileParser;
@@ -23,6 +23,7 @@ import org.unicode.cldr.util.XPathParts;
 
 import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.text.Transform;
+import com.ibm.icu.util.Output;
 
 /**
  * Tests the parts of the Ldml2IcuConverter that uses RegexLookups to convert
@@ -209,7 +210,7 @@ public class TestLdml2ICU extends TestFmwk {
             String errorMessage = "CLDR xpath  <" + xpath + "> with value <"
                 + value + "> was not converted to ICU.";
             if (exclusionType == null) {
-                CldrUtility.logRegexLookup(this, lookup, xpath);
+                logRegexLookup(this, lookup, xpath);
                 errln(errorMessage);
             } else if (exclusionType == ExclusionType.WARNING) {
                 logln(errorMessage);
@@ -220,11 +221,23 @@ public class TestLdml2ICU extends TestFmwk {
                 }
             }
         } else if (exclusionType == ExclusionType.UNCONVERTED) {
-            CldrUtility.logRegexLookup(this, exclusions, xpath);
+            logRegexLookup(this, exclusions, xpath);
             errln("CLDR xpath <"
                 + xpath
                 + "> is in the exclusions list but was matched. "
                 + "To make the test pass, remove the relevant regex from org/unicode/cldr/util/data/testLdml2Icu.txt");
+        }
+    }
+
+    private static <T> void logRegexLookup(TestFmwk testFramework, RegexLookup<T> lookup, String toLookup) {
+        Output<String[]> arguments = new Output<>();
+        Output<RegexLookup.Finder> matcherFound = new Output<>();
+        List<String> failures = new ArrayList<String>();
+        lookup.get(toLookup, null, arguments, matcherFound, failures);
+        testFramework.logln("lookup arguments: " + (arguments.value == null ? "null" : Arrays.asList(arguments.value)));
+        testFramework.logln("lookup matcherFound: " + matcherFound);
+        for (String s : failures) {
+            testFramework.logln(s);
         }
     }
 

--- a/tools/java/org/unicode/cldr/util/CldrUtility.java
+++ b/tools/java/org/unicode/cldr/util/CldrUtility.java
@@ -44,10 +44,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.draft.FileUtilities;
-import org.unicode.cldr.util.RegexLookup.Finder;
 
 import com.google.common.base.Splitter;
-import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.SimpleDateFormat;
@@ -57,7 +55,6 @@ import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.Freezable;
-import com.ibm.icu.util.Output;
 import com.ibm.icu.util.TimeZone;
 
 public class CldrUtility {
@@ -1468,18 +1465,6 @@ public class CldrUtility {
         Set<T> result = new LinkedHashSet<>(a);
         result.removeAll(b);
         return result;
-    }
-
-    public static <T> void logRegexLookup(TestFmwk testFramework, RegexLookup<T> lookup, String toLookup) {
-        Output<String[]> arguments = new Output<>();
-        Output<Finder> matcherFound = new Output<>();
-        List<String> failures = new ArrayList<String>();
-        lookup.get(toLookup, null, arguments, matcherFound, failures);
-        testFramework.logln("lookup arguments: " + (arguments.value == null ? "null" : Arrays.asList(arguments.value)));
-        testFramework.logln("lookup matcherFound: " + matcherFound);
-        for (String s : failures) {
-            testFramework.logln(s);
-        }
     }
 
     public static boolean deepEquals(Object... pairs) {


### PR DESCRIPTION
This moves a static utility method to the only place it's actually used, and removes one of the relatively small numbers of dependencies from "org.unicode.cldr.util" to "org.unicode.cldr.unittest".

Ideally "util" wouldn't depend on packages like "unittest" or "tool", but right now it does. Removing these will help reduce the size (and complexity) of the new API jar used by the CLDR project.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

