### PR TITLE
CLDR-13639 update territoryInfo for ms in ID; add ms_ID

### DIFF
--- a/common/main/ms_ID.xml
+++ b/common/main/ms_ID.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ms"/>
+		<territory type="ID"/>
+	</identity>
+	<dates>
+		<calendars>
+			<calendar type="generic">
+				<dateFormats>
+					<dateFormatLength type="full">
+						<dateFormat>
+							<pattern>EEEE, dd MMMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="medium">
+						<dateFormat>
+							<pattern>d MMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd/MM/yy GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+			</calendar>
+			<calendar type="gregorian">
+				<dateFormats>
+					<dateFormatLength type="full">
+						<dateFormat>
+							<pattern>EEEE, dd MMMM y</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd/MM/yy</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<timeFormats>
+					<timeFormatLength type="full">
+						<timeFormat>
+							<pattern>HH.mm.ss zzzz</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="long">
+						<timeFormat>
+							<pattern>HH.mm.ss z</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="medium">
+						<timeFormat>
+							<pattern>HH.mm.ss</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="short">
+						<timeFormat>
+							<pattern>HH.mm</pattern>
+						</timeFormat>
+					</timeFormatLength>
+				</timeFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="Bhm">h.mm B</dateFormatItem>
+						<dateFormatItem id="Bhms">h.mm.ss B</dateFormatItem>
+						<dateFormatItem id="EBhm">E h.mm B</dateFormatItem>
+						<dateFormatItem id="EBhms">E h.mm.ss B</dateFormatItem>
+						<dateFormatItem id="Ehm">E h.mm a</dateFormatItem>
+						<dateFormatItem id="EHm">E HH.mm</dateFormatItem>
+						<dateFormatItem id="Ehms">E h.mm.ss a</dateFormatItem>
+						<dateFormatItem id="EHms">E HH.mm.ss</dateFormatItem>
+						<dateFormatItem id="hm">h.mm a</dateFormatItem>
+						<dateFormatItem id="Hm">HH.mm</dateFormatItem>
+						<dateFormatItem id="hms">h.mm.ss a</dateFormatItem>
+						<dateFormatItem id="Hms">HH.mm.ss</dateFormatItem>
+						<dateFormatItem id="hmsv">h.mm.ss. a v</dateFormatItem>
+						<dateFormatItem id="Hmsv">HH.mm.ss v</dateFormatItem>
+						<dateFormatItem id="hmv">h.mm a v</dateFormatItem>
+						<dateFormatItem id="Hmv">HH.mm v</dateFormatItem>
+					</availableFormats>
+					<intervalFormats>
+						<intervalFormatItem id="Bhm">
+							<greatestDifference id="B">h.mm B – h.mm B</greatestDifference>
+							<greatestDifference id="h">h.mm – h.mm B</greatestDifference>
+							<greatestDifference id="m">h.mm – h.mm B</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hm">
+							<greatestDifference id="a">h.mm a – h.mm a</greatestDifference>
+							<greatestDifference id="h">h.mm–h.mm a</greatestDifference>
+							<greatestDifference id="m">h.mm–h.mm a</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hm">
+							<greatestDifference id="H">HH.mm–HH.mm</greatestDifference>
+							<greatestDifference id="m">HH.mm–HH.mm</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hmv">
+							<greatestDifference id="a">h.mm a – h.mm a v</greatestDifference>
+							<greatestDifference id="h">h.mm–h.mm a v</greatestDifference>
+							<greatestDifference id="m">h.mm–h.mm a v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmv">
+							<greatestDifference id="H">HH.mm–HH.mm v</greatestDifference>
+							<greatestDifference id="m">HH.mm–HH.mm v</greatestDifference>
+						</intervalFormatItem>
+					</intervalFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic">
+				<dateFormats>
+					<dateFormatLength type="full">
+						<dateFormat>
+							<pattern>EEEE, dd MMMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="medium">
+						<dateFormat>
+							<pattern>d MMM y G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+			</calendar>
+		</calendars>
+		<timeZoneNames>
+			<hourFormat>+HH.mm;-HH.mm</hourFormat>
+		</timeZoneNames>
+	</dates>
+	<numbers>
+		<symbols numberSystem="latn">
+			<decimal>,</decimal>
+			<group>.</group>
+			<timeSeparator>.</timeSeparator>
+		</symbols>
+		<currencyFormats numberSystem="latn">
+			<currencyFormatLength>
+				<currencyFormat type="accounting">
+					<pattern>¤#,##0.00</pattern>
+				</currencyFormat>
+			</currencyFormatLength>
+		</currencyFormats>
+		<currencies>
+			<currency type="IDR">
+				<symbol>Rp</symbol>
+			</currency>
+		</currencies>
+	</numbers>
+</ldml>

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -1692,8 +1692,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Malay; ?; ? } => { Malay; Latin; Malaysia }-->
 		<likelySubtag from="ms_CC" to="ms_Arab_CC"/>
 		<!--{ Malay; ?; Cocos (Keeling) Islands } => { Malay; Arabic; Cocos (Keeling) Islands }-->
