### PR TITLE
CLDR-13330 Make ExampleGenerator simpler, faster by removing ExampleType

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -37,7 +37,6 @@ import org.unicode.cldr.test.CheckCLDR.Options;
 import org.unicode.cldr.test.CheckCLDR.StatusAction;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.ExampleGenerator;
-import org.unicode.cldr.test.ExampleGenerator.ExampleType;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
 import org.unicode.cldr.util.CLDRConfig;
@@ -476,7 +475,7 @@ public class DataSection implements JSONString {
              * Called only by DataSection.DataRow.CandidateItem.toJSONString()
              */
             private String getExample() {
-                return nativeExampleGenerator.getExampleHtml(xpath, rawValue, ExampleType.NATIVE);
+                return nativeExampleGenerator.getExampleHtml(xpath, rawValue);
             }
 
             /**
@@ -1210,7 +1209,7 @@ public class DataSection implements JSONString {
 
                 String displayExample = null;
                 if (displayName != null) {
-                    displayExample = sm.getTranslationHintsExample().getExampleHtml(xpath, displayName, ExampleType.ENGLISH);
+                    displayExample = sm.getTranslationHintsExample().getExampleHtml(xpath, displayName);
                 }
 
                 String code = "?";

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -12,7 +12,6 @@ import java.util.TreeSet;
 
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.test.ExampleGenerator;
-import org.unicode.cldr.test.ExampleGenerator.ExampleType;
 import org.unicode.cldr.test.ExampleGenerator.UnitLength;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -57,19 +56,18 @@ public class TestExampleGenerator extends TestFmwk {
         String sampleTemplateSuffix = "\"]";
 
         for (String[] row : tests) {
-            ExampleType exType = row[0].equals("en") ? ExampleType.ENGLISH : ExampleType.NATIVE;
             ExampleGenerator exampleGenerator = getExampleGenerator(row[0]);
             String value = "value-" + row[1];
 
             String path = sampleCurrencyPrefix + row[1] + sampleTemplateSuffix;
             String result = ExampleGenerator
-                .simplify(exampleGenerator.getExampleHtml(path, value, exType), false);
+                .simplify(exampleGenerator.getExampleHtml(path, value), false);
             assertEquals(row[0] + "-" + row[1] + "-BMD", row[2], result);
 
             value = "{0}_{1}";
             path = sampleCurrencyPatternPrefix + row[1] + sampleTemplateSuffix;
             result = ExampleGenerator
-                .simplify(exampleGenerator.getExampleHtml(path, value, exType), false);
+                .simplify(exampleGenerator.getExampleHtml(path, value), false);
             assertEquals(row[0] + "-" + row[1] + "-pat", row[3], result);
         }
     }
@@ -238,7 +236,7 @@ public class TestExampleGenerator extends TestFmwk {
                 }
                 continue;
             }
-            String example = exampleGenerator.getExampleHtml(path, value, ExampleType.NATIVE);
+            String example = exampleGenerator.getExampleHtml(path, value);
             String javaEscapedStarred = "\""
                 + plainStarred.replace("\"", "\\\"") + "\",";
             if (example == null) {
@@ -310,7 +308,7 @@ public class TestExampleGenerator extends TestFmwk {
     private void checkValue(String message, String expected,
         ExampleGenerator exampleGenerator, String path) {
         String value = exampleGenerator.getCldrFile().getStringValue(path);
-        String actual = exampleGenerator.getExampleHtml(path, value, ExampleType.NATIVE);
+        String actual = exampleGenerator.getExampleHtml(path, value);
         assertEquals(message, expected,
             ExampleGenerator.simplify(actual, false));
     }
@@ -382,7 +380,7 @@ public class TestExampleGenerator extends TestFmwk {
         String expected) {
         String value = exampleGenerator.getCldrFile().getStringValue(path);
         String result = ExampleGenerator.simplify(
-            exampleGenerator.getExampleHtml(path, value, ExampleType.NATIVE), false);
+            exampleGenerator.getExampleHtml(path, value), false);
         assertEquals("Ellipsis", expected, result);
     }
 
@@ -430,7 +428,7 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGenerator = getExampleGenerator("it");
         String actual = exampleGenerator.getExampleHtml(
             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-            "{0} [{1}]", ExampleType.NATIVE);
+            "{0} [{1}]");
         assertEquals(
             "localePattern example faulty",
             "<div class='cldr_example'><span class='cldr_substituted'>uzbeco</span> [<span class='cldr_substituted'>Afghanistan</span>]</div>"
@@ -440,7 +438,7 @@ public class TestExampleGenerator extends TestFmwk {
         actual = exampleGenerator
             .getExampleHtml(
                 "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
-                "{0}. {1}", ExampleType.NATIVE);
+                "{0}. {1}");
         assertEquals(
             "localeSeparator example faulty",
             "<div class='cldr_example'><span class='cldr_substituted'>uzbeco (arabo</span>. <span class='cldr_substituted'>Afghanistan)</span></div>"
@@ -453,9 +451,9 @@ public class TestExampleGenerator extends TestFmwk {
         String actual = simplify(exampleGenerator
             .getExampleHtml(
                 "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength/currencyFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
-                "¤ #0.00", ExampleType.ENGLISH));
+                "¤ #0.00"));
         assertEquals("Currency format example faulty",
-            "〖USD ❬1295,00❭〗〖-USD ❬1295,00❭〗", actual);
+            "〖€ ❬1295,00❭〗〖-€ ❬1295,00❭〗", actual);
     }
 
     public void TestSymbols() {
@@ -465,7 +463,7 @@ public class TestExampleGenerator extends TestFmwk {
         String actual = exampleGenerator
             .getExampleHtml(
                 "//ldml/numbers/symbols[@numberSystem=\"latn\"]/superscriptingExponent",
-                "x", ExampleType.NATIVE);
+                "x");
 
         assertEquals(
             "superscriptingExponent faulty",
@@ -478,7 +476,7 @@ public class TestExampleGenerator extends TestFmwk {
             info.getEnglish(), info.getEnglish(),
             CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY);
         String actual = exampleGenerator.getExampleHtml(
-            "//ldml/dates/timeZoneNames/fallbackFormat", "{1} [{0}]", ExampleType.NATIVE);
+            "//ldml/dates/timeZoneNames/fallbackFormat", "{1} [{0}]");
         assertEquals("fallbackFormat faulty", "〖❬Central Time❭ [❬Cancun❭]〗",
             ExampleGenerator.simplify(actual, false));
     }
@@ -489,13 +487,13 @@ public class TestExampleGenerator extends TestFmwk {
             "//ldml/dates/timeZoneNames",
             exampleGenerator.getCldrFile().getComparator()))) {
             String value = exampleGenerator.getCldrFile().getStringValue(xpath);
-            String actual = exampleGenerator.getExampleHtml(xpath, value, ExampleType.NATIVE);
+            String actual = exampleGenerator.getExampleHtml(xpath, value);
             if (actual == null) {
                 if (!xpath.contains("singleCountries")
                     && !xpath.contains("gmtZeroFormat")) {
                     errln("Null value for " + value + "\t" + xpath);
                     // for debugging
-                    exampleGenerator.getExampleHtml(xpath, value, ExampleType.NATIVE);
+                    exampleGenerator.getExampleHtml(xpath, value);
                 }
             } else {
                 logln(actual + "\t" + value + "\t" + xpath);
@@ -519,7 +517,7 @@ public class TestExampleGenerator extends TestFmwk {
             String xpath = testPair[0];
             String expected = testPair[1];
             String value = exampleGenerator.getCldrFile().getStringValue(xpath);
-            String actual = simplify(exampleGenerator.getExampleHtml(xpath, value, ExampleType.NATIVE));
+            String actual = simplify(exampleGenerator.getExampleHtml(xpath, value));
             assertEquals("specifics", expected, actual);
         }
     }
@@ -542,7 +540,7 @@ public class TestExampleGenerator extends TestFmwk {
             String xpath = testPair[0];
             String expected = testPair[1];
             String value = nativeCldrFile.getStringValue(xpath);
-            String actual = exampleGenerator.getExampleHtml(xpath, value, ExampleType.NATIVE);
+            String actual = exampleGenerator.getExampleHtml(xpath, value);
             assertEquals("specifics", expected, actual);
         }
     }
@@ -571,36 +569,34 @@ public class TestExampleGenerator extends TestFmwk {
     private void checkPathValue(ExampleGenerator exampleGenerator,
         String xpath, String value, String expected) {
         Set<String> alreadySeen = new HashSet<String>();
-        for (ExampleType exType : ExampleType.values()) {
-            try {
-                String text = exampleGenerator.getExampleHtml(xpath, value, exType);
-                if (text == null)
-                    continue;
-                if (text.contains("Exception")) {
-                    errln("getExampleHtml\t" + exType + "\t" + text);
-                } else if (!alreadySeen.contains(text)) {
-                    if (text.contains("n/a")) {
-                        if (text.contains("&lt;")) {
-                            errln("Text not quoted correctly:" + "\t" + text
-                                + "\t" + xpath);
-                        }
+        try {
+            String text = exampleGenerator.getExampleHtml(xpath, value);
+            if (text == null) {
+                // skip
+            } else if (text.contains("Exception")) {
+                errln("getExampleHtml\t" + text);
+            } else if (!alreadySeen.contains(text)) {
+                if (text.contains("n/a")) {
+                    if (text.contains("&lt;")) {
+                        errln("Text not quoted correctly:" + "\t" + text
+                            + "\t" + xpath);
                     }
-                    boolean skipLog = false;
-                    if (expected != null && exType == ExampleType.NATIVE) {
-                        String simplified = ExampleGenerator.simplify(text, false);
-                        // redo for debugging
-                        text = exampleGenerator.getExampleHtml(xpath, value, exType);
-                        skipLog = !assertEquals("Example text for «" + value + "»", expected, simplified);
-                    }
-                    if (!skipLog) {
-                        logln("getExampleHtml\t" + exType + "\t" + text + "\t"
-                            + xpath);
-                    }
-                    alreadySeen.add(text);
                 }
-            } catch (Exception e) {
-                errln("getExampleHtml\t" + exType + "\t" + e.getMessage());
+                boolean skipLog = false;
+                if (expected != null) {
+                    String simplified = ExampleGenerator.simplify(text, false);
+                    // redo for debugging
+                    text = exampleGenerator.getExampleHtml(xpath, value);
+                    skipLog = !assertEquals("Example text for «" + value + "»", expected, simplified);
+                }
+                if (!skipLog) {
+                    logln("getExampleHtml\t" + text + "\t"
+                        + xpath);
+                }
+                alreadySeen.add(text);
             }
+        } catch (Exception e) {
+            errln("getExampleHtml\t" + e.getMessage());
         }
 
         try {
@@ -743,7 +739,7 @@ public class TestExampleGenerator extends TestFmwk {
             if (path.equals("//ldml/numbers/currencies/currency[@type=\"EUR\"]/symbol")) {
                 System.out.println("Got " + path + " in first loop ...");
             }
-            egBase.getExampleHtml(path, value, ExampleType.NATIVE);
+            egBase.getExampleHtml(path, value);
         }
 
         /*
@@ -809,8 +805,8 @@ public class TestExampleGenerator extends TestFmwk {
                 ExampleGenerator egTest = new ExampleGenerator(cldrFile, englishFile, CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY);
                 egTest.disableCaching();
                 // egTest.icuServiceBuilder.setCldrFile(cldrFile); // clear caches in icuServiceBuilder; has to be public
-                String exBase = egBase.getExampleHtml(pathB, valueB, ExampleType.NATIVE); // this will come from cache
-                String exTest = egTest.getExampleHtml(pathB, valueB, ExampleType.NATIVE); // this won't come from cache
+                String exBase = egBase.getExampleHtml(pathB, valueB); // this will come from cache
+                String exTest = egTest.getExampleHtml(pathB, valueB); // this won't come from cache
                 if ((exTest == null) != (exBase == null)) {
                     System.out.println("One null but not both? " + pathA + " --- " + pathB); // hasn't happened yet
                 } else if (exTest != null && !exTest.equals(exBase)) {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import javax.xml.xpath.XPathException;
 
 import org.unicode.cldr.test.ExampleGenerator;
-import org.unicode.cldr.test.ExampleGenerator.ExampleType;
 import org.unicode.cldr.util.AttributeValueValidity;
 import org.unicode.cldr.util.AttributeValueValidity.MatcherPattern;
 import org.unicode.cldr.util.CLDRConfig;
@@ -419,7 +418,7 @@ public class TestLocale extends TestFmwkPlus {
 
                 if (row[5] != null) {
                     String path = CLDRFile.getKey(typeCode, row[1]);
-                    String example = eg.getExampleHtml(path, "?" + row[2] + "?", ExampleType.NATIVE);
+                    String example = eg.getExampleHtml(path, "?" + row[2] + "?");
                     assertEquals("example " + row[3], row[5], ExampleGenerator.simplify(example));
                 }
             }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
@@ -20,7 +20,6 @@ import java.util.regex.Matcher;
 
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.test.ExampleGenerator;
-import org.unicode.cldr.test.ExampleGenerator.ExampleType;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
@@ -331,7 +330,7 @@ public class TestPathHeader extends TestFmwkPlus {
                 placeholderInfo2.example);
         }
         ExampleGenerator eg = new ExampleGenerator(cldrFile, cldrFile, CLDRPaths.SUPPLEMENTAL_DIRECTORY);
-        String example = eg.getExampleHtml(APPEND_TIMEZONE, cldrFile.getStringValue(APPEND_TIMEZONE), ExampleType.NATIVE);
+        String example = eg.getExampleHtml(APPEND_TIMEZONE, cldrFile.getStringValue(APPEND_TIMEZONE));
         String result = ExampleGenerator.simplify(example, false);
         assertEquals("", "〖❬6:25:59 PM❭ ❬GMT❭〗", result);
     }

--- a/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -27,7 +27,6 @@ import org.unicode.cldr.test.CheckCLDR.FormatDemo;
 import org.unicode.cldr.test.CheckCLDR.Options;
 import org.unicode.cldr.test.CheckCLDR.Phase;
 import org.unicode.cldr.test.CheckCLDR.SimpleDemo;
-import org.unicode.cldr.test.ExampleGenerator.ExampleType;
 import org.unicode.cldr.tool.Option;
 import org.unicode.cldr.tool.Option.Params;
 import org.unicode.cldr.tool.ShowData;
@@ -660,7 +659,7 @@ public class ConsoleCheckCLDR {
                 String example = "";
 
                 if (SHOW_EXAMPLES) {
-                    example = ExampleGenerator.simplify(exampleGenerator.getExampleHtml(path, value, ExampleType.NATIVE));
+                    example = ExampleGenerator.simplify(exampleGenerator.getExampleHtml(path, value));
                     showExamples(checkCldr, prettyPath, localeID, path, value, fullPath, example);
                 }
 
@@ -794,7 +793,7 @@ public class ConsoleCheckCLDR {
                      * TODO: fix this code. Calling getExampleHtml with value = null will always return null,
                      * so what's this supposed to accomplish?
                      */
-                    String example = ExampleGenerator.simplify(exampleGenerator.getExampleHtml(path, null /* value */, ExampleType.NATIVE));
+                    String example = ExampleGenerator.simplify(exampleGenerator.getExampleHtml(path, null /* value */));
                     showExamples(checkCldr, prettyPath, localeID, path, null, fullPath, example);
                 }
             }
