### PR TITLE
CLDR-13420 add missing names for scripts Mtei,Olck,Qaag,Aran; validity for Aran

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -565,6 +565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">العربية</script>
 			<script type="Arab" alt="variant">العربية الفارسية</script>
+			<script type="Aran" draft="contributed">نستعليق</script>
 			<script type="Armn">الأرمينية</script>
 			<script type="Bali">البالية</script>
 			<script type="Batk">الباتاك</script>
@@ -638,10 +639,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Mlym">الماليالام</script>
 			<script type="Mong">المغولية</script>
 			<script type="Moon">مون</script>
+			<script type="Mtei" draft="contributed">ميتي ماييك</script>
 			<script type="Mymr">الميانمار</script>
 			<script type="Narb">العربية الشمالية القديمة</script>
 			<script type="Nkoo">أنكو</script>
 			<script type="Ogam">الأوجهام</script>
+			<script type="Olck" draft="contributed">أول تشيكي</script>
 			<script type="Orkh">الأورخون</script>
 			<script type="Orya">الأوريا</script>
 			<script type="Osma">الأوسمانيا</script>
@@ -649,6 +652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phag">الفاجسبا</script>
 			<script type="Phnx">الفينيقية</script>
 			<script type="Plrd">الصوتيات الجماء</script>
+			<script type="Qaag" draft="contributed">زوجيي</script>
 			<script type="Roro">رنجورنجو</script>
 			<script type="Runr">الروني</script>
 			<script type="Sara">الساراتي</script>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -609,6 +609,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">ahom</script>
 			<script type="Arab">àrab</script>
 			<script type="Arab" alt="variant">persoaràbic</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">arameu imperial</script>
 			<script type="Armn">armeni</script>
 			<script type="Avst">avèstic</script>
@@ -729,6 +730,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">fenici</script>
 			<script type="Plrd">pollard miao</script>
 			<script type="Prti">parthià inscripcional</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang</script>
 			<script type="Roro">rongo-rongo</script>
 			<script type="Runr">rúnic</script>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -649,6 +649,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb">kavkazskoalbánské</script>
 			<script type="Arab">arabské</script>
 			<script type="Arab" alt="variant">persko-arabské</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">aramejské (imperiální)</script>
 			<script type="Armn">arménské</script>
 			<script type="Avst">avestánské</script>
@@ -765,6 +766,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">fénické</script>
 			<script type="Plrd">Pollardova fonetická abeceda</script>
 			<script type="Prti">parthské klínové</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">redžanské</script>
 			<script type="Roro">rongorongo</script>
 			<script type="Runr">runové</script>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -567,6 +567,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Afak" draft="contributed">afaka</script>
 			<script type="Arab">arabisk</script>
 			<script type="Arab" alt="variant">persisk-arabisk</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">armi</script>
 			<script type="Armn">armensk</script>
 			<script type="Avst">avestansk</script>
@@ -679,6 +680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">fønikisk</script>
 			<script type="Plrd">pollardtegn</script>
 			<script type="Prti">prti</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang</script>
 			<script type="Roro">rongo-rongo</script>
 			<script type="Runr">runer</script>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -640,6 +640,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="unconfirmed">↑↑↑</script>
 			<script type="Arab">Arabisch</script>
 			<script type="Arab" alt="variant">Persisch</script>
+			<script type="Aran" draft="contributed">Nastaliq</script>
 			<script type="Armn">Armenisch</script>
 			<script type="Avst">Avestisch</script>
 			<script type="Bali">Balinesisch</script>
@@ -766,6 +767,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">Phönizisch</script>
 			<script type="Plrd">Pollard Phonetisch</script>
 			<script type="Prti" draft="contributed">Parthisch</script>
+			<script type="Qaag" draft="contributed">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
 			<script type="Rohg" draft="unconfirmed">Hanifi Rohingya</script>
 			<script type="Roro">Rongorongo</script>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -560,6 +560,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">Αραβικό</script>
 			<script type="Arab" alt="variant">Περσικό-Αραβικό</script>
+			<script type="Aran" draft="contributed">Νασταλίκ</script>
 			<script type="Armi">Αυτοκρατορικό Αραμαϊκό</script>
 			<script type="Armn">Αρμενικό</script>
 			<script type="Avst">Αβεστάν</script>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -665,6 +665,7 @@ annotations.
 			<script type="Ahom">Ahom</script>
 			<script type="Arab">Arabic</script>
 			<script type="Arab" alt="variant">Perso-Arabic</script>
