### PR TITLE
CLDR-12023 Speed up LogicalGrouping.getPaths return null not empty

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -638,8 +638,11 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 continue;
             }
             Set<String> grouping = LogicalGrouping.getPaths(cldrFile, path);
+            seen.add(path);
+            if (grouping == null) {
+                continue;
+            }
             seen.addAll(grouping);
-            seen.add(path); // needed too?
             levelToPaths.clear();
             for (String groupingPath : grouping) {
                 if (LogicalGrouping.isOptional(cldrFile, groupingPath)) {

--- a/tools/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/java/org/unicode/cldr/test/CheckDates.java
@@ -342,33 +342,36 @@ public class CheckDates extends FactoryCheckCLDR {
                             wideValue);
                     result.add(item);
                 }
-                for (String lgPath : LogicalGrouping.getPaths(getCldrFileToCheck(), path)) {
-                    String lgPathValue = getCldrFileToCheck().getWinningValueWithBailey(lgPath);
-                    if (lgPathValue == null) {
-                        continue;
-                    }
-                    String lgPathToWide = lgPath.replace("[@type=\"abbreviated\"]", "[@type=\"wide\"]");
-                    String lgPathWideValue = getCldrFileToCheck().getWinningValueWithBailey(lgPathToWide);
-                    // This helps us get around things like "de març" vs. "març" in Catalan
-                    String thisValueStripped = stripPrefix(value);
-                    String wideValueStripped = stripPrefix(wideValue);
-                    String lgPathValueStripped = stripPrefix(lgPathValue);
-                    String lgPathWideValueStripped = stripPrefix(lgPathWideValue);
-                    boolean thisPathHasPeriod = value.contains(".");
-                    boolean lgPathHasPeriod = lgPathValue.contains(".");
-                    if (!thisValueStripped.equalsIgnoreCase(wideValueStripped) && !lgPathValueStripped.equalsIgnoreCase(lgPathWideValueStripped) &&
-                        thisPathHasPeriod != lgPathHasPeriod) {
-                        CheckStatus.Type et = CheckStatus.errorType;
-                        if (path.contains("dayPeriod")) {
-                            et = CheckStatus.warningType;
+                Set<String> grouping = LogicalGrouping.getPaths(getCldrFileToCheck(), path);
+                if (grouping != null) {
+                    for (String lgPath : grouping) {
+                        String lgPathValue = getCldrFileToCheck().getWinningValueWithBailey(lgPath);
+                        if (lgPathValue == null) {
+                            continue;
                         }
-                        CheckStatus item = new CheckStatus()
-                            .setCause(this)
-                            .setMainType(et)
-                            .setSubtype(Subtype.inconsistentPeriods)
-                            .setMessage("Inconsistent use of periods in abbreviations for this section.");
-                        result.add(item);
-                        break;
+                        String lgPathToWide = lgPath.replace("[@type=\"abbreviated\"]", "[@type=\"wide\"]");
+                        String lgPathWideValue = getCldrFileToCheck().getWinningValueWithBailey(lgPathToWide);
+                        // This helps us get around things like "de març" vs. "març" in Catalan
+                        String thisValueStripped = stripPrefix(value);
+                        String wideValueStripped = stripPrefix(wideValue);
+                        String lgPathValueStripped = stripPrefix(lgPathValue);
+                        String lgPathWideValueStripped = stripPrefix(lgPathWideValue);
+                        boolean thisPathHasPeriod = value.contains(".");
+                        boolean lgPathHasPeriod = lgPathValue.contains(".");
+                        if (!thisValueStripped.equalsIgnoreCase(wideValueStripped) && !lgPathValueStripped.equalsIgnoreCase(lgPathWideValueStripped) &&
+                            thisPathHasPeriod != lgPathHasPeriod) {
+                            CheckStatus.Type et = CheckStatus.errorType;
+                            if (path.contains("dayPeriod")) {
+                                et = CheckStatus.warningType;
+                            }
+                            CheckStatus item = new CheckStatus()
+                                .setCause(this)
+                                .setMainType(et)
+                                .setSubtype(Subtype.inconsistentPeriods)
+                                .setMessage("Inconsistent use of periods in abbreviations for this section.");
+                            result.add(item);
+                            break;
+                        }
                     }
                 }
             } else if (path.indexOf("[@type=\"narrow\"]") >= 0) {

--- a/tools/java/org/unicode/cldr/test/CheckLogicalGroupings.java
+++ b/tools/java/org/unicode/cldr/test/CheckLogicalGroupings.java
@@ -88,7 +88,7 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
         }
 
         Set<String> paths = LogicalGrouping.getPaths(getCldrFileToCheck(), path);
-        if (paths.size() < 2) return this; // skip if not part of a logical grouping
+        if (paths == null || paths.size() < 2) return this; // skip if not part of a logical grouping
 
         // TODO 
         Set<String> paths2 = new HashSet<String>(paths);

--- a/tools/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/java/org/unicode/cldr/tool/CLDRModify.java
@@ -2187,7 +2187,7 @@ public class CLDRModify {
                     return;
                 }
                 Set<String> paths = LogicalGrouping.getPaths(cldrFileToFilter, xpath);
-                if (paths.size() < 2) {
+                if (paths == null || paths.size() < 2) {
                     return;
                 }
                 Set<String> needed = new LinkedHashSet<>();

--- a/tools/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -356,7 +356,7 @@ public class GenerateProductionData {
                 // TODO Should be done in the converter tool!!
                 if (ADD_LOGICAL_GROUPS && !LogicalGrouping.isOptional(cldrFileResolved, xpath)) {
                     Set<String> paths = LogicalGrouping.getPaths(cldrFileResolved, xpath);
-                    if (paths.size() > 1) {
+                    if (paths != null && paths.size() > 1) {
                         for (String possiblePath : paths) {
                             // Unclear from API whether we need to do this filtering
                             if (!LogicalGrouping.isOptional(cldrFileResolved, possiblePath)) {

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -1012,69 +1012,71 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
             boolean logicDuplicate = true;
 
             if (!checked.contains(curXpath)) {
-                // we compare logic Group and only removen when all are duplicate
+                // we compare logic Group and only remove when all are duplicate
                 Set<String> logicGroups = LogicalGrouping.getPaths(this, curXpath);
-                Iterator<String> iter = logicGroups.iterator();
-                while (iter.hasNext() && logicDuplicate) {
-                    String xpath = iter.next();
-                    switch (keepIfMatches.getRetention(xpath)) {
-                    case RETAIN:
-                        logicDuplicate = false;
-                        continue;
-                    case RETAIN_IF_DIFFERENT:
-                        String currentValue = dataSource.getValueAtPath(xpath);
-                        if (currentValue == null) {
+                if (logicGroups != null) {
+                    Iterator<String> iter = logicGroups.iterator();
+                    while (iter.hasNext() && logicDuplicate) {
+                        String xpath = iter.next();
+                        switch (keepIfMatches.getRetention(xpath)) {
+                        case RETAIN:
                             logicDuplicate = false;
                             continue;
-                        }
-                        String otherXpath = xpath;
-                        String otherValue = other.dataSource.getValueAtPath(otherXpath);
-                        if (!currentValue.equals(otherValue)) {
-                            if (MINIMIZE_ALT_PROPOSED) {
-                                otherXpath = CLDRFile.getNondraftNonaltXPath(xpath);
-                                if (otherXpath.equals(xpath)) {
-                                    logicDuplicate = false;
-                                    continue;
-                                }
-                                otherValue = other.dataSource.getValueAtPath(otherXpath);
-                                if (!currentValue.equals(otherValue)) {
-                                    logicDuplicate = false;
-                                    continue;
-                                }
-                            } else {
+                        case RETAIN_IF_DIFFERENT:
+                            String currentValue = dataSource.getValueAtPath(xpath);
+                            if (currentValue == null) {
                                 logicDuplicate = false;
                                 continue;
                             }
+                            String otherXpath = xpath;
+                            String otherValue = other.dataSource.getValueAtPath(otherXpath);
+                            if (!currentValue.equals(otherValue)) {
+                                if (MINIMIZE_ALT_PROPOSED) {
+                                    otherXpath = CLDRFile.getNondraftNonaltXPath(xpath);
+                                    if (otherXpath.equals(xpath)) {
+                                        logicDuplicate = false;
+                                        continue;
+                                    }
+                                    otherValue = other.dataSource.getValueAtPath(otherXpath);
+                                    if (!currentValue.equals(otherValue)) {
+                                        logicDuplicate = false;
+                                        continue;
+                                    }
+                                } else {
+                                    logicDuplicate = false;
+                                    continue;
+                                }
+                            }
+                            String keepValue = (String) XMLSource.getPathsAllowingDuplicates().get(xpath);
+                            if (keepValue != null && keepValue.equals(currentValue)) {
+                                logicDuplicate = false;
+                                continue;
+                            }
+                            // we've now established that the values are the same
+                            String currentFullXPath = dataSource.getFullPath(xpath);
+                            String otherFullXPath = other.dataSource.getFullPath(otherXpath);
+                            if (!equalsIgnoringDraft(currentFullXPath, otherFullXPath)) {
+                                logicDuplicate = false;
+                                continue;
+                            }
+                            if (DEBUG) {
+                                keepIfMatches.getRetention(xpath);
+                            }
+                            break;
+                        case REMOVE:
+                            if (DEBUG) {
+                                keepIfMatches.getRetention(xpath);
+                            }
+                            break;
                         }
-                        String keepValue = (String) XMLSource.getPathsAllowingDuplicates().get(xpath);
-                        if (keepValue != null && keepValue.equals(currentValue)) {
-                            logicDuplicate = false;
-                            continue;
-                        }
-                        // we've now established that the values are the same
-                        String currentFullXPath = dataSource.getFullPath(xpath);
-                        String otherFullXPath = other.dataSource.getFullPath(otherXpath);
-                        if (!equalsIgnoringDraft(currentFullXPath, otherFullXPath)) {
-                            logicDuplicate = false;
-                            continue;
-                        }
-                        if (DEBUG) {
-                            keepIfMatches.getRetention(xpath);
-                        }
-                        break;
-                    case REMOVE:
-                        if (DEBUG) {
-                            keepIfMatches.getRetention(xpath);
-                        }
-                        break;
+
                     }
 
+                    if (first) {
+                        first = false;
+                        if (butComment) appendFinalComment("Duplicates removed:");
+                    }
                 }
-                if (first) {
-                    first = false;
-                    if (butComment) appendFinalComment("Duplicates removed:");
-                }
-
                 // we can't remove right away, since that disturbs the iterator.
                 checked.addAll(logicGroups);
                 if (logicDuplicate) {

--- a/tools/java/org/unicode/cldr/util/LogicalGrouping.java
+++ b/tools/java/org/unicode/cldr/util/LogicalGrouping.java
@@ -71,7 +71,7 @@ public class LogicalGrouping {
      * Return a sorted set of paths that are in the same logical set as the given path
      *
      * @param path the distinguishing xpath
-     * @return the set of paths
+     * @return the set of paths, or null (to be treated as equivalent to empty set)
      *
      * For example, given the path
      *
@@ -92,7 +92,8 @@ public class LogicalGrouping {
      */
     public static Set<String> getPaths(CLDRFile cldrFile, String path) {
         if (path == null) {
-            return new TreeSet<String>(); // return empty set for null path
+            return null; // return null for null path
+            // return new TreeSet<String>(); // return empty set for null path
         }
         XPathParts parts = null;
         PathType pathType = null;
@@ -113,6 +114,7 @@ public class LogicalGrouping {
         if (pathType == PathType.SINGLETON) {
             /*
              * Skip cache for PathType.SINGLETON and simply return a set of one.
+             * TODO: should we ever return null instead of singleton here?
              */
             Set<String> set = new TreeSet<String>();
             set.add(path);


### PR DESCRIPTION
-Change all callers to allow for null return

-Return null instead of empty new TreeSet if path is null

-Comment TODO: should we ever return null instead of singleton here?

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-12023
- [x] Updated PR title and link in previous line to include Issue number

