### PR TITLE
CLDR-13388 Importing copies of various utilities into CLDR API

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/api/AllTests.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/AllTests.java
@@ -1,17 +1,19 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableList;
-import com.ibm.icu.dev.test.TestFmwk.TestGroup;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import java.io.PrintWriter;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import com.google.common.collect.ImmutableList;
+import com.ibm.icu.dev.test.TestFmwk.TestGroup;
 
 public class AllTests extends TestGroup {
     private static final ImmutableList<Class<?>> TEST_CLASSES = ImmutableList.of(
         CldrFileDataSourceTest.class,
         CldrPathTest.class,
         CldrValueTest.class,
+        FilteredDataTest.class,
+        PathMatcherTest.class,
         PrefixVisitorTest.class,
         XmlDataSourceTest.class);
     

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/CldrFileDataSourceTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/CldrFileDataSourceTest.java
@@ -1,9 +1,7 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.ibm.icu.dev.test.TestFmwk;
-import org.unicode.cldr.util.CLDRConfig;
+import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -12,8 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
-import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
+import org.unicode.cldr.util.CLDRConfig;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.ibm.icu.dev.test.TestFmwk;
 
 public class CldrFileDataSourceTest extends TestFmwk {
     // The config knows if it's being run as part of a test. This is NOT immutable (but this test

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/CldrPathTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/CldrPathTest.java
@@ -1,12 +1,12 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.ibm.icu.dev.test.TestFmwk;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import java.util.Comparator;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.dev.test.TestFmwk;
 
 /**
  * Tests for the core CLDR path representation. Since this is an immutable value type, the tests

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/FilteredDataTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/FilteredDataTest.java
@@ -1,0 +1,101 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package org.unicode.cldr.api;
+
+import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.ibm.icu.dev.test.TestFmwk;
+
+public class FilteredDataTest extends TestFmwk {
+    public void TestSimple() {
+        CldrValue keep =
+            ldml("numbers/currencies/currency[@type=\"USD\"]/displayName", "US Dollar");
+        CldrValue remove =
+            ldml("numbers/currencies/currency[@type=\"USD\"]/symbol", "US$");
+        CldrValue replace =
+            ldml("units/durationUnit[@type=\"foo\"]/durationUnitPattern", "YYY");
+        CldrValue replacement =
+            ldml("units/durationUnit[@type=\"foo\"]/durationUnitPattern", "ZZZ");
+
+        CldrData src = CldrDataSupplier.forValues(ImmutableList.of(keep, remove, replace));
+        CldrData filtered = new FilteredData(src) {
+            @Override protected CldrValue filter(CldrValue value) {
+                if (value.equals(remove)) {
+                    return null;
+                } else if (value.equals(replace)) {
+                    return replacement;
+                } else {
+                    return value;
+                }
+            }
+        };
+
+        List<CldrValue> filteredValues = new ArrayList<>();
+        filtered.accept(ARBITRARY, filteredValues::add);
+        assertEquals("filtered values", filteredValues, Arrays.asList(keep, replacement));
+
+        assertNull("removed value is null", filtered.get(remove.getPath()));
+        assertEquals("keep is unchanged", filtered.get(keep.getPath()), keep);
+        assertEquals("filtered is replaced", filtered.get(replace.getPath()), replacement);
+    }
+
+    public void TestBadReplacementPath() {
+        CldrValue replace =
+            ldml("numbers/currencies/currency[@type=\"USD\"]/displayName", "VALUE");
+        CldrValue replacement =
+            ldml("numbers/currencies/currency[@type=\"USD\"]/symbol", "VALUE");
+
+        CldrData src = CldrDataSupplier.forValues(ImmutableList.of(replace));
+        CldrData filtered = new FilteredData(src) {
+            @Override protected CldrValue filter(CldrValue value) {
+                return replacement;
+            }
+        };
+        try {
+            filtered.accept(ARBITRARY, v -> {});
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "not permitted to modify distinguishing paths");
+            assertErrorMessageContains(e, replace.toString());
+            assertErrorMessageContains(e, replacement.toString());
+        }
+    }
+
+    public void TestBadReplacementAttributes() {
+        CldrValue replace =
+            ldml("numbers/currencies/currency[@type=\"USD\"]/displayName", "XXX");
+        CldrValue replacement =
+            ldml("numbers/currencies/currency[@type=\"GBP\"]/displayName", "XXX");
+
+        CldrData src = CldrDataSupplier.forValues(ImmutableList.of(replace));
+        CldrData filtered = new FilteredData(src) {
+            @Override protected CldrValue filter(CldrValue value) {
+                return replacement;
+            }
+        };
+        try {
+            filtered.accept(ARBITRARY, v -> {});
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "not permitted to modify distinguishing paths");
+            assertErrorMessageContains(e, replace.toString());
+            assertErrorMessageContains(e, replacement.toString());
+        }
+    }
+
+    private static CldrValue ldml(String path, String value) {
+        return CldrValue.parseValue("//ldml/" + path, value);
+    }
+
+    private void assertErrorMessageContains(Throwable e, String expected) {
+        // This test "framework" is such a limited API it encourages brittle assertions.
+        assertTrue(
+            "error message \"" + e.getMessage() + "\" contains \"" + expected + "\"",
+            e.getMessage().contains(expected));
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/PathMatcherTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/PathMatcherTest.java
@@ -1,0 +1,115 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package org.unicode.cldr.api;
+
+import static java.util.stream.Collectors.toList;
+import static org.unicode.cldr.api.CldrPath.parseDistinguishingPath;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.ibm.icu.dev.test.TestFmwk;
+
+public class PathMatcherTest extends TestFmwk {
+    public void TestMatcher() {
+        CldrPath calEra = parseDistinguishingPath(
+            "//ldml/dates/calendars/calendar[@type=\"buddhist\"]/eras/eraAbbr/era[@type=\"0\"]");
+        CldrPath chineseMon1 = monthInfo("chinese", "format", "abbreviated", 1);
+        CldrPath chineseMon2 = monthInfo("chinese", "format", "abbreviated", 2);
+        CldrPath genericMon1 = monthInfo("generic", "stand-alone", "narrow", 1);
+        CldrPath genericMon2 = monthInfo("generic", "stand-alone", "narrow", 2);
+        List<CldrPath> calPaths =
+            Arrays.asList(calEra, chineseMon1, chineseMon2, genericMon1, genericMon2);
+
+        PathMatcher calendarPrefix = PathMatcher.of("//ldml/dates/calendars/calendar[@type=*]");
+        assertTrue("is prefix match", calPaths.stream().allMatch(calendarPrefix::matchesPrefixOf));
+        assertTrue("not full match", calPaths.stream().noneMatch(calendarPrefix::matches));
+
+        PathMatcher chineseCalendars =
+            PathMatcher.of("//ldml/dates/calendars/calendar[@type=\"chinese\"]");
+        assertEquals("chinese data",
+            calPaths.stream().filter(chineseCalendars::matchesPrefixOf).collect(toList()),
+            Arrays.asList(chineseMon1, chineseMon2));
+
+        PathMatcher anyMonth = calendarPrefix
+            .withSuffix("months/monthContext[@type=*]/monthWidth[@type=*]/month[@type=*]");
+        assertEquals("any month",
+            calPaths.stream().filter(anyMonth::matches).collect(toList()),
+            Arrays.asList(chineseMon1, chineseMon2, genericMon1, genericMon2));
+
+        PathMatcher narrowMonth = calendarPrefix
+            .withSuffix("months/monthContext[@type=*]/monthWidth[@type=\"narrow\"]/month[@type=*]");
+        assertEquals("narrow month",
+            calPaths.stream().filter(narrowMonth::matches).collect(toList()),
+            Arrays.asList(genericMon1, genericMon2));
+
+        PathMatcher firstMonth = calendarPrefix
+            .withSuffix("months/monthContext[@type=*]/monthWidth[@type=*]/month[@type=\"1\"]");
+        assertEquals("narrow month",
+            calPaths.stream().filter(firstMonth::matches).collect(toList()),
+            Arrays.asList(chineseMon1, genericMon1));
+
+        PathMatcher fullMatch = PathMatcher.of("//ldml/dates"
+            + "/calendars/calendar[@type=\"generic\"]"
+            + "/months/monthContext[@type=\"stand-alone\"]"
+            + "/monthWidth[@type=\"narrow\"]"
+            + "/month[@type=\"2\"]");
+        assertEquals("full match",
+            calPaths.stream().filter(fullMatch::matches).collect(toList()),
+            Arrays.asList(genericMon2));
+    }
+
+    public void TestWildcardSegment() {
+        PathMatcher wildcard = PathMatcher.of("//ldml/dates"
+            + "/calendars/calendar[@type=\"generic\"]"
+            + "/*/*[@type=\"format\"]/*[@type=\"narrow\"]/*[@type=*]");
+
+        assertTrue("", wildcard.matches(monthInfo("generic", "format", "narrow", 1)));
+        assertTrue("", wildcard.matches(monthInfo("generic", "format", "narrow", 9)));
+        assertTrue("", wildcard.matches(dayInfo("generic", "format", "narrow", "sun")));
+
+        assertFalse("", wildcard.matches(monthInfo("chinese", "format", "narrow", 1)));
+        assertFalse("", wildcard.matches(monthInfo("generic", "stand-alone", "narrow", 1)));
+        assertFalse("", wildcard.matches(dayInfo("generic", "format", "wide", "mon")));
+    }
+
+    public void TestBadSpecifiers() {
+        assertInvalidPathSpecification("");
+        // Leading and trailing '/' are not permitted (they imply empty segments.
+        assertInvalidPathSpecification("/foo/");
+        assertInvalidPathSpecification("foo//bar");
+        assertInvalidPathSpecification("foo/bad segment name");
+        assertInvalidPathSpecification("foo/bar[type=*]");
+        assertInvalidPathSpecification("foo/bar[@type=**]");
+        assertInvalidPathSpecification("foo/bar[@type='double-quotes-only']");
+    }
+
+    private void assertInvalidPathSpecification(String spec) {
+        try {
+            PathMatcher.of(spec);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue("invalid spec: " + spec,
+                e.getMessage().startsWith("invalid path pattern")
+                    && e.getMessage().contains(spec));
+        }
+    }
+
+    private static CldrPath monthInfo(String type, String context, String width, int number) {
+        return CldrPath.parseDistinguishingPath(String.format(
+            "//ldml/dates/calendars/calendar[@type=\"%s\"]"
+                + "/months/monthContext[@type=\"%s\"]"
+                + "/monthWidth[@type=\"%s\"]"
+                + "/month[@type=\"%d\"]",
+            type, context, width, number));
+    }
+
+    private static CldrPath dayInfo(String type, String context, String width, String id) {
+        return CldrPath.parseDistinguishingPath(String.format(
+            "//ldml/dates/calendars/calendar[@type=\"%s\"]"
+                + "/days/dayContext[@type=\"%s\"]"
+                + "/dayWidth[@type=\"%s\"]"
+                + "/day[@type=\"%s\"]",
+            type, context, width, id));
+    }
+}

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/PrefixVisitorTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/PrefixVisitorTest.java
@@ -1,17 +1,15 @@
 package org.unicode.cldr.api;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.ibm.icu.dev.test.TestFmwk;
