### PR TITLE
CLDR-13468 fix deadlock between STFactory and PerLocaleData

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/STFactory.java
@@ -612,6 +612,16 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             stamp = mintLocaleStamp(locale);
         }
 
+        private void initFiles() {
+            // Initialize file and rFile early, soon after PLD c'tion.
+            // this should be done after the PLD is in 
+            if (getSupplementalDirectory() == null)
+                throw new InternalError("getSupplementalDirectory() == null!");
+            rFile = new CLDRFile(makeSource(true)).setSupplementalDirectory(getSupplementalDirectory());
+            rFile.getSupplementalDirectory();
+            file = new CLDRFile(makeSource(false)).setSupplementalDirectory(getSupplementalDirectory());
+        }
+
         public boolean isEmpty() {
             return xpathToData.isEmpty();
         }
@@ -832,21 +842,10 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             }
         }
 
-        public synchronized CLDRFile getFile(boolean resolved) {
+        public CLDRFile getFile(boolean resolved) {
             if (resolved) {
-                if (rFile == null) {
-                    if (getSupplementalDirectory() == null)
-                        throw new InternalError("getSupplementalDirectory() == null!");
-                    rFile = new CLDRFile(makeSource(true)).setSupplementalDirectory(getSupplementalDirectory());
-                    rFile.getSupplementalDirectory();
-                }
                 return rFile;
             } else {
-                if (file == null) {
-                    if (getSupplementalDirectory() == null)
-                        throw new InternalError("getSupplementalDirectory() == null!");
-                    file = new CLDRFile(makeSource(false)).setSupplementalDirectory(getSupplementalDirectory());
-                }
                 return file;
             }
         }
@@ -1707,6 +1706,8 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 locales.put(locale, (new SoftReference<PerLocaleData>(pld)));
                 // update the locale display name cache.
                 OutputFileManager.updateLocaleDisplayName(pld.getFile(true), locale);
+
+                pld.initFiles(); // must do this after it's in the hash
             } else {
                 rLocales.put(locale, pld); // keep it in the lru
             }


### PR DESCRIPTION
[CLDR-13468]

- Contention between makeVettedFile() and voteForValue()
  makeVettedFile grabs lock on STFactory via get() and then PerLocaleData (for parent locale).getFile()
  voteForValue is synchronized on PLD and later grabs lock on STFactory via get()

Solution is to, soon after PLD c'tor, initialize the resolved and unresolved CLDRFiles.

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13468
- [x] Updated PR title and link in previous line to include Issue number
- [X] This is not a fix that could be done via a survey tool account. Just in case you were wondering.
- [ ] Did not test this yet.


[CLDR-13468]: https://unicode-org.atlassian.net/browse/CLDR-13468