### PR TITLE
CLDR-13243 BRS 36: Fix TR35 broken links (to CLDR repo, ICU User Guide, ...)

### DIFF
--- a/specs/ldml/tr35-collation.html
+++ b/specs/ldml/tr35-collation.html
@@ -758,7 +758,7 @@
     "Root_Data_Files">Root Collation Data Files</a></h3>
     <p>The CLDR root collation data files are in the CLDR
     repository and release, under the path <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/uca/">common/uca/</a>.</p>
+    "https://github.com/unicode-org/cldr/tree/latest/common/uca/">common/uca/</a>.</p>
     <p>For most data files there are <strong>_SHORT</strong>
     versions available. They contain the same data but only minimal
     comments, to reduce the file sizes.</p>
@@ -2337,13 +2337,13 @@ FDD0 0065; [, B1, 09]       # [1644.0020.0004] [0000.0061.0004]     * U+A7A1 LAT
     <p>The following is a simple example that combines portions of
     different tailorings for illustration. For more complete
     examples, see the actual locale data: <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/collation/ja.xml">
+    "https://github.com/unicode-org/cldr/tree/latest/common/collation/ja.xml">
     Japanese</a>, <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/collation/zh.xml">
+    "https://github.com/unicode-org/cldr/tree/latest/common/collation/zh.xml">
     Chinese</a>, <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/collation/sv.xml">
+    "https://github.com/unicode-org/cldr/tree/latest/common/collation/sv.xml">
     Swedish</a>, and <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/collation/de.xml">
+    "https://github.com/unicode-org/cldr/tree/latest/common/collation/de.xml">
     German</a> (type="phonebook") are particularly
     illustrative.</p>
     <pre>&lt;collation&gt;

--- a/specs/ldml/tr35-info.html
+++ b/specs/ldml/tr35-info.html
@@ -1276,7 +1276,7 @@ LY MA OM PS QA SA SD SY TN YE"/&gt;
     <strong>//supplementalData/CoverageLevels</strong>. For a view
     of the trunk version of this data<strike>file</strike>, see
     <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/supplemental/coverageLevels.xml">
+    "https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/coverageLevels.xml">
     coverageLevels.xml</a>. (As described in the <a href=
     "tr35-info.html#Supplemental_Data">introduction to Supplemental
     Data</a>, the specific XML filename may change.)</p>

--- a/specs/ldml/tr35-keyboards.html
+++ b/specs/ldml/tr35-keyboards.html
@@ -2489,8 +2489,8 @@
           Because there is &lt;likelySubtag from="en"
           to="en_Latn_US"/&gt;, en-US → en.</li>
           <li>The data is in <a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/supplemental/likelySubtags.xml">
-          http://unicode.org/repos/cldr/tags/latest/common/supplemental/likelySubtags.xml</a></li>
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/likelySubtags.xml">
+          https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/likelySubtags.xml</a></li>
         </ol>
       </li>
       <li>The platform goes first, if it exists. If a keyboard on
@@ -2505,12 +2505,12 @@
       -azerty, …</li>
       <li>In order to get to 8 letters, abbreviations are reused
       that are already in <a href=
-      "http://unicode.org/repos/cldr/tags/latest/common/bcp47/">bcp47</a>
+      "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/">bcp47</a>
       -u/-t extensions and in <a href=
       "http://www.iana.org/assignments/language-subtag-registry">language-subtag-registry</a>
       variants, eg for Traditional use "-trad" or "-traditio" (both
       exist in <a href=
-      "http://unicode.org/repos/cldr/tags/latest/common/bcp47/">bcp47</a>).</li>
+      "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/">bcp47</a>).</li>
       <li>Multiple languages cannot be indicated, so the
       predominant target is used.
         <ol>

--- a/specs/ldml/tr35.html
+++ b/specs/ldml/tr35.html
@@ -102,7 +102,7 @@
       </tr>
       <tr>
         <td>Date</td>
