### PR TITLE
CLDR-13571 fix currencySpacing example in spec to match current root data

### DIFF
--- a/docs/ldml/tr35-numbers.html
+++ b/docs/ldml/tr35-numbers.html
@@ -2031,14 +2031,14 @@ System Data</a>.</em> ) &gt;<br>
     following.</p>
     <pre>&lt;currencySpacing&gt;
   &lt;beforeCurrency&gt;
-    &lt;currencyMatch&gt;[:letter:]&lt;/currencyMatch&gt;
+    &lt;currencyMatch&gt;[:<span class="changed">^S</span>:]&lt;/currencyMatch&gt;
     &lt;surroundingMatch&gt;[:digit:]&lt;/surroundingMatch&gt;
-    &lt;insertBetween&gt;&amp;#x00a0;&lt;/insertBetween&gt;
+    &lt;insertBetween&gt;<span class="changed"> </span>&lt;/insertBetween&gt;
   &lt;/beforeCurrency&gt;
   &lt;afterCurrency&gt;
-    &lt;currencyMatch&gt;[:letter:]&lt;/currencyMatch&gt;
+    &lt;currencyMatch&gt;[:<span class="changed">^S</span>:]&lt;/currencyMatch&gt;
     &lt;surroundingMatch&gt;[:digit:]&lt;/surroundingMatch&gt;
-    &lt;insertBetween&gt;&amp;#x00a0;&lt;/insertBetween&gt;
+    &lt;insertBetween&gt;<span class="changed"> </span>&lt;/insertBetween&gt;
   &lt;/afterCurrency&gt;
 &lt;/currencySpacing&gt;
 </pre>

--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -102,7 +102,7 @@
       </tr>
       <tr>
         <td>Date</td>
-        <td class="changed">2012-03-18</td>
+        <td class="changed">2012-03-22</td>
       </tr>
       <tr>
         <!-- This link must be made live when posting the final version but is disabled during proposed update stage. -->
@@ -6360,7 +6360,7 @@ root</pre>
           | 'U00' ('0' hex{5} | '10' hex{4})<br>
           | 'N{' propName '}'<br>
           | <span class='changed'>[</span>[\u0000-\U00010FFFF]<span class='changed'>-[uxUN]]</span></code></td>
-          <td span class='changed'><em><strong>error</strong> if lengths not exact</em></td>
+          <td class='changed'><em><strong>error</strong> if lengths not exact</em></td>
         </tr>
         <tr class='changed'>
           <th>charName</th>
@@ -7118,7 +7118,7 @@ decimal?, group?, special*)) &gt;</pre>
         <tr class='changed'>
           <td>validity/unit/regular deprecated</td>
           <td>matches only <em>deprecated</em> and <em>regular</em></td>
-        </tr class='changed'>
+        </tr>
         <tr class='changed'>
           <td>validity/unit/!deprecated</td>
           <td>matches all but <em>deprecated</em></td>
@@ -9043,8 +9043,8 @@ decimal?, group?, special*)) &gt;</pre>
     "tr35-numbers.html#Contents">Numbers</a> (number &amp; currency
 	      formatting)</strong></p>
         <ul>
-          <li><em>no changes</em>
-          </li>
+              <li ><strong>Section 4 <a href="tr35-numbers.html#Currencies" >Currencies</a></strong>: Updated
+              &lt;currencySpacing&gt; example to match current root data.</li>
         </ul>
         <p><strong>Part 4: <a href="tr35-dates.html#Contents">Dates</a> (date, time, time zone formatting)</strong></p>
         <ul>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13571
- [x] Updated PR title and link in previous line to include Issue number

Updated spec example of currencySpacing data to match the current root data, to avoid confusion. Also fixed HTML validation errors from earlier spec changes.
