### PR TITLE
CLDR-13455 Add "pcm" Nigerian Pidgin to plurals/pluralRanges

### DIFF
--- a/common/supplemental/pluralRanges.xml
+++ b/common/supplemental/pluralRanges.xml
@@ -27,7 +27,7 @@
 			<pluralRange start="other" end="one"   result="one"/>
 			<pluralRange start="other" end="other" result="other"/>
 		</pluralRanges>
-		<pluralRanges locales="af an bg ca en es et eu fi ia io nb sv ur">
+		<pluralRanges locales="af an bg ca en es et eu fi ia io nb pcm sv ur">
 			<pluralRange start="one"   end="other" result="other"/>
 			<pluralRange start="other" end="one"   result="other"/>
 			<pluralRange start="other" end="other" result="other"/>

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -30,7 +30,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">i = 0..1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="ast ca de en et fi fy gl ia io it ji nl pt_PT sc scn sv sw ur yi">
+        <pluralRules locales="ast ca de en et fi fy gl ia io it ji nl pcm pt_PT sc scn sv sw ur yi">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13455
- [x] Updated PR title and link in previous line to include Issue number

Add "pcm" Nigerian Pidgin to plurals/pluralRanges in same category as "en"
