### PR TITLE
CLDR-13620 Add permillion alias to units.xml

### DIFF
--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -157,7 +157,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         <convertUnit source='mole' baseUnit='item' factor='6.02214076E+23'/>
         
         <!-- portion -->
-        <convertUnit source='part-per-million' baseUnit='portion' factor='1/1000000'/>
+        <convertUnit source='permillion' baseUnit='portion' factor='1/1000000'/>
         <convertUnit source='permyriad' baseUnit='portion' factor='1/10000'/>
         <convertUnit source='permille' baseUnit='portion' factor='1/1000'/>
         <convertUnit source='percent' baseUnit='portion' factor='1/100'/>
@@ -458,6 +458,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <unitAlias type="liter-per-100kilometers" replacement="liter-per-100-kilometer" reason="deprecated"/>
             <unitAlias type="meter-per-second-squared" replacement="meter-per-square-second" reason="deprecated"/>
             <unitAlias type="millimeter-of-mercury" replacement="millimeter-ofhg" reason="deprecated"/>
+            <unitAlias type="part-per-million" replacement="permillion" reason="deprecated"/>
             <unitAlias type="pound-foot" replacement="pound-force-foot" reason="deprecated"/>
             <unitAlias type="pound-per-square-inch" replacement="pound-force-per-square-inch" reason="deprecated"/>
             <usageAlias type="music-track" replacement="media" reason="deprecated"/>

--- a/common/testData/units/unitsTest.txt
+++ b/common/testData/units/unitsTest.txt
@@ -111,7 +111,7 @@ mass    ;   metric-ton  ;   kilogram    ;   1000 * x    ;   1000000.0
 mass    ;   earth-mass  ;   kilogram    ;   5972200000000000000000000 * x   ;   5.9722E27
 mass    ;   solar-mass  ;   kilogram    ;   1988470000000000000000000000000 * x ;   1.98847E33
 mass-density    ;   milligram-per-deciliter ;   kilogram-per-cubic-meter    ;   1 / 100 * x ;   10.0
-portion ;   part-per-million    ;   portion ;   1 / 1000000 * x ;   0.001
+portion ;   permillion  ;   portion ;   1 / 1000000 * x ;   0.001
 portion ;   permyriad   ;   portion ;   1 / 10000 * x   ;   0.1
 portion ;   permille    ;   portion ;   1 / 1000 * x    ;   1.0
 portion ;   percent ;   portion ;   1 / 100 * x ;   10.0


### PR DESCRIPTION
We had agreed to map "part-per-million" to "permillion", but this was not reflected in units.xml.

Reasons to replace this one:

1. "-per-" is a reserved syntax.
2. More consistent with "percent", "permille", and "permyriad".

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13620
- [x] Updated PR title and link in previous line to include Issue number

