### PR TITLE
CLDR-13099 Remove alt values for North Macedonia

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -674,7 +674,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalleilande</territory>
 			<territory type="MK">Noord-Macedonië</territory>
-			<territory type="MK" alt="variant">Noord-Macedonië</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mianmar (Birma)</territory>
 			<territory type="MN">Mongolië</territory>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -757,7 +757,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ማዳጋስካር</territory>
 			<territory type="MH">ማርሻል አይላንድ</territory>
 			<territory type="MK">ሰሜን መቄዶንያ</territory>
-			<territory type="MK" alt="variant" draft="contributed">መቄዶንያ (የቀድሞ የዩጎስላቭ መቄዶንያ ሪፐብሊክ)</territory>
 			<territory type="ML">ማሊ</territory>
 			<territory type="MM">ማይናማር(በርማ)</territory>
 			<territory type="MN">ሞንጎሊያ</territory>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -874,7 +874,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">مدغشقر</territory>
 			<territory type="MH">جزر مارشال</territory>
 			<territory type="MK">مقدونيا الشمالية</territory>
-			<territory type="MK" alt="variant">مقدونيا- جمهورية مقدونيا اليوغسلافية السابقة</territory>
 			<territory type="ML">مالي</territory>
 			<territory type="MM">ميانمار (بورما)</territory>
 			<territory type="MN">منغوليا</territory>

--- a/common/main/ar_SA.xml
+++ b/common/main/ar_SA.xml
@@ -687,7 +687,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">↑↑↑</territory>
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -657,7 +657,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">মাদাগাস্কাৰ</territory>
 			<territory type="MH">মাৰ্শ্বাল দ্বীপপুঞ্জ</territory>
 			<territory type="MK">উত্তৰ মেচিডোনীয়া</territory>
-			<territory type="MK" alt="variant">মেচিডোনীয়া (FYROM)</territory>
 			<territory type="ML">মালি</territory>
 			<territory type="MM">ম্যানমাৰ (বাৰ্মা)</territory>
 			<territory type="MN">মঙ্গোলিয়া</territory>

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -1001,7 +1001,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">Saint Martin</territory>
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Islles Marshall</territory>
-			<territory type="MK" alt="variant">Macedonia (ARYDM)</territory>
 			<territory type="ML">Malí</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -862,7 +862,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madaqaskar</territory>
 			<territory type="MH">Marşal adaları</territory>
 			<territory type="MK">Şimali Makedoniya</territory>
