### PR TITLE
CLDR-13592 BRS37 da,fi,th: fix problems with intervalFormats for GyM* skeletons

### DIFF
--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -2088,19 +2088,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">M/y GGGG–M/y GGGG</greatestDifference>
-							<greatestDifference id="M">M/y–M/y GGGGG</greatestDifference>
-							<greatestDifference id="y">M/y–M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">MM.y GGGGG–MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M">MM.y–MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM.y–MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">d/M/y–d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="G">d/M/y GGGGG–d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="d">dd.MM.y–dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="G">dd.MM.y GGGGG–dd.MM.y GGGGG</greatestDifference>
 							<greatestDifference id="M">dd.MM.y–dd.MM.y GGGGG</greatestDifference>
 							<greatestDifference id="y">dd.MM.y–dd.MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">E dd. MM. y–E dd. MM. y GGGGG</greatestDifference>
-							<greatestDifference id="G">E, d/M/y GGGGG–E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="d">E dd.MM.y–E dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="G">E dd.MM.y GGGGG–E dd.MM.y GGGGG</greatestDifference>
 							<greatestDifference id="M">E dd.MM.y–E dd.MM.y GGGGG</greatestDifference>
 							<greatestDifference id="y">E dd.MM.y–E dd.MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -1920,6 +1920,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">E d.M. – E d.M.y G</greatestDifference>
 							<greatestDifference id="y">E d.M.y – E d.M.y G</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="GyMMMM">
+							<greatestDifference id="G">LLLL y G – LLLL y G</greatestDifference>
+							<greatestDifference id="M">LLLL–LLLL y G</greatestDifference>
+							<greatestDifference id="y">LLLL y – LLLL y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="GyMMMMd">
+							<greatestDifference id="d">d.–d. MMMM y G</greatestDifference>
+							<greatestDifference id="G">d. MMMM y G – d. MMMM y G</greatestDifference>
+							<greatestDifference id="M">d. MMMM – d. MMMM y G</greatestDifference>
+							<greatestDifference id="y">d. MMMM y – d. MMMM y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="GyMMMMEd">
+							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="G">E d. MMMM y G – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="M">E d. MMMM – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="y">E d. MMMM y – E d. MMMM y G</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>
 							<greatestDifference id="h">h–h a</greatestDifference>
@@ -2479,9 +2496,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">E d.M.y – E d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
-							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
-							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
+							<greatestDifference id="G">M.y G – M.y G</greatestDifference>
+							<greatestDifference id="M">M.–M.y G</greatestDifference>
+							<greatestDifference id="y">M.y–M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
 							<greatestDifference id="d">d.–d.M.y G</greatestDifference>
@@ -2494,6 +2511,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="G">E d.M.y – E d.M.y G</greatestDifference>
 							<greatestDifference id="M">E d.M. – E d.M.y G</greatestDifference>
 							<greatestDifference id="y">E d.M.y – E d.M.y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="GyMMMM">
+							<greatestDifference id="G">LLLL y G – LLLL y G</greatestDifference>
+							<greatestDifference id="M">LLLL–LLLL y G</greatestDifference>
+							<greatestDifference id="y">LLLL y – LLLL y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="GyMMMMd">
+							<greatestDifference id="d">d.–d. MMMM y G</greatestDifference>
+							<greatestDifference id="G">d. MMMM y G – d. MMMM y G</greatestDifference>
+							<greatestDifference id="M">d. MMMM – d. MMMM y G</greatestDifference>
+							<greatestDifference id="y">d. MMMM y – d. MMMM y G</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="GyMMMMEd">
+							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="G">E d. MMMM y G – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="M">E d. MMMM – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="y">E d. MMMM y – E d. MMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -2920,20 +2920,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
 							<greatestDifference id="G">MM/GGGGG y – MM/GGGGG y</greatestDifference>
-							<greatestDifference id="M">M/y – M/y</greatestDifference>
-							<greatestDifference id="y">M/y – M/y</greatestDifference>
+							<greatestDifference id="M">M/y – M/y G</greatestDifference>
+							<greatestDifference id="y">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">d/M/y – d/M/y</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y G</greatestDifference>
 							<greatestDifference id="G">d/MM/GGGGG y – d/MM/GGGGG y</greatestDifference>
-							<greatestDifference id="M">d/M/y – d/M/y</greatestDifference>
-							<greatestDifference id="y">d/M/y – d/M/y</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">E d/M/y – E d/M/y</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y G</greatestDifference>
 							<greatestDifference id="G">E d/MM/GGGGG y – E d/MM/GGGGG y</greatestDifference>
-							<greatestDifference id="M">E d/M/y – E d/M/y</greatestDifference>
-							<greatestDifference id="y">E d/M/y – E d/M/y</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y G</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
 							<greatestDifference id="G">MMM G y – MMM G y</greatestDifference>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13592
- [x] Updated PR title and link in previous line to include Issue number

Fix problems with intervalFormats for GyM* skeletons introduced in CLDR 36 for 3 locales:
- da, restore consistent use of separator '.' for gregorian formats, matching similar formats
- fi, add entries for MMMM mapping to MMMM, since MMM is now mapping to M. Model on patterns for yMMMM*
- th, restore use of G in gregorian patterns for GyM* skeletons, modeled on the generic patterns.