### PR TITLE
CLDR-13522 Latency in recognizing clicks and turning into votes

### DIFF
--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -255,9 +255,16 @@ const cldrSurveyTable = (function() {
 			}
 
 			/*
-			 * Update the tr's contents
+			 * Update the row's contents, unless it has an individual update pending.
+			 * We're working with a multiple-row response from the server, and should not use
+			 * this response to update any row(s) in which the user has just voted and for which
+			 * we're still waiting for single-row response(s).
 			 */
-			updateRow(tr, theRow);
+			if (tr.className === 'tr_checking1' || tr.className === 'tr_checking2') {
+				// console.log("Skipping updateRow for tr.className === " + tr.className);
+			} else {
+				updateRow(tr, theRow);
+			}
 		}
 		// downloadObjectAsHtml(tbody);
 		// downloadObjectAsJson(tbody);
@@ -314,7 +321,7 @@ const cldrSurveyTable = (function() {
 	 * Dashboard columns are:
 	 * Code    English    CLDR 33    Winning 34    Action
 	 * 
-	 * Called by insertRowsIntoTbody and loadHandler (in refreshRow2),
+	 * Called by insertRowsIntoTbody and loadHandler (in refreshSingleRow),
 	 * AND by insertFixInfo in review.js!
 	 */
 	function updateRow(tr, theRow) {

--- a/tools/cldr-apps/WebContent/surveytool.css
+++ b/tools/cldr-apps/WebContent/surveytool.css
@@ -2386,13 +2386,24 @@ label.menutop-active, label.menutop-other,
 	color:  navy;
 }
 
-tr.tr_checking {
-	background-color: #f1ecec;
+/*
+ * tr_checking1, tr_checking2:
+ * A row temporarily changes its background color to indicate that the user has
+ * initiated an action, such as voting for an item.
+ * The color changes per tr_checking1 as soon as the user clicks.
+ * The color changes per tr_checking2 when a response is received from the server.
+ * The color changes back to normal after the response has been processed.
+ * The classes tr_checking1, tr_checking2 are used not only to change the appearance,
+ * but also to prevent the row from being updated when a multiple-row response is received;
+ * see insertRowsIntoTbody.
+ */
+tr.tr_checking1 {
+	background-color: orange;
 	opacity: 0.5;
 }
 
 tr.tr_checking2 {
-	background-color: #d4edd9;
+	background-color: #d4edd9; /* green */
 	opacity: 0.75;
 }
 
@@ -2406,6 +2417,7 @@ tr.tr_err {
 
 /*
   ready to submit
+  TODO: when/where/why is this tr_submit used? Or is it unused?
   */
 
 tr.tr_submit {


### PR DESCRIPTION
-Skip updateRow in insertRowsIntoTbody for rows whose single-row responses are pending

-Identify such rows by HTML classes tr_checking1 and tr_checking2

-When user clicks to vote, change class immediately to tr_checking1

-Style for tr_checking1 (orange) similar to tr_checking2 (green)

-Delete style for unused HTML class tr_checking

-Rename refreshRow2 to refreshSingleRow for clarity, and remove unused param vHash

-In refreshSingleRow use surveySessionId not (equivalent) tr.theTable.session, for consistency

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13522
- [x] Updated PR title and link in previous line to include Issue number

