### PR TITLE
CLDR-13426 Update Orissa state name to Odisha

### DIFF
--- a/common/subdivisions/af.xml
+++ b/common/subdivisions/af.xml
@@ -459,7 +459,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmh" draft="contributed">Maharashtra</subdivision>
 			<subdivision type="inmn" draft="contributed">Manipoer</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="insk" draft="contributed">Sikkim</subdivision>
 			<subdivision type="intn" draft="contributed">Tamil Nadu</subdivision>
 			<subdivision type="intr" draft="contributed">Tripoera</subdivision>

--- a/common/subdivisions/az.xml
+++ b/common/subdivisions/az.xml
@@ -620,7 +620,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmn" draft="contributed">Manipur</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Naqalend</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Pəncab ştatı</subdivision>
 			<subdivision type="inrj" draft="contributed">Racastan</subdivision>
 			<subdivision type="insk" draft="contributed">Sikkim</subdivision>

--- a/common/subdivisions/ca.xml
+++ b/common/subdivisions/ca.xml
@@ -1502,7 +1502,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Panjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Pondicherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/cy.xml
+++ b/common/subdivisions/cy.xml
@@ -610,7 +610,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/da.xml
+++ b/common/subdivisions/da.xml
@@ -1584,7 +1584,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Pondicherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/es.xml
+++ b/common/subdivisions/es.xml
@@ -1876,7 +1876,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizorán</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punyab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajastán</subdivision>

--- a/common/subdivisions/et.xml
+++ b/common/subdivisions/et.xml
@@ -899,7 +899,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Pandžab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry liiduterritoorium</subdivision>
 			<subdivision type="inrj" draft="contributed">Rājasthān</subdivision>

--- a/common/subdivisions/eu.xml
+++ b/common/subdivisions/eu.xml
@@ -1193,7 +1193,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/fi.xml
+++ b/common/subdivisions/fi.xml
@@ -1641,7 +1641,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/gl.xml
+++ b/common/subdivisions/gl.xml
@@ -905,7 +905,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="indn" draft="contributed">Dadra e Nagar Haveli</subdivision>
 			<subdivision type="inga" draft="contributed">Goa</subdivision>
 			<subdivision type="inhr" draft="contributed">Haryana</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="insk" draft="contributed">Sikkim</subdivision>
 			<subdivision type="intg" draft="contributed">Telangana</subdivision>
 			<subdivision type="intn" draft="contributed">Tamil Nadu</subdivision>

--- a/common/subdivisions/hr.xml
+++ b/common/subdivisions/hr.xml
@@ -687,7 +687,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Pondicherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Radžastan</subdivision>

--- a/common/subdivisions/id.xml
+++ b/common/subdivisions/id.xml
@@ -1556,7 +1556,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/it.xml
+++ b/common/subdivisions/it.xml
@@ -1887,7 +1887,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Pondicherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/ms.xml
+++ b/common/subdivisions/ms.xml
@@ -1531,7 +1531,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/nb.xml
+++ b/common/subdivisions/nb.xml
@@ -1730,7 +1730,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/pt.xml
+++ b/common/subdivisions/pt.xml
@@ -1799,7 +1799,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajastão</subdivision>

--- a/common/subdivisions/ro.xml
+++ b/common/subdivisions/ro.xml
@@ -1350,7 +1350,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/sq.xml
+++ b/common/subdivisions/sq.xml
@@ -505,7 +505,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inkl" draft="contributed">Kerala</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="insk" draft="contributed">Sikkim</subdivision>
 			<subdivision type="intn" draft="contributed">Tamil Nadu</subdivision>
 			<subdivision type="intr" draft="contributed">Tripura</subdivision>

--- a/common/subdivisions/sv.xml
+++ b/common/subdivisions/sv.xml
@@ -1876,7 +1876,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Pondicherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/sw.xml
+++ b/common/subdivisions/sw.xml
@@ -641,7 +641,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/tr.xml
+++ b/common/subdivisions/tr.xml
@@ -1643,7 +1643,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Pencap</subdivision>
 			<subdivision type="inpy" draft="contributed">Puduçeri</subdivision>
 			<subdivision type="inrj" draft="contributed">Racasthan</subdivision>

--- a/common/subdivisions/uz.xml
+++ b/common/subdivisions/uz.xml
@@ -275,7 +275,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmn" draft="contributed">Manipur</subdivision>
 			<subdivision type="inmp" draft="contributed">Madhya-pradesh</subdivision>
 			<subdivision type="innl" draft="contributed">Nagalend</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Panjob</subdivision>
 			<subdivision type="inrj" draft="contributed">Rojasthon</subdivision>
 			<subdivision type="intn" draft="contributed">Tamilnad</subdivision>

--- a/common/subdivisions/vi.xml
+++ b/common/subdivisions/vi.xml
@@ -1699,7 +1699,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/common/subdivisions/yo.xml
+++ b/common/subdivisions/yo.xml
@@ -184,7 +184,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<subdivision type="inmp" draft="contributed">Madhya Pradesh</subdivision>
 			<subdivision type="inmz" draft="contributed">Mizoram</subdivision>
 			<subdivision type="innl" draft="contributed">Nagaland</subdivision>
-			<subdivision type="inor" draft="contributed">Orissa</subdivision>
+			<subdivision type="inor" draft="contributed">Odisha</subdivision>
 			<subdivision type="inpb" draft="contributed">Punjab</subdivision>
 			<subdivision type="inpy" draft="contributed">Puducherry</subdivision>
 			<subdivision type="inrj" draft="contributed">Rajasthan</subdivision>

--- a/tools/java/org/unicode/cldr/util/data/external/subdivisionData.txt
+++ b/tools/java/org/unicode/cldr/util/data/external/subdivisionData.txt
@@ -2043,7 +2043,7 @@ district council area	GB-CLR	Coleraine	en		GB-NIR
 	IN-MP	Madhya Pradesh			
 	IN-MZ	Mizoram			
 	IN-NL	Nagaland			
-	IN-OR	Orissa			
+	IN-OR	Odisha			
 	IN-PB	Punjab			
 	IN-PY	Pondicherry			
 	IN-RJ	Rajasthan			


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Odisha

State officially changed name from Orissa to Odisha: http://indiatoday.intoday.in/story/orissa-to-odisha-negotiable-instruments-act/1/158874.html

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13426
- [X] Updated PR title and link in previous line to include Issue number

