### PR TITLE
CLDR-13431 Update CLDR version (to 36.1), Unicode version (to 13.0), reaadme

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -46,7 +46,7 @@ $Revision$
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "36" >
+<!ATTLIST version cldrVersion CDATA #FIXED "36.1" >
     <!--@MATCH:any-->
     <!--@VALUE-->
 <!ATTLIST version draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/dtd/ldmlBCP47.dtd
+++ b/common/dtd/ldmlBCP47.dtd
@@ -16,7 +16,7 @@ $Revision$
 <!ATTLIST version number CDATA #REQUIRED >
 	<!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "36" >
+<!ATTLIST version cldrVersion CDATA #FIXED "36.1" >
 	<!--@MATCH:version-->
     <!--@VALUE-->
 

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -17,10 +17,10 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST version number CDATA #REQUIRED >
 	<!--@MATCH:any-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "36" >
+<!ATTLIST version cldrVersion CDATA #FIXED "36.1" >
 	<!--@MATCH:version-->
     <!--@VALUE-->
-<!ATTLIST version unicodeVersion CDATA #FIXED "12.1.0" >
+<!ATTLIST version unicodeVersion CDATA #FIXED "13.0" >
 	<!--@MATCH:version-->
     <!--@VALUE-->
 

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -21,7 +21,7 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST version number CDATA #REQUIRED >
 	<!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "36" >
+<!ATTLIST version cldrVersion CDATA #FIXED "36.1" >
 	<!--@MATCH:version-->
     <!--@METADATA-->
 

--- a/readme.html
+++ b/readme.html
@@ -11,17 +11,17 @@
 
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
-    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 36</h3>
-    <p>Last updated: 2019-Sep-30</p>
+    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 36.1</h3>
+    <p>Last updated: 2019-Nov-20</p>
 
-    <!--<p><b>Note:</b> CLDR 36 is in development and not recommended for use at this stage.</p>-->
-    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 36, intended for those wishing to do pre-release testing.
+    <!--<p><b>Note:</b> CLDR 36.1 is in development and not recommended for use at this stage.</p>-->
+    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 36.1, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a preliminary version of CLDR 36, intended for those wishing to do pre-release testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 36.1, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 36, intended for testing.
-    It is not recommended for production use.</p>-->
-    <p>This is the final release version of CLDR 36.</p>
+    <p><b>Note:</b> This is a pre-release candidate version of CLDR 36.1, intended for testing.
+    It is not recommended for production use.</p>
+    <!--<p>This is the final release version of CLDR 36.1.</p>-->
     
     <p><strong>Important notes for CLDR 36 and later:</strong></p>
     <ul>

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -123,7 +123,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
     public static final String SUPPLEMENTAL_NAME = "supplementalData";
     public static final String SUPPLEMENTAL_METADATA = "supplementalMetadata";
     public static final String SUPPLEMENTAL_PREFIX = "supplemental";
-    public static final String GEN_VERSION = "36";
+    public static final String GEN_VERSION = "36.1";
     public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "languageInfo",
         "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "plurals", "postalCodeData", "rgScope", "supplementalData",
         "supplementalMetadata",


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13431
- [x] Updated PR title and link in previous line to include Issue number

Update CLDR version to 36.1 (dtds and CLDRVersion), update Unicode version to 13.0 (supplemental dtd), update readme.

Note that this PR targets the maint/maint-36 branch, not master.