### PR TITLE
CLDR-11049 make sure all depends on api

### DIFF
--- a/tools/java/build.xml
+++ b/tools/java/build.xml
@@ -13,8 +13,10 @@
 		<property name="jarDocs.file" value="cldr-docs.jar" />
 		<property name="doc.dir" value="doc" />
 		<property name="doc.params" value="" />
-		<!-- Load local definitions from an optional build.properties file, if 
-			available. build.properties is NOT checked into CVS. -->
+		<!-- Load local definitions from an optional
+		     build.properties file, if
+		     available. build.properties is NOT checked into
+		     CVS. -->
 		<property file="build.properties" />
 		<!-- Load environment variables -->
 		<property environment="env" />
@@ -58,7 +60,7 @@
 	</target>
 
 	<!-- build everything but dist-related stuff -->
-	<target name="all" depends="util,ant-plugin,tool,posix,icu,json,test"
+	<target name="all" depends="util,ant-plugin,tool,posix,icu,json,test,api"
 		description="build all primary targets" />
 	<target name="ant-plugin" depends="init" description="build utility classes">
 		<javac includeantruntime="false" includes="org/unicode/cldr/ant/*.java"


### PR DESCRIPTION
[CLDR-11049]
FYI @hagbard 

- 7a782455a103c45a5ae5b7656b14691fbd9322e1 included the APIs in cldr.jar
- fix so that the APIs end up being built before cldr.jar is created

see https://github.com/unicode-org/cldr/pull/107


[CLDR-11049]: https://unicode-org.atlassian.net/browse/CLDR-11049