### PR TITLE
CLDR-13421 Add some alt=menu/variant names for ars, ckb

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">المابودونغونية</language>
 			<language type="arp">الأراباهو</language>
 			<language type="ars">اللهجة النجدية</language>
+			<language type="ars" alt="menu">العربية، النجدية</language>
 			<language type="arw">الأراواكية</language>
 			<language type="as">الأسامية</language>
 			<language type="asa">الآسو</language>
@@ -105,6 +106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">الشيروكي</language>
 			<language type="chy">الشايان</language>
 			<language type="ckb">السورانية الكردية</language>
+			<language type="ckb" alt="menu">الكردية، السورانية</language>
 			<language type="co">الكورسيكية</language>
 			<language type="cop">القبطية</language>
 			<language type="cr">الكرى</language>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -113,6 +113,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">xeiene</language>
 			<language type="ckb">kurd central</language>
+			<language type="ckb" alt="variant">kurd sorani</language>
 			<language type="co">cors</language>
 			<language type="cop">copte</language>
 			<language type="cr">cree</language>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">mapudungun</language>
 			<language type="arp">arapaho</language>
 			<language type="ars">Najd-arabisk</language>
+			<language type="ars" alt="menu">arabisk, najdi</language>
 			<language type="arw">arawak</language>
 			<language type="as">assamesisk</language>
 			<language type="asa">asu</language>
@@ -105,6 +106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">sorani</language>
+			<language type="ckb" alt="menu">kurdisk, sorani</language>
 			<language type="co">korsikansk</language>
 			<language type="cop">koptisk</language>
 			<language type="cr">cree</language>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -122,6 +122,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Cherokee</language>
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Zentralkurdisch</language>
+			<language type="ckb" alt="menu" draft="contributed">Kurdisch (Sorani)</language>
 			<language type="co">Korsisch</language>
 			<language type="cop">Koptisch</language>
 			<language type="cps">Capiznon</language>

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -17,6 +17,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ach">Acholi-Sprache</language>
 			<language type="ar_001">Modernes Hocharabisch</language>
 			<language type="ars">Nadschd-Arabisch</language>
+			<language type="ars" alt="menu">Arabisch (Nadschd)</language>
 			<language type="bas">Basaa-Sprache</language>
 			<language type="be">Weissrussisch</language>
 			<language type="bik">Bikol-Sprache</language>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -52,6 +52,7 @@ annotations.
 			<language type="arp">Arapaho</language>
 			<language type="arq">Algerian Arabic</language>
 			<language type="ars">Najdi Arabic</language>
+			<language type="ars" alt="menu">Arabic, Najdi</language>
 			<language type="arw">Arawak</language>
 			<language type="ary">Moroccan Arabic</language>
 			<language type="arz">Egyptian Arabic</language>
@@ -126,6 +127,8 @@ annotations.
 			<language type="chy">Cheyenne</language>
 			<language type="cic">Chickasaw</language>
 			<language type="ckb">Central Kurdish</language>
+			<language type="ckb" alt="menu">Kurdish, Central</language>
+			<language type="ckb" alt="variant">Kurdish, Sorani</language>
 			<language type="co">Corsican</language>
 			<language type="cop">Coptic</language>
 			<language type="cps">Capiznon</language>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -122,6 +122,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">sorani</language>
+			<language type="ckb" alt="menu">kurdi – soranî</language>
 			<language type="co">korsika</language>
 			<language type="cop">kopti</language>
 			<language type="cps">capiznon</language>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -122,6 +122,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">sorani</language>
+			<language type="ckb" alt="menu">kurde sorani</language>
 			<language type="co">corse</language>
 			<language type="cop">copte</language>
 			<language type="cps">capiznon</language>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">मापूचे</language>
 			<language type="arp">अरापाहो</language>
 			<language type="ars">नज्दी अरबी</language>
+			<language type="ars" alt="menu">अरबी, नज्दी</language>
 			<language type="arw">अरावक</language>
 			<language type="as">असमिया</language>
 			<language type="asa">असु</language>