-		<likelySubtag from="ms_ID" to="ms_Arab_ID"/>
-		<!--{ Malay; ?; Indonesia } => { Malay; Arabic; Indonesia }-->
+		<likelySubtag from="ms_ID" to="ms_Latn_ID"/>
+		<!--{ Malay; ?; Indonesia } => { Malay; Latin; Indonesia }-->
 		<likelySubtag from="mt" to="mt_Latn_MT"/>
 		<!--{ Maltese; ?; ? } => { Maltese; Latin; Malta }-->
 		<likelySubtag from="mtc" to="mtc_Latn_ZZ"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -3091,13 +3091,14 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="jv" literacyPercent="10" populationPercent="34" references="R1294"/>	<!--Javanese-->
 			<languagePopulation type="su" populationPercent="12" references="R1269"/>	<!--Sundanese-->
 			<languagePopulation type="mad" literacyPercent="40" populationPercent="6.3"/>	<!--Madurese-->
-			<languagePopulation type="ms_Arab" populationPercent="4.6"/>	<!--Malay (Arabic)-->
+			<languagePopulation type="ms" populationPercent="3.4"/>	<!--Malay-->
 			<languagePopulation type="min" literacyPercent="10" populationPercent="3"/>	<!--Minangkabau-->
 			<languagePopulation type="bew" populationPercent="2.1"/>	<!--Betawi-->
 			<languagePopulation type="ban" literacyPercent="10" populationPercent="1.8" references="R1144"/>	<!--Balinese-->
 			<languagePopulation type="bug" literacyPercent="10" populationPercent="1.6" references="R1145"/>	<!--Buginese-->
 			<languagePopulation type="bjn" literacyPercent="10" populationPercent="1.5"/>	<!--Banjar-->
 			<languagePopulation type="ace" populationPercent="1.4"/>	<!--Achinese-->
+			<languagePopulation type="ms_Arab" populationPercent="1.2"/>	<!--Malay (Arabic)-->
 			<languagePopulation type="sas" populationPercent="0.97"/>	<!--Sasak-->
 			<languagePopulation type="bbc" populationPercent="0.92"/>	<!--Batak Toba-->
 			<languagePopulation type="zh_Hant" populationPercent="0.92"/>	<!--Chinese (Traditional)-->

--- a/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -565,7 +565,8 @@ Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Komering	kge	"844,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Lampung Api	ljp	"1,810,000"			
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Madurese	mad	6.3%	40%		
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Makasar	mak	"1,930,000"			
-Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Malay (Arabic)	ms_Arab	4.6%			
+Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Malay	ms	3.4%			
+Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Malay (Arabic)	ms_Arab	1.2%			
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Mandar	mdr	"241,000"			
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Mentawai	mwv	"64,100"			
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Minangkabau	min	"7,840,000"	10%		


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13639
- [x] Updated PR title and link in previous line to include Issue number

Changed ms usage in ID from ms_arab 4.6% of population to
ms[_Latn] 3.4%, ms_Arab 1.2% based on the data and calculations  in the JIRA ticket. This may still slightly overstate the ms_Arab usage (local sources say most ms_ID writing is in Latn) but at least it gets the likelySubtags right (still asking for more usage data from local sources).

Also added ms_ID locale. This needed to be more than a pure stub (inheriting from ms which defaults to region MY) since:
- The two regions have different preferred time cycles, h for MY vs H for ID
- The two regions have different time separators, : for MY vs . for ID
- And since I was making those changes, also supported the differences in standard date formats

Just copied the necessary items from the "id" locale (defaults to region ID).