### PR TITLE
CLDR-13501 Fix typo in TR 35, part 4, section 2.1

### DIFF
--- a/docs/ldml/tr35-dates.html
+++ b/docs/ldml/tr35-dates.html
@@ -449,15 +449,15 @@
     width and the context.</p>
     <p>The context is either <i>format</i> (the default), the form
     used within a complete date format string (such as "Saturday,
-    November 12", or <i>stand-alone</i>, the form for date elements
-    used independently, such as in calendar headers. The most
-    important distinction between format and stand-alone forms is a
-    grammatical distinction, for languages that require it. For
-    example, many languages require that a month name without an
-    associated day number (i.e. an independent form) be in the
-    basic <i>nominative</i> form, while a month name with an
-    associated day number (as in a complete date format) should be
-    in a different grammatical form: <i>genitive</i>,
+    November 12"), or <i>stand-alone</i>, the form for date
+    elements used independently, such as in calendar headers. The
+    most important distinction between format and stand-alone
+    forms is a grammatical distinction, for languages that require
+    it. For example, many languages require that a month name
+    without an associated day number (i.e. an independent form) be
+    in the basic <i>nominative</i> form, while a month name with
+    an associated day number (as in a complete date format) should
+    be in a different grammatical form: <i>genitive</i>,
     <i>partitive</i>, etc. In past versions of CLDR, the
     distinction between format and stand-alone forms was also used
     to control capitalization (with stand-alone forms using


### PR DESCRIPTION
Adds closing paranthesis.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13501
- [X] Updated PR title and link in previous line to include Issue number

