### PR TITLE
CLDR-13503 Add cad,pcm to NEW_CLDR_LOCALES and CLDR locales

### DIFF
--- a/tools/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -11,13 +11,14 @@ import com.google.common.collect.ImmutableSet;
 public final class SubmissionLocales {
     public static Set<String> NEW_CLDR_LOCALES = ImmutableSet.of(
         "ceb",  // Cebuano (not new in release, but needs major changes)
-//        "mai",  // Maithili
+        "mai",  // Maithili
         "mni",  // Manipuri (Bengali script)-Apple as well
         "sat",  // Santali -(Apple use Olck script)
         "kok",  // Konkani -(Note: this is already covered by a MS vetter at Modern level)
         "sd_Deva",   // Sindhi (Devanagari) 
         "su",   // Sundanese (script TBD)
-//        "pcm",  // Nigerian Pidgin
+        "cad",  // Caddo
+        "pcm",  // Nigerian Pidgin
         "gn"    // Guarani
         );
     

--- a/tools/java/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/java/org/unicode/cldr/util/data/Locales.txt
@@ -638,6 +638,8 @@ Cldr	; kok ; basic ; Konkani
 Cldr	; su ; basic ; Sundanese (script TBD)
 Cldr	; gn ; basic ; Guarani (Bengali script)
 Cldr	; sd_Deva ; basic ; Sindhi (Devanagari script)
+Cldr	; cad ; basic ; Caddo
+Cldr	; pcm ; basic ; Nigerian Pidgin
 
 
 Bangor_Univ ;   cy   ;    modern  ; Welsh


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13503
- [x] Updated PR title and link in previous line to include Issue number

I am not sure both sets of changes here are absolutely required, but having both should ensure that these locales are enabled for submission. We can clean up later.