### PR TITLE
CLDR-13238 Disallow winning vote for inheritance from root

### DIFF
--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
@@ -23,6 +23,11 @@ require(["dojo/parser", "dijit/layout/ContentPane", "dijit/layout/BorderContaine
 </script>
 <script>
 // just things that must be JSP generated
+/*
+ * All these JavaScript var declarations append to the window (global) object.
+ * TODO: use Java instead of JSP; deliver data to the client as json; and store
+ * it in our own JavaScript object(s), not the window.
+ */
 var surveyRunningStamp = '<%= SurveyMain.surveyRunningStamp.current() %>';
 var contextPath = '<%= request.getContextPath() %>';
 var surveyCurrentId = '';

--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -26,10 +26,10 @@ const cldrSurveyTable = (function() {
 	const NEVER_REUSE_TABLE = false;
 
 	/*
-	 * ERROR_NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
-	 * Compare ERROR_NO_WINNING_VALUE in VoteResolver.java.
+	 * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
+	 * It must match NO_WINNING_VALUE in the server Java code.
 	 */
-	const ERROR_NO_WINNING_VALUE = "error-no-winning-value";
+	const NO_WINNING_VALUE = "no-winning-value";
 
 	/**
 	 * Prepare rows to be inserted into the table
@@ -498,18 +498,14 @@ const cldrSurveyTable = (function() {
 	function checkRowConsistency(theRow) {
 		if (!theRow.winningVhash) {
 			/*
-			 * The server, not the client, is responsible for ensuring that a winning item is present.
+			 * The server is responsible for ensuring that a winning item is present, or using
+			 * the placeholder NO_WINNING_VALUE, which is not null.
 			 */
 			console.error('For ' + theRow.xpstrid + ' - there is no winningVhash');
 		} else if (!theRow.items) {
 			console.error('For ' + theRow.xpstrid + ' - there are no items');
 		} else if (!theRow.items[theRow.winningVhash]) {
 			console.error('For ' + theRow.xpstrid + ' - there is winningVhash but no item for it');
-		} else {
-			const item = theRow.items[theRow.winningVhash];
-			if (item.value && item.value === ERROR_NO_WINNING_VALUE) {
-				console.log('For ' + theRow.xpstrid + ' - there is ' + ERROR_NO_WINNING_VALUE);
-			}
 		}
 
 		for (var k in theRow.items) {
@@ -650,7 +646,9 @@ const cldrSurveyTable = (function() {
 		var n = 0;
 		while (n < vr.value_vote.length) {
 			var value = vr.value_vote[n++];
-			if (value == null) continue;
+			if (value == null || value === NO_WINNING_VALUE) {
+				continue;
+			}
 			var vote = vr.value_vote[n++];
 			var item = tr.rawValueToItem[value]; // backlink to specific item in hash
 			if (item == null) continue;
@@ -1183,8 +1181,8 @@ const cldrSurveyTable = (function() {
 
 	/**
 	 * Get the winning value for the given row, if it's a valid value.
-	 * Null and ERROR_NO_WINNING_VALUE ('error-no-winning-value') are not valid.
-	 * See ERROR_NO_WINNING_VALUE in VoteResolver.java.
+	 * Null and NO_WINNING_VALUE ('no-winning-value') are not valid.
+	 * See NO_WINNING_VALUE in VoteResolver.java.
 	 *
 	 * @param theRow
 	 * @returns the winning value, or null if there is not a valid winning value
@@ -1194,7 +1192,7 @@ const cldrSurveyTable = (function() {
 			const item = theRow.items[theRow.winningVhash];
 			if (item.value) {
 				const val = item.value;
-				if (val !== ERROR_NO_WINNING_VALUE) {
+				if (val !== NO_WINNING_VALUE) {
 					return val;
 				}
 			}

--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -194,6 +194,8 @@ define({
 		voteInfo_moreInfo: "Click here for a full explanation of the icons and their meanings.",
 		voteInfo_votesForInheritance: "These are votes for inheritance.",
 		voteInfo_votesForSpecificValue: "These are votes for the specific value currently matching the inherited value. Votes for this specific value are combined with any votes for inheritance.",
+		voteInfo_valueDisqualified: "This value is disqualified from winning due to failing a test.",
+
 		// CheckCLDR.StatusAction 
 		StatusAction_msg:              "Not submitted: ${0}",
 		StatusAction_popupmsg:         "Sorry, your vote for '${1}' could not be submitted: ${0}", // same as StatusAction_msg but with context
@@ -360,7 +362,4 @@ define({
 		E_BAD_VALUE: "The vote was not accepted: ${err_data.message}",
 		E_BAD_XPATH: "This item does not exist in this locale.",
 		"": ""})
-//		"mt-MT": false
-
-		// sublocales
 });

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.apache.derby.jdbc.EmbeddedDataSource;
+import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRFile;
@@ -84,6 +85,7 @@ public class TestAll extends TestGroup {
     public static final String DERBY_PREFIX = "jdbc:derby:";
 
     public static void main(String[] args) {
+        CheckCLDR.setDisplayInformation(CLDRConfig.getInstance().getEnglish());
         args = TestAll.doResetDb(args);
         new TestAll().run(args);
     }
@@ -93,14 +95,6 @@ public class TestAll extends TestGroup {
             throw new InternalError(
                 "Error: the CLDRConfig Environment is not UNITTEST. Please set -DCLDR_ENVIRONMENT=UNITTESTS (replaces old -DCLDR_WEB_TESTS");
         }
-
-        // TODO remove this after some time- just warn people about the old message
-        final String cwt = System.getProperty("CLDR_WEB_TESTS");
-        if (cwt != null && cwt.equals("true")) {
-            throw new InternalError(
-                "Error: CLDR_WEB_TESTS is obsolete - please set the CLDR_ENVIRONMENT to UNITTEST or LOCAL (or don't set it) -  ( -DCLDR_ENVIRONMENT=UNITTEST");
-        }
-
         if (CldrUtility.getProperty(CLDR_TEST_KEEP_DB, false)) {
             if (DEBUG)
                 SurveyLog.logger.warning("Keeping database..");
@@ -348,20 +342,17 @@ public class TestAll extends TestGroup {
 
             @Override
             public CLDRProgressTask openProgress(String what, int max) {
-                // TODO Auto-generated method stub
                 final String whatP = what;
                 return new CLDRProgressTask() {
 
                     @Override
                     public void close() {
-                        // TODO Auto-generated method stub
 
                     }
 
                     @Override
                     public void update(int count) {
                         update(count, "");
-
                     }
 
                     @Override
@@ -376,7 +367,6 @@ public class TestAll extends TestGroup {
 
                     @Override
                     public long startTime() {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
                 };

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
@@ -456,17 +456,16 @@ public class TestSTFactory extends TestFmwk {
                     try {
                         box.voteForValue(u, xpath, value);
                         if (needException) {
-                            errln(pathCount + " Expected exceptoin, didn't get one");
+                            errln(pathCount + " Expected exception, didn't get one");
                         }
                     } catch (InvalidXPathException e) {
-                        // TODO Auto-generated catch block
                         errln("Error: invalid xpath exception " + xpath + " : " + e);
                     } catch (VoteNotAcceptedException iae) {
                         if (needException == true) {
                             logln("Caught expected: " + iae);
                         } else {
                             iae.printStackTrace();
-                            errln("Unexpected exceptoin: " + iae);
+                            errln("Unexpected exception: " + iae);
                         }
                     }
                     logln(u + " " + elem + "d for " + xpath + " = " + value);

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -1138,9 +1138,6 @@ public class DataSection implements JSONString {
                 System.out.println("Error in checkDataRowConsistency: inheritedItem without inheritedLocale or pathWhereFound" +
                     "; xpath = " + xpath + "; inheritedValue = " + inheritedValue);
             }
-            /*
-             * Note: we could also report if ERROR_NO_WINNING_VALUE.equals(winningValue) here...
-             */
         }
 
         /**

--- a/tools/cldr-apps/src/org/unicode/cldr/web/Race.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/Race.java
@@ -95,10 +95,6 @@ public class Race {
             + " " + resolver.getWinningStatus() + "\n";
     }
 
-    public String getOrgVote(String organization) {
-        return getOrgVote(Organization.valueOf(organization));
-    }
-
     public String getOrgVote(Organization org) {
         return resolver.getOrgVote(org);
     }

--- a/tools/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/CheckCLDR.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1380,5 +1381,13 @@ abstract public class CheckCLDR {
 
     public void setEnglishFile(CLDRFile englishFile) {
         this.englishFile = englishFile;
+    }
+
+    public static void logInternalErrors(LinkedList<CheckStatus> result) {
+        for (CheckStatus s : result) {
+            if (s.subtype == Subtype.internalError) {
+                System.err.println(s.getMessage());
+            }
+        }
     }
 }

--- a/tools/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/CheckCLDR.java
@@ -924,6 +924,26 @@ abstract public class CheckCLDR {
             }
             return false;
         }
+
+        /**
+         * Do any items in this list have the given type and subtype?
+         *
+         * @param result the list of CheckStatus items
+         * @param type the Type
+         * @param sub the Subtype
+         * @return true if any items in result are of given type and subtype, else false
+         */
+        public static boolean hasTypeAndSubtype(LinkedList<CheckStatus> result, Type type, Subtype sub) {
+            if (result == null || type == null || sub == null) {
+                return false;
+            }
+            for (CheckStatus s : result) {
+                if (s.getType().equals(type) && sub.equals(s.subtype)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     public static abstract class SimpleDemo {

--- a/tools/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/java/org/unicode/cldr/test/CheckForCopy.java
@@ -78,17 +78,6 @@ public class CheckForCopy extends FactoryCheckCLDR {
 
         Status status = new Status();
 
-        // don't check inherited values unless they are from ^^^
-        String topStringValue = getCldrFileToCheck().getUnresolved().getStringValue(path);
-        final boolean isExplicitBailey = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
-        if (!isExplicitBailey) {
-            String loc = getCldrFileToCheck().getSourceLocaleID(path, status);
-            if (!getCldrFileToCheck().getLocaleID().equals(loc) 
-                || !path.equals(status.pathWhereFound)) {
-                return this;
-            }
-        }       
-
         if (Boolean.TRUE == skip.get(path)) {
             return this;
         }
@@ -110,9 +99,14 @@ public class CheckForCopy extends FactoryCheckCLDR {
         // May override English test
         if (Boolean.TRUE != SKIP_CODE_CHECK.get(path)) {
             String value2 = value;
-            if (isExplicitBailey) {
+            /*
+             * TODO: clarify the purpose of using topStringValue and getConstructedValue here;
+             * maybe related to getConstructedBaileyValue
+             */
+            String topStringValue = getCldrFileToCheck().getUnresolved().getStringValue(path);
+            if (CldrUtility.INHERITANCE_MARKER.equals(topStringValue)) {
                 value2 = getCldrFileToCheck().getConstructedValue(path);
-                if (value2 == null) { // no special constucted value
+                if (value2 == null) { // no special constructed value
                     value2 = value;
                 }
             }

--- a/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -441,7 +441,7 @@ public class ConsoleCheckCLDR {
             .setSupplementalDirectory(new File(CLDRPaths.SUPPLEMENTAL_DIRECTORY));
         english = backCldrFactory.make("en", true);
 
-        checkCldr.setDisplayInformation(english);
+        CheckCLDR.setDisplayInformation(english);
         checkCldr.setEnglishFile(english);
         setExampleGenerator(new ExampleGenerator(english, english, CLDRPaths.SUPPLEMENTAL_DIRECTORY));
         PathShower pathShower = new PathShower();

--- a/tools/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/java/org/unicode/cldr/util/VoteResolver.java
@@ -8,6 +8,7 @@ import java.util.Date;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -798,7 +799,9 @@ public class VoteResolver<T> {
      * @param value
      * @param voter
      * @param withVotes override to lower the user's voting permission. May be null for default.
-     * @param date 
+     * @param date
+     *
+     * Called by getResolverInternal
      */
     public void add(T value, int voter, Integer withVotes, Date date) {
         if (resolved) {
@@ -817,7 +820,8 @@ public class VoteResolver<T> {
      * @param value
      * @param voter
      * @param withVotes override to lower the user's voting permission. May be null for default.
-    
+     *
+     * Called only for TestUtilities, not used in Survey Tool.
      */
     public void add(T value, int voter, Integer withVotes) {
         if (resolved) {
@@ -829,13 +833,18 @@ public class VoteResolver<T> {
     }
 
     /**
+     * Used only in add(value, voter) for making a pseudo-Date
+     */
+    private int maxcounter = 100;
+
+    /**
      * Call once for each voter for a value. If there are no voters for an item, then call add(value);
      *
      * @param value
      * @param voter
+     *
+     * Called by ConsoleCheckCLDR and TestUtilities; not used in SurveyTool.
      */
-    int maxcounter = 100;
-
     public void add(T value, int voter) {
         Date date = new Date(++maxcounter);
         add(value, voter, null, date);
@@ -846,6 +855,8 @@ public class VoteResolver<T> {
      *
      * @param value
      * @param voter
+     *
+     * Called by getResolverInternal for the baseline (trunk) value; also called for ConsoleCheckCLDR.
      */
     public void add(T value) {
         if (resolved) {
@@ -855,6 +866,8 @@ public class VoteResolver<T> {
     }
 
     private Set<T> values = new TreeSet<T>(ucaCollator);
+
+    private Set<T> disqualifiedValues = null;
 
     private final Comparator<T> votesThenUcaCollator = new Comparator<T>() {
         Collator col = Collator.getInstance(ULocale.ENGLISH);
@@ -1932,5 +1945,17 @@ public class VoteResolver<T> {
      */
     public boolean canFlagOnLosing() {
         return valueIsLocked || (requiredVotes == HIGH_BAR);
+    }
+
+    /**
+     * Disqualify the given value for winning with this VoteResolver.
+     *
+     * @param value the value to be disqualified
+     */
+    public void disqualify(T value) {
+        if (disqualifiedValues == null) {
+            disqualifiedValues = new HashSet<T>();
+        }
+        disqualifiedValues.add(value);
     }
 }


### PR DESCRIPTION
-Change PerLocaleData.ERRORS_ALLOWED_IN_VETTING to false

-New boolean PerLocaleData.ERRORS_PREVENT_WINNING = true

-New function VoteResolver.disqualify, called by getResolverInternal

-New function CheckCLDR.logInternalErrors, called by ValueChecker.canUseValue

-Call setDisplayInformation in cldr-apps TestAll.main to fix null in CheckForCopy.handleCheck

-Throw InternalCldrException if getDisplayInformation null in CheckForCopy.handleCheck

-Fix warnings for deprecated CharSequences.equals and unused Options

-Fix warnings for setDisplayInformation static in ConsoleCheckCLDR.java

-Fix typo exceptoin in comments

-Remove obsolete CLDR_WEB_TESTS check

-Remove code that is commented out or dead

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13238
- [x] Updated PR title and link in previous line to include Issue number

