### PR TITLE
CLDR-11350 Added some clarifications on use of unitPatterns

### DIFF
--- a/docs/ldml/tr35-general.html
+++ b/docs/ldml/tr35-general.html
@@ -1349,11 +1349,13 @@
     west) #REQUIRED &gt;<br>
     <br>
     &lt;!ELEMENT durationUnitPattern ( #PCDATA ) &gt;<br></p>
+
     <p>These elements specify the localized way of formatting
     quantities of units such as years, months, days, hours, minutes
     and seconds— for example, in English, "1 day" or "3 days". The
     English rules that produce this example are as follows ({0}
     indicates the position of the formatted numeric value):</p>
+
     <pre>&lt;unit type="duration-day"&gt;
   &lt;displayName&gt;days&lt;/displayName&gt;
   &lt;unitPattern count="one"&gt;<span style=
@@ -1361,17 +1363,37 @@
   &lt;unitPattern count="other"&gt;<span style=
 "color: blue">{0} days</span>&lt;/unitName&gt;
 &lt;/unit&gt;</pre>
+
     <p>In addition to supporting language-specific plural cases
     such as “one” and “other”, unitPatterns support the
     language-independent explicit cases “0” and “1” for special
     handling of numeric values that are exactly 0 or 1; see
     <a href="tr35-numbers.html#Explicit_0_1_rules">Explicit 0 and 1
     rules</a>.</p>
+
+    <p class="changed">The &lt;unitPattern&gt; elements may be used to format
+    quantities with decimal values; in such cases the choice of plural form will
+    depend not only on the numeric value, but also on its formatting (see
+    <a href="tr35-numbers.html#Language_Plural_Rules">Language Plural Rules</a>).
+    In addition to formatting units for stand-alone use,  &lt;unitPattern&gt;
+    elements are increasingly being used to format units for use in running text;
+    for such usages, the developing <a href="#Grammatical_Features">Grammatical Features</a>
+    information will be very useful.</p>
+
+    <p class="changed">Note that for certain plural cases, the unit pattern may not
+    provide for inclusion of a numeric value—that is, it may not include “{0}”. This
+    is especially true for the explicit cases “0” and “1” (which may have patterns like
+    “zero seconds”). In certain languages such as Arabic and Hebrew, this may also be
+    true with certain units for the plural cases “zero”, “one”, or “two” (in these
+    languages, such plural cases are only used for the corresponding exact numeric
+    values, so there is no concern about loss of precision without the numeric value).</p>
+
     <p>Units, like other values with a <strong>count</strong>
     attribute, use a special inheritance. See <strong>Part 1:
     Core:</strong> <em>Section 4.1 <a href=
     "tr35.html#Multiple_Inheritance">Multiple Inheritance</a></em>
     .</p>
+
     <p>The displayName is used for labels, such as in a UI. It is
     typically lowercased and as neutral a plural form as possible,
     and then uses the casing context for the proper display. For
@@ -2481,6 +2503,7 @@ The formal syntax for identifiers is provided below.
     <p>The patterns can have different unit lengths, so the
     appropriate unit length should be used (with fallbacks if
     necessary).</p>
+
     <h3>6.<span class='changed'>5</span> <a name="Unit_Sequences" href="#Unit_Sequences" id=
     "Unit_Sequences">Unit Sequences<span class='changed'> (Mixed Units)</span></a></h3>
     <p>Units may be used in composed sequences <span  class='changed'>(aka <em>mixed units</em>)</span>, such as <strong>5°
@@ -2491,6 +2514,9 @@ The formal syntax for identifiers is provided below.
 &lt;listPattern type="unit-narrow"&gt;
 &lt;listPattern type="unit-short"&gt;
 </pre>
+    <p class="changed">In such a sequence, decimal fractions are typically only displayed for
+    the last element of the sequence, if at all.</p>
+
     <h3>6.<span class='changed'>6</span> <a name="durationUnit" href="#durationUnit" id=
     "durationUnit">durationUnit</a></h3>
     <p>The durationUnit is a special type of unit used for composed

--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -102,7 +102,7 @@
       </tr>
       <tr>
         <td>Date</td>
-        <td class="changed">2012-03-22</td>
+        <td class="changed">2012-03-23</td>
       </tr>
       <tr>
         <!-- This link must be made live when posting the final version but is disabled during proposed update stage. -->
@@ -9027,15 +9027,17 @@ decimal?, group?, special*)) &gt;</pre>
     "tr35-general.html#Contents">General</a> (display names &amp;
 	  transforms, etc.)</strong>
 	    <ul>
-	      <li> <strong>Section 6 <a href="tr35-general.html#Unit_Elements">Unit Elements</a></strong>: added new subsections, and  renumbered other subsections
-<ul>
-            <li ><strong>6.1 <a href="tr35-general.html#Unit_Preference_and_Conversion">Unit Preference and Conversion Data</a></strong></li>
-              <li ><strong>6.2 <a href="tr35-general.html#Unit_Identifiers">Unit Identifiers</a></strong>: extended the syntax of unit identifiers substantially</li>
-              <li ><strong>6.3 <a href="tr35-general.html#Example_Units">Example Units</a></strong><a href="tr35-general.html#Example_Units"></a></li>
+	      <li> <strong>Section 6 <a href="tr35-general.html#Unit_Elements">Unit Elements</a></strong>: 
+            <ul>
+              <li>Added information on patterns without “{0}”.</li>
+              <li>Added new subsections below, and renumbered other subsections.</li>
+              <li><strong>6.1 <a href="tr35-general.html#Unit_Preference_and_Conversion">Unit Preference and Conversion Data</a></strong></li>
+              <li><strong>6.2 <a href="tr35-general.html#Unit_Identifiers">Unit Identifiers</a></strong>: extended the syntax of unit identifiers substantially.</li>
+              <li><strong>6.9 <a href="tr35-general.html#Private_Use_Units">Private-Use Units</a></strong>: New reserved prefix for private-use units.</li>
             </ul>
 	      </li>
 	      <li><strong>Section 11 <a href="tr35-general.html#ListPatterns" >List Patterns</a></strong>: added examples of customized  processing for specific languages</li>
- 	        <li><strong>Section 15 <a href="tr35-general.html#Grammatical_Features">Grammatical Features</a></strong>: added structure and data for grammatical features</li>
+ 	      <li><strong>Section 15 <a href="tr35-general.html#Grammatical_Features">Grammatical Features</a></strong>: added structure and data for grammatical features</li>
         </ul>
       </li>
 	  <li>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11350
- [x] Updated PR title and link in previous line to include Issue number

Added some info on unitPatterns in tr35-general that I hope is helpful, partly in addressing some of the issues raised in the JIRA ticket:
1. Near the beginning of section 6 Unit Patterns, added:

> The <unitPattern> elements may be used to format quantities with decimal values; in such cases the choice of plural form will depend not only on the numeric value, but also on its formatting (see Language Plural Rules). In addition to formatting units for stand-alone use, <unitPattern> elements are increasingly being used to format units for use in running text; for such usages, the new Grammatical Features information will be very useful.
> 
> Note that for certain plural cases, the unit pattern may not provide for inclusion of a numeric value—that is, it may not include “{0}”. This is especially true for the explicit cases “0” and “1” (which may have patterns like “zero seconds”). In certain languages such as Arabic and Hebrew, this may also be true with certain units for the plural cases “zero”, “one”, or “two” (in these languages, such plural cases are only used for the corresponding exact numeric values, so there is no concern about loss of precision without the numeric value).

2. At the end of section 6.5 on Unicode Sequences:
> In such sequences, decimal values are typically only used with the last element of the sequence, if at all.



