### PR TITLE
CLDR-13895 Correct Russian spelling of "China" in documentation

### DIFF
--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -5362,7 +5362,7 @@ root</pre>
     suppose we have found a Breton bundle, but it does not contain
     translation for the key "CN" (for the country China). It is
     best to return "chine", rather than falling back to the value
-    default language such as Russian and getting "Кітай".&nbsp; The
+    default language such as Russian and getting "Китай".&nbsp; The
     language matching data can be used to get the closest fallback
     locales (of those supported) to a given language.</p>
     <p>For the relationship between Inheritance, DefaultContent,


### PR DESCRIPTION
https://github.com/unicode-org/cldr/blob/f443882bd0fc9267ad7b2b534da6428929bd7b0f/common/main/ru.xml#L818