### PR TITLE
CLDR-9326 show 'no items at this coverage level' in the sidebar

### DIFF
--- a/tools/cldr-apps/WebContent/js/redesign.js
+++ b/tools/cldr-apps/WebContent/js/redesign.js
@@ -310,6 +310,7 @@ function unpackMenuSideBar(json) {
 	html += '<ul>';
 	$.each(menus, function(index, element) {
 		var menuName = element.name;
+	        let childCount = 0;
 		html += '<li class="list-unstyled open-menu"><div>' + menuName +
 			'<span class="pull-right glyphicon glyphicon-chevron-right"></span></div><ul class="second-level">';
 		$.each(element.pages, function(index, element) {
@@ -318,9 +319,13 @@ function unpackMenuSideBar(json) {
 			$.each(element.levs, function(index, element) {
 				if (parseInt(element) <= level) {
 					html += '<li class="sidebar-chooser list-unstyled" id="' + pageId + '"><div>' + pageName + '</div></li>';
+					childCount ++;
 				}
 			});
 		});
+	    if( childCount === 0) {
+                html += '<i>' + stui.str('coverage_no_items') + '</i>';
+            }
 		html += '</ul></li>';
 	});
 

--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -324,7 +324,7 @@ define({
 		coverage_modern: 'Modern',
 		coverage_comprehensive: 'Comprehensive',
 		coverage_optional: 'Optional',
-
+                coverage_no_items: 'No items at this current coverage level.',
 		coverage_menu_desc: 'Change the displayed coverage level. "Automatic" will use your organization\'s preferred value for this locale, if any.',
 
 		section_mail: 'Messages',


### PR DESCRIPTION
[CLDR-9326]

The prior patch didn't take coverage into account.
This puts a static message in the sidebar when there's no coverage.


[CLDR-9326]: https://unicode-org.atlassian.net/browse/CLDR-9326