### PR TITLE
CLDR-13071 ars addition to country_language_population_raw.txt

### DIFF
--- a/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -1075,6 +1075,7 @@ San Marino	SM	"33,779"	96%	"2,064,000,000"		Esperanto	eo	300			"http://en.wikipe
 San Marino	SM	"33,779"	96%	"2,064,000,000"	official	Italian	it	89%			
 São Tomé & Príncipe	ST	"204,454"	70%	"686,000,000"	official	Portuguese	pt	85%			
 Saudi Arabia	SA	"33,091,113"	87%	"1,775,000,000,000"	official	Arabic	ar	100%			
+Saudi Arabia	SA	"33,091,113"	87%	"1,775,000,000,000"		Najdi Arabic	ars	2.99%	5%		"For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
 Senegal	SN	"15,020,945"	50%	"54,800,000,000"	official_regional	Balanta-Ganja	bjt	"91,200"	100%		"http://en.wikipedia.org/wiki/Senegal 50k Europeans, mostly French. The figure for writing population is derived from literacy * population, and may be too high."
 Senegal	SN	"15,020,945"	50%	"54,800,000,000"	official_regional	Bassari	bsc	"14,600"	10%		http://www.ethnologue.com/language/dyo only 10% monolingual
 Senegal	SN	"15,020,945"	50%	"54,800,000,000"	official	French	fr	39%	100%		"http://en.wikipedia.org/wiki/Senegal 50k Europeans, mostly French. The figure for writing population is derived from literacy * population, and may be too high."


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13071
- [x] Updated PR title and link in previous line to include Issue number

This follow-on to https://github.com/unicode-org/cldr/pull/39 completes the steps needed to add the languagePopulation data for "ars" in such a way that it will not be over-written by later updates; this final step adds it into the country_language_population_raw.txt spreadsheet data.