### PR TITLE
CLDR-10647 Add warning if stand-alone script names == non-standalone...

### DIFF
--- a/seed/main/en_ZZ.xml
+++ b/seed/main/en_ZZ.xml
@@ -17,6 +17,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</languages>
 		<scripts>
 			<script type="Aran">Nastaliq (translation hint: Special code identifies a style variant of Arabic script.)</script>
+			<script type="Hans">Simplified (translation hint: This version of the script name is used in combination with the language name for Chinese.)</script>
+			<script type="Hans" alt="stand-alone">Simplified Han (translation hint: This version of the script name is used in isolation, not combined with the language name for Chinese.)</script>
+			<script type="Hant">Traditional (translation hint: This version of the script name is used in combination with the language name for Chinese.)</script>
+			<script type="Hant" alt="stand-alone">Traditional Han (translation hint: This version of the script name is used in isolation, not combined with the language name for Chinese.)</script>
 			<script type="Qaag">Zawgyi (translation hint: Special code identifies non-standard Myanmar encoding for use with Zawgyi font.)</script>
 		</scripts>
 		<territories>

--- a/tools/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -132,6 +132,7 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
     private final Matcher typePattern = PatternCache.get("\\[@type=\"([^\"]*+)\"]").matcher("");
     private final Matcher ignoreAltAndCountAttributes = PatternCache.get("\\[@(?:count|alt)=\"[^\"]*+\"]").matcher("");
     private final Matcher ignoreAltAttributes = PatternCache.get("\\[@(?:alt)=\"[^\"]*+\"]").matcher("");
+    private final Matcher ignoreAltShortOrVariantAttributes = PatternCache.get("\\[@(?:alt)=\"(?:short|variant)\"]").matcher("");
     private final Matcher compoundUnitPatterns = PatternCache.get("compoundUnitPattern").matcher("");
 
     // map unique path fragment to set of unique fragments for other
@@ -306,6 +307,9 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
                 return this; // special root 'other' value
             }
             currentAttributesToIgnore = ignoreAltAttributes;
+            paths = getPathsWithValue(getResolvedCldrFileToCheck(), path, value, myType, myPrefix, matcher, currentAttributesToIgnore, Equivalence.normal);
+        } else if (myType == Type.SCRIPT) {
+            currentAttributesToIgnore = ignoreAltShortOrVariantAttributes; // i.e. do NOT ignore alt="stand-alone"
             paths = getPathsWithValue(getResolvedCldrFileToCheck(), path, value, myType, myPrefix, matcher, currentAttributesToIgnore, Equivalence.normal);
         } else {
             paths = getPathsWithValue(getResolvedCldrFileToCheck(), path, value, myType, myPrefix, matcher, currentAttributesToIgnore, Equivalence.normal);
@@ -535,6 +539,11 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
                     collidingZoneTypes.contains("generic-short")) {
                     thisErrorType = CheckStatus.warningType;
                 }
+            }
+        } else if (myType == Type.SCRIPT && collidingTypes.size() == 1) {
+            String collisionString = collidingTypes.toString();
+            if (path.contains("stand-alone") || collisionString.contains("stand-alone")) {
+                thisErrorType = CheckStatus.warningType;
             }
         }
         CheckStatus item = new CheckStatus().setCause(this)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10647
- [x] Updated PR title and link in previous line to include Issue number

Add warning if alt="stand-alone" script names match the standard (non-stand-alone) forms; this is mainly intended for the variants of Hans and Hant. Also add translation hint explaining the difference between the standard and stand-alone versions of Hans, Hant.