### PR TITLE
CLDR-11049 Resorting imports.

### DIFF
--- a/tools/java/org/unicode/cldr/api/AbstractDataSource.java
+++ b/tools/java/org/unicode/cldr/api/AbstractDataSource.java
@@ -1,11 +1,5 @@
 package org.unicode.cldr.api;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.util.Map;
-
-import org.unicode.cldr.util.CldrUtility;
-
 /**
  * Base class for any non-trivial implementation of the CldrData interface. The main benefit of
  * using this class is that it implements prefix visitation automatically using {@link

--- a/tools/java/org/unicode/cldr/api/AttributeKey.java
+++ b/tools/java/org/unicode/cldr/api/AttributeKey.java
@@ -1,17 +1,5 @@
 package org.unicode.cldr.api;
 
-import com.google.common.base.Ascii;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableTable;
-import org.unicode.cldr.util.DtdData.Attribute;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -19,6 +7,19 @@ import static com.google.common.collect.ImmutableTable.toImmutableTable;
 import static java.util.function.Function.identity;
 import static org.unicode.cldr.util.DtdData.AttributeStatus.distinguished;
 import static org.unicode.cldr.util.DtdData.AttributeStatus.value;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.unicode.cldr.util.DtdData.Attribute;
+
+import com.google.common.base.Ascii;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableTable;
 
 /**
  * Immutable identifier which holds both an attribute's name and the path element it is associated

--- a/tools/java/org/unicode/cldr/api/CldrDataType.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataType.java
@@ -1,11 +1,11 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.unicode.cldr.util.DtdData;
-import org.unicode.cldr.util.DtdData.Attribute;
-import org.unicode.cldr.util.DtdData.Element;
-import org.unicode.cldr.util.DtdType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.function.Function.identity;
+import static org.unicode.cldr.util.DtdData.AttributeStatus.distinguished;
+import static org.unicode.cldr.util.DtdData.AttributeStatus.value;
+import static org.unicode.cldr.util.DtdData.Mode.OPTIONAL;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -14,12 +14,13 @@ import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.function.Function.identity;
-import static org.unicode.cldr.util.DtdData.AttributeStatus.distinguished;
-import static org.unicode.cldr.util.DtdData.AttributeStatus.value;
-import static org.unicode.cldr.util.DtdData.Mode.OPTIONAL;
+import org.unicode.cldr.util.DtdData;
+import org.unicode.cldr.util.DtdData.Attribute;
+import org.unicode.cldr.util.DtdData.Element;
+import org.unicode.cldr.util.DtdType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Data types for non-locale based CLDR data. For the canonical specification for LDML data can

--- a/tools/java/org/unicode/cldr/api/CldrDraftStatus.java
+++ b/tools/java/org/unicode/cldr/api/CldrDraftStatus.java
@@ -1,9 +1,10 @@
 package org.unicode.cldr.api;
 
-import com.google.common.base.Ascii;
+import java.util.Optional;
+
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 
-import java.util.Optional;
+import com.google.common.base.Ascii;
 
 /**
  * Draft status for controlling which values to visit. Draft statuses are ordered by ordinal value,

--- a/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
+++ b/tools/java/org/unicode/cldr/api/CldrFileDataSource.java
@@ -1,9 +1,6 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.Lists;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.XPathParts;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -13,8 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.XPathParts;
+
+import com.google.common.collect.Lists;
 
 /**
  * Serializes a CLDRFile as a sequence of {@link CldrValue CldrValues}.

--- a/tools/java/org/unicode/cldr/api/CldrPaths.java
+++ b/tools/java/org/unicode/cldr/api/CldrPaths.java
@@ -1,9 +1,9 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSetMultimap;
-import org.unicode.cldr.util.DtdData;
-import org.unicode.cldr.util.XPathParts;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Integer.signum;
+import static org.unicode.cldr.api.CldrDataType.LDML;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -15,10 +15,11 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Integer.signum;
-import static org.unicode.cldr.api.CldrDataType.LDML;
+import org.unicode.cldr.util.DtdData;
+import org.unicode.cldr.util.XPathParts;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 
 /**
  * Utilities related to CLDR paths. It's possible that one day we might wish to expose the path

--- a/tools/java/org/unicode/cldr/api/InMemoryData.java
+++ b/tools/java/org/unicode/cldr/api/InMemoryData.java
@@ -1,15 +1,15 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Comparator.comparing;
-import static java.util.Comparator.naturalOrder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 /** An in-memory representation of CldrData based on a simple map. */
 final class InMemoryData extends AbstractDataSource implements CldrData {

--- a/tools/java/org/unicode/cldr/api/PrefixVisitorHost.java
+++ b/tools/java/org/unicode/cldr/api/PrefixVisitorHost.java
@@ -1,18 +1,18 @@
 package org.unicode.cldr.api;
 
-import org.unicode.cldr.api.CldrData.PathOrder;
-import org.unicode.cldr.api.CldrData.PrefixVisitor;
-import org.unicode.cldr.api.CldrData.PrefixVisitor.Context;
-import org.unicode.cldr.api.CldrData.ValueVisitor;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
+import org.unicode.cldr.api.CldrData.PathOrder;
+import org.unicode.cldr.api.CldrData.PrefixVisitor;
+import org.unicode.cldr.api.CldrData.PrefixVisitor.Context;
+import org.unicode.cldr.api.CldrData.ValueVisitor;
 
 /**
  * Utility class for reconstructing nested path visitation from a sequence of path/value pairs. See

--- a/tools/java/org/unicode/cldr/api/XmlDataSource.java
+++ b/tools/java/org/unicode/cldr/api/XmlDataSource.java
@@ -1,25 +1,8 @@
 package org.unicode.cldr.api;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multiset;
-
-import org.unicode.cldr.util.CLDRFile;
-import org.xml.sax.Attributes;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.DefaultHandler;
-import org.xml.sax.helpers.XMLReaderFactory;
+import static com.google.common.base.CharMatcher.whitespace;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -38,10 +21,25 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.google.common.base.CharMatcher.whitespace;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.stream.Collectors.joining;
+import org.xml.sax.Attributes;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multiset;
 
 /** Serializes a set of LDML XML files as a sequence of {@code CldrValue}s. */
 final class XmlDataSource extends AbstractDataSource {


### PR DESCRIPTION
100% automatic resorting and tidying of imports. For some reason some of these files did not have their imports sorted.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11049
- [x] Updated PR title and link in previous line to include Issue number

