### PR TITLE
CLDR-13243 Update zip utilities to use git instead of SVN

### DIFF
--- a/tools/build.xml
+++ b/tools/build.xml
@@ -1,7 +1,7 @@
 <project name="CLDR Distribution" default="all" basedir=".">
   <target name="init">
     <tstamp/>
-    <property name="version" value="35.0"/>
+    <property name="version" value="36.0"/>
     <property name="dist.dir" value="dist"/>
     <property name="dist.conf.dir" value="dist.conf"/>
     <property name="excludes.file" value="${dist.conf.dir}/distExcludes.txt"/>

--- a/tools/scripts/distUpdateExcludes.sh
+++ b/tools/scripts/distUpdateExcludes.sh
@@ -9,7 +9,7 @@ fi
 DISTFILE=tools/dist.conf/distExcludes.txt
 cd ../..
 > "${DISTFILE}"
-for item in $(svn status --no-ignore  | grep -v '^M' | cut -c9-);
+for item in $(git ls-files -o);
 do
     if [[ "${item}" == "tools/java/cldr.jar" ]]; # allow this
     then


### PR DESCRIPTION
[CLDR-13243]

Update tools that create the ZIP files to use git instead of svn, and update version used to 36.

[CLDR-13243]: https://unicode-org.atlassian.net/browse/CLDR-13243