### PR TITLE
CLDR-13457 Dashboard does not show all Error/Missing/New... values

### DIFF
--- a/tools/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -72,10 +72,10 @@ public final class SubmissionLocales {
      * @param localeString
      * @param path
      * @param isError
-     * @param missingInLastRelease
-     * @return
+     * @param isMissing
+     * @return true if submission is allowed, else false
      */
-    public static boolean allowEvenIfLimited(String localeString, String path, boolean isError, boolean missingInLastRelease) {
+    public static boolean allowEvenIfLimited(String localeString, String path, boolean isError, boolean isMissing) {
 
         // don't limit new locales or errors
 
@@ -95,7 +95,7 @@ public final class SubmissionLocales {
 
         // in those locales, lock all paths except missing and special
 
-        if (missingInLastRelease) {
+        if (isMissing) {
             return true;
         } else {
             int debug = 0; // for debugging


### PR DESCRIPTION
-Use baselineFile.getUnresolved().getWinningValue() for oldValue

-Bug fix: status was uninitialized in getMissingStatus; call getSourceLocaleID, use local variable not parameter

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13457
- [x] Updated PR title and link in previous line to include Issue number

