### PR TITLE
CLDR-13299 Add new seed locale "pcm" Nigerian Pidgin, delete old exemplars

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1521,7 +1521,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			naq_NA nb_NO nd_ZW nds_DE ne_NP nl_NL nmg_CM nn_NO nnh_CM nqo_GN nr_ZA nso_ZA
 			nus_SS ny_MW nyn_UG
 			oc_FR om_ET or_IN os_GE osa_US
-			pa_Arab_PK pa_Guru pa_Guru_IN pl_PL prg_001 ps_AF pt_BR
+			pa_Arab_PK pa_Guru pa_Guru_IN pcm_NG pl_PL prg_001 ps_AF pt_BR
 			qu_PE quc_GT
 			rm_CH rn_BI ro_RO rof_TZ ru_RU rw_RW rwk_TZ
 			sa_IN sah_RU saq_KE sat_Deva_IN sat_Olck sat_Olck_IN sbp_TZ sc_IT scn_IT

--- a/seed/main/pcm.xml
+++ b/seed/main/pcm.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2019 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="pcm"/>
+	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="pcm" draft="unconfirmed">Nigerian Pidgin</language>
+		</languages>
+		<territories>
+			<territory type="NG" draft="unconfirmed">Nigeria</territory>
+		</territories>
+	</localeDisplayNames>
+	<characters>
+		<exemplarCharacters>[a á b {ch} d e é ẹ {ẹ́}f g {gb} h i í j k {kp} l m n o ó ọ {ọ́} p r s {sh} t u ú v w y z {zh}]</exemplarCharacters>
+        <exemplarCharacters type="auxiliary">[c q x à è {ẹ̀} ì ò {ọ̀} ù]</exemplarCharacters>
+        <exemplarCharacters type="index">[A B {CH} D E F G H I J K L M N O P R S T U V W Y Z]</exemplarCharacters>
+        <exemplarCharacters type="numbers">[\- , . % ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
+        <exemplarCharacters type="punctuation">[\- ‐ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
+	</characters>
+	<dates>
+		<calendars>
+			<calendar type="gregorian">
+				<months>
+					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<month type="1">Jén</month>
+							<month type="2">Fẹ́b</month>
+							<month type="3">Mach</month>
+							<month type="4">Épr</month>
+							<month type="5">Mee</month>
+							<month type="6">Jun</month>
+							<month type="7">Jul</month>
+							<month type="8">Ọgọ</month>
+							<month type="9">Sẹp</month>
+							<month type="10">Ọkt</month>
+							<month type="11">Nọv</month>
+							<month type="12">Dis</month>
+						</monthWidth>						
+						<monthWidth type="wide">
+							<month type="1">Jénúári</month>
+							<month type="2">Fẹ́búári</month>
+							<month type="3">Mach</month>
+							<month type="4">Éprel</month>
+							<month type="5">Mee</month>
+							<month type="6">Jun</month>
+							<month type="7">Julai</month>
+							<month type="8">Ọgọst</month>
+							<month type="9">Sẹptẹ́mba</month>
+							<month type="10">Ọktóba</month>
+							<month type="11">Nọvẹ́mba</month>
+							<month type="12">Disẹ́mba</month>
+						</monthWidth>
+					</monthContext>
+				</months>
+				<days>
+					<dayContext type="format">
+						<dayWidth type="abbreviated">
+							<day type="sun">Sọ́n</day>
+							<day type="mon">Mọ́n</day>
+							<day type="tue">Tiú</day>
+							<day type="wed">Wẹ́n</day>
+							<day type="thu">Tọ́z</day>
+							<day type="fri">Fraí</day>
+							<day type="sat">Sát</day>
+						</dayWidth>
+						<dayWidth type="wide">
+							<day type="sun">Sọ́ndè</day>
+							<day type="mon">Mọ́ndè</day>
+							<day type="tue">Tiúzdè</day>
+							<day type="wed">Wẹ́nẹ́zdè</day>
+							<day type="thu">Tọ́zdè</day>
+							<day type="fri">Fraídè</day>
+							<day type="sat">Sátọdè</day>
+						</dayWidth>
+					</dayContext>
+				</days>
+				<dateFormats>
+					<dateFormatLength type="full">
+						<dateFormat>
+							<pattern draft="unconfirmed">EEEE, d MMMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="long">
+						<dateFormat>
+							<pattern draft="unconfirmed">d MMMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="medium">
+						<dateFormat>
+							<pattern draft="unconfirmed">d MMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern draft="unconfirmed">dd/MM/y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<timeFormats>
+					<timeFormatLength type="full">
+						<timeFormat>
+							<pattern draft="unconfirmed">HH:mm:ss zzzz</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="long">
+						<timeFormat>
+							<pattern draft="unconfirmed">H:mm:ss z</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="medium">
+						<timeFormat>
+							<pattern draft="unconfirmed">HH:mm:ss</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="short">
+						<timeFormat>
+							<pattern draft="unconfirmed">HH:mm</pattern>
+						</timeFormat>
+					</timeFormatLength>
+				</timeFormats>
+			</calendar>
+		</calendars>
+	</dates>
+	<numbers>
+		<symbols numberSystem="latn">
+			<decimal draft="unconfirmed">.</decimal>
+			<group draft="unconfirmed">,</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<exponential draft="unconfirmed">E</exponential>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+		</symbols>
+	</numbers>
+	<units>
+		<unitLength type="short">
+			<unit type="duration-year">
+				<displayName draft="provisional">Yiẹ</displayName>
+				<unitPattern count="other">Yiẹ {0}</unitPattern>
+			</unit>
+			<unit type="duration-month">
+				<displayName draft="provisional">Mọnt</displayName>
+				<unitPattern count="other">Mọnt {0}</unitPattern>
+			</unit>
+			<unit type="duration-week">
+				<displayName draft="provisional">Wik</displayName>
+				<unitPattern count="other">Wik {0}</unitPattern>
+			</unit>
+			<unit type="duration-day">
+				<displayName draft="provisional">Dè</displayName>
+				<unitPattern count="other">{0} Dè</unitPattern>
+			</unit>
+			<unit type="duration-hour">
+				<displayName draft="provisional">Awa</displayName>
+				<unitPattern count="other">Awa {0}</unitPattern>
+			</unit>
+			<unit type="duration-minute">
+				<displayName draft="provisional">Mínit</displayName>
+				<unitPattern count="other">Mínit {0}</unitPattern>
+			</unit>
+			<unit type="duration-second">
+				<displayName draft="provisional">Sẹ́kọn</displayName>
+				<unitPattern count="other">Sẹ́kọn {0}</unitPattern>
+			</unit>			
+		</unitLength>
+	</units>
+</ldml>

--- a/seed/main/pcm_NG.xml
+++ b/seed/main/pcm_NG.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2018 Unicode, Inc.
+<!-- Copyright © 1991-2019 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -9,15 +9,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<identity>
 		<version number="$Revision$"/>
 		<language type="pcm"/>
+		<territory type="NG"/>
 	</identity>
-	<layout>
-		<orientation>
-			<characterOrder>left-to-right</characterOrder>
-			<lineOrder>top-to-bottom</lineOrder>
-		</orientation>
-	</layout>
-	<characters>
-		<exemplarCharacters draft="unconfirmed">[a b d e f g h i j k l m n o p r s t u v w x y z]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary" draft="unconfirmed">[c q]</exemplarCharacters>
-	</characters>
 </ldml>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13299
- [x] Updated PR title and link in previous line to include Issue number

The pcm xml data is the same as provided by Craig via e-mail 2019-Dec-11, except that:
- I made the locale display names draft="unconfirmed"
- The day names supplied as "narrow" were really "abbreviated", so I made them that
- The supplied unit patterns were only for width "full"; but for units the only required width is "short" so I made them that.

"pcm" entries already exist in likelySubtags, territoryInfo, etc. Just needed a defaultContent for pcm_NG.

I removed a now-obsolete file exemplars/main/pcm.xml (the PR incorrectly shows this as a rename to the newly added default content file seed/main/pcm_NG.xml) 