### PR TITLE
CLDR-13489 Fix geq values for mixed units

### DIFF
--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -264,10 +264,10 @@ For terms of use, see http://www.unicode.org/copyright.html
             <unitPreference regions="001">item-per-cubic-meter</unitPreference>
         </unitPreferences>
         <unitPreferences category="consumption" usage="default">
-            <unitPreference regions="001">liter-per-100kilometers</unitPreference>
+            <unitPreference regions="001">liter-per-100-kilometer</unitPreference>
         </unitPreferences>
         <unitPreferences category="consumption" usage="vehicle-fuel">
-            <unitPreference regions="001">liter-per-100kilometers</unitPreference>
+            <unitPreference regions="001">liter-per-100-kilometer</unitPreference>
             <unitPreference regions="BR IT JP KR MX MY NL TH TR">liter-per-kilometer</unitPreference>
         </unitPreferences>
         <unitPreferences category="consumption-inverse" usage="default">
@@ -312,7 +312,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         </unitPreferences>
         <unitPreferences category="length" usage="person-height">
             <unitPreference regions="001">centimeter</unitPreference>
-            <unitPreference regions="CA GB IN US" geq="3.0">foot:inch</unitPreference>
+            <unitPreference regions="CA GB IN US" geq="36.0">foot:inch</unitPreference>
             <unitPreference regions="AT BE BR CN DE DK DZ EG ES FR HK ID IL IT JO MX MY NL NO PL PT RU SA SE TR VN">meter:centimeter</unitPreference>
         </unitPreferences>
         <unitPreferences category="length" usage="rainfall">
@@ -446,7 +446,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         </unitPreferences>
         <unitPreferences category="year-duration" usage="person-age">
             <unitPreference regions="001" geq="2.5">year-person</unitPreference>
-            <unitPreference regions="001">year-person:month-person</unitPreference>
+            <unitPreference regions="001" geq="12">year-person:month-person</unitPreference>
             <unitPreference regions="001">month-person</unitPreference>
         </unitPreferences>
     </unitPreferenceData>

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestUnits.java
@@ -1178,16 +1178,21 @@ public class TestUnits extends TestFmwk {
                     preferences:
                         for (UnitPreference up : uPrefs) {
                             String unitQuantity = null;
-                            String topUnit = null;
+                            Rational resolvedSize = null;
+                            Rational rationalGeq = Rational.of(BigDecimal.valueOf(up.geq));
                             if ("minute:second".equals(up.unit)) {
                                 int debug = 0;
                             }
                             for (String unit : SPLIT_COLON.split(up.unit)) {
                                 try {
-                                    if (topUnit == null) {
-                                        topUnit = unit;
-                                    }
                                     unitQuantity = converter.getQuantityFromUnit(unit, false);
+                                    String baseUnit = converter.getBaseUnitFromQuantity(unitQuantity);
+                                    Rational size = converter.convert(rationalGeq, unit, baseUnit, false);
+                                    if (resolvedSize == null) {
+                                        resolvedSize = size;
+                                    } else if (size.compareTo(resolvedSize) > 0) {
+                                        resolvedSize = size;
+                                    }
                                 } catch (Exception e) {
                                     errln("Unit is not covertible: " + up.unit);
                                     continue preferences;
@@ -1196,22 +1201,19 @@ public class TestUnits extends TestFmwk {
                                     int debug = 0;
                                 }
                             }
-                            String baseUnit = converter.getBaseUnitFromQuantity(unitQuantity);
-                            Rational rationalGeq = Rational.of(BigDecimal.valueOf(up.geq));
-                            Rational size = converter.convert(rationalGeq, topUnit, baseUnit, false);
                             if (lastSize != null) { // ensure descending order
                                 if (!assertTrue("Successive items must be ≥ previous:\n\t" + quantityPlusUsage 
                                     + "; unit: " + up.unit
-                                    + "; size: " + size
+                                    + "; size: " + resolvedSize
                                     + "; regions: " + regions
                                     + "; lastUnit: " + lastUnit
                                     + "; lastSize: " + lastSize
                                     + "; lastRegions: " + lastRegions
-                                    , size.compareTo(lastSize) <= 0)) {
+                                    , resolvedSize.compareTo(lastSize) <= 0)) {
                                     int debug = 0;
                                 }
                             }
-                            lastSize = size;
+                            lastSize = resolvedSize;
                             lastUnit = up.unit;
                             lastRegions = regions;
                             System.out.println(quantity + "\t" + usage + "\t" + regions + "\t" + up.geq + "\t" + up.unit + "\t" + up.skeleton);


### PR DESCRIPTION
Also changes "liter-per-100kilometers" to "liter-per-100-kilometer" in the text.

It's really important to get the correct `geq` values in.  I think we should also change the `:` syntax for mixed/sequence units.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13489
- [x] Updated PR title and link in previous line to include Issue number

