### PR TITLE
CLDR-13554 correct nn spelling of millions and up for rbnf 

### DIFF
--- a/common/rbnf/nn.xml
+++ b/common/rbnf/nn.xml
@@ -63,19 +63,19 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="40">førti[­→→];</rbnfrule>
                 <rbnfrule value="50">femti[­→→];</rbnfrule>
                 <rbnfrule value="60">seksti[­→→];</rbnfrule>
-                <rbnfrule value="70">søtti[­→→];</rbnfrule>
+                <rbnfrule value="70">sytti[­→→];</rbnfrule>
                 <rbnfrule value="80">åtti[­→→];</rbnfrule>
                 <rbnfrule value="90">nitti[­→→];</rbnfrule>
                 <rbnfrule value="100">←%spellout-cardinal-neuter← hundre[ og →→];</rbnfrule>
                 <rbnfrule value="1000">←%spellout-cardinal-neuter← tusen[ og →→];</rbnfrule>
-                <rbnfrule value="1000000">éin miljon[ →→];</rbnfrule>
-                <rbnfrule value="2000000">←← miljoner[ →→];</rbnfrule>
-                <rbnfrule value="1000000000">éin miljard[ →→];</rbnfrule>
-                <rbnfrule value="2000000000">←← miljarder[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000">éin biljon[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←← biljoner[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">éin biljard[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←← biljarder[ →→];</rbnfrule>
+                <rbnfrule value="1000000">éin million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←← millionar[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">éin milliard[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←← milliardar[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">éin billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←← billionar[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">éin billiard[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←← biliardar[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>


### PR DESCRIPTION
cf. https://ordbok.uib.no/perl/ordbok.cgi?OPP=millionar&nynorsk=+

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13554
- [X] Updated PR title and link in previous line to include Issue number

