### PR TITLE
CLDR-13364: Fix regressed spelling of Azerbaijani month names

### DIFF
--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -1426,9 +1426,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">yanvar</month>
+							<month type="1">Yanvar</month>
 							<month type="2">Fevral</month>
-							<month type="3">mart</month>
+							<month type="3">Mart</month>
 							<month type="4">Aprel</month>
 							<month type="5">May</month>
 							<month type="6">İyun</month>
@@ -1437,7 +1437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="9">Sentyabr</month>
 							<month type="10">Oktyabr</month>
 							<month type="11">Noyabr</month>
-							<month type="12">dekabr</month>
+							<month type="12">Dekabr</month>
 						</monthWidth>
 					</monthContext>
 				</months>


### PR DESCRIPTION
The spelling had regressed between CLDR 35 and 36.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13364
- [x] Updated PR title and link in previous line to include Issue number