-        <td class="changed">2019-09-26</td>
+        <td class="changed">2019-10-01</td>
       </tr>
       <tr>
         <!-- This link must be made live when posting the final version but is disabled during proposed update stage. -->
@@ -1477,7 +1477,7 @@
     field values are based on [<a href="#BCP47">BCP47</a>] subtag
     values, their validity status in CLDR is specified by means of
     machine-readable files in the <a href=
-    'http://unicode.org/repos/cldr/tags/latest/common/validity/'>common/validity/</a>
+    'https://github.com/unicode-org/cldr/releases/tag/latest/common/validity/'>common/validity/</a>
     subdirectory, such as language.xml. For the format of those
     files and more information, see <em><a href=
     '#Validity_Data'>Section 3.11 Validity Data</a></em>.</p>
@@ -2758,12 +2758,12 @@ zh-Hant-HK</pre>
     for those numbering systems are defined in the file
     <strong>bcp47/number.xml</strong>. For example, for the 'trunk'
     version of the data see <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/bcp47/number.xml">
+    "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/number.xml">
     bcp47/number.xml</a>.<br></p>
     <p>Details about those numbering systems are defined in
     <strong>supplemental/numberingSystems.xml</strong>. For
     example, for the 'trunk' version of the data see <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/supplemental/numberingSystems.xml">
+    "https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/numberingSystems.xml">
     supplemental/numberingSystems.xml</a>.<br></p>
     <p>LDML makes certain stability guarantees on this
     data:&nbsp;<br></p>
@@ -2846,12 +2846,12 @@ zh-Hant-HK</pre>
     contains the locale extension key/type values and their
     backward compatibility mappings appropriate for a particular
     domain. <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/bcp47/collation.xml">
+    "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/collation.xml">
     common/bcp47/collation.xml</a> contains key/type values for
     collation, including optional collation parameters and valid
     type values for each key.</p>
     <p>The 't' extension data is stored in <a href=
-    "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform.xml">
+    "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform.xml">
     common/bcp47/transform.xml</a>.</p>
     <p class="dtd">&lt;!ELEMENT keyword ( key* )&gt;</p>
     <p class="dtd">&lt;!ELEMENT key ( type* )&gt;<br>
@@ -3273,7 +3273,7 @@ zh-Hant-HK</pre>
           reference an authority or rules for a type of
           transformation</td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform.xml">
           ​transform.xml</a></td>
         </tr>
         <tr>
@@ -3282,7 +3282,7 @@ zh-Hant-HK</pre>
           non-languages/scripts, such as fullwidth-halfwidth
           conversion.</td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform-destination.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform-destination.xml">
           ​transform-destination.xml</a></td>
         </tr>
         <tr>
@@ -3293,7 +3293,7 @@ zh-Hant-HK</pre>
           a sequence would typically be a 'platform' or vendor
           designation.</td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform_ime.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform_ime.xml">
           ​transform_ime.xml</a></td>
         </tr>
         <tr>
@@ -3308,7 +3308,7 @@ zh-Hant-HK</pre>
           One or more subsequent fields may occur, but are only
           added where needed to distinguish from others.</td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform_keyboard.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform_keyboard.xml">
           ​transform_keyboard.xml</a></td>
         </tr>
         <tr>
@@ -3319,7 +3319,7 @@ zh-Hant-HK</pre>
           content. The first subfield in a sequence would typically
           be a 'platform' or vendor designation.</td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform_mt.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform_mt.xml">
           ​transform_mt.xml</a></td>
         </tr>
         <tr>
@@ -3331,14 +3331,14 @@ zh-Hant-HK</pre>
           <em>Section 3.10.2 <a href="#Hybrid_Locale">Hybrid Locale
           Identifiers</a>.</em></td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform_hybrid.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform_hybrid.xml">
           ​transform_hybrid.xml</a></td>
         </tr>
         <tr>
           <td>x0</td>
           <td><strong>Private use transform</strong></td>
           <td><a href=