@@ -97,6 +98,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">चेरोकी</language>
 			<language type="chy">शेयेन्न</language>
 			<language type="ckb">सोरानी कुर्दिश</language>
+			<language type="ckb" alt="menu">कुर्दी, सोरानी</language>
 			<language type="co">कोर्सीकन</language>
 			<language type="cop">कॉप्टिक</language>
 			<language type="cr">क्री</language>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">mapuche</language>
 			<language type="arp">arapaho</language>
 			<language type="ars">najdi arapski</language>
+			<language type="ars" alt="menu">arapski, najdi</language>
 			<language type="arw">aravački</language>
 			<language type="as">asamski</language>
 			<language type="asa">asu</language>
@@ -106,6 +107,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">čerokijski</language>
 			<language type="chy">čejenski</language>
 			<language type="ckb">soranski kurdski</language>
+			<language type="ckb" alt="menu">kurdski, sorani</language>
 			<language type="co">korzički</language>
 			<language type="cop">koptski</language>
 			<language type="cr">cree</language>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">mapucse</language>
 			<language type="arp">arapaho</language>
 			<language type="ars">nedzsdi arab</language>
+			<language type="ars" alt="menu">arab, nedzsdi</language>
 			<language type="arw">aravak</language>
 			<language type="as">asszámi</language>
 			<language type="asa">asu</language>
@@ -105,6 +106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cseroki</language>
 			<language type="chy">csejen</language>
 			<language type="ckb">közép-ázsiai kurd</language>
+			<language type="ckb" alt="menu" draft="contributed">kurd, szoráni</language>
 			<language type="co">korzikai</language>
 			<language type="cop">kopt</language>
 			<language type="cr">krí</language>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -49,6 +49,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">アラパホー語</language>
 			<language type="arq">アルジェリア・アラビア語</language>
 			<language type="ars">ナジュド地方・アラビア語</language>
+			<language type="ars" alt="menu">アラビア語（ナジュド地方）</language>
 			<language type="arw">アラワク語</language>
 			<language type="ary">モロッコ・アラビア語</language>
 			<language type="arz">エジプト・アラビア語</language>
@@ -122,6 +123,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">チェロキー語</language>
 			<language type="chy">シャイアン語</language>
 			<language type="ckb">中央クルド語</language>
+			<language type="ckb" alt="menu">クルド語（中央）</language>
+			<language type="ckb" alt="variant">クルド語（ソラニー）</language>
 			<language type="co">コルシカ語</language>
 			<language type="cop">コプト語</language>
 			<language type="cps">カピス語</language>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -110,6 +110,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">체로키어</language>
 			<language type="chy">샤이엔어</language>
 			<language type="ckb">소라니 쿠르드어</language>
+			<language type="ckb" alt="menu">쿠르드어(소라니)</language>
 			<language type="co">코르시카어</language>
 			<language type="cop">콥트어</language>
 			<language type="cr">크리어</language>

--- a/common/main/nb.xml
+++ b/common/main/nb.xml
@@ -49,6 +49,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">arapaho</language>
 			<language type="arq">algerisk arabisk</language>
 			<language type="ars">najdi-arabisk</language>
+			<language type="ars" alt="menu">arabisk (najd)</language>
 			<language type="arw">arawak</language>
 			<language type="ary">marokkansk-arabisk</language>
 			<language type="arz">egyptisk arabisk</language>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -49,6 +49,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">Arapaho</language>
 			<language type="arq">Algerijns Arabisch</language>
 			<language type="ars">Nadjdi-Arabisch</language>
+			<language type="ars" alt="menu">Arabisch, Nadjdi</language>
 			<language type="arw">Arawak</language>
 			<language type="ary">Marokkaans Arabisch</language>
 			<language type="arz">Egyptisch Arabisch</language>
@@ -122,6 +123,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Cherokee</language>
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Soranî</language>
+			<language type="ckb" alt="menu">Koerdisch, Soranî</language>
 			<language type="co">Corsicaans</language>
 			<language type="cop">Koptisch</language>
 			<language type="cps">Capiznon</language>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -122,6 +122,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">czirokeski</language>
 			<language type="chy">czejeński</language>
 			<language type="ckb">sorani</language>
