### PR TITLE
CLDR-9560 spurious account-is-locked for guest users

### DIFF
--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
@@ -105,7 +105,7 @@ var surveyUserPerms = {
         userCanUseVettingSummary: <%=UserRegistry.userCanUseVettingSummary(myUser)%>,
         userIsTC: <%=UserRegistry.userIsTC(myUser)%>,
         userIsVetter: <%=!UserRegistry.userIsTC(myUser) && UserRegistry.userIsVetter(myUser)%>,
-        userIsLocked: <%=!UserRegistry.userIsTC(myUser) && !UserRegistry.userIsVetter(myUser) && !UserRegistry.userIsLocked(myUser)%>,
+        userIsLocked: <%=UserRegistry.userIsLocked(myUser)%>,
         hasDataSource: <%=curSurveyMain.dbUtils.hasDataSource()%>,
 };
 var surveyUserURL = {


### PR DESCRIPTION
-Fix userIsLocked in ajax_status.jsp in straightforward way

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-9560
- [x] Updated PR title and link in previous line to include Issue number

