### PR TITLE
CLDR-13668 su, delete bogus data for currency XXX

### DIFF
--- a/common/main/su.xml
+++ b/common/main/su.xml
@@ -805,10 +805,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">$</symbol>
 				<symbol alt="narrow" draft="contributed">$</symbol>
 			</currency>
-			<currency type="XXX">
-				<displayName>-</displayName>
-				<displayName count="other">-</displayName>
-			</currency>
 		</currencies>
 	</numbers>
 	<units>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13668
- [x] Updated PR title and link in previous line to include Issue number

In locale "su", delete bogus data (display name and plural name) for currency "XXX". We cannot just set those values to XXX since that causes CLDR errors ("name same as code"). But deleting the data will have the same result.