+			<script type="Aran">Nastaliq</script>
 			<script type="Armi">Imperial Aramaic</script>
 			<script type="Armn">Armenian</script>
 			<script type="Avst">Avestan</script>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -565,6 +565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">árabe</script>
 			<script type="Arab" alt="variant">perso-árabe</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armn">armenio</script>
 			<script type="Avst">avéstico</script>
 			<script type="Bali">balinés</script>
@@ -652,6 +653,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phag">phags-pa</script>
 			<script type="Phnx">fenicio</script>
 			<script type="Plrd">Pollard Miao</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng" draft="contributed">rejang</script>
 			<script type="Roro" draft="contributed">rongo-rongo</script>
 			<script type="Runr">rúnico</script>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -594,6 +594,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Mlym">malayalam</script>
 			<script type="Mong">mongol</script>
 			<script type="Mymr">birmano</script>
+			<script type="Olck" draft="contributed">ol chiki</script>
 			<script type="Orya">oriya</script>
 			<script type="Sinh">cingalés</script>
 			<script type="Taml">tamil</script>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -656,6 +656,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom">ahom</script>
 			<script type="Arab">arabialainen</script>
 			<script type="Arab" alt="variant">persialaisarabialainen</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">valtakunnanaramealainen</script>
 			<script type="Armn">armenialainen</script>
 			<script type="Avst">avestalainen</script>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -654,6 +654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="unconfirmed">ahom</script>
 			<script type="Arab">arabe</script>
 			<script type="Arab" alt="variant">arabo-persan</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">araméen impérial</script>
 			<script type="Armn">arménien</script>
 			<script type="Avst">avestique</script>
@@ -787,6 +788,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">phénicien</script>
 			<script type="Plrd">phonétique de Pollard</script>
 			<script type="Prti">parthe des inscriptions</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang</script>
 			<script type="Rohg" draft="unconfirmed">hanifi</script>
 			<script type="Roro">rongorongo</script>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -680,6 +680,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Mlym">↑↑↑</script>
 			<script type="Mong">mongol</script>
 			<script type="Mymr">birman</script>
+			<script type="Olck" draft="contributed">ol chiki</script>
 			<script type="Orya">odia</script>
 			<script type="Sinh">↑↑↑</script>
 			<script type="Taml">tamoul</script>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -749,7 +749,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Phnx">Pheniceach</script>
 			<script type="Plrd">Miao Phollard</script>
 			<script type="Prti">Partais snaidh-sgrìobhte</script>
-			<script type="Qaag">Qaag</script>
+			<script type="Qaag" draft="contributed">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
 			<script type="Rohg">Hanifi Rohingya</script>
 			<script type="Roro">Rongorongo</script>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -565,6 +565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">ערבי</script>
 			<script type="Arab" alt="variant">ערבי-פרסי</script>
+			<script type="Aran" draft="contributed">נסתעליק</script>
 			<script type="Armn">ארמני</script>
 			<script type="Bali">באלינזי</script>
 			<script type="Beng">בנגלי</script>
@@ -610,9 +611,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Maya" draft="contributed">מאיה</script>
 			<script type="Mlym">מליאלאם</script>
 			<script type="Mong">מונגולי</script>
+			<script type="Mtei" draft="contributed">מאיטי מאייק</script>
 			<script type="Mymr">מיאנמר</script>
+			<script type="Olck" draft="contributed">אול צ׳יקי</script>
 			<script type="Orya">אודייה</script>
 			<script type="Phnx">פיניקי</script>
+			<script type="Qaag" draft="contributed">זאוגיי</script>
 			<script type="Runr">רוני</script>
 			<script type="Sinh">סינהלה</script>
 			<script type="Syrc">סורי</script>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -549,6 +549,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">अरबी</script>
 			<script type="Arab" alt="variant">फ़ारसी-अरबी</script>
+			<script type="Aran" draft="contributed">नस्तालीक़</script>
 			<script type="Armi">इम्पिरियल आर्मेनिक</script>
 			<script type="Armn">आर्मेनियाई</script>
 			<script type="Avst">अवेस्तन</script>
@@ -644,6 +645,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">फोनिशियन</script>
 			<script type="Plrd">पॉलार्ड फोनेटिक</script>
 			<script type="Prti">इंस्क्रिपश्नल पार्थियन</script>
