### PR TITLE
CLDR-13591 BRS37 add missing vowel matras to mai exemplars

### DIFF
--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -92,7 +92,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[क {क्ष} ख-घ च-ज {ज्ञ} झ-डड़{डं} ढढ़ ण त {त्र} थ-न प-र ल व श {श्र} ष-ह]</exemplarCharacters>
+		<exemplarCharacters>[क {क्ष} ख-घ च-ज {ज्ञ} झ-डड़{डं} ढढ़ ण त {त्र} थ-न प-र ल व श {श्र} ष-ह ा ि ी \u0941 \u0942 \u0947 \u0948 ो ौ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[अ{अं} {अः} आ-ऌ ॡ ए ऐ ओ औ]</exemplarCharacters>
 		<exemplarCharacters type="index">[अ{अं} {अः} आ-ऌ ॡ ए ऐ ओ-क {क्ष} ख-घ च-ज {ज्ञ} झ-डड़{डं} ढढ़ ण त {त्र} थ-न प-र ल व श {श्र} ष-ह]</exemplarCharacters>
 		<exemplarCharacters type="numbers" draft="contributed">↑↑↑</exemplarCharacters>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13591
- [x] Updated PR title and link in previous line to include Issue number

Maithili (mai) uses certain vowel matras, 093E-0942, 0947-0948, 094B-094C (a subset of those used by Hindi); see for example https://www.omniglot.com/writing/maithili.htm. However, these are currently missing in the Maithili exemplars. And some of these are used in the Maithili locale data (e.g. 093F,0940,0948 used in calendar symbol and language names), so that the ICU tests produce "characters not in the exemplars" errors.

Just add the missing exemplars (copied the necessary subset from the Hindi exemplars).