### PR TITLE
CLDR-13415 SBRS Task S16 - Use -z build during ST phase

### DIFF
--- a/tools/cldr-unittest/build.xml
+++ b/tools/cldr-unittest/build.xml
@@ -189,7 +189,7 @@
 	<target name="datacheck" description="Run the standard data tests"
 		depends="init,build">
 		<antcall target="_dataCheck">
-			<param name="datacheck.arg" value="-S common,seed -e -z FINAL_TESTING" />
+			<param name="datacheck.arg" value="-S common,seed -e -z BUILD" />
 			<param name="datacheck.jvmarg" value="${jvm_options}" />
 		</antcall>
 	</target>
@@ -197,7 +197,7 @@
 	<target name="cldr.datacheck.logged" description="Run the standard data tests"
 		depends="init,build">
 		<antcall target="_dataCheck_logged">
-			<param name="datacheck.arg" value="-S common,seed -e -z FINAL_TESTING" />
+			<param name="datacheck.arg" value="-S common,seed -e -z BUILD" />
 			<param name="datacheck.jvmarg" value="${jvm_options}" />
 		</antcall>
 	</target>


### PR DESCRIPTION
[CLDR-13415]

Use -z build for testing during ST submission.

[CLDR-13415]: https://unicode-org.atlassian.net/browse/CLDR-13415