+			<script type="Qaag" draft="contributed">ज़ौजी</script>
 			<script type="Rjng">रीजांग</script>
 			<script type="Roro">रोन्गोरोन्गो</script>
 			<script type="Runr">रूनिक</script>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -568,6 +568,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Afak" draft="contributed">afaka pismo</script>
 			<script type="Arab">arapsko pismo</script>
 			<script type="Arab" alt="variant">perzijsko-arapsko pismo</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">aramejsko pismo</script>
 			<script type="Armn">armensko pismo</script>
 			<script type="Avst">avestansko pismo</script>
@@ -679,6 +680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">feničko pismo</script>
 			<script type="Plrd">pollard fonetsko pismo</script>
 			<script type="Prti">pisani parthian</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang pismo</script>
 			<script type="Roro">rongorongo pismo</script>
 			<script type="Runr">runsko pismo</script>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -565,6 +565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">Arab</script>
 			<script type="Arab" alt="variant">Perzsa-arab</script>
+			<script type="Aran" draft="contributed">Nasztalik</script>
 			<script type="Armi">Birodalmi arámi</script>
 			<script type="Armn">Örmény</script>
 			<script type="Avst">Avesztán</script>
@@ -658,6 +659,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">Főniciai</script>
 			<script type="Plrd">Pollard fonetikus</script>
 			<script type="Prti">Feliratos parthian</script>
+			<script type="Qaag" draft="contributed">Zawgyi</script>
 			<script type="Rjng">Redzsang</script>
 			<script type="Roro">Rongorongo</script>
 			<script type="Runr">Runikus</script>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -589,6 +589,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb">Albania Kaukasia</script>
 			<script type="Arab">Arab</script>
 			<script type="Arab" alt="variant">Arab Persia</script>
+			<script type="Aran" draft="contributed">Nastaliq</script>
 			<script type="Armi">Aram Imperial</script>
 			<script type="Armn">Armenia</script>
 			<script type="Avst">Avesta</script>
@@ -699,6 +700,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">Phoenix</script>
 			<script type="Plrd">Fonetik Pollard</script>
 			<script type="Prti">Prasasti Parthia</script>
+			<script type="Qaag" draft="contributed">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
 			<script type="Roro">Rongorongo</script>
 			<script type="Runr">Runik</script>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -643,6 +643,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb" draft="unconfirmed">albanese caucasico</script>
 			<script type="Arab">arabo</script>
 			<script type="Arab" alt="variant">arabo-persiano</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi" draft="contributed">aramaico imperiale</script>
 			<script type="Armn">armeno</script>
 			<script type="Avst" draft="contributed">avestico</script>
@@ -755,6 +756,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx" draft="contributed">fenicio</script>
 			<script type="Plrd" draft="contributed">fonetica di pollard</script>
 			<script type="Prti" draft="contributed">partico delle iscrizioni</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng" draft="contributed">rejang</script>
 			<script type="Roro" draft="contributed">rongorongo</script>
 			<script type="Runr">runico</script>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -653,6 +653,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb" draft="contributed">カフカス・アルバニア文字</script>
 			<script type="Arab">アラビア文字</script>
 			<script type="Arab" alt="variant">ペルソ・アラビア文字</script>
+			<script type="Aran" draft="contributed">ナスタアリーク体</script>
 			<script type="Armi">帝国アラム文字</script>
 			<script type="Armn">アルメニア文字</script>
 			<script type="Avst">アヴェスター文字</script>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -582,6 +582,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb" draft="contributed">코카시안 알바니아 문자</script>
 			<script type="Arab">아랍 문자</script>
 			<script type="Arab" alt="variant">페르소-아라비아 문자</script>
+			<script type="Aran" draft="contributed">나스탈리크체</script>
 			<script type="Armi" draft="contributed">아랍제국 문자</script>
 			<script type="Armn">아르메니아 문자</script>
 			<script type="Avst" draft="contributed">아베스타 문자</script>
@@ -696,6 +697,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx" draft="contributed">페니키아 문자</script>
 			<script type="Plrd" draft="contributed">폴라드 표음 문자</script>
 			<script type="Prti" draft="contributed">명문 파라티아 문자</script>
+			<script type="Qaag" draft="contributed">저지 문자</script>
 			<script type="Rjng" draft="contributed">레장 문자</script>
 			<script type="Roro" draft="contributed">롱고롱고</script>
 			<script type="Runr">룬 문자</script>

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -455,6 +455,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</languages>
 		<scripts>
 			<script type="Arab">اَربی</script>
