### PR TITLE
CLDR-13390 Votes for identical inheritance and hard values

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
@@ -513,7 +513,7 @@ public class TestSTFactory extends TestFmwk {
 
                     Status xpathStatus;
                     CLDRFile.Status newPath = new CLDRFile.Status();
-                    CLDRLocale newLocale = CLDRLocale.getInstance(cf.getSourceLocaleID(fullXpath, newPath));
+                    CLDRLocale newLocale = CLDRLocale.getInstance(cf.getSourceLocaleIdExtended(fullXpath, newPath, false));
                     final boolean localeChanged = newLocale != null && !newLocale.equals(locale);
                     final boolean pathChanged = newPath.pathWhereFound != null && !newPath.pathWhereFound.equals(xpath);
                     final boolean itMoved = localeChanged || pathChanged;

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
@@ -154,6 +154,34 @@
  	<verify status="approved" locale="und_ZZ" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/eras/eraNarrow/era[@type='0']">BBB</verify> <!--  only one vote for AAA now -->
     <vote name="E" locale="und_ZZ" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/eras/eraNarrow/era[@type='0']">↑↑↑</vote> <!--  effective vote for AAA -->
  	<verify status="approved" locale="und_ZZ" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/eras/eraNarrow/era[@type='0']">AAA</verify> <!--  not split- inheritance goes w/ AAA -->
+
+	<!-- Make sure Bailey is determined correctly and inheritance is combined with Bailey.
+	     This scenario is based on one for which a bug was encountered previously.
+	     Reference: https://unicode-org.atlassian.net/browse/CLDR-13390
+	     Four vetters, two of them (G1, G2) in the same organization (Google).-->
+	<user name="F1" org="facebook" level="vetter" locales="*"/>
+	<user name="M1" org="microsoft" level="vetter" locales="*"/>
+	<user name="G1" org="google" level="vetter" locales="*"/>
+	<user name="G2" org="google" level="vetter" locales="*"/>
+
+	<!-- TC vote for aprel for the 'format' path should make aprel the Bailey for the 'stand-alone' path. -->
+	<user name="TC1" org="afrigen" level="tc" locales="*"/>
+	<vote name="TC1" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='format']/monthWidth[@type='wide']/month[@type='4']">aprel</vote>
+
+	<!-- The four vetters vote as follows:
+			F1 aprel
+			M1 Aprel
+			G1 Aprel
+			G2 ↑↑↑
+		Assume the path with 'stand-alone' inherits from the path with 'format' in the same locale.
+		Baseline is Aprel (per az.xml). -->
+	<vote name="F1" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='wide']/month[@type='4']">aprel</vote>
+	<vote name="M1" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='wide']/month[@type='4']">Aprel</vote>
+	<vote name="G1" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='wide']/month[@type='4']">Aprel</vote>
+	<vote name="G2" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='wide']/month[@type='4']">↑↑↑</vote>
+
+	<!-- G1 Aprel should be eliminated. G2 ↑↑↑ should combine with F1 aprel to beat M1 Aprel.
+		Winner should be ↑↑↑, and ↑↑↑ resolves to the Bailey value aprel. -->
+	<verify status="approved" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='wide']/month[@type='4']" >aprel</verify>
 	
- 
 </TestSTFactory>

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -1075,11 +1075,6 @@ public class DataSection implements JSONString {
             /*
              * Set the inheritedValue field of the DataRow containing this CandidateItem.
              * Also possibly set the inheritedLocale and pathWhereFound fields of the DataRow.
-             *
-             * TODO: fix bug, return value of getConstructedBaileyValue here gives
-             * inheritedValue = "Chineesisch (Veräifachti Chineesischi Schrift)"
-             * but getResolverInternal gets baileyValue = "Veräifachts Chineesisch".
-             * That's for http://localhost:8080/cldr-apps/v#/gsw_FR/Languages_A_D/3f16ed8804cebb7d
              */
             Output<String> inheritancePathWhereFound = new Output<String>(); // may become pathWhereFound
             Output<String> localeWhereFound = new Output<String>(); // may be used to construct inheritedLocale


### PR DESCRIPTION
-In getResolverInternal call CLDRFile.getConstructedBaileyValue as DataSection does

-New regression test in TestSTFactory.xml

-Use getSourceLocaleIdExtended with skip=false to avoid spurious warning in TestSTFactory.xml

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13390
- [x] Updated PR title and link in previous line to include Issue number

