### PR TITLE
CLDR-13071 really add ars to likeySubtags

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -144,6 +144,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Araona; ?; ? } => { Araona; Latin; Bolivia }-->
 		<likelySubtag from="arq" to="arq_Arab_DZ"/>
 		<!--{ Algerian Arabic; ?; ? } => { Algerian Arabic; Arabic; Algeria }-->
+		<likelySubtag from="ars" to="ars_Arab_SA"/>
+		<!--{ Najdi Arabic; ?; ? } => { Najdi Arabic; Arabic; Saudi Arabia }-->
 		<likelySubtag from="ary" to="ary_Arab_MA"/>
 		<!--{ Moroccan Arabic; ?; ? } => { Moroccan Arabic; Arabic; Morocco }-->
 		<likelySubtag from="arz" to="arz_Arab_EG"/>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13071
- [x] Updated PR title and link in previous line to include Issue number

https://unicode-org.atlassian.net/browse/CLDR-13071 is about adding an entry for "ars" n likelySubtags. However, although it already has 2 earlier pull requests (#39, #136), neither of them actually added the "ars" entry in likelySubtags. The latter PR does add it in the country_language_population_raw.txt so when likelySubtags is regenerated, "ars" should get added. However, I need "ars" in likelySubtags now for the CLDR-ICU integration, not having it is blocking me. So this PR just finally adds "'ars" to likelySubtags.