@@ -1519,8 +1518,7 @@ public class ConsoleCheckCLDR {
             String englishExample = null;
             final String englishPathValue = path == null ? null : getEnglishPathValue(path);
             if (SHOW_EXAMPLES && path != null) {
-                englishExample = ExampleGenerator.simplify(getExampleGenerator().getExampleHtml(path, englishPathValue,
-                    ExampleType.ENGLISH));
+                englishExample = ExampleGenerator.simplify(getExampleGenerator().getExampleHtml(path, englishPathValue));
             }
             englishExample = englishExample == null ? "" : englishExample;
             String cleanPrettyPath = path == null ? null : prettyPath; // prettyPathMaker.getOutputForm(prettyPath);

--- a/tools/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/java/org/unicode/cldr/util/TestUtilities.java
@@ -28,7 +28,6 @@ import java.util.regex.Matcher;
 
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.test.ExampleGenerator;
-import org.unicode.cldr.test.ExampleGenerator.ExampleType;
 import org.unicode.cldr.tool.GenerateAttributeList;
 
 import com.ibm.icu.dev.util.CollectionUtilities;
@@ -133,7 +132,7 @@ public class TestUtilities {
         for (String path : english) {
             String value = english.getStringValue(path);
             result.setLength(0);
-            String examples = englishExampleGenerator.getExampleHtml(path, value, ExampleType.NATIVE);
+            String examples = englishExampleGenerator.getExampleHtml(path, value);
             if (examples != null) {
                 result.append(examples).append("<hr>");
             }


### PR DESCRIPTION
-Remove third parameter of getExampleHtml

-Replace public ExampleType with private boolean typeIsEnglish

-Simplify and shorten ExampleGenerator cache key

-No loop on ExampleType in checkPathValue

-Euro sign instead of USD for Italian currency example in unit test

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13330
- [x] Updated PR title and link in previous line to include Issue number

