### PR TITLE
CLDR-13243 BRS 36: Update unittest logKnownIssues

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestTransforms.java
@@ -517,8 +517,15 @@ public class TestTransforms extends TestFmwkPlus {
             turkishSource, true);
 
         String lithuanianSource = "I \u00CF J J\u0308 \u012E \u012E\u0308 \u00CC \u00CD \u0128 xi\u0307\u0308 xj\u0307\u0308 x\u012F\u0307\u0308 xi\u0307\u0300 xi\u0307\u0301 xi\u0307\u0303 XI X\u00CF XJ XJ\u0308 X\u012E X\u012E\u0308";
-        if (!logKnownIssue("11094",
-            "Fix ICU4J UCharacter.toTitleCase/toLowerCase for lt")) {
+        // The following test was formerly skipped with
+        // !logKnownIssue("11094", "Fix ICU4J UCharacter.toTitleCase/toLowerCase for lt").
+        // However [https://unicode-org.atlassian.net/browse/ICU-11094] is supposedly
+        // fixed in the version of ICU4J currently in CLDR, but removing the logKnownIssue
+        // to execute the test results in test failures, mainly for  i\u0307\u0308.
+        // So I am changing the logKnownIssue to reference a CLDR ticket about
+        // investigating the test (it may be wrong).
+        if (!logKnownIssue("cldrbug:13313",
+            "Investigate the Lithuanian casing test, it may be wrong")) {
             Transliterator ltTitle = checkString(
                 "lt",
                 Casing.Title,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13243
- [x] Updated PR title and link in previous line to include Issue number

This is for the CLDR 36 BRS task to update the KnownIssues in the CLDR unit tests. All of the CLDR bugs referenced by logKnowIssue statements are still open; the one ICU issue referenced by a logKnownIssue [https://unicode-org.atlassian.net/browse/ICU-11094) is supposedly fixed in the version of ICU4J currently in CLDR, but removing the logKnownIssue to execute the test results in test failures. So I created a new CLDR ticket to investigate the test failure and just changed the logKnownIssue to reference that instead.