### PR TITLE
CLDR-13457 Dashboard does not show all Error/Missing/New... values

### DIFF
--- a/tools/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/java/org/unicode/cldr/util/VettingViewer.java
@@ -578,7 +578,7 @@ public class VettingViewer<T> {
             for (String path : sourceFile.fullIterable()) {
                 if (xpath != null && !xpath.equals(path))
                     continue;
-                String value = sourceFile.getWinningValue(path);
+                String value = sourceFile.getWinningValueForVettingViewer(path);
                 statusMessage.setLength(0);
                 subtypes.clear();
                 ErrorChecker.Status errorStatus = errorChecker.getErrorStatus(path, value, statusMessage, subtypes);


### PR DESCRIPTION
-Fix bogus Dashboard Errors due to wrong inherited value, should be constructed value

-Move part of getConstructedBaileyValue to new subroutine getConstructedValue (the behavior of getConstructedBaileyValue is unchanged)

-VettingViewer.FileInfo.getFileInfo call new getWinningValueForVettingViewer instead of getWinningValue

-New subroutines getStringValueForVettingViewer and getStringValueUnresolved

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13457
- [x] Updated PR title and link in previous line to include Issue number

