### PR TITLE
CLDR-13243 Add failureaccess.jar in Eclipse .classpath files

### DIFF
--- a/tools/cldr-unittest/.classpath
+++ b/tools/cldr-unittest/.classpath
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src" />
-	<classpathentry combineaccessrules="false" kind="src"
-		path="/cldr-tools" />
-	<classpathentry kind="lib" path="/cldr-tools/libs/icu4j-src.jar" />
-	<classpathentry kind="lib" path="/cldr-tools/libs/icu4j.jar"
-		sourcepath="/cldr-tools/libs/icu4j-src.jar" />
-	<classpathentry kind="lib"
-		path="/cldr-tools/libs/utilities-src.jar" />
-	<classpathentry kind="lib" path="/cldr-tools/libs/utilities.jar"
-		sourcepath="/cldr-tools/libs/utilities-src.jar" />
-	<classpathentry kind="lib" path="/cldr-tools/libs/xercesImpl.jar" />
-	<classpathentry kind="lib" path="/cldr-tools/classes"
-		sourcepath="/cldr-tools" />
-	<classpathentry kind="con"
-		path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8" />
-	<classpathentry kind="lib" path="/cldr-tools/libs/guava.jar" />
-	<classpathentry kind="lib" path="/cldr-tools/libs/myanmar-tools-1.1.1.jar" />
-	<classpathentry kind="output" path="build/classes" />
+	<classpathentry kind="src" path="src"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/cldr-tools"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/icu4j-src.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/icu4j.jar" sourcepath="/cldr-tools/libs/icu4j-src.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/utilities-src.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/utilities.jar" sourcepath="/cldr-tools/libs/utilities-src.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/xercesImpl.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/classes" sourcepath="/cldr-tools"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/guava.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/failureaccess.jar"/>
+	<classpathentry kind="lib" path="/cldr-tools/libs/myanmar-tools-1.1.1.jar"/>
+	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/tools/java/.classpath
+++ b/tools/java/.classpath
@@ -8,6 +8,7 @@
 	<classpathentry kind="lib" path="libs/xercesImpl.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="lib" path="libs/guava.jar"/>
+	<classpathentry kind="lib" path="libs/failureaccess.jar"/>
 	<classpathentry kind="lib" path="libs/gson.jar"/>
 	<classpathentry kind="lib" path="libs/myanmar-tools-1.1.1.jar"/>
 	<classpathentry kind="output" path="classes"/>


### PR DESCRIPTION
[CLDR-13243]

Fix Eclipse classpaths to include failureaccess.jar ( introduced by Guava update to 28.1 ) so that things run properly in Eclipse.



[CLDR-13243]: https://unicode-org.atlassian.net/browse/CLDR-13243