+			<language type="ckb" alt="menu">kurdyjski sorani</language>
 			<language type="co">korsykański</language>
 			<language type="cop">koptyjski</language>
 			<language type="cps">capiznon</language>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -106,6 +106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cheroqui</language>
 			<language type="chy">cheiene</language>
 			<language type="ckb">curdo central</language>
+			<language type="ckb" alt="variant">curdo sorâni</language>
 			<language type="co">corso</language>
 			<language type="cop">copta</language>
 			<language type="cr">cree</language>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -107,6 +107,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">sorani curdo</language>
+			<language type="ckb" alt="menu">curdo sorani</language>
 			<language type="co">córsico</language>
 			<language type="cop" draft="contributed">copta</language>
 			<language type="cr">↑↑↑</language>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -105,6 +105,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">kurdă centrală</language>
+			<language type="ckb" alt="variant">kurdă sorani</language>
 			<language type="co">corsicană</language>
 			<language type="cop">coptă</language>
 			<language type="cr">cree</language>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">мапуче</language>
 			<language type="arp">арапахо</language>
 			<language type="ars">недждийский арабский</language>
+			<language type="ars" alt="menu">арабская (недждийский)</language>
 			<language type="arw">аравакский</language>
 			<language type="as">ассамский</language>
 			<language type="asa">асу</language>
@@ -105,6 +106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">чероки</language>
 			<language type="chy">шайенский</language>
 			<language type="ckb">сорани</language>
+			<language type="ckb" alt="menu">курдская (сорани)</language>
 			<language type="co">корсиканский</language>
 			<language type="cop">коптский</language>
 			<language type="cr">кри</language>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -49,6 +49,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">arapaho</language>
 			<language type="arq">algerisk arabiska</language>
 			<language type="ars">najdiarabiska</language>
+			<language type="ars" alt="menu">arabiska (najd)</language>
 			<language type="arw">arawakiska</language>
 			<language type="ary">marockansk arabiska</language>
 			<language type="arz">egyptisk arabiska</language>
@@ -122,6 +123,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokesiska</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">soranisk kurdiska</language>
+			<language type="ckb" alt="menu">kurdiska (sorani)</language>
 			<language type="co">korsikanska</language>
 			<language type="cop">koptiska</language>
 			<language type="cps">kapisnon</language>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -122,6 +122,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">เชอโรกี</language>
 			<language type="chy">เชเยนเน</language>
 			<language type="ckb">เคิร์ดตอนกลาง</language>
+			<language type="ckb" alt="variant">เคิร์ดโซรานี</language>
 			<language type="co">คอร์ซิกา</language>
 			<language type="cop">คอปติก</language>
 			<language type="cps">กาปิซนอน</language>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -49,6 +49,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">Arapaho Dili</language>
 			<language type="arq">Cezayir Arapçası</language>
 			<language type="ars">Necd Arapçası</language>
+			<language type="ars" alt="menu">Arapça, Necd</language>
 			<language type="arw">Arawak Dili</language>
 			<language type="ary">Fas Arapçası</language>
 			<language type="arz">Mısır Arapçası</language>
@@ -123,6 +124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Çerokice</language>
 			<language type="chy">Şayence</language>
 			<language type="ckb">Orta Kürtçe</language>
+			<language type="ckb" alt="menu" draft="contributed">Kürtçe, Sorani</language>
 			<language type="co">Korsikaca</language>
 			<language type="cop">Kıptice</language>
 			<language type="cps">Capiznon</language>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -47,6 +47,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">арапахо</language>
 			<language type="arq">алжирська арабська</language>
 			<language type="ars">надждійська арабська</language>
+			<language type="ars" alt="menu">арабська, надждійська</language>
 			<language type="arw">аравакська</language>
 			<language type="as">асамська</language>
 			<language type="asa">асу</language>
@@ -116,6 +117,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">черокі</language>
 			<language type="chy">чейєнн</language>
 			<language type="ckb">центральнокурдська</language>
