### PR TITLE
CLDR-13190 Remove latin a-z from aux examplars, fix build break.

### DIFF
--- a/seed/main/osa.xml
+++ b/seed/main/osa.xml
@@ -26,7 +26,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[𐓘 {𐓘̄} {𐓘́} {𐓘̋} {𐓘͘} {𐓘̄͘} {𐓘́͘} {𐓘̋͘} 𐓙 {𐓙̄} {𐓙́} {𐓙̋} 𐓚 {𐓚̄} {𐓚́} {𐓚̋} 𐓛 {𐓛͘} 𐓜 𐓝 𐓞 𐓟 {𐓟̄} {𐓟́} {𐓟̋} 𐓠 {𐓠̄} {𐓠́} {𐓠̋} 𐓡 𐓢 𐓣 {𐓣̄} {𐓣́} {𐓣̋} {𐓣͘} {𐓣̄͘} {𐓣́͘} {𐓣̋͘} 𐓤 𐓥 𐓦 𐓧 𐓨 𐓩 𐓪 {𐓪̄} {𐓪́} {𐓪̋} {𐓪͘} {𐓪̄͘} {𐓪́͘} {𐓪̋͘} 𐓫 {𐓫̄} {𐓫́} {𐓫̋} 𐓬 𐓭 𐓮 𐓯 𐓰 𐓱 𐓲 𐓳 𐓴 𐓵 𐓶 {𐓶̄} {𐓶́} {𐓶̋} 𐓷 𐓸 𐓹 𐓺 𐓻]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[a b c d e f g h i j k l m n o p q r s t u v w x y z]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[]</exemplarCharacters>
 		<exemplarCharacters type="index">[𐒰 {𐒰͘} 𐒱 𐒲 𐒳 𐒴 𐒵 𐒶 𐒷 𐒸 𐒹 𐒺 𐒻 {𐒻͘} 𐒼 𐒽 𐒾 𐒿 𐓀 𐓁 𐓂 {𐓂͘} 𐓃 𐓄 𐓅 𐓆 𐓇 𐓈 𐓉 𐓊 𐓋 𐓌 𐓍 𐓎 𐓏 𐓐 𐓑 𐓒 𐓓]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\- , . % ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>


### PR DESCRIPTION
[CLDR-13190] Removing a-z from auxiliary examplars, since having them there breaks the build.

[CLDR-13190]: https://unicode-org.atlassian.net/browse/CLDR-13190