-          "http://unicode.org/repos/cldr/tags/latest/common/bcp47/transform_private_use.xml">
+          "https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/transform_private_use.xml">
           ​transform_private_use.xml</a></td>
         </tr>
       </tbody>
@@ -3972,7 +3972,7 @@ zh-Hant-HK</pre>
     &lt;!ATTLIST id type NMTOKEN #REQUIRED &gt;<br>
     &lt;!ATTLIST id idStatus NMTOKEN #REQUIRED &gt;</p>
     <p>The directory <a href=
-    'http://unicode.org/repos/cldr/tags/latest/common/validity/'>common/validity</a>
+    'https://github.com/unicode-org/cldr/releases/tag/latest/common/validity/'>common/validity</a>
     contains machine-readable data for validating the language,
     region, script, and variant subtags, as well as currency,
     subdivisions and measure units. Each file contains a number of
@@ -8677,7 +8677,7 @@ decimal?, group?, special*)) &gt;</pre>
 
         Actual List<br>
         <a href=
-        "http://www.iso.org/iso/country_names_and_code_elements">http://www.iso.org/iso/country_names_and_code_elements</a></td>
+        "https://www.iso.org/obp/ui/#search">https://www.iso.org/obp/ui/#search</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="ISO4217" href=
@@ -8820,8 +8820,8 @@ decimal?, group?, special*)) &gt;</pre>
         "ICUCollation">ICUCollation</a>]</td>
         <td class="noborder" width="730">ICU rule syntax<br>
         <a href=
-        "http://www.icu-project.org/userguide/Collate_Customization.html">
-        http://www.icu-project.org/userguide/Collate_Customization.html</a></td>
+        "http://userguide.icu-project.org/Collate_Customization">
+        http://userguide.icu-project.org/Collate_Customization</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="ICUTransforms"
@@ -8829,8 +8829,8 @@ decimal?, group?, special*)) &gt;</pre>
         "ICUTransforms">ICUTransforms</a>]</td>
         <td class="noborder" width="730">Transforms<br>
         <a href=
-        "http://www.icu-project.org/userguide/Transformations.html">
-        http://www.icu-project.org/userguide/Transformations.html</a><br>
+        "http://userguide.icu-project.org/Transformations">
+        http://userguide.icu-project.org/Transformations</a><br>
 
         Transforms Demo<br>
         <a href=
@@ -8842,7 +8842,7 @@ decimal?, group?, special*)) &gt;</pre>
         "ICUUnicodeSet">ICUUnicodeSet</a>]</td>
         <td class="noborder" width="730">ICU UnicodeSet<br>
         <a href=
-        "http://www.icu-project.org/userguide/unicodeSet.html">http://www.icu-project.org/userguide/unicodeSet.html<br>
+        "http://userguide.icu-project.org/strings/unicodeset">http://userguide.icu-project.org/strings/unicodeset<br>
         </a> API<br>
         <a href=
         "http://www.icu-project.org/apiref/icu4j/com/ibm/icu/text/UnicodeSet.html">
@@ -8899,8 +8899,8 @@ decimal?, group?, special*)) &gt;</pre>
         <td class="noborder" width="730">Rule-Based Break
         Iterator<br>
         <a href=
-        "http://www.icu-project.org/userguide/boundaryAnalysis.html">
-        http://www.icu-project.org/userguide/boundaryAnalysis.html</a></td>
+        "http://userguide.icu-project.org/boundaryanalysis">
+        http://userguide.icu-project.org/boundaryanalysis</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="UCAChart" href=


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13243
- [x] Updated PR title and link in previous line to include Issue number

Fixed broken links into CLDR repo, ICU User Guide, ISO 3166 codes, etc. There is at least one broken link to ICU demos that we cannot fix yet.