### PR TITLE
CLDR-13253 Add grammatical features schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Copyright &copy; 1991-2019 Unicode, Inc.
 All rights reserved.
 [Terms of use](http://www.unicode.org/copyright.html)
 
+<!-- Ignore! -->

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -10,7 +10,7 @@ Except as contained in this notice, the name of a copyright holder shall not be 
     $Revision$
 -->
 
-<!ELEMENT supplementalData ( version, generation?, cldrVersion?, currencyData?, territoryContainment?, subdivisionContainment?, languageData?, territoryInfo?, postalCodeData?, calendarData?, calendarPreferenceData?, weekData?, timeData?, measurementData?, unitPreferenceData?, timezoneData?, characters?, transforms?, metadata?, codeMappings?, parentLocales?, likelySubtags?, metazoneInfo?, plurals?, telephoneCodeData?, numberingSystems?, bcp47KeywordMappings?, gender?, references?, languageMatching?, dayPeriodRuleSet*, metaZones?, primaryZones?, windowsZones?, coverageLevels?, idValidity?, rgScope?, languageGroups? ) >
+<!ELEMENT supplementalData ( version, generation?, cldrVersion?, currencyData?, territoryContainment?, subdivisionContainment?, languageData?, territoryInfo?, postalCodeData?, calendarData?, calendarPreferenceData?, weekData?, timeData?, measurementData?, unitPreferenceData?, timezoneData?, characters?, transforms?, metadata?, codeMappings?, parentLocales?, likelySubtags?, metazoneInfo?, plurals?, telephoneCodeData?, numberingSystems?, bcp47KeywordMappings?, gender?, references?, languageMatching?, dayPeriodRuleSet*, metaZones?, primaryZones?, windowsZones?, coverageLevels?, idValidity?, rgScope?, languageGroups?, grammaticalData? ) >
 
 <!ELEMENT version EMPTY >
     <!--@METADATA-->
@@ -1154,3 +1154,32 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ELEMENT languageGroup ( #PCDATA ) >
 <!ATTLIST languageGroup parent NMTOKEN #REQUIRED >
 	<!--@MATCH:validity/language-->
+
+<!-- # Grammatical Features -->
+<!ELEMENT grammaticalData ( grammaticalFeatures* )>
+
+<!ELEMENT grammaticalFeatures ( grammaticalCase?, grammaticalGender?, grammaticalDefiniteness?, grammaticalState? ) >
+<!ATTLIST grammaticalFeatures targets NMTOKENS #REQUIRED >
+    <!--@MATCH:set/literal/nominal-->
+<!ATTLIST grammaticalFeatures locales NMTOKENS #REQUIRED >
+    <!--@MATCH:set/validity/language-->
+
+<!ELEMENT grammaticalCase EMPTY>
+<!ATTLIST grammaticalCase values NMTOKENS #REQUIRED >
+    <!--@VALUE-->
+    <!--@MATCH:set/literal/ablative, accusative, comitative, dative, ergative, genitive, instrumental, locative, locativecopulative, nominative, oblique, partitive, prepositional, sociative, vocative-->
+
+<!ELEMENT grammaticalGender EMPTY>
+<!ATTLIST grammaticalGender values NMTOKENS #REQUIRED >
+    <!--@VALUE-->
+    <!--@MATCH:set/literal/animate, common, feminine, inanimate, masculine, neuter, personal-->
+
+<!ELEMENT grammaticalDefiniteness EMPTY>
+<!ATTLIST grammaticalDefiniteness values NMTOKENS #REQUIRED >
+    <!--@VALUE-->
+    <!--@MATCH:set/literal/definite, indefinite, unspecified-->
+
+<!ELEMENT grammaticalState EMPTY>
+<!ATTLIST grammaticalState values NMTOKENS #REQUIRED >
+    <!--@VALUE-->
+    <!--@MATCH:set/literal/construct, definite, indefinite-->

--- a/common/supplemental/grammaticalFeatures.xml
+++ b/common/supplemental/grammaticalFeatures.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE supplementalData SYSTEM "../../common/dtd/ldmlSupplemental.dtd">
+<!--
+Copyright © 2019 Unicode, Inc.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+For terms of use, see http://www.unicode.org/copyright.html
+-->
+
+<!--
+
+These are the grammatical features that are used in each locale to mark inflected forms of nouns.
+
+CLDR textual items may be tagged with grammatical features when these are needed to ensure that the
+correct forms are used in context.
+
+For instance, in Russian "Уменьши яркость света до 10 процентов" ("dim the light to 10 percent"),
+the 'percent' unit must be expressed in plural and in the genitive case, whereas "1%" would be
+expressed in different cases depending on the context. The case usage is implicit in short form
+"10%", but the full form requires the grammatical variant marked by case and number to be expressed
+correctly.
+
+In romance languages, nouns such as unit names have an intrinsic grammatical gender, which
+propagates by agreement to other parts of sentence. For example, in French "2 jours sont passés"
+("two days have gone by") expresses the participle "passés" in the plural masculine form, whereas
+"2 heures sont passées" requires the participle in the plural feminine form to agree with the
+grammatical gender of the unit "h", even when short forms are used.
+
+Note that plural status is not included here: CLDR handles plurals with special categories in
+plurals.xml and ordinals.xml. See those files and the LDML spec for more information.
+
+-->
+
+<supplementalData>
+  <version number="$Revision: 1 $"/>
+  <grammaticalData>
+    <grammaticalFeatures targets="nominal" locales="en fil ja ms th tl vi zh">
+      <!-- No grammatical features (number is not considered). -->
+      <!-- Note both fil and tl are included -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="es fr it pt">
+      <grammaticalGender values="masculine feminine"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="nl">
+      <grammaticalGender values="common neuter"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="te">
+      <grammaticalCase values="nominative oblique accusative dative locative instrumental"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="ta">
+      <grammaticalCase values="nominative genitive accusative dative locative instrumental ablative vocative"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="tr">
+      <grammaticalCase values="nominative genitive dative accusative instrumental ablative locative"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="id">
+      <grammaticalDefiniteness values="definite indefinite"/>
+      <!-- Indonesian nouns inflect in a possessive expression, with agreement on person. -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="de">
+      <grammaticalCase values="nominative genitive dative accusative"/>
+      <grammaticalGender values="masculine feminine neuter"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="hi pa ur">
+      <grammaticalCase values="nominative oblique"/>
+      <grammaticalGender values="masculine feminine"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="ml">
+      <grammaticalCase values="nominative genitive dative accusative instrumental locative comitative locativecopulative sociative"/>
+      <grammaticalGender values="animate inanimate feminine neuter"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="mr">
+      <grammaticalCase values="nominative oblique accusative dative ergative locative ablative genitive"/>
+      <grammaticalGender values="masculine feminine neuter"/>
+      <!-- Genitive agrees in gender, case and number with the antecedent. -->
+      <!-- Oblique can be further inflected by semantics-defining suffixes. -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="gu kn">
+      <grammaticalCase values="nominative genitive accusative dative locative instrumental vocative"/>
+      <grammaticalGender values="masculine feminine neuter"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="he">
+      <grammaticalGender values="masculine feminine"/>
+      <grammaticalState values="definite indefinite construct"/>
+      <!-- Note that Hebrew nouns also inflect in possessives, with agreement on person, number and gender -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="ar">
+      <grammaticalCase values="nominative genitive accusative"/>
+      <grammaticalGender values="masculine feminine"/>
+      <grammaticalState values="definite indefinite construct"/>
+      <!-- Note that Arabic nouns also inflect in possessives, with agreement on person, number and gender -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="bn">
+      <grammaticalCase values="nominative accusative genitive locative"/>
+      <grammaticalGender values="masculine feminine"/>
+      <grammaticalDefiniteness values="definite indefinite"/>
+      <!-- Gender is only used for expressing human activities/professions. -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="da">
+      <grammaticalCase values="nominative genitive"/>
+      <grammaticalGender values="common neuter"/>
+      <grammaticalDefiniteness values="definite indefinite unspecified"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="sv">
+      <grammaticalCase values="nominative genitive"/>
+      <grammaticalGender values="common neuter"/>
+      <grammaticalDefiniteness values="definite indefinite"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="nb ro">
+      <grammaticalCase values="nominative genitive"/>
+      <grammaticalGender values="masculine feminine neuter"/>
+      <grammaticalDefiniteness values="definite indefinite"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="cs sk">
+      <grammaticalCase values="nominative genitive dative accusative instrumental vocative locative"/>
+      <grammaticalGender values="animate inanimate feminine neuter"/>
+      <!-- Czech also inflects in polarity (negation is a prefix) -->
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="ru">
+      <grammaticalCase values="nominative genitive dative accusative instrumental prepositional partitive vocative locative"/>
+      <grammaticalGender values="masculine feminine neuter"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="pl">
+      <grammaticalCase values="nominative genitive dative accusative instrumental prepositional partitive vocative locative"/>
+      <grammaticalGender values="animate inanimate personal feminine neuter"/>
+    </grammaticalFeatures>
+  </grammaticalData>
+</supplementalData>

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestDtdData.java
@@ -563,7 +563,8 @@ public class TestDtdData extends TestFmwk {
                 || elementName.equals("languageMatch")
                     && (attribute.equals("desired") || attribute.equals("supported"))
                 || (elementName.equals("transform") && (attribute.equals("source") || attribute.equals("target") || attribute.equals("direction") || attribute
-                    .equals("variant")));
+                    .equals("variant")))
+		|| (elementName.equals("grammaticalFeatures") && (attribute.equals("locales") || attribute.equals("targets")));
 
         case keyboard:
             return attribute.equals("_q")

--- a/tools/java/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/java/org/unicode/cldr/util/data/PathHeader.txt
@@ -422,6 +422,11 @@
 //supplementalData/dayPeriodRuleSet[@type="%A"]/dayPeriodRules[@locales="%A"]/dayPeriodRule[@type="%A"]/_%E			; Supplemental ; DayPeriod ; $1-$2 ; $3-$4 ; HIDE
 //supplementalData/dayPeriodRuleSet/dayPeriodRules[@locales="%A"]/dayPeriodRule[@type="%A"]/_%E			; Supplemental ; DayPeriod ; $1 ; $2-$3 ; HIDE
 
+//supplementalData/grammaticalData/grammaticalFeatures[@locales="%A"][@targets="%A"]/grammaticalCase/%E ; Supplemental ; Grammar ; Case ; $1-$2 ; HIDE
+//supplementalData/grammaticalData/grammaticalFeatures[@locales="%A"][@targets="%A"]/grammaticalDefiniteness/%E ; Supplemental ; Grammar ; Definiteness ; $1-$2 ; HIDE
+//supplementalData/grammaticalData/grammaticalFeatures[@locales="%A"][@targets="%A"]/grammaticalGender/%E ; Supplemental ; Grammar ; Gender ; $1-$2 ; HIDE
+//supplementalData/grammaticalData/grammaticalFeatures[@locales="%A"][@targets="%A"]/grammaticalState/%E ; Supplemental ; Grammar ; State ; $1-$2 ; HIDE
+
 # Ultimate fallback (Error)
 //supplementalData/%S/(.*)                                                                              ; Supplemental ; Unknown ; $1 ; $2 ; DEPRECATED
 //supplementalData/(.*)                                                                                 ; Supplemental ; Unknown ; Unknown ; $2 ; DEPRECATED


### PR DESCRIPTION
This adds schema elements and values to tag nominal phrases with their grammatical attributes across 35 languages (namely ar bn cs da de en es fil(tl) fr gu he hi id it ja kn ml mr ms nb nl pa pl pt ro ru sk sv ta te th tr ur vi zh)

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13253
- [x] Updated PR title and link in previous line to include Issue number