+			<script type="Aran" draft="contributed">نستعلیق</script>
 			<script type="Armn">اَرمانیَن</script>
 			<script type="Avst">اَویستَن</script>
 			<script type="Bali">بالَنیٖز</script>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -480,6 +480,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">↑↑↑</script>
 			<script type="Arab">Arab</script>
 			<script type="Arab" alt="variant">Perso-Arab</script>
+			<script type="Aran" draft="contributed">Nastaliq</script>
 			<script type="Armi" draft="contributed">Aramia Imperial</script>
 			<script type="Armn">Armenia</script>
 			<script type="Avst" draft="contributed">Avestan</script>

--- a/common/main/nb.xml
+++ b/common/main/nb.xml
@@ -652,6 +652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">ahom</script>
 			<script type="Arab">arabisk</script>
 			<script type="Arab" alt="variant">persisk-arabisk</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">arameisk</script>
 			<script type="Armn">armensk</script>
 			<script type="Avst">avestisk</script>
@@ -770,6 +771,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">fønikisk</script>
 			<script type="Plrd">pollard-fonetisk</script>
 			<script type="Prti">inskripsjonsparthisk</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang</script>
 			<script type="Roro">rongorongo</script>
 			<script type="Runr">runer</script>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -654,6 +654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">Ahom</script>
 			<script type="Arab">Arabisch</script>
 			<script type="Arab" alt="variant">Perso-Arabisch</script>
+			<script type="Aran" draft="contributed">Nastaliq</script>
 			<script type="Armi">Keizerlijk Aramees</script>
 			<script type="Armn">Armeens</script>
 			<script type="Avst">Avestaans</script>
@@ -784,7 +785,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">Foenicisch</script>
 			<script type="Plrd">Pollard-fonetisch</script>
 			<script type="Prti">Inscriptioneel Parthisch</script>
-			<script type="Qaag" draft="contributed">Qaag</script>
+			<script type="Qaag" draft="contributed">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
 			<script type="Rohg" draft="contributed">Hanifi Rohingya</script>
 			<script type="Roro">Rongorongo</script>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -442,6 +442,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</languages>
 		<scripts>
 			<script type="Arab">ਅਰਬੀ</script>
+			<script type="Aran" draft="contributed">ਨਸਤਾਲੀਕ</script>
 			<script type="Armn">ਅਰਮੀਨੀਆਈ</script>
 			<script type="Beng">ਬੰਗਾਲੀ</script>
 			<script type="Bopo">ਬੋਪੋਮੋਫੋ</script>

--- a/common/main/pa_Arab.xml
+++ b/common/main/pa_Arab.xml
@@ -17,6 +17,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</languages>
 		<scripts>
 			<script type="Arab">عربی</script>
+			<script type="Aran" draft="contributed">نستعلیق</script>
 			<script type="Guru">گُرمُکھی</script>
 		</scripts>
 		<territories>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -650,6 +650,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Afak" draft="unconfirmed">afaka</script>
 			<script type="Arab">arabskie</script>
 			<script type="Arab" alt="variant">perso-arabskie</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">armi</script>
 			<script type="Armn">ormiańskie</script>
 			<script type="Avst">awestyjskie</script>
@@ -762,6 +763,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">fenicki</script>
 			<script type="Plrd">fonetyczny Pollard’a</script>
 			<script type="Prti">partyjski inskrypcyjny</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang</script>
 			<script type="Roro">rongorongo</script>
 			<script type="Runr">runiczne</script>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -566,6 +566,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">árabe</script>
 			<script type="Arab" alt="variant">perso-árabe</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi" draft="contributed">armi</script>
 			<script type="Armn">armênio</script>
 			<script type="Avst">avéstico</script>
@@ -663,6 +664,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">fenício</script>
 			<script type="Plrd" draft="contributed">fonético pollard</script>
 			<script type="Prti" draft="contributed">prti</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng" draft="contributed">rejang</script>
 			<script type="Roro" draft="contributed">rongorongo</script>
 			<script type="Runr">rúnico</script>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -565,6 +565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">árabe</script>
 			<script type="Arab" alt="variant">perso-árabe</script>
