### PR TITLE
CLDR-11049 Tidy todos

### DIFF
--- a/tools/java/org/unicode/cldr/api/AttributeKey.java
+++ b/tools/java/org/unicode/cldr/api/AttributeKey.java
@@ -204,7 +204,6 @@ public final class AttributeKey {
      * @param src the {@link CldrPath} or {@link CldrValue} from which values are to be obtained.
      * @return a list of split attribute values, possible empty if the attribute does not exist.
      */
-    // TODO: Perhaps extend this if non-whitespace separated lists need to be handled.
     public List<String> listOfValuesFrom(AttributeSupplier src) {
         String v = src.get(this);
         return v != null ? LIST_SPLITTER.splitToList(v) : ImmutableList.of();

--- a/tools/java/org/unicode/cldr/api/CldrDataType.java
+++ b/tools/java/org/unicode/cldr/api/CldrDataType.java
@@ -183,11 +183,10 @@ public enum CldrDataType {
     }
 
     /**
-     * Returns whether the specified attribute is optional. Attributes unknown to the DTD are
+     * Returns whether the specified attribute is optional. Attributes unknown to the DTD are also
      * considered optional, which can happen if attribute keys are speculatively generated, which
      * sometimes happens in transformation logic.
      */
-    // TODO: Perhaps we need an isValidAttribute() method as well?
     boolean isOptionalAttribute(AttributeKey key) {
         Attribute attribute = getAttribute(key.getElementName(), key.getAttributeName());
         return attribute == null || attribute.mode == OPTIONAL;

--- a/tools/java/org/unicode/cldr/api/CldrPath.java
+++ b/tools/java/org/unicode/cldr/api/CldrPath.java
@@ -150,8 +150,14 @@ public final class CldrPath implements AttributeSupplier, Comparable<CldrPath> {
         this.elementName = checkValidName(name, "element");
         this.attributeKeyValuePairs = checkKeyValuePairs(attributeKeyValuePairs);
         this.draftStatus = resolveDraftStatus(parent, localDraftStatus);
-        // TODO: Maybe check via the DTD data that it's only not -1 for ORDERED elements ?
-        checkArgument(sortIndex >= -1, "invalid sort index: %s", sortIndex);
+        // Ordered elements have a sort index of 0 or more, and un-ordered have an index of -1.
+        if (CldrPaths.isOrdered(dtdType, elementName)) {
+            checkArgument(sortIndex >= 0,
+                "missing or invalid sort index '%s' for element: %s", sortIndex, elementName);
+        } else {
+            checkArgument(sortIndex == -1,
+                "unexpected sort index '%s' for element: %s", sortIndex, elementName);
+        }
         this.sortIndex = sortIndex;
         this.dtdType = checkNotNull(dtdType);
         this.ordering = CldrPaths.getPathComparator(dtdType);

--- a/tools/java/org/unicode/cldr/api/CldrPaths.java
+++ b/tools/java/org/unicode/cldr/api/CldrPaths.java
@@ -40,9 +40,6 @@ final class CldrPaths {
     // has elements with both data and (deprecated) child elements present.
     private static final Predicate<DtdData.Element> IS_NOT_DEPRECATED = e -> !e.isDeprecated();
 
-    // TODO: Consider moving these basic (string/name) maps to CldrDataType.
-    // TODO: Maybe change to have explict Element and Attribute classes with metadata?
-
     // A map of the leaf element names for each supported DTD.
     private static final ImmutableSetMultimap<CldrDataType, String> LEAF_ELEMENTS_MAP;
     // A map of the ordered element names for each supported DTD.

--- a/tools/java/org/unicode/cldr/api/CldrValue.java
+++ b/tools/java/org/unicode/cldr/api/CldrValue.java
@@ -177,7 +177,6 @@ public final class CldrValue implements AttributeSupplier {
      *
      * @return a map of the value attributes for this CLDR value instance.
      */
-    // TODO: This is used in only two places outside this package, so consider making it non-public.
     public ImmutableMap<AttributeKey, String> getValueAttributes() {
         return attributes;
     }

--- a/tools/java/org/unicode/cldr/api/LocaleIds.java
+++ b/tools/java/org/unicode/cldr/api/LocaleIds.java
@@ -5,9 +5,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.regex.Pattern;
 
 /**
- * Utility methods for working with locale IDs as strings.
+ * Utility methods for working with locale IDs as strings. This could, with a little thought, be
+ * made public if necessary.
  */
-// TODO: Consider making this public when moving "SupplementalData" into the API.
 final class LocaleIds {
     // From: https://unicode.org/reports/tr35/#Identifiers
     // Locale ID is:

--- a/tools/java/org/unicode/cldr/api/XmlDataSource.java
+++ b/tools/java/org/unicode/cldr/api/XmlDataSource.java
@@ -125,7 +125,7 @@ final class XmlDataSource implements CldrData {
 
     @Override
     public void accept(PathOrder order, ValueVisitor visitor) {
-        getPathValueMap(order).values().forEach(v -> visitor.visit(v));
+        getPathValueMap(order).values().forEach(visitor::visit);
     }
 
     @Override
@@ -359,9 +359,7 @@ final class XmlDataSource implements CldrData {
     // Handler used by the XML SAX parser to handle various events during parsing.
     private static ErrorHandler ERROR_HANDLER = new ErrorHandler() {
         @Override
-        public void warning(SAXParseException exception) {
-            // TODO: Maybe log a warning here?
-        }
+        public void warning(SAXParseException exception) { }
 
         @Override
         public void error(SAXParseException exception) throws SAXException {
@@ -375,6 +373,5 @@ final class XmlDataSource implements CldrData {
     };
 
     // A private exception used to allow non-matching DTDs to be ignored.
-    private static final class IncompatibleDtdException extends RuntimeException {
-    }
+    private static final class IncompatibleDtdException extends RuntimeException { }
 }


### PR DESCRIPTION
Removed some "weak" TODOs from code to leave only actionable/interesting ones (TODOs which would be hit as part of a natural refactoring are "weak" even if they are actionable).

Also actually did one of the TODOs to strengthen the checking for sort indices.

A couple of small IDE warnings fixed on the way.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-_____
- [x] Updated PR title and link in previous line to include Issue number

