### PR TITLE
CLDR-13591 BRS37 yo, fix bad metazone

### DIFF
--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -3716,8 +3716,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Mexico_Northwest">
 				<long>
 					<generic>Àkókò Apá Ìwọ̀ Oorùn Mẹ́ṣíkò</generic>
-					<standard>↑↑↑</standard>
-					<daylight>Àkókò Apá Ìwọ̀ Oorùn OjúmọmọMẹ́ṣíkò</daylight>
+					<standard>Àkókò Àfẹnukò Apá Ìwọ̀ Oorùn Mẹ́ṣíkò</standard>
+					<daylight>Àkókò Ojúmọmọ Apá Ìwọ̀ Oorùn Mẹ́ṣíkò</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Pacific">


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13591
- [x] Updated PR title and link in previous line to include Issue number

Yoruba (yo) had a bad metazone value "↑↑↑" for Mexico_Northwest which caused a failure in GenerateProductionData. Fixed by using pattern of other daylight/standard names.