+			<script type="Aran" draft="contributed">nasta’liq</script>
 			<script type="Armi" draft="provisional">aramaico imperial</script>
 			<script type="Armn">arménio</script>
 			<script type="Beng">bengalês</script>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -564,6 +564,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">arabă</script>
 			<script type="Arab" alt="variant">persano-arabă</script>
+			<script type="Aran" draft="contributed">nastaaliq</script>
 			<script type="Armn">armeană</script>
 			<script type="Bali">balineză</script>
 			<script type="Beng">bengaleză</script>
@@ -617,9 +618,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Maya">hieroglife maya</script>
 			<script type="Mlym">malayalam</script>
 			<script type="Mong">mongolă</script>
+			<script type="Mtei" draft="contributed">meitei mayek</script>
 			<script type="Mymr">birmană</script>
+			<script type="Olck" draft="contributed">ol chiki</script>
 			<script type="Orya">oriya</script>
 			<script type="Phnx">feniciană</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Runr">runică</script>
 			<script type="Sinh">singaleză</script>
 			<script type="Syrc">siriacă</script>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -567,6 +567,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Afak" draft="contributed">афака</script>
 			<script type="Arab">арабица</script>
 			<script type="Arab" alt="variant">персидско-арабская</script>
+			<script type="Aran" draft="contributed">насталик</script>
 			<script type="Armi">арамейская</script>
 			<script type="Armn">армянская</script>
 			<script type="Avst">авестийская</script>
@@ -679,6 +680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx" draft="contributed">финикийская</script>
 			<script type="Plrd" draft="contributed">поллардовская фонетика</script>
 			<script type="Prti" draft="contributed">парфянская</script>
+			<script type="Qaag" draft="contributed">зоджи</script>
 			<script type="Rjng" draft="contributed">реджангская</script>
 			<script type="Roro">ронго-ронго</script>
 			<script type="Runr">руническая</script>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -558,6 +558,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">arabské</script>
 			<script type="Arab" alt="variant">perzsko-arabské</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armn">arménske</script>
 			<script type="Bali" draft="contributed">balijský</script>
 			<script type="Beng">bengálske</script>
@@ -596,9 +597,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Maya" draft="contributed">mayské hieroglyfy</script>
 			<script type="Mlym">malajálamske</script>
 			<script type="Mong">mongolské</script>
+			<script type="Mtei" draft="contributed">mejtej majek (manipurské)</script>
 			<script type="Mymr">barmské</script>
+			<script type="Olck" draft="contributed">santálske (ol chiki)</script>
 			<script type="Orya">uríjske</script>
 			<script type="Osma" draft="contributed">osmanský</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Runr" draft="contributed">Runové písmo</script>
 			<script type="Sinh">sinhálske</script>
 			<script type="Taml">tamilské</script>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -654,6 +654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb">kaukasiska albanska</script>
 			<script type="Ahom">ahom</script>
 			<script type="Arab">arabiska</script>
+			<script type="Aran" draft="contributed">nastaliq</script>
 			<script type="Armi">imperisk arameiska</script>
 			<script type="Armn">armeniska</script>
 			<script type="Avst">avestiska</script>
@@ -784,7 +785,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">feniciska</script>
 			<script type="Plrd">pollardtecken</script>
 			<script type="Prti">tidig parthianska</script>
-			<script type="Qaag" draft="provisional">Zawgyi</script>
+			<script type="Qaag" draft="contributed">zawgyi</script>
 			<script type="Rjng">rejang</script>
 			<script type="Rohg">hanifiska</script>
 			<script type="Roro">rongo-rongo</script>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -652,6 +652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Aghb" draft="contributed">Kafkas Albanyası</script>
 			<script type="Arab">Arap</script>
 			<script type="Arab" alt="variant">Fars-Arap</script>
+			<script type="Aran" draft="contributed">Nestâlik</script>
 			<script type="Armi">İmparatorluk Aramicesi</script>
 			<script type="Armn">Ermeni</script>
 			<script type="Avst">Avesta</script>
@@ -768,6 +769,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">Fenike</script>
 			<script type="Plrd">Pollard Fonetik</script>
 			<script type="Prti">Partça Kitabe Dili</script>
+			<script type="Qaag" draft="contributed">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
 			<script type="Roro">Rongorongo</script>
 			<script type="Runr">Runik</script>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -582,6 +582,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">ахом</script>
 			<script type="Arab">арабиця</script>
 			<script type="Arab" alt="variant">персько-арабська</script>