+			<language type="ckb" alt="menu" draft="contributed">курдська, сорані</language>
 			<language type="co">корсиканська</language>
 			<language type="cop">коптська</language>
 			<language type="cr">крі</language>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -119,6 +119,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Tiếng Cherokee</language>
 			<language type="chy">Tiếng Cheyenne</language>
 			<language type="ckb">Tiếng Kurd Miền Trung</language>
+			<language type="ckb" alt="variant">Tiếng Kurd Sorani</language>
 			<language type="co">Tiếng Corsica</language>
 			<language type="cop">Tiếng Coptic</language>
 			<language type="cps">Tiếng Capiznon</language>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -44,6 +44,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arn">马普切语</language>
 			<language type="arp">阿拉帕霍语</language>
 			<language type="ars">纳吉迪阿拉伯语</language>
+			<language type="ars" alt="menu">阿拉伯语（纳吉迪）</language>
 			<language type="arw">阿拉瓦克语</language>
 			<language type="as">阿萨姆语</language>
 			<language type="asa">帕雷语</language>
@@ -106,6 +107,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">切罗基语</language>
 			<language type="chy">夏延语</language>
 			<language type="ckb">中库尔德语</language>
+			<language type="ckb" alt="menu" draft="contributed">库尔德语（索拉尼）</language>
 			<language type="co">科西嘉语</language>
 			<language type="cop">科普特语</language>
 			<language type="cr">克里族语</language>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -50,6 +50,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="arp">阿拉帕霍文</language>
 			<language type="arq">阿爾及利亞阿拉伯文</language>
 			<language type="ars">納吉迪阿拉伯文</language>
+			<language type="ars" alt="menu">阿拉伯文（納吉迪）</language>
 			<language type="arw">阿拉瓦克文</language>
 			<language type="ary">摩洛哥阿拉伯文</language>
 			<language type="arz">埃及阿拉伯文</language>
@@ -123,6 +124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">柴羅基文</language>
 			<language type="chy">沙伊安文</language>
 			<language type="ckb">中庫德文</language>
+			<language type="ckb" alt="menu" draft="contributed">庫德文（索拉尼）</language>
 			<language type="co">科西嘉文</language>
 			<language type="cop">科普特文</language>
 			<language type="cps">卡皮茲文</language>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13421
- [x] Updated PR title and link in previous line to include Issue number

The idea is to make available forms of the names for "ars" (Najdi Arabic) and "ckb" (Central/Sorani Kurdish) that make them sort with other related languages (e.g. Arabic, Kurdish); this is similar to what was done in [CLDR-11834](https://unicode-org.atlassian.net/browse/CLDR-11834) to have name variants that would sort Chinese languages together, e.g. `<language type="yue" alt="menu">Chinese, Cantonese</language>`

For "ars", if the current standard name is not already in a form like "Arabic, Najdi", then add an alt="menu" item that is in that form.

For "ckb" the choices are more complicated:
- If the current standard name is already in a form like "Kurdish, Sorani" then do nothing.
- If the current standard name is already in a form like "Sorani" or "Sorani Kurdish" then add an alt="menu" item that is like "Kurdish, Sorani".
- If the current standard name is in a form like "Kurdish, Central" then add add an alt="variant" (not menu) item that is like "Kurdish, Sorani".
- If the current standard name is in form like "Central Kurdish", then either
1. If we have localized data for the equivalent of both "Kurdish, Central" and "Kurdish, Sorani" then add the former as alt="menu" and the latter as alt="variant"
2. Otherwise, if we only have localized data for the equivalent of "Kurdish, Sorani", then add it as alt="menu" but mark as draft="contributed".

Many locales already have both names in a form like "Arabic, Najdi" and "Kurdish, Sorani": For example cs, el, es, id, it, ms, sk. No change was made for these. Other locales already have one of the names in that form, so only the other was changed.

When adding names, the formatting (use of commas, dashes or parens for the modifier part) was modeled on the way the loicale already handled other such names with modifiers (including if it already had one of the names for ars or ckb in the desired form)

This was only checked/modified for the ~40 locales for which Apple had in-house localization resources to provied the updated names.