-import org.unicode.cldr.api.CldrData.PrefixVisitor;
-
-import java.util.ArrayList;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
 import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.unicode.cldr.api.CldrData.PrefixVisitor;
+
+import com.google.common.collect.ImmutableList;
+import com.ibm.icu.dev.test.TestFmwk;
 
 /**
  * Tests for the code which converts a sequence of path/value pairs into a nested sequence of path

--- a/tools/cldr-unittest/src/org/unicode/cldr/api/XmlDataSourceTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/api/XmlDataSourceTest.java
@@ -1,17 +1,14 @@
 package org.unicode.cldr.api;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ListMultimap;
-import com.ibm.icu.dev.test.TestFmwk;
+import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
+import static org.unicode.cldr.api.CldrDataType.BCP47;
+import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
+import static org.unicode.cldr.api.CldrDraftStatus.UNCONFIRMED;
 
-import java.io.File;
-import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -19,12 +16,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
-import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
-import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
-import static org.unicode.cldr.api.CldrDataType.BCP47;
-import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
-import static org.unicode.cldr.api.CldrDraftStatus.UNCONFIRMED;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.ibm.icu.dev.test.TestFmwk;
 
 /**
  * Tests XML file parsing and path/value generation. These focus on end-to-end parsing of fake data

--- a/tools/java/org/unicode/cldr/api/CldrData.java
+++ b/tools/java/org/unicode/cldr/api/CldrData.java
@@ -188,5 +188,14 @@ public interface CldrData {
          *               sub-hierarchy visitation.
          */
         default void visitPrefixEnd(CldrPath prefix) {}
