### PR TITLE
CLDR-13585 Move more Survey Tool code from jsp to java files

### DIFF
--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
@@ -161,7 +161,8 @@ var TRANS_HINT_LOCALE = "<%=SurveyMain.TRANS_HINT_LOCALE%>";
 var TRANS_HINT_LANGUAGE_NAME = "<%=SurveyMain.TRANS_HINT_LANGUAGE_NAME%>";
 </script>
 
-<%--TODO Refactor to add this at the end of every page instead of top, will increase performance --%>
-<%@include file="/WEB-INF/tmpl/js_include.jsp" %>
+<%--TODO Refactor to add this at the end of every page instead of top, will increase performance.
+       Alternatively, include "defer" in the "script" tags to achieve similar effect. --%>
+<% SurveyAjax.includeJavaScript(request, out); %>
 
 <!--  end ajax_status.jsp -->

--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/js_include.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/js_include.jsp
@@ -1,9 +1,0 @@
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
-<script src="<%= request.getContextPath() %>/js/jquery.autosize.min.js"></script>
-<script src='<%= request.getContextPath() %>/js/survey.js'></script>
-<script src="<%= request.getContextPath() %>/js/CldrSurveyVettingLoader.js"></script>
-<script src="<%= request.getContextPath() %>/js/CldrSurveyVettingTable.js"></script>
-<script src="<%= request.getContextPath() %>/js/bootstrap.min.js"></script>
-<script src="<%= request.getContextPath() %>/js/redesign.js"></script>
-<script src="<%= request.getContextPath() %>/js/review.js"></script>

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -3055,4 +3055,55 @@ public class SurveyAjax extends HttpServlet {
         }
         out.write("</body>\n</html>\n");
     }
+
+    /**
+     * Write the script tags for Survey Tool JavaScript files
+     *
+     * @param request the HttpServletRequest
+     * @param out the Writer
+     * @throws IOException
+     *
+     * Some code was moved here from js_include.jsp
+     * Reference: https://unicode-org.atlassian.net/browse/CLDR-13585
+     *
+     * Called from ajax_status.jsp
+     */
+    public static void includeJavaScript(HttpServletRequest request, Writer out) throws IOException {
+        /*
+         * TODO: investigate putting "defer" after "script"; may cause page to appear
+         * to load faster, though order of loading jquery, dojo may be problematic...
+         */
+        out.write("<script src='//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js'></script>\n");
+
+        /*
+         * TODO: figure out what we're using jquery-ui for.
+         * If we don't use it, don't include it.
+         * If we don't include jquery-ui we get "TypeError: p.easing[this.easing] is not a function"
+         */
+        out.write("<script src='//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js'></script>\n");
+
+        String prefix = "<script src='" + request.getContextPath() + "/js/";
+        String tail = "'></script>\n";
+
+        /**
+         * INCLUDE_SCRIPT_VERSION leave false for now (CLDR-13585).
+         * May change to true per:
+         *    https://unicode-org.atlassian.net/browse/CLDR-13582
+         *    "Make sure browser uses most recent JavaScript files for ST"
+         */
+        final boolean INCLUDE_SCRIPT_VERSION = false;
+        final String v = INCLUDE_SCRIPT_VERSION ? "?v=" + CLDRConfig.getInstance().getProperty("CLDR_DIR_HASH") : "";
+
+        out.write(prefix + "jquery.autosize.min.js" + tail);
+
+        out.write(prefix + "survey.js" + v + tail);
+        out.write(prefix + "CldrStAjax.js" + v + tail);
+        out.write(prefix + "CldrSurveyVettingLoader.js" + v + tail);
+        out.write(prefix + "CldrSurveyVettingTable.js" + v + tail);
+
+        out.write(prefix + "bootstrap.min.js" + tail);
+
+        out.write(prefix + "redesign.js" + v + tail);
+        out.write(prefix + "review.js" + v + tail);
+    }
 }


### PR DESCRIPTION
-Remove js_include.jsp, move code to new SurveyAjax.includeJavaScript()

-New boolean INCLUDE_SCRIPT_VERSION, false for now, see CLDR-13582

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13585
- [x] Updated PR title and link in previous line to include Issue number

