### PR TITLE
CLDR-11049 Fix Ant build files (main and test) to build and run everything.

### DIFF
--- a/tools/cldr-unittest/build.xml
+++ b/tools/cldr-unittest/build.xml
@@ -62,7 +62,7 @@
 	<target name="jar" depends="build"
 		description="build full cldr-unittest.jar' jar file">
 		<jar jarfile="${jar.file}" compress="true"
-			includes="org/unicode/cldr/unittest/**/*" basedir="${build.dir}" />
+			includes="org/unicode/cldr/**/*" basedir="${build.dir}" />
 	</target>
 	<target name="tests" depends="build" />
 	<target name="all" depends="build" />
@@ -90,7 +90,8 @@
 	<target name="build" depends="init" description="build web classes">
 		<mkdir dir="${build.dir}" />
 		<mkdir dir="${log.dir}" />
-		<javac srcdir="${src.dir}" includes="org/unicode/cldr/unittest/*.java"
+		<javac srcdir="${src.dir}"
+			includes="org/unicode/cldr/**/*.java"
 			destdir="${build.dir}" classpathref="project.class.path" source="1.8"
 			target="1.8" debug="on" deprecation="off" includeantruntime="false"
 			encoding="UTF-8" />
@@ -176,8 +177,8 @@
 		<echo
 			message="JVM argument:   ${rununittest.jvmarg} -DCLDR_ENVIRONMENT=UNITTEST  -Djava.awt.headless=true" />
 		<echo message="Test argument:   ${rununittest.arg}" />
-		<java classname="org.unicode.cldr.unittest.TestAll" fork="yes"
-			failonerror="true" classpathref="project.class.path">
+		<java classname="org.unicode.cldr.unittest.TestAll" fork="yes" dir="${basedir}"
+			  failonerror="true" classpathref="project.class.path">
 			<arg line="${rununittest.arg}" />
 			<jvmarg
 				line="${rununittest.jvmarg} -DCLDR_ENVIRONMENT=UNITTEST -Djava.awt.headless=true" />

--- a/tools/java/build.xml
+++ b/tools/java/build.xml
@@ -8,7 +8,6 @@
 		<property name="build.dir" value="classes" />
 		<property name="libs.dir" value="libs" />
 		<property name="jar.file" value="cldr.jar" />
-		<property name="apiJar.file" value="cldr-api.jar" />
 		<property name="jarSrc.file" value="cldr-src.jar" />
 		<property name="jarDocs.file" value="cldr-docs.jar" />
 		<property name="doc.dir" value="doc" />
@@ -58,7 +57,7 @@
 	</target>
 
 	<!-- build everything but dist-related stuff -->
-	<target name="all" depends="util,ant-plugin,tool,posix,icu,json,test"
+	<target name="all" depends="util,api,ant-plugin,tool,posix,icu,json,test"
 		description="build all primary targets" />
 	<target name="ant-plugin" depends="init" description="build utility classes">
 		<javac includeantruntime="false" includes="org/unicode/cldr/ant/*.java"
@@ -68,8 +67,8 @@
 	</target>
 	<!-- WARNING: The "util" target actually depends upon the "tool" target at runtime via
 		CLDRPaths and ToolConstants. This only appears to work when building this target
-		because Ant does not do any kind of source isolation during builds, and so builds
-		all the transitive dependencies anyway.
+		because Ant does not do any kind of source isolation during builds, so it just
+		builds all the transitive dependencies anyway.
 	-->
 	<target name="util" depends="init" description="build utility classes">
 		<javac includeantruntime="false"
@@ -89,11 +88,7 @@
 			srcdir="${src.dir}" destdir="${build.dir}"
 			classpathref="project.class.path" source="1.8" target="1.8" debug="on"
 			deprecation="off" encoding="UTF-8" />
-		<!-- copy data files into classes.. -->
-		<mkdir dir="${build.dir}/org/unicode/cldr/tool" />
-		<copy todir="${build.dir}/org/unicode/cldr/tool">
-			<fileset dir="${src.dir}/org/unicode/cldr/tool" excludes="**/CVS/**/* **/**/*.java" />
-		</copy>
+		<!-- API package doesn't have dta files -->
 	</target>
 	<target name="tool" depends="init,util" description="build tool classes">
 		<javac includeantruntime="false" includes="org/unicode/cldr/tool/**/*.java"
@@ -185,33 +180,6 @@
                                 <attribute name="CLDR-Tools-Git-Commit" value="${build.githash}" />
 				<attribute name="Class-Path"
 					value="./libs/${cldr.libs.icu4j} ./libs/${cldr.libs.utilities} ./libs/${cldr.libs.xerces} ./libs/${cldr.libs.guava} ./libs/${cldr.libs.gson} ${cldr.libs.icu4j} ${cldr.libs.utilities} ${cldr.libs.xerces} ${cldr.libs.gson} ./libs/myanmar-tools-1.1.1.jar" />
-			</manifest>
-		</jar>
-	</target>
-
-	<!-- API JAR for use in ICU project. This is expected to have ICU library dependcies
-		provided at runtime, rather than being directly compiled in and should contain only
-		the classes necessary to support the API.
-
-		The need to include the com.ibm.icu classes and the "tool"/"test" package is a hack
-		to work around the entangled dependencies in the CLDR classes. In particular the
-		CLDRConfig class depends on many unexpected classes, such as the testing framework
-		classes! The API classes should ideally depend only on the "util" package.
-
-		Additionally, until the "com.ibm.icu" dependencies can be removed, there is a risk
-		of having multiple (potentially incompatible) copies of "com.ibm.icu" classes
-		available at runime when using the API jar in the ICU project. -->
-	<target name="api-jar" depends="init-githash,api" description="build API jar file">
-		<jar jarfile="${apiJar.file}" compress="true"
-			includes="org/unicode/cldr/api/**/*,
-				org/unicode/cldr/util/**/*,
-	        		org/unicode/cldr/test/**/*,
-	        		org/unicode/cldr/tool/**/*,
-	        		com/ibm/icu/**/*"
-			basedir="${build.dir}">
-			<manifest>
-				<attribute name="Built-By" value="${user.name}" />
-                                <attribute name="CLDR-Tools-Git-Commit" value="${build.githash}" />
 			</manifest>
 		</jar>
 	</target>


### PR DESCRIPTION
Additionally fixed the tests to honour Ant's idea of the current working directory during testing.
This reliance on the test environment is nasty, but I added an explicit directory setting in the build file to deal with it. The ../../ back-path in the tests is for getting up from the base test directory into the main release root, which has the "real" DTDs in (the "test" DTDs are not complete and don't work for me and weren't obviously upgradeable to the latest ones).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