-			<territory type="MK" alt="variant">Makedoniya (KYRM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanma</territory>
 			<territory type="MN">Monqolustan</territory>

--- a/common/main/az_Cyrl.xml
+++ b/common/main/az_Cyrl.xml
@@ -591,7 +591,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">Сент Мартин</territory>
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршал адалары</territory>
-			<territory type="MK" alt="variant">Македонија (КЈРМ)</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мјанма</territory>
 			<territory type="MN">Монголустан</territory>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -685,7 +685,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалавы астравы</territory>
 			<territory type="MK">Паўночная Македонія</territory>
-			<territory type="MK" alt="variant">Македонія</territory>
 			<territory type="ML">Малі</territory>
 			<territory type="MM">М’янма (Бірма)</territory>
 			<territory type="MN">Манголія</territory>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -843,7 +843,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалови острови</territory>
 			<territory type="MK">Северна Македония</territory>
-			<territory type="MK" alt="variant">Северна Македония</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мианмар (Бирма)</territory>
 			<territory type="MN">Монголия</territory>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -872,7 +872,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">মাদাগাস্কার</territory>
 			<territory type="MH">মার্শাল দ্বীপপুঞ্জ</territory>
 			<territory type="MK">উত্তর ম্যাসেডোনিয়া</territory>
-			<territory type="MK" alt="variant">ম্যাসিডোনিয়া (FYROM)</territory>
 			<territory type="ML">মালি</territory>
 			<territory type="MM">মায়ানমার (বার্মা)</territory>
 			<territory type="MN">মঙ্গোলিয়া</territory>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -849,7 +849,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Inizi Marshall</territory>
 			<territory type="MK">Makedonia an Norzh</territory>
-			<territory type="MK" alt="variant">Makedonia (RYKM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -894,7 +894,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Maršalova ostrva</territory>
 			<territory type="MK">Sjeverna Makedonija</territory>
-			<territory type="MK" alt="variant">Makedonija (BJR)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mjanmar</territory>
 			<territory type="MN">Mongolija</territory>

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -835,7 +835,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалска Острва</territory>
 			<territory type="MK">Сјеверна Македонија</territory>
-			<territory type="MK" alt="variant">МК</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мјанмар</territory>
 			<territory type="MN">Монголија</territory>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -860,7 +860,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">𑄟𑄘𑄉𑄌𑄴𑄇𑄢𑄴</territory>
 			<territory type="MH">𑄟𑄢𑄴𑄥𑄣𑄴 𑄉𑄭 𑄉𑄭 𑄞𑄨𑄘𑄳𑄠</territory>
 			<territory type="MK">𑄟𑄳𑄠𑄥𑄓𑄮𑄚𑄨𑄠</territory>
-			<territory type="MK" alt="variant">𑄟𑄬𑄥𑄨𑄓𑄮𑄚𑄠(FYROM)</territory>
 			<territory type="ML">𑄟𑄣𑄨</territory>
 			<territory type="MM">𑄟𑄠𑄚𑄴𑄟𑄢𑄴 (𑄝𑄢𑄴𑄟)</territory>
 			<territory type="MN">𑄟𑄧𑄋𑄴𑄉𑄮𑄣𑄨𑄠</territory>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -658,7 +658,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">ᎹᏓᎦᏍᎧᎵ</territory>
 			<territory type="MH">ᎹᏌᎵ ᏚᎦᏚᏛᎢ</territory>
 			<territory type="MK">ᏧᏴᏜ ᎹᏎᏙᏂᏯ</territory>
-			<territory type="MK" alt="variant">ᎹᏎᏙᏂᏯ (FYROM)</territory>
 			<territory type="ML">ᎹᎵ</territory>
 			<territory type="MM">ᎹᏯᎹᎵ (ᏇᎵᎹ)</territory>
 			<territory type="MN">ᎹᏂᎪᎵᎠ</territory>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -799,7 +799,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Ynysoedd Marshall</territory>
 			<territory type="MK">Gogledd Macedonia</territory>
-			<territory type="MK" alt="variant">Macedonia (CWIM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -917,7 +917,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalløerne</territory>
 			<territory type="MK">Nordmakedonien</territory>
-			<territory type="MK" alt="variant">Nordmakedonien</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongoliet</territory>

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -881,7 +881,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -516,7 +516,6 @@ terms of use, see http://www.unicode.org/copyright.html
 			<territory type="MF">St. Martin</territory>
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallowe kupy</territory>
-			<territory type="MK" alt="variant">Makedońska (PRJ)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar</territory>
 			<territory type="MN">Mongolska</territory>

--- a/common/main/dz.xml
+++ b/common/main/dz.xml
@@ -390,7 +390,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">སེནཊ་ མཱར་ཊིན</territory>
 			<territory type="MG">མ་དཱ་གེས་ཀར</territory>
 			<territory type="MH">མར་ཤེལ་གླིང་ཚོམ</territory>
-			<territory type="MK" alt="variant">མ་སེ་ཌོ་ནི་ཡ་ (ཡུ་གོ་སླཱ་བི་ཡ)</territory>
 			<territory type="ML">མཱ་ལི</territory>
 			<territory type="MM">མི་ཡཱན་མར་ (བྷར་མ)</territory>
 			<territory type="MN">སོག་པོ་ཡུལ</territory>

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -600,7 +600,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">Saint Martin nutome</territory>
 			<territory type="MG">Madagaska nutome</territory>
 			<territory type="MH">Marshal ƒudomekpowo nutome</territory>
-			<territory type="MK" alt="variant">Makedonia (FYROM) nutome</territory>
 			<territory type="ML">Mali nutome</territory>
 			<territory type="MM">Myanmar (Burma) nutome</territory>
 			<territory type="MN">Mongolia nutome</territory>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -885,7 +885,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Μαδαγασκάρη</territory>
 			<territory type="MH">Νήσοι Μάρσαλ</territory>
 			<territory type="MK">Βόρεια Μακεδονία</territory>
-			<territory type="MK" alt="variant">Βόρεια Μακεδονία</territory>
 			<territory type="ML">Μάλι</territory>
 			<territory type="MM">Μιανμάρ (Βιρμανία)</territory>
 			<territory type="MN">Μογγολία</territory>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -889,7 +889,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MM" alt="short">↑↑↑</territory>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -887,7 +887,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MM" alt="short">↑↑↑</territory>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -862,7 +862,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Marshall Islands</territory>
 			<territory type="MK" draft="contributed">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MM" alt="short">↑↑↑</territory>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -888,7 +888,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MM" alt="short">↑↑↑</territory>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -882,7 +882,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Islas Marshall</territory>
 			<territory type="MK">Macedonia del Norte</territory>
-			<territory type="MK" alt="variant">Macedonia (ERYM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -798,7 +798,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Islas Marshall</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -798,7 +798,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -797,7 +797,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -1006,7 +1006,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalli Saared</territory>
 			<territory type="MK">Põhja-Makedoonia</territory>
-			<territory type="MK" alt="variant">MK</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birma)</territory>
 			<territory type="MN">Mongoolia</territory>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -667,7 +667,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshall Uharteak</territory>
 			<territory type="MK">Ipar Mazedonia</territory>
-			<territory type="MK" alt="variant">Mazedonia</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -876,7 +876,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ماداگاسکار</territory>
 			<territory type="MH">جزایر مارشال</territory>
 			<territory type="MK">مقدونیهٔ شمالی</territory>
-			<territory type="MK" alt="variant">مقدونیه شمالی</territory>
 			<territory type="ML">مالی</territory>
 			<territory type="MM">میانمار (برمه)</territory>
 			<territory type="MN">مغولستان</territory>

--- a/common/main/fa_AF.xml
+++ b/common/main/fa_AF.xml
@@ -546,7 +546,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">مادغاسکر</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">منگولیا</territory>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -1038,7 +1038,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallinsaaret</territory>
 			<territory type="MK">Pohjois-Makedonia</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -674,7 +674,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Marshall Islands</territory>
 			<territory type="MK">North Macedonia</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -672,7 +672,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">St-Martin</territory>
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalloyggjar</territory>
-			<territory type="MK" alt="variant">Makedónia (FJM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -1030,7 +1030,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Îles Marshall</territory>
 			<territory type="MK">Macédoine du Nord</territory>
-			<territory type="MK" alt="variant">Macédoine (ARYM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmanie)</territory>
 			<territory type="MN">Mongolie</territory>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -884,7 +884,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Îles Marshall</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">Macédoine (ARYM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar</territory>
 			<territory type="MN">Mongolie</territory>

--- a/common/main/fur.xml
+++ b/common/main/fur.xml
@@ -447,7 +447,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG" draft="contributed">Madagascar</territory>
 			<territory type="MH" draft="contributed">Isulis Marshall</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant" draft="contributed">Macedonie (FYROM)</territory>
 			<territory type="ML" draft="contributed">Mali</territory>
 			<territory type="MM" draft="contributed">Birmanie</territory>
 			<territory type="MN" draft="contributed">Mongolie</territory>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -882,7 +882,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG" draft="contributed">Madeiaskar</territory>
 			<territory type="MH" draft="contributed">Marshalleilannen</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant" draft="contributed">Macedonië (FYROM)</territory>
 			<territory type="ML" draft="contributed">Mali</territory>
 			<territory type="MM" draft="contributed">Myanmar (Birma)</territory>
 			<territory type="MN" draft="contributed">Mongolië</territory>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -827,7 +827,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Oileáin Marshall</territory>
 			<territory type="MK">an Mhacadóin Thuaidh</territory>
-			<territory type="MK" alt="variant">an Mhacadóin (PIIM)</territory>
 			<territory type="ML">Mailí</territory>
 			<territory type="MM">Maenmar (Burma)</territory>
 			<territory type="MN">an Mhongóil</territory>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -995,7 +995,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagasgar</territory>
 			<territory type="MH">Eileanan Mharshall</territory>
 			<territory type="MK">A’ Mhasadon a Tuath</territory>
-			<territory type="MK" alt="variant">A’ Mhasadon (FYROM)</territory>
 			<territory type="ML">Màili</territory>
 			<territory type="MM">Miànmar</territory>
 			<territory type="MN">Dùthaich nam Mongol</territory>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -673,7 +673,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Illas Marshall</territory>
 			<territory type="MK">Macedonia do Norte</territory>
-			<territory type="MK" alt="variant">Macedonia (ARIM)</territory>
 			<territory type="ML">Malí</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -768,7 +768,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaschkar</territory>
 			<territory type="MH">Marshallinsle</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">Mazedoonie (EJRM)</territory>
 			<territory type="ML">Maali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolei</territory>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -886,7 +886,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">મેડાગાસ્કર</territory>
 			<territory type="MH">માર્શલ આઇલેન્ડ્સ</territory>
 			<territory type="MK">ઉત્તર મેસેડોનિયા</territory>
-			<territory type="MK" alt="variant" draft="contributed">↑↑↑</territory>
 			<territory type="ML">માલી</territory>
 			<territory type="MM">મ્યાંમાર (બર્મા)</territory>
 			<territory type="MN">મંગોલિયા</territory>

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -506,7 +506,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Tsibiran Marshal</territory>
 			<territory type="MK">Macedonia ta Arewa</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Burma, Miyamar</territory>
 			<territory type="MN">Mangoliya</territory>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -824,7 +824,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">מדגסקר</territory>
 			<territory type="MH">איי מרשל</territory>
 			<territory type="MK">מקדוניה הצפונית</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">מאלי</territory>
 			<territory type="MM">מיאנמר (בורמה)</territory>
 			<territory type="MN">מונגוליה</territory>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -873,7 +873,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">मेडागास्कर</territory>
 			<territory type="MH">मार्शल द्वीपसमूह</territory>
 			<territory type="MK">उत्तरी मकदूनिया</territory>
-			<territory type="MK" alt="variant">मकदूनिया (FYROM)</territory>
 			<territory type="ML">माली</territory>
 			<territory type="MM">म्यांमार (बर्मा)</territory>
 			<territory type="MN">मंगोलिया</territory>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -917,7 +917,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Maršalovi Otoci</territory>
 			<territory type="MK">Sjeverna Makedonija</territory>
-			<territory type="MK" alt="variant">Makedonija</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mjanmar (Burma)</territory>
 			<territory type="MN">Mongolija</territory>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -514,7 +514,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallowe kupy</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">Makedonska (FYROM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar</territory>
 			<territory type="MN">Mongolska</territory>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -738,7 +738,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Մադագասկար</territory>
 			<territory type="MH">Մարշալյան կղզիներ</territory>
 			<territory type="MK">Հյուսիսային Մակեդոնիա</territory>
-			<territory type="MK" alt="variant">Մակեդոնիա (ՄՆՀՀ)</territory>
 			<territory type="ML">Մալի</territory>
 			<territory type="MM">Մյանմա (Բիրմա)</territory>
 			<territory type="MN">Մոնղոլիա</territory>

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -615,7 +615,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Insulas Marshall</territory>
 			<territory type="MK">Macedonia</territory>
-			<territory type="MK" alt="variant">Macedonia (ARYM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM" draft="unconfirmed">Birmania/Myanmar</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -940,7 +940,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Kepulauan Marshall</territory>
 			<territory type="MK">Makedonia Utara</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -288,7 +288,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Agwaetiti Marshall</territory>
 			<territory type="MK">North Macedonia</territory>
-			<territory type="MK" alt="variant">MK</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -845,7 +845,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalleyjar</territory>
 			<territory type="MK">Norður-Makedónía</territory>
-			<territory type="MK" alt="variant">Makedónía (Fyrrverandi lýðveldi Júgóslavíu)</territory>
 			<territory type="ML">Malí</territory>
 			<territory type="MM">Mjanmar (Búrma)</territory>
 			<territory type="MN">Mongólía</territory>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -995,7 +995,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Isole Marshall</territory>
 			<territory type="MK">Macedonia del Nord</territory>
-			<territory type="MK" alt="variant" draft="contributed">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -1007,7 +1007,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">マダガスカル</territory>
 			<territory type="MH">マーシャル諸島</territory>
 			<territory type="MK">北マケドニア</territory>
-			<territory type="MK" alt="variant" draft="contributed">↑↑↑</territory>
 			<territory type="ML">マリ</territory>
 			<territory type="MM">ミャンマー (ビルマ)</territory>
 			<territory type="MN">モンゴル</territory>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -503,7 +503,6 @@ terms of use, see http://www.unicode.org/copyright.html
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Kapuloan Marshall</territory>
 			<territory type="MK" draft="provisional">Makédonia</territory>
-			<territory type="MK" alt="variant" draft="provisional">Républik Makédonia Lor</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -860,7 +860,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">მადაგასკარი</territory>
 			<territory type="MH">მარშალის კუნძულები</territory>
 			<territory type="MK">ჩრდილოეთ მაკედონია</territory>
-			<territory type="MK" alt="variant">მაკედონია (ყოფილი იუგოსლავიის რესპუბლიკა მაკედონია)</territory>
 			<territory type="ML">მალი</territory>
 			<territory type="MM">მიანმარი (ბირმა)</territory>
 			<territory type="MN">მონღოლეთი</territory>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -651,7 +651,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF" draft="unconfirmed">San Maṛtan</territory>
 			<territory type="MG">Madaɣecqer</territory>
 			<territory type="MH">Tigzirin n Marcal</territory>
-			<territory type="MK" alt="variant" draft="unconfirmed">Masidunya (Tagduda Taqbuṛt Tayuguslavit n Masidunya)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar</territory>
 			<territory type="MN">Mungulya</territory>

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -476,7 +476,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Ilhas Marxal</territory>
 			<territory type="MK">Masidónia di Norti</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mianmar (Birmánia)</territory>
 			<territory type="MN">Mongólia</territory>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -666,7 +666,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалл аралдары</territory>
 			<territory type="MK">Солтүстік Македония</territory>
-			<territory type="MK" alt="variant" draft="contributed">Македония Республикасы</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мьянма (Бирма)</territory>
 			<territory type="MN">Моңғолия</territory>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -667,7 +667,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ម៉ាដាហ្គាស្កា</territory>
 			<territory type="MH">កោះ​ម៉ាស់សល</territory>
 			<territory type="MK">ម៉ាសេដ្វានខាងជើង</territory>
-			<territory type="MK" alt="variant">ម៉ាសេដ្វាន (អតីត​សាធារណរដ្ឋ​យូហ្គោស្លាវី)</territory>
 			<territory type="ML">ម៉ាលី</territory>
 			<territory type="MM">មីយ៉ាន់ម៉ា (ភូមា)</territory>
 			<territory type="MN">ម៉ុងហ្គោលី</territory>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -875,7 +875,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ಮಡಗಾಸ್ಕರ್</territory>
 			<territory type="MH">ಮಾರ್ಷಲ್ ದ್ವೀಪಗಳು</territory>
 			<territory type="MK">ಉತ್ತರ ಮ್ಯಾಸಿಡೋನಿಯಾ</territory>
-			<territory type="MK" alt="variant">ಮ್ಯಾಸಿಡೋನಿಯಾ (FYROM)</territory>
 			<territory type="ML">ಮಾಲಿ</territory>
 			<territory type="MM">ಮಯನ್ಮಾರ್ (ಬರ್ಮಾ)</territory>
 			<territory type="MN">ಮಂಗೋಲಿಯಾ</territory>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -936,7 +936,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">마다가스카르</territory>
 			<territory type="MH">마셜 제도</territory>
 			<territory type="MK">북마케도니아</territory>
-			<territory type="MK" alt="variant">마케도니아(FYROM)</territory>
 			<territory type="ML">말리</territory>
 			<territory type="MM">미얀마</territory>
 			<territory type="MN">몽골</territory>

--- a/common/main/ksh.xml
+++ b/common/main/ksh.xml
@@ -596,7 +596,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF" draft="contributed">de Zint-Määtes-Ensel</territory>
 			<territory type="MG" draft="contributed">Maddajaska</territory>
 			<territory type="MH" draft="contributed">de Machschall-Enselle</territory>
-			<territory type="MK" alt="variant" draft="contributed">de vörmaals ens jugoßlaawesch jewääse Republik Mazedoonije</territory>
 			<territory type="ML" draft="contributed">Maali</territory>
 			<territory type="MM" draft="contributed">Birma</territory>
 			<territory type="MN" draft="contributed">Mongjolei</territory>

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -456,7 +456,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Giravên Marşal</territory>
 			<territory type="MK">Makedonya</territory>
-			<territory type="MK" alt="variant">MK</territory>
 			<territory type="ML">Malî</territory>
 			<territory type="MM">Myanmar (Birmanya)</territory>
 			<territory type="MN">Mongolya</territory>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -670,7 +670,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалл аралдары</territory>
 			<territory type="MK">Түндүк Македония</territory>
-			<territory type="MK" alt="variant" draft="contributed">Түндүк Македония</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мьянма (Бирма)</territory>
 			<territory type="MN">Монголия</territory>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -943,7 +943,6 @@ terms of use, see http://www.unicode.org/copyright.html
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallinselen</territory>
 			<territory type="MK">Nordmazedonien</territory>
-			<territory type="MK" alt="variant">Mazedonien (EJR)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar</territory>
 			<territory type="MN">Mongolei</territory>

--- a/common/main/ln.xml
+++ b/common/main/ln.xml
@@ -253,7 +253,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagasikari</territory>
 			<territory type="MH">Bisanga bya Marishalɛ</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant" draft="unconfirmed">Masedoni (RYYYK)</territory>
 			<territory type="ML">Malí</territory>
 			<territory type="MM">Birmanie</territory>
 			<territory type="MN">Mongolí</territory>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -906,7 +906,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ມາດາກາສະກາ</territory>
 			<territory type="MH">ຫມູ່ເກາະມາແຊວ</territory>
 			<territory type="MK">ແມຊິໂດເນຍເໜືອ</territory>
-			<territory type="MK" alt="variant">ແມຊິໂດເນຍ (FYROM)</territory>
 			<territory type="ML">ມາລີ</territory>
 			<territory type="MM">ມຽນມາ (ເບີມາ)</territory>
 			<territory type="MN">ມອງໂກເລຍ</territory>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -1005,7 +1005,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskaras</territory>
 			<territory type="MH">Maršalo Salos</territory>
 			<territory type="MK">Šiaurės Makedonija</territory>
-			<territory type="MK" alt="variant">Šiaurės Makedonija</territory>
 			<territory type="ML">Malis</territory>
 			<territory type="MM">Mianmaras (Birma)</territory>
 			<territory type="MN">Mongolija</territory>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -827,7 +827,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskara</territory>
 			<territory type="MH">Māršala salas</territory>
 			<territory type="MK">Ziemeļmaķedonija</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mjanma (Birma)</territory>
 			<territory type="MN">Mongolija</territory>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -1003,7 +1003,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалски Острови</territory>
 			<territory type="MK">Северна Македонија</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мјанмар (Бурма)</territory>
 			<territory type="MN">Монголија</territory>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -889,7 +889,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">മഡഗാസ്കർ</territory>
 			<territory type="MH">മാർഷൽ ദ്വീപുകൾ</territory>
 			<territory type="MK">നോർത്ത് മാസിഡോണിയ</territory>
-			<territory type="MK" alt="variant">എം‌കെ</territory>
 			<territory type="ML">മാലി</territory>
 			<territory type="MM">മ്യാൻമാർ (ബർമ്മ)</territory>
 			<territory type="MN">മംഗോളിയ</territory>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -663,7 +663,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршаллын арлууд</territory>
 			<territory type="MK">Хойд Македон</territory>
-			<territory type="MK" alt="variant">Македон (Хуучин ЮБНМУ)</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мьянмар</territory>
 			<territory type="MN">Монгол</territory>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -874,7 +874,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">मादागास्कर</territory>
 			<territory type="MH">मार्शल बेटे</territory>
 			<territory type="MK">उत्तर मॅसेडोनिया</territory>
-			<territory type="MK" alt="variant" draft="provisional">↑↑↑</territory>
 			<territory type="ML">माली</territory>
 			<territory type="MM">म्यानमार (बर्मा)</territory>
 			<territory type="MN">मंगोलिया</territory>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -834,7 +834,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Kepulauan Marshall</territory>
 			<territory type="MK">Macedonia Utara</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -690,7 +690,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">မဒါဂတ်စကား</territory>
 			<territory type="MH">မာရှယ် ကျွန်းစု</territory>
 			<territory type="MK">မြောက် မက်ဆီဒိုးနီးယား</territory>
-			<territory type="MK" alt="variant">မက်ဆီဒိုးနီးယား (ယခင် ယူဂိုစလားဗီးယား မက်ဆီဒိုးနီးယားပြည်ထောင်စု)</territory>
 			<territory type="ML">မာလီ</territory>
 			<territory type="MM">မြန်မာ</territory>
 			<territory type="MN">မွန်ဂိုးလီးယား</territory>

--- a/common/main/mzn.xml
+++ b/common/main/mzn.xml
@@ -463,7 +463,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">ماداگاسکار</territory>
 			<territory type="MH">مارشال جزایر</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">مقدونیه جمهوری</territory>
 			<territory type="ML">مالی</territory>
 			<territory type="MM">میانمار</territory>
 			<territory type="MN">مغولستون</territory>

--- a/common/main/nb.xml
+++ b/common/main/nb.xml
@@ -1010,7 +1010,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalløyene</territory>
 			<territory type="MK">Nord-Makedonia</territory>
-			<territory type="MK" alt="variant">Nord-Makedonia</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -907,7 +907,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">माडागास्कर</territory>
 			<territory type="MH">मार्शल टापुहरु</territory>
 			<territory type="MK">उत्तर म्यासेडोनिया</territory>
-			<territory type="MK" alt="variant">म्यासेडोनिया (फाइरम)</territory>
 			<territory type="ML">माली</territory>
 			<territory type="MM">म्यान्मार (बर्मा)</territory>
 			<territory type="MN">मङ्गोलिया</territory>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -1030,7 +1030,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshalleilanden</territory>
 			<territory type="MK">Noord-Macedonië</territory>
-			<territory type="MK" alt="variant">Macedonië</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birma)</territory>
 			<territory type="MN">Mongolië</territory>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -859,7 +859,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ମାଡାଗାସ୍କର୍</territory>
 			<territory type="MH">ମାର୍ଶାଲ୍ ଦ୍ୱୀପପୁଞ୍ଜ</territory>
 			<territory type="MK">ଉତ୍ତର ମାସେଡୋନିଆ</territory>
-			<territory type="MK" alt="variant">ମାସେଡୋନିଆ (ଏଫ୍‌‌ୱାଇଆର୍‌‌ଓଏମ୍)</territory>
 			<territory type="ML">ମାଲି</territory>
 			<territory type="MM">ମିଆଁମାର</territory>
 			<territory type="MN">ମଙ୍ଗୋଲିଆ</territory>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -678,7 +678,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">ਮੈਡਾਗਾਸਕਰ</territory>
 			<territory type="MH">ਮਾਰਸ਼ਲ ਟਾਪੂ</territory>
 			<territory type="MK">ਉੱਤਰੀ ਮੈਕਡੋਨੀਆ</territory>
-			<territory type="MK" alt="variant">ਮੈਕਡੋਨੀਆ (ਪੂਰਵ ਯੂਗੋਸਲਾਵ ਮੈਕਡੋਨੀਆਈ ਗਣਰਾਜ)</territory>
 			<territory type="ML">ਮਾਲੀ</territory>
 			<territory type="MM">ਮਿਆਂਮਾਰ (ਬਰਮਾ)</territory>
 			<territory type="MN">ਮੰਗੋਲੀਆ</territory>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -1001,7 +1001,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Wyspy Marshalla</territory>
 			<territory type="MK">Macedonia Północna</territory>
-			<territory type="MK" alt="variant" draft="contributed">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mjanma (Birma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -659,7 +659,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">مدغاسکر</territory>
 			<territory type="MH">مارشل ټاپوګان</territory>
 			<territory type="MK">شمالي مقدونيه</territory>
-			<territory type="MK" alt="variant" draft="provisional">↑↑↑</territory>
 			<territory type="ML">مالي</territory>
 			<territory type="MM">ميانمار (برما)</territory>
 			<territory type="MN">منګوليا</territory>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -893,7 +893,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Ilhas Marshall</territory>
 			<territory type="MK">Macedônia do Norte</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mianmar (Birmânia)</territory>
 			<territory type="MN">Mongólia</territory>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -812,7 +812,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagáscar</territory>
 			<territory type="MH">Ilhas Marshall</territory>
 			<territory type="MK">Macedónia do Norte</territory>
-			<territory type="MK" alt="variant">Macedónia (ARJM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mianmar (Birmânia)</territory>
 			<territory type="MN">Mongólia</territory>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -515,7 +515,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Islas Marshall</territory>
 			<territory type="MK">Macedonia del Norte</territory>
-			<territory type="MK" alt="variant">ERY Macedonia</territory>
 			<territory type="ML">Malí</territory>
 			<territory type="MM">Myanmar</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -830,7 +830,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Insulele Marshall</territory>
 			<territory type="MK">Macedonia de Nord</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Birmania)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -917,7 +917,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалловы Острова</territory>
 			<territory type="MK">Северная Македония</territory>
-			<territory type="MK" alt="variant">Македония</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мьянма (Бирма)</territory>
 			<territory type="MN">Монголия</territory>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -659,7 +659,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">مداگيسڪر</territory>
 			<territory type="MH">مارشل ڀيٽ</territory>
 			<territory type="MK">شمالي مقدونيا</territory>
-			<territory type="MK" alt="variant">ميڪدونيا</territory>
 			<territory type="ML">مالي</territory>
 			<territory type="MM">ميانمار (برما)</territory>
 			<territory type="MN">منگوليا</territory>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -668,7 +668,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">මැඩගස්කරය</territory>
 			<territory type="MH">මාෂල් දූපත්</territory>
 			<territory type="MK">උතුරු මැසිඩෝනියාව</territory>
-			<territory type="MK" alt="variant">මැසිඩෝනියාව (FYROM)</territory>
 			<territory type="ML">මාලි</territory>
 			<territory type="MM">මියන්මාරය (බුරුමය)</territory>
 			<territory type="MN">මොන්ගෝලියාව</territory>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -803,7 +803,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallove ostrovy</territory>
 			<territory type="MK">Severné Macedónsko</territory>
-			<territory type="MK" alt="variant">Severné Macedónsko</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mjanmarsko</territory>
 			<territory type="MN">Mongolsko</territory>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -854,7 +854,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallovi otoki</territory>
 			<territory type="MK">Severna Makedonija</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mjanmar (Burma)</territory>
 			<territory type="MN">Mongolija</territory>

--- a/common/main/smn.xml
+++ b/common/main/smn.xml
@@ -564,7 +564,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF">St. Martin</territory>
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallsuolluuh</territory>
-			<territory type="MK" alt="variant">OJT Makedonia</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -506,7 +506,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Jasiiradda Maarshal</territory>
 			<territory type="MK">Masedooniya Waqooyi</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Maali</territory>
 			<territory type="MM">Miyanmar</territory>
 			<territory type="MN">Mongooliya</territory>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -666,7 +666,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Ishujt Marshall</territory>
 			<territory type="MK">Maqedonia e Veriut</territory>
-			<territory type="MK" alt="variant" draft="provisional">Maqedoni e Veriut</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mianmar (Burmë)</territory>
 			<territory type="MN">Mongoli</territory>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -870,7 +870,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалска Острва</territory>
 			<territory type="MK">Северна Македонија</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мијанмар (Бурма)</territory>
 			<territory type="MN">Монголија</territory>

--- a/common/main/sr_Cyrl_BA.xml
+++ b/common/main/sr_Cyrl_BA.xml
@@ -625,7 +625,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MF" draft="contributed">Свети Мартин (Француска)</territory>
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
-			<territory type="MK" alt="variant" draft="contributed">БЈР Македонија</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/sr_Cyrl_ME.xml
+++ b/common/main/sr_Cyrl_ME.xml
@@ -35,7 +35,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CZ" draft="contributed">Чешка Република</territory>
 			<territory type="DE" draft="contributed">Њемачка</territory>
 			<territory type="KN" draft="contributed">Свети Китс и Невис</territory>
-			<territory type="MK" alt="variant" draft="contributed">БЈР Македонија</territory>
 			<territory type="PM" draft="contributed">Свети Пјер и Микелон</territory>
 			<territory type="RE" draft="contributed">Реунион</territory>
 			<territory type="UM" draft="contributed">Мања удаљена острва САД</territory>

--- a/common/main/sr_Cyrl_XK.xml
+++ b/common/main/sr_Cyrl_XK.xml
@@ -35,7 +35,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CZ" draft="contributed">Чешка Република</territory>
 			<territory type="HK" draft="contributed">САР Хонгконг</territory>
 			<territory type="KN" draft="contributed">Свети Китс и Невис</territory>
-			<territory type="MK" alt="variant" draft="contributed">БЈР Македонија</territory>
 			<territory type="MO" draft="contributed">САР Макао</territory>
 			<territory type="PM" draft="contributed">Свети Пјер и Микелон</territory>
 			<territory type="RE" draft="contributed">Реунион</territory>

--- a/common/main/sr_Latn_BA.xml
+++ b/common/main/sr_Latn_BA.xml
@@ -37,7 +37,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CZ" draft="contributed">Češka Republika</territory>
 			<territory type="DE" draft="contributed">Njemačka</territory>
 			<territory type="KN" draft="contributed">Sveti Kits i Nevis</territory>
-			<territory type="MK" alt="variant" draft="contributed">BJR Makedonija</territory>
 			<territory type="MO" draft="contributed">SAR Makao</territory>
 			<territory type="PM" draft="contributed">Sveti Pjer i Mikelon</territory>
 			<territory type="RE" draft="contributed">Reunion</territory>

--- a/common/main/sr_Latn_ME.xml
+++ b/common/main/sr_Latn_ME.xml
@@ -35,7 +35,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CZ" draft="contributed">Češka Republika</territory>
 			<territory type="DE" draft="contributed">Njemačka</territory>
 			<territory type="KN" draft="contributed">Sveti Kits i Nevis</territory>
-			<territory type="MK" alt="variant" draft="contributed">BJR Makedonija</territory>
 			<territory type="PM" draft="contributed">Sveti Pjer i Mikelon</territory>
 			<territory type="RE" draft="contributed">Reunion</territory>
 			<territory type="UM" draft="contributed">Manja udaljena ostrva SAD</territory>

--- a/common/main/sr_Latn_XK.xml
+++ b/common/main/sr_Latn_XK.xml
@@ -35,7 +35,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CZ" draft="contributed">Češka Republika</territory>
 			<territory type="HK" draft="contributed">SAR Hongkong</territory>
 			<territory type="KN" draft="contributed">Sveti Kits i Nevis</territory>
-			<territory type="MK" alt="variant" draft="contributed">BJR Makedonija</territory>
 			<territory type="MO" draft="contributed">SAR Makao</territory>
 			<territory type="PM" draft="contributed">Sveti Pjer i Mikelon</territory>
 			<territory type="RE" draft="contributed">Reunion</territory>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -1030,7 +1030,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshallöarna</territory>
 			<territory type="MK">Nordmakedonien</territory>
-			<territory type="MK" alt="variant">Nordmakedonien</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongoliet</territory>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -702,7 +702,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaska</territory>
 			<territory type="MH">Visiwa vya Marshall</territory>
 			<territory type="MK">Masedonia ya Kaskazini</territory>
-			<territory type="MK" alt="variant">Macedonia (FYROM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Mongolia</territory>

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -702,7 +702,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">Masedonia</territory>
-			<territory type="MK" alt="variant">Masedonia (FYROM)</territory>
 			<territory type="ML">↑↑↑</territory>
 			<territory type="MM">Myama (Burma)</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -880,7 +880,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">மடகாஸ்கர்</territory>
 			<territory type="MH">மார்ஷல் தீவுகள்</territory>
 			<territory type="MK">வடக்கு மாசிடோனியா</territory>
-			<territory type="MK" alt="variant">மாசிடோனியா (ஃபைரோம்)</territory>
 			<territory type="ML">மாலி</territory>
 			<territory type="MM">மியான்மார் (பர்மா)</territory>
 			<territory type="MN">மங்கோலியா</territory>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -878,7 +878,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">మడగాస్కర్</territory>
 			<territory type="MH">మార్షల్ దీవులు</territory>
 			<territory type="MK">ఉత్తర మాసిడోనియా</territory>
-			<territory type="MK" alt="variant">పూర్వ రిపబ్లిక్ యుగోస్లావ్ మేసిడోనియా</territory>
 			<territory type="ML">మాలి</territory>
 			<territory type="MM">మయన్మార్</territory>
 			<territory type="MN">మంగోలియా</territory>

--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -344,7 +344,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Ҷазираҳои Маршалл</territory>
 			<territory type="MK">Македонияи Шимолӣ</territory>
-			<territory type="MK" alt="variant">Мақдун (ҶСЮМ)</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MM">Мянма</territory>
 			<territory type="MN">Муғулистон</territory>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -1007,7 +1007,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">มาดากัสการ์</territory>
 			<territory type="MH">หมู่เกาะมาร์แชลล์</territory>
 			<territory type="MK">มาซิโดเนียเหนือ</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">มาลี</territory>
 			<territory type="MM">เมียนมาร์ (พม่า)</territory>
 			<territory type="MN">มองโกเลีย</territory>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -654,7 +654,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marşall adalary</territory>
 			<territory type="MK">Demirgazyk Makedoniýa</territory>
-			<territory type="MK" alt="variant">Makedoniýa (ÖÝR)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Mýanma (Burma)</territory>
 			<territory type="MN">Mongoliýa</territory>

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -1025,7 +1025,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Matakasika</territory>
 			<territory type="MH">ʻOtumotu Māsolo</territory>
 			<territory type="MK">Masetōnia fakatokelau</territory>
-			<territory type="MK" alt="variant">Masetōnia (FYROM)</territory>
 			<territory type="ML">Māli</territory>
 			<territory type="MM">Mianimā (Pema)</territory>
 			<territory type="MN">Mongokōlia</territory>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -1007,7 +1007,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshall Adaları</territory>
 			<territory type="MK">Kuzey Makedonya</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Burma)</territory>
 			<territory type="MN">Moğolistan</territory>

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -338,7 +338,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршалл утраулары</territory>
 			<territory type="MK">Төньяк Македония</territory>
-			<territory type="MK" alt="variant">Македония (Македония Элекке Югославия Республикасы)</territory>
 			<territory type="ML">Мали</territory>
 			<territory type="MN">Монголия</territory>
 			<territory type="MO">Макао Махсус Идарәле Төбәге</territory>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -913,7 +913,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Мадагаскар</territory>
 			<territory type="MH">Маршаллові Острови</territory>
 			<territory type="MK">Північна Македонія</territory>
-			<territory type="MK" alt="variant" draft="contributed">Колишня Югославська Республіка Македонія</territory>
 			<territory type="ML">Малі</territory>
 			<territory type="MM">Мʼянма (Бірма)</territory>
 			<territory type="MN">Монголія</territory>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -677,7 +677,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">مڈغاسکر</territory>
 			<territory type="MH">مارشل آئلینڈز</territory>
 			<territory type="MK">شمالی مقدونیہ</territory>
-			<territory type="MK" alt="variant">مقدونیہ (FYROM)</territory>
 			<territory type="ML">مالی</territory>
 			<territory type="MM">میانمار (برما)</territory>
 			<territory type="MN">منگولیا</territory>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -667,7 +667,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagaskar</territory>
 			<territory type="MH">Marshall orollari</territory>
 			<territory type="MK">Shimoliy Makedoniya</territory>
-			<territory type="MK" alt="variant">Makedoniya (SYRM)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanma (Birma)</territory>
 			<territory type="MN">Mongoliya</territory>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -975,7 +975,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">Madagascar</territory>
 			<territory type="MH">Quần đảo Marshall</territory>
 			<territory type="MK">Bắc Macedonia</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Myanmar (Miến Điện)</territory>
 			<territory type="MN">Mông Cổ</territory>

--- a/common/main/wae.xml
+++ b/common/main/wae.xml
@@ -375,7 +375,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG" draft="contributed">Madagaskar</territory>
 			<territory type="MH" draft="contributed">Maršalinslä</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant" draft="contributed">Mazedonie (EJR)</territory>
 			<territory type="ML" draft="contributed">Mali</territory>
 			<territory type="MM" draft="contributed">Burma</territory>
 			<territory type="MN" draft="contributed">Mongolei</territory>

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -323,7 +323,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Madagaskaar</territory>
 			<territory type="MH">Duni Marsaal</territory>
 			<territory type="MK">Maseduwaan bëj Gànnaar</territory>
-			<territory type="MK" alt="variant">Maseduwaan (Réewum yugoslawi gu yàgg ga)</territory>
 			<territory type="ML">Mali</territory>
 			<territory type="MM">Miyanmaar</territory>
 			<territory type="MN">Mongoli</territory>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -358,7 +358,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">Orílẹ́ède Madasika</territory>
 			<territory type="MH">Orílẹ́ède Etikun Máṣali</territory>
 			<territory type="MK">Àríwá Macedonia</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">Orílẹ́ède Mali</territory>
 			<territory type="MM">Orílẹ́ède Manamari</territory>
 			<territory type="MN">Orílẹ́ède Mogolia</territory>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -999,7 +999,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">馬達加斯加</territory>
 			<territory type="MH">馬紹爾群島</territory>
 			<territory type="MK">北馬其頓</territory>
-			<territory type="MK" alt="variant">北馬其頓</territory>
 			<territory type="ML">馬利</territory>
 			<territory type="MM">緬甸</territory>
 			<territory type="MN">蒙古</territory>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -945,7 +945,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">马达加斯加</territory>
 			<territory type="MH">马绍尔群岛</territory>
 			<territory type="MK">北马其顿</territory>
-			<territory type="MK" alt="variant" draft="contributed">马其顿</territory>
 			<territory type="ML">马里</territory>
 			<territory type="MM">缅甸</territory>
 			<territory type="MN">蒙古</territory>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -1018,7 +1018,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">馬達加斯加</territory>
 			<territory type="MH">馬紹爾群島</territory>
 			<territory type="MK">北馬其頓</territory>
-			<territory type="MK" alt="variant">北馬其頓</territory>
 			<territory type="ML">馬利</territory>
 			<territory type="MM">緬甸</territory>
 			<territory type="MN">蒙古</territory>

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -1020,7 +1020,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG">↑↑↑</territory>
 			<territory type="MH">↑↑↑</territory>
 			<territory type="MK">↑↑↑</territory>
-			<territory type="MK" alt="variant">↑↑↑</territory>
 			<territory type="ML">馬里</territory>
 			<territory type="MM">↑↑↑</territory>
 			<territory type="MN">↑↑↑</territory>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -796,7 +796,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="MG">i-Madagascar</territory>
 			<territory type="MH">i-Marshall Islands</territory>
 			<territory type="MK">i-North Macedonia</territory>
-			<territory type="MK" alt="variant">i-Macedonia (FYROM)</territory>
 			<territory type="ML">iMali</territory>
 			<territory type="MM">i-Myanmar (Burma)</territory>
 			<territory type="MN">i-Mongolia</territory>

--- a/seed/main/sc.xml
+++ b/seed/main/sc.xml
@@ -627,7 +627,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MG" draft="unconfirmed">Madagascàr</territory>
 			<territory type="MH" draft="unconfirmed">Ìsulas Marshall</territory>
 			<territory type="MK" draft="unconfirmed">Matzedònia de su Nord</territory>
-			<territory type="MK" alt="variant" draft="unconfirmed">↑↑↑</territory>
 			<territory type="ML" draft="unconfirmed">Mali</territory>
 			<territory type="MM" draft="unconfirmed">Myanmàr (Birmània)</territory>
 			<territory type="MN" draft="unconfirmed">Mongòlia</territory>

--- a/seed/main/und.xml
+++ b/seed/main/und.xml
@@ -23,8 +23,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<exemplarCharacters>[a b c č d e f g h i j k l m n o p q r s š t u v w x y z]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[]</exemplarCharacters>
 		<exemplarCharacters type="index">[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z]</exemplarCharacters>
+		<!-- Sandbox locale.  DO NOT MODIFY.
+			 This file is listed as 'scratch' in SpecialLocales.txt.  If your tool modified this file, it is in error.
+		-->
 	</characters>
-
-	<!-- Sandbox locale.  DO NOT MODIFY. -->
-	<!-- This file is listed as 'scratch' in SpecialLocales.txt.  If your tool modified this file, it is in error. -->
 </ldml>

--- a/seed/main/und_ZZ.xml
+++ b/seed/main/und_ZZ.xml
@@ -14,9 +14,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<version number="$Revision$"/>
 		<language type="und"/>
 		<territory type="ZZ"/>
+		<!-- Sandbox locale. DO NOT MODIFY.
+			 This file is listed as 'scratch' in SpecialLocales.txt.  If your tool modified this file, it is in error.
+		-->
 	</identity>
-	<!--
-	    Sandbox locale. DO NOT MODIFY.
-	-->
-	<!-- This file is listed as 'scratch' in SpecialLocales.txt.  If your tool modified this file, it is in error. -->
 </ldml>


### PR DESCRIPTION
[CLDR-13099]

Removing alt values for territory North Macedonia

[CLDR-13099]: https://unicode-org.atlassian.net/browse/CLDR-13099