### PR TITLE
CLDR-11049 Allow subclassing of CldrDataSupplier for easier testing.

### DIFF
--- a/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
@@ -138,9 +138,6 @@ public abstract class CldrDataSupplier {
         return new InMemoryData(values);
     }
 
-    // Package protected to keep suppliers in a closed type hierarchy.
-    CldrDataSupplier() {}
-
     /**
      * Returns a modified data supplier which only provides paths/values with a draft status at or
      * above the specified value. To create a supplier that will process all CLDR paths/values, use


### PR DESCRIPTION
Since the CLDR API is very stable now, I feel happy in opening up the data supplier for subclassing.
It was only ever done like this to keep control while it was in flux. Now I'm convinced it's fit for purpose there's no reason to keep it locked down so much (and this lets me make a fake version for testing).

Please merge once you're happy (this blocks a PR on the ICU side).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

