### PR TITLE
CLDR-13591 BRS37 add exemplars 093C,0902,0903 for mai, 0902 for sd_Deva

### DIFF
--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -92,7 +92,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[क {क्ष} ख-घ च-ज {ज्ञ} झ-डड़{डं} ढढ़ ण त {त्र} थ-न प-र ल व श {श्र} ष-ह ा ि ी \u0941 \u0942 \u0947 \u0948 ो ौ]</exemplarCharacters>
+		<exemplarCharacters>[\u093C \u0902 ः क {क्ष} ख-घ च-ज {ज्ञ} झ-डड़{डं} ढढ़ ण त {त्र} थ-न प-र ल व श {श्र} ष-ह ा ि ी \u0941 \u0942 \u0947 \u0948 ो ौ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[अ{अं} {अः} आ-ऌ ॡ ए ऐ ओ औ]</exemplarCharacters>
 		<exemplarCharacters type="index">[अ{अं} {अः} आ-ऌ ॡ ए ऐ ओ-क {क्ष} ख-घ च-ज {ज्ञ} झ-डड़{डं} ढढ़ ण त {त्र} थ-न प-र ल व श {श्र} ष-ह]</exemplarCharacters>
 		<exemplarCharacters type="numbers" draft="contributed">↑↑↑</exemplarCharacters>

--- a/common/main/sd_Deva.xml
+++ b/common/main/sd_Deva.xml
@@ -94,7 +94,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters draft="contributed">[\u093C अ आ इ ई उ ऊ ए ऐ ओ औ क ख ग ॻ घ ङ च छ ज ॼ झ ञ ट ठ ड ॾ ढ ण त थ द ध न प फ ब ॿ भ म य र ल व श ष स ह ा ि ी \u0941 \u0942 \u0943 \u0944 \u0945 \u0947 \u0948 ॉ ो ौ \u094D]</exemplarCharacters>
+		<exemplarCharacters draft="contributed">[\u093C \u0902 अ आ इ ई उ ऊ ए ऐ ओ औ क ख ग ॻ घ ङ च छ ज ॼ झ ञ ट ठ ड ॾ ढ ण त थ द ध न प फ ब ॿ भ म य र ल व श ष स ह ा ि ी \u0941 \u0942 \u0943 \u0944 \u0945 \u0947 \u0948 ॉ ो ौ \u094D]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[\u200C\u200D]</exemplarCharacters>
 		<exemplarCharacters type="numbers" draft="contributed">[\- ‑ , . % ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="contributed">[\- ‐ ‑ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13591
- [x] Updated PR title and link in previous line to include Issue number

Fix exemplar set issues caught by ICU exhaustive tests.
1. For mai: Per Omniglot (and CLDR data for 093C), mai exemplars need to add 093C, 0902, 0903.
2. For sd_Deva: Per CLDR data, sd_Deva exemplars need to add 0902.
