### PR TITLE
CLDR-13240 fix subdivisions in production

### DIFF
--- a/tools/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -68,7 +69,7 @@ public class GenerateProductionData {
             .setMatch(".*")),
         destinationDirectory(new Params()
             .setHelp("destination common directory")
-            .setDefault(CLDRPaths.AUX_DIRECTORY + "production/common")
+            .setDefault(CLDRPaths.STAGING_DIRECTORY + "production/common")
             .setMatch(".*")),
         logicalGroups(new Params()
             .setHelp("add path/values for logical groups")
@@ -163,7 +164,10 @@ public class GenerateProductionData {
             }
         }
         if (!localeToSubdivisionsToMigrate.isEmpty()) {
-            throw new IllegalArgumentException("Missing subdivision files: " + localeToSubdivisionsToMigrate);
+            System.err.println("WARNING: Subdivision files not written");
+            for (Entry<String, Pair<String, String>> entry : localeToSubdivisionsToMigrate.entries()) {
+                System.err.println(entry.getKey() + " \t" + entry.getValue());
+            }
         }
     }
 
@@ -332,7 +336,7 @@ public class GenerateProductionData {
 
                 // Move subdivisions elsewhere
                 if (!isSubdivisionDirectory && xpath.startsWith("//ldml/localeDisplayNames/subdivisions/subdivision")) {
-                    localeToSubdivisionsToMigrate.put(localeId, Pair.of(xpath, bailey));
+                    localeToSubdivisionsToMigrate.put(localeId, Pair.of(xpath, value));
                     toRemove.add(xpath);
                     continue;
                 }

--- a/tools/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -27,6 +27,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LogicalGrouping;
+import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
@@ -35,6 +36,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
 import com.google.common.io.Files;
 import com.ibm.icu.util.Output;
 
@@ -56,6 +58,8 @@ public class GenerateProductionData {
     static final Set<String> NON_XML = ImmutableSet.of("dtd", "properties", "testData", "uca");
     static final Set<String> COPY_ANYWAY = ImmutableSet.of("casing", "collation"); // don't want to "clean up", makes format difficult to use
     static final SupplementalDataInfo SDI = CLDRConfig.getInstance().getSupplementalDataInfo();
+    
+    static final Multimap<String, Pair<String, String>> localeToSubdivisionsToMigrate = TreeMultimap.create();
 
     enum MyOptions {
         sourceDirectory(new Params()
@@ -157,6 +161,9 @@ public class GenerateProductionData {
                 Stats stats = new Stats();
                 copyFilesAndReturnIsEmpty(sourceDir, destinationDir, null, isLdmlDtdType, stats);
             }
+        }
+        if (!localeToSubdivisionsToMigrate.isEmpty()) {
+            throw new IllegalArgumentException("Missing subdivision files: " + localeToSubdivisionsToMigrate);
         }
     }
 
@@ -266,6 +273,9 @@ public class GenerateProductionData {
                 }
             }
             boolean isRoot = localeId.equals("root");
+            String directoryName = sourceFile.getParentFile().getName();
+            boolean isSubdivisionDirectory = "subdivisions".equals(directoryName);
+            
             CLDRFile cldrFileUnresolved = factory.make(localeId, false);
             CLDRFile cldrFileResolved = factory.make(localeId, true);
             boolean gotOne = false;
@@ -320,6 +330,12 @@ public class GenerateProductionData {
                     continue;
                 }
 
+                // Move subdivisions elsewhere
+                if (!isSubdivisionDirectory && xpath.startsWith("//ldml/localeDisplayNames/subdivisions/subdivision")) {
+                    localeToSubdivisionsToMigrate.put(localeId, Pair.of(xpath, bailey));
+                    toRemove.add(xpath);
+                    continue;
+                }
                 // remove level=comprehensive (under setting)
 
                 if (!INCLUDE_COMPREHENSIVE) {
@@ -356,10 +372,18 @@ public class GenerateProductionData {
                 gotOne = true;
             }
 
-
             // we even add empty files, but can delete them back on the directory level.
             try (PrintWriter pw = new PrintWriter(destinationFile)) {
                 CLDRFile outCldrFile = cldrFileUnresolved.cloneAsThawed();
+                if (isSubdivisionDirectory) {
+                    Collection<Pair<String, String>> path_values = localeToSubdivisionsToMigrate.get(localeId);
+                    if (path_values != null) {
+                        for (Pair<String, String>path_value : path_values) {
+                            outCldrFile.add(path_value.getFirst(), path_value.getSecond());
+                        }
+                        localeToSubdivisionsToMigrate.removeAll(localeId);
+                    }
+                }
 
                 // Remove paths, but pull out the ones to retain
                 // example:

--- a/tools/java/org/unicode/cldr/util/CLDRPaths.java
+++ b/tools/java/org/unicode/cldr/util/CLDRPaths.java
@@ -48,6 +48,8 @@ public class CLDRPaths {
     public static final String ANNOTATIONS_DERIVED_DIRECTORY = CldrUtility.getPath(CLDRPaths.COMMON_DIRECTORY, ANNOTATIONS_DERIVED_SUBDIR);
     public static final String VALIDITY_DIRECTORY = CldrUtility.getPath(CLDRPaths.COMMON_DIRECTORY, VALIDITY_SUBDIR);
 
+    public static final String STAGING_DIRECTORY = CldrUtility.getPath(CLDRPaths.BASE_DIRECTORY, "../cldr-staging/");
+
     public static final String TEST_DATA = COMMON_DIRECTORY + "testData/";
 
     public static final String SEED_DIRECTORY1 = CldrUtility.getProperty("CLDR_SEED",


### PR DESCRIPTION
As the main/ files are processed, we record their subdivisions (and remove them).
As the subdivisions/ files are processed, we add in the corresponding path/value pairs we recorded from main/
There is a warning message if there are subdivisions in main/ that aren't captured in a subdivisions/. NOTE: we don't typically have sublocales in subdivisions/, so messages about those can be ignored.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13240
- [ ] Updated PR title and link in previous line to include Issue number

