### PR TITLE
CLDR-10783 af, durationUnitPattern should use h not hh

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -7818,10 +7818,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
-			<durationUnitPattern>hh:mm</durationUnitPattern>
+			<durationUnitPattern>h:mm</durationUnitPattern>
 		</durationUnit>
 		<durationUnit type="hms">
-			<durationUnitPattern>hh:mm:ss</durationUnitPattern>
+			<durationUnitPattern>h:mm:ss</durationUnitPattern>
 		</durationUnit>
 		<durationUnit type="ms">
 			<durationUnitPattern>mm:ss</durationUnitPattern>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10783
- [x] Updated PR title and link in previous line to include Issue number

