### PR TITLE
CLDR-11770 Document difference in key between RFC6067 and UTS35

### DIFF
--- a/specs/ldml/tr35.html
+++ b/specs/ldml/tr35.html
@@ -968,18 +968,22 @@
         &nbsp; (sep alphanum{2,8})+ ;</code></td>
       </tr>
       <tr>
-        <td><code>keyword</code></td>
+        <td><code>keyword</code><span class='changed'><br>
+			(Also known as <code>uvalue</code>)</span></td>
         <td><code>= key (sep type)? ;</code></td>
       </tr>
       <tr>
-        <td><code>key</code></td>
-        <td><code>= alphanum alpha ;</code></td>
+        <td><code>key</code><span class='changed'><br>
+			(Also known as <code>ukey</code>)</span></td>
+        <td><code>= alphanum alpha ;</code><span class='changed'><br>
+          (Note that this is narrower than in [<a href="https://www.ietf.org/rfc/rfc6067.txt" title="https://www.ietf.org/rfc/rfc6067.txt">RFC6067</a>], so that it is disjoint with tkey.)</span></td>
         <td><code><a href="#Key_Type_Definitions">validity</a><br>
         <a href=
         'http://unicode.org/cldr/latest/common/bcp47'>latest-data</a></code></td>
       </tr>
       <tr>
-        <td><code>type</code></td>
+        <td><code>type</code><span class='changed'><br>
+			(Also known as <code>uvalue</code>)</span></td>
         <td><code>= alphanum{3,8}<br>
         &nbsp; (sep alphanum{3,8})* ;</code></td>
         <td><code><a href="#Key_Type_Definitions">validity</a><br>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11770
- [x] Updated PR title and link in previous line to include Issue number