+			<script type="Aran" draft="contributed">насталік</script>
 			<script type="Armi">армі</script>
 			<script type="Armn">вірменська</script>
 			<script type="Avst">авестійський</script>
@@ -670,6 +671,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Nkoo">нко</script>
 			<script type="Ogam">огамічний</script>
 			<script type="Olck">сантальський</script>
+			<script type="Olck" alt="variant" draft="contributed">ол чікі</script>
 			<script type="Orkh">орхонський</script>
 			<script type="Orya">орія</script>
 			<script type="Osge" draft="contributed">осейджиська</script>
@@ -682,6 +684,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">фінікійський</script>
 			<script type="Plrd">писемність Полларда</script>
 			<script type="Prti">парфянський</script>
+			<script type="Qaag" draft="contributed">зоджі</script>
 			<script type="Rjng">реджанг</script>
 			<script type="Roro">ронго-ронго</script>
 			<script type="Runr">рунічний</script>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -441,6 +441,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Arab">عربی</script>
 			<script type="Arab" alt="variant">فارسی عربی</script>
+			<script type="Aran" draft="contributed">نستعلیق</script>
 			<script type="Armn">آرمینیائی</script>
 			<script type="Beng">بنگالی</script>
 			<script type="Bopo">بوپوموفو</script>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -598,6 +598,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">↑↑↑</script>
 			<script type="Arab">Chữ Ả Rập</script>
 			<script type="Arab" alt="variant">Chữ Ba Tư-Ả Rập</script>
+			<script type="Aran" draft="contributed">Chữ Nastaliq</script>
 			<script type="Armi" draft="contributed">Chữ Imperial Aramaic</script>
 			<script type="Armn">Chữ Armenia</script>
 			<script type="Avst" draft="contributed">Chữ Avestan</script>
@@ -728,7 +729,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx" draft="contributed">Chữ Phoenicia</script>
 			<script type="Plrd" draft="contributed">Ngữ âm Pollard</script>
 			<script type="Prti" draft="contributed">Chữ Parthia Văn bia</script>
-			<script type="Qaag" draft="contributed">↑↑↑</script>
+			<script type="Qaag" draft="contributed">Chữ Zawgyi</script>
 			<script type="Rjng" draft="contributed">Chữ Rejang</script>
 			<script type="Rohg" draft="contributed">↑↑↑</script>
 			<script type="Roro" draft="contributed">Chữ Rongorongo</script>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -632,6 +632,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Aghb" draft="contributed">高加索阿尔巴尼亚文</script>
 			<script type="Arab">阿拉伯文</script>
 			<script type="Arab" alt="variant">波斯阿拉伯文字</script>
+			<script type="Aran" draft="contributed">波斯体</script>
 			<script type="Armi">皇室亚美尼亚文</script>
 			<script type="Armn">亚美尼亚文</script>
 			<script type="Avst" draft="contributed">阿维斯陀文</script>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -571,6 +571,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="provisional">Ahom</script>
 			<script type="Arab">阿拉伯文</script>
 			<script type="Arab" alt="variant">波斯阿拉伯文</script>
+			<script type="Aran" draft="contributed">波斯体</script>
 			<script type="Armi">皇室亚拉姆文</script>
 			<script type="Armn">亚美尼亚文</script>
 			<script type="Avst">阿维斯陀文</script>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -654,6 +654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Ahom" draft="contributed">阿洪姆文</script>
 			<script type="Arab">阿拉伯文</script>
 			<script type="Arab" alt="variant">波斯阿拉伯文字</script>
+			<script type="Aran" draft="contributed">波斯體</script>
 			<script type="Armi">皇室亞美尼亞文</script>
 			<script type="Armn">亞美尼亞文</script>
 			<script type="Avst" draft="contributed">阿維斯陀文</script>
@@ -777,6 +778,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Phnx">腓尼基文</script>
 			<script type="Plrd">柏格理拼音符</script>
 			<script type="Prti" draft="contributed">帕提亞文（碑銘體）</script>
+			<script type="Qaag" draft="contributed">佐基文</script>
 			<script type="Rjng">拉讓文</script>
 			<script type="Roro">朗格朗格象形文</script>
 			<script type="Runr">古北歐文字</script>

--- a/common/validity/script.xml
+++ b/common/validity/script.xml
@@ -38,7 +38,8 @@
 			Xpeo Xsux
 			Yezi Yiii
 		</id>
