### PR TITLE
CLDR-13186 - Subdivions SE, Asturian translations [ast]

### DIFF
--- a/common/subdivisions/ast.xml
+++ b/common/subdivisions/ast.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2019 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ast"/>
+	</identity>
+	<localeDisplayNames>
+		<subdivisions>
+			<subdivision type="seab" draft="contributed">Provincia d'Estocolmu</subdivision>
+			<subdivision type="seac" draft="contributed">Provincia de Västerbotten</subdivision>
+			<subdivision type="sebd" draft="contributed">Provincia de Norrbotten</subdivision>
+			<subdivision type="sec" draft="contributed">Provincia d'Upsala</subdivision>
+			<subdivision type="sed" draft="contributed">Provincia de Södermanland</subdivision>
+			<subdivision type="see" draft="contributed">Provincia d'Östergötland</subdivision>
+			<subdivision type="sef" draft="contributed">Provincia de Jönköping</subdivision>
+			<subdivision type="seg" draft="contributed">Provincia de Kronoberg</subdivision>
+			<subdivision type="seh" draft="contributed">Provincia de Kalmar</subdivision>
+			<subdivision type="sei" draft="contributed">Provincia de Gotland</subdivision>
+			<subdivision type="sek" draft="contributed">Provincia de Blekinge</subdivision>
+			<subdivision type="sem" draft="contributed">Provincia d'Escania</subdivision>
+			<subdivision type="sen" draft="contributed">Provincia de Halland</subdivision>
+			<subdivision type="seo" draft="contributed">Provincia de Västra Götaland</subdivision>
+			<subdivision type="ses" draft="contributed">Provincia de Värmland</subdivision>
+			<subdivision type="set" draft="contributed">Provincia d'Örebro</subdivision>
+			<subdivision type="seu" draft="contributed">Provincia de Västmanland</subdivision>
+			<subdivision type="sew" draft="contributed">Provincia de Dalarna</subdivision>
+			<subdivision type="sex" draft="contributed">Provincia de Gävleborg</subdivision>
+			<subdivision type="sey" draft="contributed">Provincia de Västernorrland</subdivision>
+			<subdivision type="sez" draft="contributed">Provincia de Jämtland</subdivision>
+		</subdivisions>
+	</localeDisplayNames>
+</ldml>
+<!-- Comments without bases
+deprecated	 - was on: //ldml/localeDisplayNames/subdivisions/subdivision[@type="lug"]
+deprecated	 - was on: //ldml/localeDisplayNames/subdivisions/subdivision[@type="lul"]
+-->


### PR DESCRIPTION
Swedish [SE] subdivisions. Translations for Asturian [ast]
Creating new file for subdivisions.

All translations are imported from Wikipedia:
https://ast.wikipedia.org/wiki/Provincies_de_Suecia




<br><br>
Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13186
