### PR TITLE
CLDR-11049 Minor change primarily to remove the "seed" directory from the data supplier.

### DIFF
--- a/tools/java/org/unicode/cldr/api/CldrData.java
+++ b/tools/java/org/unicode/cldr/api/CldrData.java
@@ -48,7 +48,7 @@ public interface CldrData {
     /* @Nullable */ CldrValue get(CldrPath path);
 
     /** Ordering options for path visitation. */
-    // Note more orderings can be added if needed (e.g. a fully stable lexicographical ordering).
+    // TODO (CLDR-13275): Remove PathOrder and stabilize tools to use only DTD order.
     enum PathOrder {
         /**
          * Visits {@code CldrPath}s in an arbitrary, potentially unstable, order. Only use this

--- a/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
+++ b/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
@@ -17,12 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Serializes a CLDRFile as a sequence of {@code (CldrPath, CldrValue)} pairs.
- *
- * <p>Ordering affects the cost of processing the CLDRFile, but not excessively. In testing, the
- * resolved paths for "en_GB" took ~65ms to process in ARBITRARY order, and ~340ms for DTD order.
- * It's expected that compared to producing these paths, any matching and processing of path
- * elements will be the most significant issue.
+ * Serializes a CLDRFile as a sequence of {@link CldrValue CldrValues}.
  */
 final class CldrFileDataSource extends AbstractDataSource {
     private static final Pattern CAPTURE_SORT_INDEX = Pattern.compile("#[0-9]+");


### PR DESCRIPTION
Minor change primarily to remove the "seed" directory from the data supplier.
This is not currently needed for ICU data generation and will be trivial to support as a option once a proper use case exists.

Also includes a few additional comment improvements.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

