### PR TITLE
CLDR-13243 revert de CompactDecimals, ar@numbers=latn decimalSep

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -5945,7 +5945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
-			<decimal draft="contributed">٫</decimal>
+			<decimal draft="contributed">.</decimal>
 			<group draft="contributed">,</group>
 			<percentSign>‎%‎</percentSign>
 			<plusSign>‎+</plusSign>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -5823,12 +5823,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>
-					<pattern type="1000" count="one">0 Tsd'.'</pattern>
-					<pattern type="1000" count="other">0 Tsd'.'</pattern>
-					<pattern type="10000" count="one">00 Tsd'.'</pattern>
-					<pattern type="10000" count="other">00 Tsd'.'</pattern>
-					<pattern type="100000" count="one">000 Tsd'.'</pattern>
-					<pattern type="100000" count="other">000 Tsd'.'</pattern>
+					<pattern type="1000" count="one">0</pattern>
+					<pattern type="1000" count="other">0</pattern>
+					<pattern type="10000" count="one">0</pattern>
+					<pattern type="10000" count="other">0</pattern>
+					<pattern type="100000" count="one">0</pattern>
+					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">0 Mio'.'</pattern>
 					<pattern type="1000000" count="other">0 Mio'.'</pattern>
 					<pattern type="10000000" count="one">00 Mio'.'</pattern>
@@ -5875,12 +5875,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">¤0 Tsd'.'</pattern>
-					<pattern type="1000" count="other">¤0 Tsd'.'</pattern>
-					<pattern type="10000" count="one">¤00 Tsd'.'</pattern>
-					<pattern type="10000" count="other">¤00 Tsd'.'</pattern>
-					<pattern type="100000" count="one">¤000 Tsd'.'</pattern>
-					<pattern type="100000" count="other">¤000 Tsd'.'</pattern>
+					<pattern type="1000" count="one">0</pattern>
+					<pattern type="1000" count="other">0</pattern>
+					<pattern type="10000" count="one">0</pattern>
+					<pattern type="10000" count="other">0</pattern>
+					<pattern type="100000" count="one">0</pattern>
+					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">0 Mio'.' ¤</pattern>
 					<pattern type="1000000" count="other">0 Mio'.' ¤</pattern>
 					<pattern type="10000000" count="one">00 Mio'.' ¤</pattern>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13243
- [x] Updated PR title and link in previous line to include Issue number

36 BRS work: Per discussion in CLDR TC 2019-09-04, revert the following:
- de CompactDecimals, revert formats for 1000,10000,100000 to use just 0, not formats with Tsd. (we seem to do this every release)
- ar latn numbers decimal separator, change from \u066B back to ASCII period (more common with Latin digits)
