### PR TITLE
CLDR-13572 pcm, fix quotes and use of w/W in week-of patterns

### DIFF
--- a/seed/main/pcm.xml
+++ b/seed/main/pcm.xml
@@ -1302,8 +1302,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">‘Wik’ W ‘fọ’ MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="other">‘Wik’ W ‘fọ’ MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="one">'Wik' W 'fọ' MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="other">'Wik' W 'fọ' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
 						<dateFormatItem id="yM">M/y</dateFormatItem>
@@ -1315,7 +1315,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
 						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
-						<dateFormatItem id="yw" count="one">‘Wik’ W ‘fọ’ Y</dateFormatItem>
+						<dateFormatItem id="yw" count="one">'Wik' w 'fọ' Y</dateFormatItem>
 						<dateFormatItem id="yw" count="other">↑↑↑</dateFormatItem>
 					</availableFormats>
 					<appendItems>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13572
- [x] Updated PR title and link in previous line to include Issue number

In pcm week-of patterns: Fix curly quotes to be straight quotes, and in the pattern for "yw" change 'W' to 'w'

This fixes 3 of the ~60 errors in master, Mark is fixing the rest (which are all same-as-code errors)
