### PR TITLE
CLDR-13422 Add autonyms for 14 seed locales that lack them

### DIFF
--- a/seed/main/ba.xml
+++ b/seed/main/ba.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="ba"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="ba" draft="contributed">башҡорт теле</language>
+		</languages>
+	</localeDisplayNames>
 	<layout>
 		<orientation>
 			<characterOrder>left-to-right</characterOrder>

--- a/seed/main/co.xml
+++ b/seed/main/co.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="co"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="co" draft="contributed">corsu</language>
+		</languages>
+	</localeDisplayNames>
 	<layout>
 		<orientation>
 			<characterOrder>left-to-right</characterOrder>

--- a/seed/main/gaa.xml
+++ b/seed/main/gaa.xml
@@ -37,6 +37,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fr" draft="unconfirmed">Frɛntsi</language>
 			<language type="fr_CA" draft="unconfirmed">Kanada Frɛntsi</language>
 			<language type="fr_CH" draft="unconfirmed">Switzerland Frɛntsi</language>
+			<language type="gaa" draft="contributed">Gã</language>
 			<language type="hi" draft="unconfirmed">Hindi</language>
 			<language type="id" draft="unconfirmed">Indonesian</language>
 			<language type="it" draft="unconfirmed">Italian</language>

--- a/seed/main/gn.xml
+++ b/seed/main/gn.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="gn"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="gn" draft="contributed">avañe’ẽ</language>
+		</languages>
+	</localeDisplayNames>
 	<layout>
 		<orientation>
 			<characterOrder>left-to-right</characterOrder>

--- a/seed/main/io.xml
+++ b/seed/main/io.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="io"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="io" draft="contributed">Ido</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a b c d e f g h i j k l m n o p q r s t u v w x y z]</exemplarCharacters>
 		<exemplarCharacters type="index">[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z]</exemplarCharacters>

--- a/seed/main/jbo.xml
+++ b/seed/main/jbo.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="jbo"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="jbo" draft="contributed">la .lojban.</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a b c d e f g h i j k l m n o p r s t u v x y z]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[q w]</exemplarCharacters>

--- a/seed/main/kaj.xml
+++ b/seed/main/kaj.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="kaj"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="kaj" draft="contributed">Kaje</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters draft="unconfirmed">[a b c d e f g h i j k l m n o p q r s t u v w x y z]</exemplarCharacters>
 		<exemplarCharacters type="index" draft="unconfirmed">[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z]</exemplarCharacters>

--- a/seed/main/kcg.xml
+++ b/seed/main/kcg.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="kcg"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="kcg" draft="contributed">Katab</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters draft="unconfirmed">[a {a\u0331} b {ch} {chy} d e f g {gb} {gh} {ghw} {ghy} i {i\u0331} j {jhy} k {kh} {kp} l m n {ng} {ny} o p r s {sh} {shy} t {ts} u v w y z]</exemplarCharacters>
 		<exemplarCharacters type="index" draft="unconfirmed">[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z]</exemplarCharacters>

--- a/seed/main/kpe.xml
+++ b/seed/main/kpe.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="kpe"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="kpe" draft="contributed">Kpɛlɛɛ</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a b ɓ d e ə ɛ f g ĝ {gb} {gw} ɣ h i j k {kp} {kw} l m n {ny} ɲ ŋ {ŋw} o ɔ p t u v w y z]</exemplarCharacters>
 		<exemplarCharacters type="index" draft="unconfirmed">[A B Ɓ C D E Ə Ɛ F G Ɣ H I J K L M N Ɲ Ŋ O Ɔ P Q R S T U V W X Y Z]</exemplarCharacters>

--- a/seed/main/nqo.xml
+++ b/seed/main/nqo.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="nqo"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="nqo" draft="contributed">ߒߞߏ</language>
+		</languages>
+	</localeDisplayNames>
 	<layout>
 		<orientation>
 			<characterOrder>right-to-left</characterOrder>

--- a/seed/main/ny.xml
+++ b/seed/main/ny.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="ny"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="ny" draft="contributed">Nyanja</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a b c d e f g h i j k l m n o p r s t u w ŵ y z]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[q v x]</exemplarCharacters>

--- a/seed/main/scn.xml
+++ b/seed/main/scn.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="scn"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="scn" draft="contributed">sicilianu</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a à â b c d ḍ e è ê f g h i í î j l m n o ò ô p q r s t u ú û v z]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[ç đ é ë ə ḥ ì k š ù w x y]</exemplarCharacters>

--- a/seed/main/trv.xml
+++ b/seed/main/trv.xml
@@ -24,6 +24,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="pt_BR" draft="provisional">patas Pajey</language>
 			<language type="ru" draft="provisional">patas Ruski</language>
 			<language type="sr" draft="provisional">patas Srpian</language>
+			<language type="trv" draft="contributed">patas Taroko</language>
 			<language type="und" draft="provisional">Ini klayna patas ni</language>
 			<language type="ur" draft="provisional">patas Yurtu</language>
 			<language type="zh" draft="provisional">patas Ipaw</language>

--- a/seed/main/wa.xml
+++ b/seed/main/wa.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="wa"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="wa" draft="contributed">walon</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a à â å æ b c ç d e é è ê ë f g h i î ï j k l m n o ô œ p q r s t u ù û ü v w x y ÿ z]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[á ä ã ā ē í ì ī ñ ó ò ö ø ú ǔ]</exemplarCharacters>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13422
- [x] Updated PR title and link in previous line to include Issue number

Add language autonyms for 14 seed locales that lack them. The names are from sources such as Wikipedia. For locales that already had other language names in a particular form (such as trv Taroko), match that form.