### PR TITLE
CLDR-11786 Accelerate TestAllLocales with parallel streams

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -289,21 +289,21 @@ public class TestCheckCLDR extends TestFmwk {
     }
 
     public void TestAllLocales() {
-
         CheckCLDR test = CheckCLDR.getCheckAll(factory, INDIVIDUAL_TESTS);
         CheckCLDR.setDisplayInformation(english);
         Set<String> unique = new HashSet<String>();
-
         LanguageTagParser ltp = new LanguageTagParser();
-        int count = 0;
+        Set<String> locales = new HashSet<String>();
         for (String locale : getInclusion() <= 5 ? eightPointLocales : factory.getAvailable()) {
-            if (!ltp.set(locale).getRegion().isEmpty()) {
-                continue;
+            /*
+             * Only test locales without regions. E.g., test "pt", skip "pt_PT"
+             */
+            if (ltp.set(locale).getRegion().isEmpty()) {
+                locales.add(locale);
             }
-            checkLocale(test, locale, null, unique);
-            ++count;
         }
-        logln("Count:\t" + count);
+        locales.parallelStream().forEach(locale -> checkLocale(test, locale, null, unique));
+        logln("Count:\t" + locales.size());
     }
 
     public void TestA() {


### PR DESCRIPTION
-Make TestCheckCLDR/TestAllLocales a few seconds faster using parallelStream

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11786
- [x] Updated PR title and link in previous line to include Issue number

