### PR TITLE
CLDR-12020 DataSection performance

### DIFF
--- a/tools/cldr-apps/.classpath
+++ b/tools/cldr-apps/.classpath
@@ -78,6 +78,11 @@
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="/cldr-tools/libs/failureaccess.jar">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="lib" path="/cldr-tools/libs/myanmar-tools-1.1.1.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>

--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/row.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/row.jsp
@@ -50,7 +50,7 @@
 	<%= p.getDisplayName()  
 	%>
 </th>
-<% if(p.hasExamples()) { 
+<%
 			if(baseExample!=null) { %>
 				<td rowspan='<%= rowSpan %>' align='left' valign='top' class='generatedexample'>
 						<%= baseExample.replaceAll("\\\\", "\u200b\\\\")  %>
@@ -58,6 +58,6 @@
 			<% } else { %>
 				<td rowspan='<%= rowSpan %>'></td>
 			<% } 
-} %>
-	
+%>
+
 <% /* Note: more from showDataRow (in DataSection.java prior to svn revision 14289) could move here? */ %>

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
@@ -4714,7 +4714,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * @param section
      */
     void printSectionTableClose(WebContext ctx, DataSection section, boolean canModify) {
-        int table_width = (section != null && section.hasExamples) ? 13 : 10;
+        int table_width = (section != null) ? 13 : 10;
         if (!canModify) {
             table_width -= 4; // No vote, change, or no opinion columns
         }

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -3600,4 +3600,21 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
         if (locked) throw new UnsupportedOperationException("Attempt to modify locked object");
         this.dtdType = dtdType;
     }
+
+    /**
+     * Used only for TestExampleGenerator.
+     */
+    public void valueChanged(String xpath) {
+        if (isResolved()) {
+            ResolvingSource resSource = (ResolvingSource) dataSource;
+            resSource.valueChanged(xpath, resSource);
+        }
+    }
+
+    /**
+     * Used only for TestExampleGenerator.
+     */
+    public void disableCaching() {
+        dataSource.disableCaching();
+    }
 }


### PR DESCRIPTION
-Avoid re-creating ExampleGenerator with each http request

-Get DataSection.nativeExampleGenerator from a cache, on a per-locale basis

-Add failureaccess.jar to cldr-apps/.classpath for guava Cache

-DataSection.make consistently use session.user not ctx.session.user

-New TestCache.getExampleGenerator and exampleGeneratorCache (CacheBuilder)

-New ExampleGenerator.updateCache

-Implement disableCache methods for several objects for testing/debugging

-Test where changing the value of one path changes example-generation for another path

-New experimental TestExampleGeneratorDependencies in TestExampleGenerator.java

-Remove unused hasExamples, always true

-Move some code into subroutines, e.g., updateTestResultCache

-Rename cache to testResultCache for clarity

-Rename more items for clarity and distinctness, e.g., aliases to aliasCache or aliasMap

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-12020
- [x] Updated PR title and link in previous line to include Issue number

