### PR TITLE
CLDR-11687 Update Dojo, async true

### DIFF
--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
@@ -15,7 +15,7 @@
 <script>
 dojoConfig = {
 		parseOnLoad: true,
-		/* async: true, */
+		async: true,
 		};</script>
 <script src='//ajax.googleapis.com/ajax/libs/dojo/1.14.1/dojo/dojo.js'></script>
 <script>


### PR DESCRIPTION
-Add async: true in dojoConfig, fix warning XMLHttpRequest with the synchronous flag set to true is deprecated

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11687
- [x] Updated PR title and link in previous line to include Issue number

