### PR TITLE
CLDR-13669 CLDR_APPS_HASH null, time wasted repeating getGitHashForSlug

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
@@ -502,9 +502,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                 if(s != null && !s.isEmpty()) {
                     SurveyMain.CLDR_APPS_HASH  = s;
                     ((CLDRConfigImpl)cconfig).setCldrAppsHash(s);
-//                    String oldV = (String)cconfig.put("CLDR_APPS_HASH", s);
-//                    System.err.println("CLDR_APPS_HASH = " + s + ", was " + oldV);
-                    System.err.println("Updated CLDR_APPS_HASH to" + getCurrevStr());
+                    System.err.println("Updated CLDR_APPS_HASH to " + getCurrevStr());
                 } else {
                     System.err.println("CLDR_APPS_HASH = unknown (no value in manifest)");
                 }
@@ -1608,10 +1606,12 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * @return
      */
     public static String getCurrevCldrApps() {
-        if(CLDR_APPS_HASH != null) return CLDR_APPS_HASH; // use cachd version
-        return CLDRConfigImpl.getGitHashForSlug("CLDR_APPS_HASH");
+        if (CLDR_APPS_HASH == null) {
+            CLDR_APPS_HASH = CLDRConfigImpl.getGitHashForSlug("CLDR_APPS_HASH");
+        }
+        return CLDR_APPS_HASH;
     }
-    
+
     /**
      * Get the current source revision, as a string
      * This will either be a single string '(unknown)' or '1234568'


### PR DESCRIPTION
-Set CLDR_APPS_HASH variable in getCurrevCldrApps to avoid repeating getGitHashForSlug

-Insert space in log message, was like Updated CLDR_APPS_HASH toc18023938

-Delete some commented-out code

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13669
- [x] Updated PR title and link in previous line to include Issue number