-		<id type='script' idStatus='special'>		<!-- 8 items -->
+		<id type='script' idStatus='special'>		<!-- 9 items -->
+			Aran
 			Qaag
 			Zanb Zinh Zmth Zsye Zsym Zxxx Zyyy
 		</id>

--- a/seed/main/en_ZZ.xml
+++ b/seed/main/en_ZZ.xml
@@ -16,6 +16,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zh">Chinese (translation hint: specifically, Mandarin Chinese.)</language>
 		</languages>
 		<scripts>
+			<script type="Aran">Nastaliq (translation hint: Special code identifies a style variant of Arabic script.)</script>
 			<script type="Qaag">Zawgyi (translation hint: Special code identifies non-standard Myanmar encoding for use with Zawgyi font.)</script>
 		</scripts>
 		<territories>

--- a/seed/main/hi_Latn.xml
+++ b/seed/main/hi_Latn.xml
@@ -28,6 +28,7 @@ annotations.
 		</languages>
 		<scripts>
 			<script type="Arab">Arabi</script>
+			<script type="Aran">Nastaliq</script>
 			<script type="Deva">Devanagari</script>
 			<script type="Latn">Latin</script>
 		</scripts>

--- a/seed/main/sc.xml
+++ b/seed/main/sc.xml
@@ -387,7 +387,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Phnx" draft="unconfirmed">fenìtziu</script>
 			<script type="Plrd" draft="unconfirmed">pollard miao</script>
 			<script type="Prti" draft="unconfirmed">pàrticu de sas iscritziones</script>
-			<script type="Qaag" draft="unconfirmed">qaag</script>
+			<script type="Qaag" draft="unconfirmed">zawgyi</script>
 			<script type="Rjng" draft="unconfirmed">rejang</script>
 			<script type="Rohg" draft="unconfirmed">hanifi rohingya</script>
 			<script type="Runr" draft="unconfirmed">rùnicu</script>

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -373,7 +373,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
             + "syr|kv|umb|)");
 
         final Pattern script100 = PatternCache.get("("
-            + "Adlm|Afak|Aghb|Ahom|Armi|Avst|Bali|Bamu|Bass|Batk|Bhks|Blis|Brah|Bugi|Buhd|"
+            + "Adlm|Afak|Aghb|Ahom|Aran|Armi|Avst|Bali|Bamu|Bass|Batk|Bhks|Blis|Brah|Bugi|Buhd|"
             + "Cakm|Cans|Cari|Cham|Chrs|Cher|Cirt|Copt|Cprt|Cyrs|"
             + "Diak|Dogr|Dsrt|Dupl|Egy[dhp]|Elba|Elym|Geok|Glag|Gong|Gonm|Goth|Gran|"
             + "Hatr|Hanb|Hano|Hluw|Hmng|Hmnp|Hrkt|Hung|Inds|Ital|Jamo|Java|Jurc|"

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -374,7 +374,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             }
         }
 
-        ImmutableSet<String> variants = ImmutableSet.of("Aran", "Cyrs", "Geok", "Latf", "Latg", "Syre", "Syrj", "Syrn");
+        ImmutableSet<String> variants = ImmutableSet.of("Cyrs", "Geok", "Latf", "Latg", "Syre", "Syrj", "Syrn");
         assertRelation("getCLDRScriptCodes contains variants", false, codes, CONTAINS_SOME, variants);
     }
 

--- a/tools/java/org/unicode/cldr/tool/GenerateValidityXml.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateValidityXml.java
@@ -320,6 +320,7 @@ public class GenerateValidityXml {
                     break;
                 case script:
                     switch (code) {
+                    case "Aran":
                     case "Qaag":
                     case "Zsye": 
                     case "Zanb":


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13420
- [x] Updated PR title and link in previous line to include Issue number

For some locales that do not have them, add missing names for scripts Mtei, Olck, Qaag, Aran (mostly per Apple linguists, but I also changed values of Qaag to Zawgyi in additional cases).

Aran is new, and an interesting case. This code is for Nastaliq, a stylistic variant of Arabic script (as e.g. Latf or Latg for Fraktur and Gothic variants of Latn script). We would like a display name for this, but CLDR would probably never specify this as script for a locale (since it uses the same code points as Arab script). In this it is similar to, say, Zsye; neither are in properties/scriptMetadata.txt

Please check how I have handed this as to validity and test code: I have given this "special" status in validity/script.xml, and have adjusted some tests including removing this from the prohibited variants.
