### PR TITLE
CLDR-11687 Update Dojo, fix syntax for require dojo/string for stui.sub

### DIFF
--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -526,23 +526,32 @@ var stui = {
 	disconnected: "Disconnected",
 	startup: "Starting up...",
 	ari_sessiondisconnect_message: "Your session has been disconnected.",
-	str: function(x) {
+};
+
+/*
+ * These temporary versions of stui.str and stui.sub are "while we wait for the resources to load";
+ * see loadStui() later in this file.
+ * TODO: modernize with modules, avoid duplication here and later of stui.str, stui.sub!
+ *
+ * https://dojotoolkit.org/reference-guide/1.10/dojo/string.html
+ */
+require(["dojo/string"], function(string) {
+	stui.str = function(x) {
 		if (stui[x]) {
 			return stui[x];
 		}
 		else {
 			return "";
 		}
-	},
-	sub: function(x, y) {
-		/*
-		 * https://dojotoolkit.org/reference-guide/1.10/dojo/string.html
-		 */
-		require(["dojo/string"], function(string) {
-			return string.substitute(stui.str(x), y);
-		});
-	}
-};
+	};
+	stui.sub = function(x, y) {
+		let template = stui.str(x);
+		if (!template) {
+			return "";
+		}
+		return string.substitute(template, y);
+	};
+});
 
 var stuidebug_enabled = (window.location.search.indexOf('&stui_debug=') > -1);
 
@@ -3037,18 +3046,22 @@ function updateCoverage(theDiv) {
 function loadStui(loc, cb) {
 	if (!stui.ready) {
 		/*
+		 * https://dojotoolkit.org/reference-guide/1.10/dojo/string.html
 		 * https://dojotoolkit.org/reference-guide/1.10/dojo/i18n.html
 		 */
-		require(["dojo/i18n!./surveyTool/nls/stui.js"], function(stuibundle) {
+		require(["dojo/string", "dojo/i18n!./surveyTool/nls/stui.js"],
+		function(string, stuibundle) {
 			if (!stuidebug_enabled) {
 				stui.str = function(x) {
 					if (stuibundle[x]) return stuibundle[x];
 					else return x;
 				};
 				stui.sub = function(x, y) {
-					require(["dojo/string"], function(string) {
-						return string.substitute(stui.str(x), y);
-					});
+					let template = stui.str(x);
+					if (!template) {
+						return "";
+					}
+					return string.substitute(template, y);
 				};
 			} else {
 				stui.str = stui_str; // debug


### PR DESCRIPTION
-Fix the syntax so that stui.sub returns a value

-Combine dojo/string and dojo/i18n...stui.js in the same require array

-Ensure null or empty template is not passed to string.substitute

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11687
- [x] Updated PR title and link in previous line to include Issue number