+
+        /**
+         * Callback method invoked for each value encountered by this visitor. This is equivalent
+         * to the {@link ValueVisitor#visit(CldrValue)} method but is not normally needed for
+         * prefix visitors (which are expected to delegate to a separate ValueVisitor). This
+         * method is useful for implementing visitors with full coverage of all paths and values
+         * in the {@link CldrData} hierarchy.
+         */
+        default void visitValue(CldrValue value) {}
     }
 }

--- a/tools/java/org/unicode/cldr/api/FilteredData.java
+++ b/tools/java/org/unicode/cldr/api/FilteredData.java
@@ -1,0 +1,67 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package org.unicode.cldr.api;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Filters underlying {@link CldrData} source data to transform values or remove values on the fly.
+ * The order of transformed values produced by the class is the same order as the underlying data.
+ *
+ * <p>This class does not currently support injecting additional values due to the difficulty in
+ * ensuring correct ordering semantics.
+ *
+ * <p>A subclass should implement the {@link FilteredData#filter(CldrValue)} method to achieve the
+ * desired results. Note however that this API is currently unstable and is expected to change once
+ * DTD path ordering is enforced everywhere.
+ */
+// TODO: Once DTD ordering is the only allowed order, this can be extended to allow adding paths.
+public abstract class FilteredData implements CldrData {
+    private final CldrData src;
+
+    /** Constructs the parent class with a {@link CldrData} source. */
+    protected FilteredData(CldrData src) {
+        this.src = checkNotNull(src);
+    }
+
+    /** Returns the underlying source data to sub-class implementations. */
+    protected CldrData getSourceData() {
+        return src;
+    }
+
+    /**
+     * Returns a filtered CLDR value, replacing or removing the original value during visitation.
+     * The filtered value can only differ in its base value or value attributes, and must have
+     * the same {@link CldrPath} associated with it.
+     *
+     * @return the filtered value to be replaced, or {@code null} to remove the value.
+     */
+    protected abstract CldrValue filter(CldrValue value);
+
+    @Override
+    public final void accept(PathOrder order, ValueVisitor visitor) {
+        src.accept(order, v -> visitFiltered(v, visitor));
+    }
+
+    @Override
+    public final CldrValue get(CldrPath path) {
+        CldrValue value = src.get(path);
+        return value != null ? checkFiltered(value) : null;
+    }
+
+    private void visitFiltered(CldrValue value, ValueVisitor visitor) {
+        CldrValue filteredValue = checkFiltered(value);
+        if (filteredValue != null) {
+            visitor.visit(filteredValue);
+        }
+    }
+
+    private CldrValue checkFiltered(CldrValue value) {
+        CldrValue filteredValue = filter(value);
+        checkArgument(filteredValue == null || filteredValue.getPath().equals(value.getPath()),
+            "filtering is not permitted to modify distinguishing paths: source=%s, filtered=%s",
+            value, filteredValue);
+        return filteredValue;
+    }
+}

--- a/tools/java/org/unicode/cldr/api/PathMatcher.java
+++ b/tools/java/org/unicode/cldr/api/PathMatcher.java
@@ -1,0 +1,290 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package org.unicode.cldr.api;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkPositionIndex;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static org.unicode.cldr.api.AttributeKey.keyOf;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * An immutable matcher for {@link CldrPath} instances.
+ *
+ * <p>A path matcher pattern looks like:
+ * <ul>
+ *     <li>{@code //ldml/path/prefix/element[@attribute="value"]}
+ *     <li>{@code //ldml/path/prefix/element[@attribute=*]}
+ *     <li>{@code //ldml/path/prefix/*[@attribute="value"]}
+ *     <li>{@code //ldml/path/prefix/element[@foo=*]/*[@bar="value"]}
+ * </ul>
+ * where element names and attribute values can be wildcards. No capturing of wildcard values is
+ * done, and currently wildcards are limited to the entire field (element name, or attribute value).
+ *
+ * <h2>Matching an exact path</h2>
+ * <pre>{@code
+ * private static final PathMatcher ALIAS =
+ *     PathMatcher.of("//supplementalData/likelySubtags/likelySubtag[@from=*][@to=*]");
+ *
+ * ...
+ *
+ * if (ALIAS.matches(path)) {
+ *     // Path represents a subtag alias.
+ * }
+ * }</pre>
+ *
+ * <h2>Matching path prefixes and hierarchical matching</h2>
+ * <pre>{@code
+ * private static final PathMatcher KEY = PathMatcher.of("//ldmlBCP47/keyword/key[@name=\"ca\"]");
+ * private static final PathMatcher TYPE = key.withSuffix("type[@name=*]");
+ *
+ * ...
+ *
+ * if (KEY.matchesPrefixOf(path)) {
+ *     // Once the KEY prefix is matched, we can just "locally" match the suffix.
+ *     if (TYPE.locallyMatches(path)) {
+ *         // Path is a key-type mapping.
+ *     }
+ * }
+ * }</pre>
+ */
+public final class PathMatcher {
+    private static final Pattern ROOT_PATH_SPEC = Pattern.compile("//(\\w+)(/|$)");
+
+    /**
+     * Parses the full or partial (prefix) path pattern into a matcher. Path patterns given to this
+     * method must start with {@code "//xxx/..."} where {@code xxx} is a known CLDR XML path prefix
+     * (such as {@code "ldml"}).
+     */
+    public static PathMatcher of(String pattern) {
+        Matcher m = ROOT_PATH_SPEC.matcher(pattern);
+        checkArgument(m.lookingAt(), "invalid path pattern: %s", pattern);
+        // This throws IllegalArgumentException if the type isn't valid.
+        CldrDataType.forXmlName(m.group(1));
+        return new PathMatcher(null, parse(pattern.substring(2)));
+    }
+
+    private final Optional<PathMatcher> parent;
+    private final ImmutableList<Predicate<CldrPath>> elementMatchers;
+    private final int totalElementCount;
+
+    private PathMatcher(PathMatcher parent, List<Predicate<CldrPath>> elementMatchers) {
+        this.parent = Optional.ofNullable(parent);
+        this.elementMatchers = ImmutableList.copyOf(elementMatchers);
+        this.totalElementCount =
+            elementMatchers.size() + (parent != null ? parent.totalElementCount : 0);
+    }
+
+    /**
+     * Extends this matcher by the given path pattern suffix.
+     *
+     * <p>For example if we define:
+     * <pre>{@code
+     * private static final PathMatcher COLLATIONS = PathMatcher.of("//ldml/collations");
+     * private static final PathMatcher RULE = COLLATIONS.extendBy("collation/cr");
+     * }</pre>
+     * Then {@code RULE} would match paths like {@code "//ldml/collations/collation/cr"}.
+     */
+    public PathMatcher withSuffix(String pattern) {
+        return new PathMatcher(this, parse(pattern));
+    }
+
+    /**
+     * Returns whether this matcher fully matches the given path, including taking into account
+     * any parent matchers from which this matcher might have been extended.
+     */
+    public boolean matches(CldrPath path) {
+        if (!locallyMatches(path)) {
+            return false;
+        }
+        if (!parent.isPresent()) {
+            // No parent means this is a "root" matcher, so we've finished matching everything.
+            return true;
+        }
+        while (path.getLength() > totalElementCount - elementMatchers.size()) {
+            path = path.getParent();
+        }
+        return parent.get().locallyMatches(path);
+    }
+
+    /**
+     * Returns whether this matcher matches a proper prefix of the given path, including taking
+     * into account any parent matchers from which this matcher might have been extended. Note that
+     * the matcher for {@code "//ldml/foo/bar"} is not considered a prefix match for the path
+     * {@code //ldml/foo/barbaz}, since partial matching of an element name is not allowed.
+     */
+    public boolean matchesPrefixOf(CldrPath path) {
+        if (path.getLength() < totalElementCount) {
+            return false;
+        }
+        while (path.getLength() > totalElementCount) {
+            path = path.getParent();
+        }
+        return matches(path);
+    }
+
+    /**
+     * Returns whether this matcher matches the given path only in relation to the pattern
+     * used to generate this matcher. This method is useful for nested visitation via {@link
+     * org.unicode.cldr.api.CldrData.PrefixVisitor PrefixVisitor} when path prefixes are visited
+     * before values.
+     *
+     * <p>This method assumes that any parent matchers from which this matcher was extended already
+     * match the path. The possible length of the parent matchers is taken into account however to
+     * ensure that the sub-sequence match for this matcher starts at the correct point in the path.
+     */
+    public boolean locallyMatches(CldrPath path) {
+        return (path.getLength() == totalElementCount)
+            && matchRegion(path, totalElementCount - elementMatchers.size());
+    }
+
+    private boolean matchRegion(CldrPath path, int offset) {
+        // offset is the path element corresponding the the "top most" element matcher, it
+        // must be in the range 0 ... (path.length() - elementMatchers.size()).
+        checkPositionIndex(offset, path.getLength() - elementMatchers.size());
+        // First jump over the path parents until we find the last matcher.
+        int matchPathLength = offset + elementMatchers.size();
+        while (path.getLength() > matchPathLength) {
+            path = path.getParent();
+        }
+        return matchForward(path, elementMatchers.size() - 1);
+    }
+
+    private boolean matchForward(CldrPath path, int matcherIndex) {
+        if (matcherIndex < 0) {
+            return true;
+        }
+        return matchForward(path.getParent(), matcherIndex - 1)
+            && elementMatchers.get(matcherIndex).test(path);
+    }
+
+    // --- Parsing of matcher path patterns ----
+
+    // Make a new, non-interned, unique instance here which we can test by reference to
+    // determine if the argument is to be captured (needed as ImmutableMap prohibits null).
+    // DO NOT change this code to assign "*" as the value directly, it MUST be a new instance.
+    @SuppressWarnings("StringOperationCanBeSimplified")
+    private static final String WILDCARD = new String("*");
+
+    private static final Pattern ELEMENT_START_REGEX =
+        Pattern.compile("(\\*|[-:\\w]+)(?:/|\\[|$)");
+    private static final Pattern ATTRIBUTE_REGEX =
+        Pattern.compile("\\[@([-:\\w]+)=(?:\\*|\"([^\"]*)\")]");
+
+    // element := foo, foo[@bar="baz"], foo[@bar=*]
+    // pathspec := element{/element}*
+    private static List<Predicate<CldrPath>> parse(String pattern) {
+        List<Predicate<CldrPath>> specs = new ArrayList<>();
+        int pos = 0;
+        do {
+            pos = parse(pattern, pos, specs);
+        } while (pos >= 0);
+        return specs;
+    }
+
+    // Return next start index or -1.
+    private static int parse(String pattern, int pos, List<Predicate<CldrPath>> specs) {
+        Matcher m = ELEMENT_START_REGEX.matcher(pattern).region(pos, pattern.length());
+        checkArgument(m.lookingAt(), "invalid path pattern (index=%s): %s", pos, pattern);
+        String name = m.group(1);
+        Map<String, String> attributes = ImmutableMap.of();
+        pos = m.end(1);
+        if (pos < pattern.length() && pattern.charAt(pos) == '[') {
+            // We have attributes to add.
+            attributes = new LinkedHashMap<>();
+            do {
+                m = ATTRIBUTE_REGEX.matcher(pattern).region(pos, pattern.length());
+                checkArgument(m.lookingAt(),
+                    "invalid path pattern (index=%s): %s", pos, pattern);
+                // Null if we matched the '*' wildcard.
+                String value = m.group(2);
+                attributes.put(m.group(1), value != null ? value : WILDCARD);
+                pos = m.end();
+            } while (pos < pattern.length() && pattern.charAt(pos) == '[');
+        }
+        // Wildcard matching is less efficient because attribute keys cannot be made in advance, so
+        // since it's also very rare, we special case it.
+        Predicate<CldrPath> matcher = name.equals(WILDCARD)
+            ? new WildcardElementMatcher(attributes)::match
+            : new ElementMatcher(name, attributes)::match;
+        specs.add(matcher);
+        if (pos == pattern.length()) {
+            return -1;
+        }
+        checkState(pattern.charAt(pos) == '/',
+            "invalid path pattern (index=%s): %s", pos, pattern);
+        return pos + 1;
+    }
+
+    // Matcher for path elements like "foo[@bar=*]" where the name is known in advance.
+    private static final class ElementMatcher {
+        private final String name;
+        private final ImmutableMap<AttributeKey, String> attributes;
+
+        private ElementMatcher(String name, Map<String, String> attributes) {
+            this.name = checkNotNull(name);
+            this.attributes = attributes.entrySet().stream()
+                .collect(toImmutableMap(e -> keyOf(name, e.getKey()), Map.Entry::getValue));
+        }
+
+        @SuppressWarnings("StringEquality")
+        boolean match(CldrPath path) {
+            if (!path.getName().equals(name)) {
+                return false;
+            }
+            for (Map.Entry<AttributeKey, String> e : attributes.entrySet()) {
+                String actual = path.get(e.getKey());
+                if (actual == null) {
+                    return false;
+                }
+                String expected = e.getValue();
+                // DO NOT change this to use expected.equals(WILDCARD).
+                if (expected != WILDCARD && !expected.equals(actual)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    // Matcher for path elements like "*[@bar=*]", where the name isn't known until match time.
+    private static final class WildcardElementMatcher {
+        private final ImmutableMap<String, String> attributes;
+
+        private WildcardElementMatcher(Map<String, String> attributes) {
+            this.attributes = ImmutableMap.copyOf(attributes);
+        }
+
+        @SuppressWarnings("StringEquality")
+        private boolean match(CldrPath path) {
+            // The wildcard matcher never fails due to the element name but must create new key
+            // instances every time matching occurs (because the key name is dynamic). Since this
+            // is rare, it's worth making into a separate case.
+            for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                String actual = path.get(keyOf(path.getName(), attribute.getKey()));
+                if (actual == null) {
+                    return false;
+                }
+                String expected = attribute.getValue();
+                // DO NOT change this to use expected.equals(WILDCARD).
+                if (expected != WILDCARD && !expected.equals(actual)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
These utilities are needed for the upcoming pseudo-locale support (moving from ICU project).

The PathMatcher API is intended to be fairly "final" at this stage. There's still a somewhat different/worse PathMatcher API in the ICU project, but I'll be migrating the ICU tools across to use this version later.

As such there's still the potential for an additional method or two being added to that class, but the methods that are already there should be stable, so please give it a look as regards docs and behaviour.

The FilteredData class is much simpler, but definitely not stable yet (as explained in the docs). However it's needed for the pseudo-locale support (coming soon) _and_ the alternate path support (which is for now staying in ICU project). This is why this is a public class, which I wouldn't have done otherwise. The alternate path stuff is not stable or general-case enough to be in the CLDR project yet.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13388
- [x] Updated PR title and link in previous line to include Issue number

