### PR TITLE
CLDR-11049 tweaks and fixes plus new API method

### DIFF
--- a/tools/java/org/unicode/cldr/api/AbstractDataSource.java
+++ b/tools/java/org/unicode/cldr/api/AbstractDataSource.java
@@ -15,13 +15,6 @@ import org.unicode.cldr.util.CldrUtility;
 abstract class AbstractDataSource implements CldrData {
     AbstractDataSource() {}
 
-    // Implements prefix visitation by accepting values in nested grouping order to reconstruct
-    // intermediate prefix paths.
-    @Override
-    public final void accept(PathOrder order, PrefixVisitor visitor) {
-        PrefixVisitorHost.accept(this::accept, order, visitor);
-    }
-
     // Helper to wrap the visit method and report errors that occur.
     static void safeVisit(CldrValue cldrValue, ValueVisitor visitor) {
         try {

--- a/tools/java/org/unicode/cldr/api/CldrData.java
+++ b/tools/java/org/unicode/cldr/api/CldrData.java
@@ -37,7 +37,9 @@ public interface CldrData {
      * @param order the order in which visitation should occur.
      * @param visitor the visitor to process CLDR data.
      */
-    void accept(PathOrder order, PrefixVisitor visitor);
+    default void accept(PathOrder order, PrefixVisitor visitor) {
+        PrefixVisitorHost.accept(this::accept, order, visitor);
+    }
 
     /**
      * Returns a {@link CldrValue} for a given distinguishing path.

--- a/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataSupplier.java
@@ -75,7 +75,7 @@ public abstract class CldrDataSupplier {
          * Locale-based CLDR data should only include values specified directly in the specified
          * locale.
          */
-        UNRESOLVED;
+        UNRESOLVED
     }
 
     /**
@@ -167,7 +167,8 @@ public abstract class CldrDataSupplier {
     public abstract CldrData getDataForLocale(String localeId, CldrResolution resolution);
 
     /**
-     * Returns an unmodifiable set of available locale IDs that this supplier can provide.
+     * Returns an unmodifiable set of available locale IDs that this supplier can provide. This
+     * need not be ordered.
      *
      * @return the set of available locale IDs.
      */

--- a/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
+++ b/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Serializes a CLDRFile as a sequence of {@link CldrValue CldrValues}.
  */
 final class CldrFileDataSource extends AbstractDataSource {
-    private static final Pattern CAPTURE_SORT_INDEX = Pattern.compile("#[0-9]+");
+    private static final Pattern CAPTURE_SORT_INDEX = Pattern.compile("#([0-9]+)");
 
     private final CLDRFile source;
 
@@ -62,13 +62,17 @@ final class CldrFileDataSource extends AbstractDataSource {
     /* @Nullable */
     public CldrValue get(CldrPath cldrPath) {
         String dPath = getInternalPathString(cldrPath);
-        XPathParts fullPath = XPathParts.getFrozenInstance(source.getFullXPath(dPath));
-        int length = fullPath.size();
+        String fullXPath = source.getFullXPath(dPath);
+        if (fullXPath == null) {
+            return null;
+        }
+        XPathParts pathPaths = XPathParts.getFrozenInstance(fullXPath);
+        int length = pathPaths.size();
         Map<AttributeKey, String> attributes = new LinkedHashMap<>();
         for (int n = 0; n < length; n++) {
             CldrPaths.processPathAttributes(
-                fullPath.getElement(n),
-                fullPath.getAttributes(n),
+                pathPaths.getElement(n),
+                pathPaths.getAttributes(n),
                 cldrPath.getDataType(),
                 e -> {},
                 attributes::put);

--- a/tools/java/org/unicode/cldr/api/CldrPath.java
+++ b/tools/java/org/unicode/cldr/api/CldrPath.java
@@ -1,9 +1,12 @@
 package org.unicode.cldr.api;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.unicode.cldr.api.AttributeKey.AttributeSupplier;
+import static com.google.common.base.CharMatcher.anyOf;
+import static com.google.common.base.CharMatcher.inRange;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.toCollection;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -13,13 +16,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.google.common.base.CharMatcher.anyOf;
-import static com.google.common.base.CharMatcher.inRange;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkElementIndex;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.stream.Collectors.toCollection;
+import org.unicode.cldr.api.AttributeKey.AttributeSupplier;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A sequence of CLDR path elements and "distinguishing" attributes.


### PR DESCRIPTION
Primarily adding a new method in CldrValue to support "rewriting" CLDR paths in order to allow for "alternate values" in the ICU transformations (e.g. using short versions of various translations).

Also:
* Moved an abstract base method into the CldrData interface itself (makes implementing alternate data instances easier). This is also needed for the alt value stuff.
* Fixed a null pointer bug in the "get()" method of CldrFileDataSource. Seems important.
* Caught a weird lingering case where imports were not properly sorted (optional).
* Trivial removal of unnecessary ';' which was causing a needless lint warning in IntelliJ.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

