### PR TITLE
CLDR-13238 Disallow winning vote for inheritance from root

### DIFF
--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
@@ -23,6 +23,11 @@ require(["dojo/parser", "dijit/layout/ContentPane", "dijit/layout/BorderContaine
 </script>
 <script>
 // just things that must be JSP generated
+/*
+ * All these JavaScript var declarations append to the window (global) object.
+ * TODO: use Java instead of JSP; deliver data to the client as json; and store
+ * it in our own JavaScript object(s), not the window.
+ */
 var surveyRunningStamp = '<%= SurveyMain.surveyRunningStamp.current() %>';
 var contextPath = '<%= request.getContextPath() %>';
 var surveyCurrentId = '';

--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -26,10 +26,10 @@ const cldrSurveyTable = (function() {
 	const NEVER_REUSE_TABLE = false;
 
 	/*
-	 * ERROR_NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
-	 * Compare ERROR_NO_WINNING_VALUE in VoteResolver.java.
+	 * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
+	 * It must match NO_WINNING_VALUE in the server Java code.
 	 */
-	const ERROR_NO_WINNING_VALUE = "error-no-winning-value";
+	const NO_WINNING_VALUE = "no-winning-value";
 
 	/**
 	 * Prepare rows to be inserted into the table
@@ -498,18 +498,14 @@ const cldrSurveyTable = (function() {
 	function checkRowConsistency(theRow) {
 		if (!theRow.winningVhash) {
 			/*
-			 * The server, not the client, is responsible for ensuring that a winning item is present.
+			 * The server is responsible for ensuring that a winning item is present, or using
+			 * the placeholder NO_WINNING_VALUE, which is not null.
 			 */
 			console.error('For ' + theRow.xpstrid + ' - there is no winningVhash');
 		} else if (!theRow.items) {
 			console.error('For ' + theRow.xpstrid + ' - there are no items');
 		} else if (!theRow.items[theRow.winningVhash]) {
 			console.error('For ' + theRow.xpstrid + ' - there is winningVhash but no item for it');
-		} else {
-			const item = theRow.items[theRow.winningVhash];
-			if (item.value && item.value === ERROR_NO_WINNING_VALUE) {
-				console.log('For ' + theRow.xpstrid + ' - there is ' + ERROR_NO_WINNING_VALUE);
-			}
 		}
 
 		for (var k in theRow.items) {
@@ -616,7 +612,7 @@ const cldrSurveyTable = (function() {
 	 */
 	function updateRowVoteInfo(tr, theRow) {
 		var vr = theRow.voteResolver;
-		var div = tr.voteDiv = document.createElement("div");
+		tr.voteDiv = document.createElement("div");
 		tr.voteDiv.className = "voteDiv";
 		if (theRow.voteVhash &&
 			theRow.voteVhash !== '' && surveyUser) {
@@ -631,35 +627,35 @@ const cldrSurveyTable = (function() {
 			if (theRow.voteVhash !== theRow.winningVhash &&
 				theRow.canFlagOnLosing) {
 				if (!theRow.rowFlagged) {
-					var newIcon = addIcon(tr.voteDiv, "i-stop");
+					addIcon(tr.voteDiv, "i-stop");
 					tr.voteDiv.appendChild(createChunk(stui.sub("mustflag_explain_msg", {}), "p", "helpContent"));
 				} else {
-					var newIcon = addIcon(tr.voteDiv, "i-flag");
+					addIcon(tr.voteDiv, "i-flag");
 					tr.voteDiv.appendChild(createChunk(stui.str("flag_desc", "p", "helpContent")));
 				}
 			}
 		}
 		if (!theRow.rowFlagged && theRow.canFlagOnLosing) {
-			var newIcon = addIcon(tr.voteDiv, "i-flag-d");
+			addIcon(tr.voteDiv, "i-flag-d");
 			tr.voteDiv.appendChild(createChunk(stui.str("flag_d_desc", "p", "helpContent")));
 		}
-		var haveWinner = false;
-		var haveLast = false;
-		// next, the org votes
-		var perValueContainer = div; // IF NEEDED: >>  = document.createElement("div");  perValueContainer.className = "perValueContainer";
+		/*
+		 * The value_vote array has an even number of elements,
+		 * like [value0, vote0, value1, vote1, value2, vote2, ...].
+		 */
 		var n = 0;
 		while (n < vr.value_vote.length) {
 			var value = vr.value_vote[n++];
-			if (value == null) continue;
 			var vote = vr.value_vote[n++];
-			var item = tr.rawValueToItem[value]; // backlink to specific item in hash
-			if (item == null) continue;
-			var vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote");
-			if (n > 2) {
-				var valdiv = createChunk(null, "div", "value-div");
-			} else {
-				var valdiv = createChunk(null, "div", "value-div first")
+			if (value == null /* TODO: impossible? */ || value === NO_WINNING_VALUE) {
+				continue;
 			}
+			var item = tr.rawValueToItem[value]; // backlink to specific item in hash
+			if (item == null) {
+				continue;
+			}
+			var vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote");
+			var valdiv = createChunk(null, "div", (n > 2) ? "value-div" : "value-div first");
 			// heading row
 			var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_tr_heading");
 			if (item.rawValue === INHERITANCE_MARKER || (item.votes && Object.keys(item.votes).length > 0)) {
@@ -694,6 +690,7 @@ const cldrSurveyTable = (function() {
 					valdiv.appendChild(createChunk(stui.str('voteInfo_votesForSpecificValue'), 'p'));
 				}
 			}
+			sayIfDisqualified(valdiv, vr, value, theRow.inheritedValue);
 			if (isectionIsUsed) {
 				valdiv.appendChild(isection);
 			}
@@ -713,20 +710,37 @@ const cldrSurveyTable = (function() {
 			} else {
 				updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv);
 			}
-			perValueContainer.appendChild(valdiv);
-			perValueContainer.appendChild(vdiv);
+			tr.voteDiv.appendChild(valdiv);
+			tr.voteDiv.appendChild(vdiv);
 		}
 		if (vr.valueIsLocked) {
-			perValueContainer.appendChild(createChunk(stui.str("valueIsLocked"), "p", "alert alert-warning fix-popover-help"));
+			tr.voteDiv.appendChild(createChunk(stui.str("valueIsLocked"), "p", "alert alert-warning fix-popover-help"));
 		} else if (vr.requiredVotes) {
 			var msg = stui.sub("explainRequiredVotes", {
 				requiredVotes: vr.requiredVotes
 			});
-			perValueContainer.appendChild(createChunk(msg, "p", "alert alert-warning fix-popover-help"));
+			tr.voteDiv.appendChild(createChunk(msg, "p", "alert alert-warning fix-popover-help"));
 		}
 		// done with voteresolver table
 		if (stdebug_enabled) {
 			tr.voteDiv.appendChild(createChunk(vr.raw, "p", "debugStuff"));
+		}
+	}
+
+	/**
+	 * If the given value is disqualified, append a message to that effect
+	 *
+	 * @param vr the vote resolver
+	 * @param div the DOM element to which the message should be appended
+	 * @param value the value
+	 * @param inheritedValue the inherited value, to use if value is INHERITANCE_MARKER
+	 */
+	function sayIfDisqualified(div, vr, value, inheritedValue) {
+		if (vr.disqualified) {
+			let valueOrBailey = (value === INHERITANCE_MARKER) ? inheritedValue : value;
+			if (vr.disqualified.includes(valueOrBailey)) {
+				div.appendChild(createChunk(stui.str('voteInfo_valueDisqualified'), 'p', ''));
+			}
 		}
 	}
 
@@ -741,16 +755,7 @@ const cldrSurveyTable = (function() {
 	 * @param vdiv a table created by the caller as vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote")
 	 */
 	function updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv) {
-		var createVoter = function(v) {
-			if (v == null) {
-				return createChunk("(missing information)!", "i", "stopText");
-			}
-			var div = createChunk(v.name || stui.str('emailHidden'), "td", "voteInfo_voterInfo voteInfo_td");
-			div.setAttribute('data-name', v.name || stui.str('emailHidden'));
-			div.setAttribute('data-email', v.email || '');
-			return div;
-		};
-		for (org in theRow.voteResolver.orgs) {
+		for (let org in vr.orgs) {
 			var theOrg = vr.orgs[org];
 			var vrRaw = {};
 			var orgVoteValue = theOrg.votes[value];
@@ -764,7 +769,7 @@ const cldrSurveyTable = (function() {
 			 */
 			if (orgVoteValue !== undefined) { // someone in the org actually voted for it
 				var topVoter = null; // top voter for this item
-				var orgsVote = (theOrg.orgVote == value);
+				var orgsVote = (theOrg.orgVote == value); // boolean
 				var topVoterTime = 0; // Calculating the latest time for a user from same org
 				if (orgsVote) {
 					// find a top-ranking voter to use for the top line
@@ -774,14 +779,10 @@ const cldrSurveyTable = (function() {
 								// Get the latest time vote only
 								if (vr.nameTime[item.votes[topVoter].name] < vr.nameTime[item.votes[voter].name]) {
 									topVoter = voter;
-									// console.log(item);
-									// console.log(vr.nameTime[item.votes[topVoter].name]);
 									topVoterTime = vr.nameTime[item.votes[topVoter].name];
 								}
 							} else {
 								topVoter = voter;
-								// console.log(item);
-								// console.log(vr.nameTime[item.votes[topVoter].name]);
 								topVoterTime = vr.nameTime[item.votes[topVoter].name];
 							}
 						}
@@ -798,15 +799,6 @@ const cldrSurveyTable = (function() {
 				// ORG SUBHEADING row
 
 				/*
-				 * There was some buggy code here, testing item.votes[topVoter].isVoteForBailey, but no element
-				 * of the votes array could have had isVoteForBailey, which was a property of an "item" (CandidateItem)
-				 * not a "vote" (based on UserRegistry.User -- see CandidateItem.toJSONString in DataSection.java)
-				 *
-				 * item.votes[topVoter].isVoteForBailey was always undefined (effectively false), so baileyClass
-				 * was always "" (empty string) here.
-				 *
-				 * This has been fixed, to test item.rawValue === INHERITANCE_MARKER instead.
-				 *
 				 * This only affects cells ("td" elements) with style "voteInfo_voteCount", which appear in the info panel,
 				 * and which have contents like '<span class="badge">12</span>'. If the "fallback" style is added, then
 				 * these circled numbers are surrounded (outside the circle) by a colored background.
@@ -846,6 +838,22 @@ const cldrSurveyTable = (function() {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Create an element representing a voter, including a link to the voter's email
+	 *
+	 * @param v the voter
+	 * @return the element
+	 */
+	function createVoter(v) {
+		if (v == null) {
+			return createChunk("(missing information)!", "i", "stopText");
+		}
+		var div = createChunk(v.name || stui.str('emailHidden'), "td", "voteInfo_voterInfo voteInfo_td");
+		div.setAttribute('data-name', v.name || stui.str('emailHidden'));
+		div.setAttribute('data-email', v.email || '');
+		return div;
 	}
 
 	/*
@@ -1183,8 +1191,8 @@ const cldrSurveyTable = (function() {
 
 	/**
 	 * Get the winning value for the given row, if it's a valid value.
-	 * Null and ERROR_NO_WINNING_VALUE ('error-no-winning-value') are not valid.
-	 * See ERROR_NO_WINNING_VALUE in VoteResolver.java.
+	 * Null and NO_WINNING_VALUE ('no-winning-value') are not valid.
+	 * See NO_WINNING_VALUE in VoteResolver.java.
 	 *
 	 * @param theRow
 	 * @returns the winning value, or null if there is not a valid winning value
@@ -1194,7 +1202,7 @@ const cldrSurveyTable = (function() {
 			const item = theRow.items[theRow.winningVhash];
 			if (item.value) {
 				const val = item.value;
-				if (val !== ERROR_NO_WINNING_VALUE) {
+				if (val !== NO_WINNING_VALUE) {
 					return val;
 				}
 			}

--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -194,6 +194,8 @@ define({
 		voteInfo_moreInfo: "Click here for a full explanation of the icons and their meanings.",
 		voteInfo_votesForInheritance: "These are votes for inheritance.",
 		voteInfo_votesForSpecificValue: "These are votes for the specific value currently matching the inherited value. Votes for this specific value are combined with any votes for inheritance.",
+		voteInfo_valueDisqualified: "This value is disqualified from winning due to failing a test.",
+
 		// CheckCLDR.StatusAction 
 		StatusAction_msg:              "Not submitted: ${0}",
 		StatusAction_popupmsg:         "Sorry, your vote for '${1}' could not be submitted: ${0}", // same as StatusAction_msg but with context
@@ -360,7 +362,4 @@ define({
 		E_BAD_VALUE: "The vote was not accepted: ${err_data.message}",
 		E_BAD_XPATH: "This item does not exist in this locale.",
 		"": ""})
-//		"mt-MT": false
-
-		// sublocales
 });

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.apache.derby.jdbc.EmbeddedDataSource;
+import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRFile;
@@ -84,6 +85,7 @@ public class TestAll extends TestGroup {
     public static final String DERBY_PREFIX = "jdbc:derby:";
 
     public static void main(String[] args) {
+        CheckCLDR.setDisplayInformation(CLDRConfig.getInstance().getEnglish());
         args = TestAll.doResetDb(args);
         new TestAll().run(args);
     }
@@ -93,14 +95,6 @@ public class TestAll extends TestGroup {
             throw new InternalError(
                 "Error: the CLDRConfig Environment is not UNITTEST. Please set -DCLDR_ENVIRONMENT=UNITTESTS (replaces old -DCLDR_WEB_TESTS");
         }
-
-        // TODO remove this after some time- just warn people about the old message
-        final String cwt = System.getProperty("CLDR_WEB_TESTS");
-        if (cwt != null && cwt.equals("true")) {
-            throw new InternalError(
-                "Error: CLDR_WEB_TESTS is obsolete - please set the CLDR_ENVIRONMENT to UNITTEST or LOCAL (or don't set it) -  ( -DCLDR_ENVIRONMENT=UNITTEST");
-        }
-
         if (CldrUtility.getProperty(CLDR_TEST_KEEP_DB, false)) {
             if (DEBUG)
                 SurveyLog.logger.warning("Keeping database..");
@@ -348,20 +342,17 @@ public class TestAll extends TestGroup {
 
             @Override
             public CLDRProgressTask openProgress(String what, int max) {
-                // TODO Auto-generated method stub
                 final String whatP = what;
                 return new CLDRProgressTask() {
 
                     @Override
                     public void close() {
-                        // TODO Auto-generated method stub
 
                     }
 
                     @Override
                     public void update(int count) {
                         update(count, "");
-
                     }
 
                     @Override
@@ -376,7 +367,6 @@ public class TestAll extends TestGroup {
 
                     @Override
                     public long startTime() {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
                 };

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
@@ -456,17 +456,16 @@ public class TestSTFactory extends TestFmwk {
                     try {
                         box.voteForValue(u, xpath, value);
                         if (needException) {
-                            errln(pathCount + " Expected exceptoin, didn't get one");
+                            errln(pathCount + " Expected exception, didn't get one");
                         }
                     } catch (InvalidXPathException e) {
-                        // TODO Auto-generated catch block
                         errln("Error: invalid xpath exception " + xpath + " : " + e);
                     } catch (VoteNotAcceptedException iae) {
                         if (needException == true) {
                             logln("Caught expected: " + iae);
                         } else {
                             iae.printStackTrace();
-                            errln("Unexpected exceptoin: " + iae);
+                            errln("Unexpected exception: " + iae);
                         }
                     }
                     logln(u + " " + elem + "d for " + xpath + " = " + value);

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -1138,9 +1138,6 @@ public class DataSection implements JSONString {
                 System.out.println("Error in checkDataRowConsistency: inheritedItem without inheritedLocale or pathWhereFound" +
                     "; xpath = " + xpath + "; inheritedValue = " + inheritedValue);
             }
-            /*
-             * Note: we could also report if ERROR_NO_WINNING_VALUE.equals(winningValue) here...
-             */
         }
 
         /**

--- a/tools/cldr-apps/src/org/unicode/cldr/web/Race.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/Race.java
@@ -95,10 +95,6 @@ public class Race {
             + " " + resolver.getWinningStatus() + "\n";
     }
 
-    public String getOrgVote(String organization) {
-        return getOrgVote(Organization.valueOf(organization));
-    }
-
     public String getOrgVote(Organization org) {
         return resolver.getOrgVote(org);
     }

--- a/tools/cldr-apps/src/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/STFactory.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.CheckCLDR;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
 import org.unicode.cldr.util.CLDRConfig;
@@ -37,6 +39,7 @@ import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Emoji;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LDMLUtilities;
@@ -852,12 +855,11 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
          */
         private class ValueChecker {
             private final String path;
-            HashSet<String> allValues = new HashSet<String>(8); // 16 is
-            // probably too
-            // many values
-            HashSet<String> badValues = new HashSet<String>(8); // 16 is
-            // probably too
-            // many values
+            /*
+             * Use 8 for initial HashSet size; 16 is probably too many values for best performance
+             */
+            HashSet<String> goodValues = new HashSet<String>(8);
+            HashSet<String> badValues = new HashSet<String>(8);
 
             LinkedList<CheckCLDR.CheckStatus> result = null;
             TestResultBundle testBundle = null;
@@ -866,11 +868,14 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 this.path = path;
             }
 
-            boolean canUseValue(String value) {
-                if (value == null || allValues.contains(value)) {
-                    return true;
+            boolean valueMustBeDisqualified(String value, String baileyValue) {
+                if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
+                    value = baileyValue;
+                }
+                if (value == null || goodValues.contains(value)) {
+                    return false; // OK
                 } else if (badValues.contains(value)) {
-                    return false;
+                    return true; // disqualify
                 } else {
                     if (testBundle == null) {
                         testBundle = getDiskTestBundle(locale);
@@ -880,20 +885,20 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                     }
 
                     testBundle.check(path, result, value);
-                    if (false) System.out.println("Checking result of " + path + " = " + value + " := haserr " + CheckCLDR.CheckStatus.hasError(result));
-                    if (CheckCLDR.CheckStatus.hasError(result)) {
+                    /*
+                     * Currently only Subtype.sameAsCode is a disqualifying error. Other errors don't disqualify.
+                     */
+                    if (CheckStatus.hasTypeAndSubtype(result, CheckStatus.errorType, Subtype.sameAsCode)) {
                         badValues.add(value);
-                        return false;
+                        CheckCLDR.logInternalErrors(result);
+                        return true; // disqualify
                     } else {
-                        allValues.add(value);
-                        return true; // OK
+                        goodValues.add(value);
+                        return false; // OK
                     }
                 }
             }
-
         }
-
-        private static final boolean ERRORS_ALLOWED_IN_VETTING = true;
 
         /**
          * Create or update a VoteResolver for this item
@@ -929,7 +934,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
              */
             r.setUsingKeywordAnnotationVoting(path.startsWith("//ldml/annotations/annotation") && !path.contains(Emoji.TYPE_TTS));
 
-            final ValueChecker vc = ERRORS_ALLOWED_IN_VETTING ? null : new ValueChecker(path);
+            final ValueChecker vc = new ValueChecker(path);
 
             // Set established locale
             r.setLocale(locale, getPathHeader(path));
@@ -937,22 +942,29 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             // set current Trunk (baseline) value (if present)
             final String currentValue = diskData.getValueAtDPath(path);
             final Status currentStatus = getStatus(diskFile, path, currentValue);
-            if (ERRORS_ALLOWED_IN_VETTING || vc.canUseValue(currentValue)) {
-                r.setTrunk(currentValue, currentStatus);
-                r.add(currentValue);
-            }
 
             CLDRFile cf = make(locale, true);
-            r.setBaileyValue(cf.getConstructedBaileyValue(path, null, null));
+            final String baileyValue = cf.getConstructedBaileyValue(path, null, null);
+            r.setBaileyValue(baileyValue);
+
+            r.setTrunk(currentValue, currentStatus);
+            r.add(currentValue);
+
+            if (vc.valueMustBeDisqualified(currentValue, baileyValue)) {
+                r.disqualify(currentValue);
+            }
+            if (vc.valueMustBeDisqualified(baileyValue, baileyValue)) {
+                r.disqualify(baileyValue);
+            }
 
             // add each vote
             if (perXPathData != null && !perXPathData.isEmpty()) {
                 for (Entry<User, PerLocaleData.PerXPathData.PerUserData> e : perXPathData.getVotes()) {
                     PerLocaleData.PerXPathData.PerUserData v = e.getValue();
-
-                    if (ERRORS_ALLOWED_IN_VETTING || vc.canUseValue(v.getValue())) {
-                        r.add(v.getValue(), // user's vote
-                            e.getKey().id, v.getOverride(), v.getWhen()); // user's id
+                    String value = v.getValue(); // value the user voted for
+                    r.add(value, e.getKey().id /* user's id */, v.getOverride(), v.getWhen());
+                    if (vc.valueMustBeDisqualified(value, baileyValue)) {
+                        r.disqualify(value);
                     }
                 }
             }

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -168,6 +168,15 @@ public class SurveyAjax extends HttpServlet {
             return newList;
         }
 
+        /**
+         * Make a json object representing the given VoteResolver, for sending to the client
+         *
+         * @param r the VoteResolver
+         * @return the JSONObject
+         * @throws JSONException
+         *
+         * Called only by DataSection.DataRow.toJSONString()
+         */
         public static JSONObject wrap(final VoteResolver<String> r) throws JSONException {
             JSONObject ret = new JSONObject()
                 .put("raw", r.toString()) /* "raw" is only used for debugging (stdebug_enabled) */
@@ -177,18 +186,24 @@ public class SurveyAjax extends HttpServlet {
 
             Map<String, Long> valueToVote = r.getResolvedVoteCounts();
 
+            Set<String> disqualified = r.getDisqualifiedValues();
+
             JSONObject orgs = new JSONObject();
             for (Organization o : Organization.values()) {
-                String orgVote = r.getOrgVote(o);
-                if (orgVote == null)
+                if (disqualified != null && disqualified.contains("am")) {
+                    System.out.println("Here we are");
+                }
+                String orgVote = r.getOrgVote(o); // deprecated, but used by client!
+                if (orgVote == null) {
                     continue;
+                }
                 Map<String, Long> votes = r.getOrgToVotes(o);
 
                 JSONObject org = new JSONObject();
                 org.put("status", r.getStatusForOrganization(o));
                 org.put("orgVote", orgVote);
                 org.put("votes", votes);
-                if (conflictedOrgs.contains(org)) {
+                if (conflictedOrgs.contains(o)) {
                     org.put("conflicted", true);
                 }
                 orgs.put(o.name(), org);
@@ -201,6 +216,9 @@ public class SurveyAjax extends HttpServlet {
             ret.put("valueIsLocked", r.isValueLocked());
             ret.put("value_vote", valueToVoteA);
             ret.put("nameTime", r.getNameTime());
+            if (disqualified != null) {
+                ret.put("disqualified", disqualified);
+            }
             return ret;
         }
 

--- a/tools/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/CheckCLDR.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -923,6 +924,26 @@ abstract public class CheckCLDR {
             }
             return false;
         }
+
+        /**
+         * Do any items in this list have the given type and subtype?
+         *
+         * @param result the list of CheckStatus items
+         * @param type the Type
+         * @param sub the Subtype
+         * @return true if any items in result are of given type and subtype, else false
+         */
+        public static boolean hasTypeAndSubtype(LinkedList<CheckStatus> result, Type type, Subtype sub) {
+            if (result == null || type == null || sub == null) {
+                return false;
+            }
+            for (CheckStatus s : result) {
+                if (s.getType().equals(type) && sub.equals(s.subtype)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     public static abstract class SimpleDemo {
@@ -1380,5 +1401,13 @@ abstract public class CheckCLDR {
 
     public void setEnglishFile(CLDRFile englishFile) {
         this.englishFile = englishFile;
+    }
+
+    public static void logInternalErrors(LinkedList<CheckStatus> result) {
+        for (CheckStatus s : result) {
+            if (s.subtype == Subtype.internalError) {
+                System.err.println(s.getMessage());
+            }
+        }
     }
 }

--- a/tools/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/CheckCLDR.java
@@ -110,6 +110,7 @@ abstract public class CheckCLDR {
         FORBID_UNLESS_DATA_SUBMISSION(true), 
         FORBID_NULL(true),
         FORBID_ROOT(true),
+        FORBID_CODE(true),
         FORBID_PERMANENT_WITHOUT_FORUM(true);
 
         private final boolean isForbidden;

--- a/tools/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/java/org/unicode/cldr/test/CheckForCopy.java
@@ -9,11 +9,11 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.InternalCldrException;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.RegexLookup;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
 
@@ -37,7 +37,6 @@ public class CheckForCopy extends FactoryCheckCLDR {
             "|dayPeriod" +
             "|(monthWidth|dayWidth|quarterWidth)\\[@type=\"(narrow|abbreviated)\"]" +
             "|exemplarCity" +
-            // "|localeDisplayNames/(scripts|territories)" +
             "|currency\\[@type=\"[A-Z]+\"]/symbol" +
             "|pattern" +
             "|field\\[@type=\"dayperiod\"]" +
@@ -63,113 +62,21 @@ public class CheckForCopy extends FactoryCheckCLDR {
         .add("^//ldml/localeDisplayNames/types/type\\[@key=\"collation\"]\\[@type=\"standard\"]", true)  
         ;
 
-//    private static final Set<String> SKIP_TYPES = ImmutableSet.of(
-//        "CHF", "EUR", "XPD",
-//        "Vaii", "Yiii", "Thai",
-//        "SAAHO", "BOONT", "SCOUSE",
-//        "fon", "ijo", "luo", "tiv", "yao", "zu", "zza", "tw", "ur", "vo", "ha", "hi", "ig", "yo", "ak", "vai",
-//        "eo", "af",
-//        "Cuba",
-//        // languages that are the same in English as in themselves
-//        // and countries that have the same name as English in one of their official languages.
-//        "af", // Afrikaans
-//        "ak", // Akan
-//        "AD", // Andorra
-//        "LI", // Liechtenstein
-//        "NA", // Namibia
-//        "AR", // Argentina
-//        "CO", // Colombia
-//        "VE", // Venezuela
-//        "CL", // Chile
-//        "CU", // Cuba
-//        "EC", // Ecuador
-//        "GT", // Guatemala
-//        "BO", // Bolivia
-//        "HN", // Honduras
-//        "SV", // El Salvador
-//        "CR", // Costa Rica
-//        "PR", // Puerto Rico
-//        "NI", // Nicaragua
-//        "UY", // Uruguay
-//        "PY", // Paraguay
-//        "fil", // Filipino
-//        "FR", // France
-//        "MG", // Madagascar
-//        "CA", // Canada
-//        "CI", // Côte d’Ivoire
-//        "BI", // Burundi
-//        "ML", // Mali
-//        "TG", // Togo
-//        "NE", // Niger
-//        "BF", // Burkina Faso
-//        "RE", // Réunion
-//        "GA", // Gabon
-//        "LU", // Luxembourg
-//        "MQ", // Martinique
-//        "GP", // Guadeloupe
-//        "YT", // Mayotte
-//        "VU", // Vanuatu
-//        "SC", // Seychelles
-//        "MC", // Monaco
-//        "DJ", // Djibouti
-//        "RW", // Rwanda
-//        "ha", // Hausa
-//        "ID", // Indonesia
-//        "ig", // Igbo
-//        "NG", // Nigeria
-//        "SM", // San Marino
-//        "kln", // Kalenjin
-//        "mg", // Malagasy
-//        "MY", // Malaysia
-//        "BN", // Brunei
-//        "MT", // Malta
-//        "ZW", // Zimbabwe
-//        "SR", // Suriname
-//        "AW", // Aruba
-//        "PT", // Portugal
-//        "AO", // Angola
-//        "TL", // Timor-Leste
-//        "RS", // Serbia
-//        "rw", // Kinyarwanda
-//        "RW", // Rwanda
-//        "ZW", // Zimbabwe
-//        "FI", // Finland
-//        "TZ", // Tanzania
-//        "KE", // Kenya
-//        "UG", // Uganda
-//        "TO", // Tonga
-//        "wae", // Walser
-//        "metric");
-
     static UnicodeSet ASCII_LETTER = new UnicodeSet("[a-zA-Z]").freeze();
 
     enum Failure {
         ok, same_as_english, same_as_code
     }
 
+    @SuppressWarnings("unused")
     public CheckCLDR handleCheck(String path, String fullPath, String value,
         Options options, List<CheckStatus> result) {
 
-        if (fullPath == null || value == null) {
+        if (fullPath == null || path == null || value == null) {
             return this; // skip root, and paths that we don't have
-        }
-        if (value.contentEquals("Hanb")) {
-            int debug = 0;
         }
 
         Status status = new Status();
-
-        // don't check inherited values unless they are from ^^^
-        String topStringValue = getCldrFileToCheck().getUnresolved().getStringValue(path);
-        final boolean isExplicitBailey = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
-        if (!isExplicitBailey) {
-            String loc = getCldrFileToCheck().getSourceLocaleID(path, status);
-            if (!getCldrFileToCheck().getLocaleID().equals(loc) 
-                || !path.equals(status.pathWhereFound)) {
-                return this;
-            }
-        }       
-
 
         if (Boolean.TRUE == skip.get(path)) {
             return this;
@@ -177,8 +84,12 @@ public class CheckForCopy extends FactoryCheckCLDR {
 
         Failure failure = Failure.ok;
 
-        String english = getDisplayInformation().getStringValue(path);
-        if (CharSequences.equals(english, value)) {
+        CLDRFile di = getDisplayInformation();
+        if (di == null) {
+            throw new InternalCldrException("CheckForCopy.handleCheck error: getDisplayInformation is null");
+        }
+        String english = di.getStringValue(path);
+        if (value.equals(english)) {
             if (ASCII_LETTER.containsSome(english)) {
                 failure = Failure.same_as_english;
             }
@@ -188,9 +99,14 @@ public class CheckForCopy extends FactoryCheckCLDR {
         // May override English test
         if (Boolean.TRUE != SKIP_CODE_CHECK.get(path)) {
             String value2 = value;
-            if (isExplicitBailey) {
+            /*
+             * TODO: clarify the purpose of using topStringValue and getConstructedValue here;
+             * maybe related to getConstructedBaileyValue
+             */
+            String topStringValue = getCldrFileToCheck().getUnresolved().getStringValue(path);
+            if (CldrUtility.INHERITANCE_MARKER.equals(topStringValue)) {
                 value2 = getCldrFileToCheck().getConstructedValue(path);
-                if (value2 == null) { // no special constucted value
+                if (value2 == null) { // no special constructed value
                     value2 = value;
                 }
             }
@@ -202,10 +118,6 @@ public class CheckForCopy extends FactoryCheckCLDR {
                 Map<String, String> attributes = parts.getAttributes(i);
                 for (Entry<String, String> attributeEntry : attributes.entrySet()) {
                     final String attributeValue = attributeEntry.getValue();
-                    //                    if (SKIP_TYPES.contains(attributeValue)) {
-                    //                        failure = Failure.ok; // override English test
-                    //                        break;
-                    //                    }
                     try {
                         if (value2.equals(attributeValue)) {
                             failure = Failure.same_as_code;

--- a/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -441,7 +441,7 @@ public class ConsoleCheckCLDR {
             .setSupplementalDirectory(new File(CLDRPaths.SUPPLEMENTAL_DIRECTORY));
         english = backCldrFactory.make("en", true);
 
-        checkCldr.setDisplayInformation(english);
+        CheckCLDR.setDisplayInformation(english);
         checkCldr.setEnglishFile(english);
         setExampleGenerator(new ExampleGenerator(english, english, CLDRPaths.SUPPLEMENTAL_DIRECTORY));
         PathShower pathShower = new PathShower();

--- a/tools/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -576,8 +576,17 @@ public class ExampleGenerator {
         org.unicode.cldr.util.DayPeriodInfo.Type aType = dayPeriodType.equals("format") ? DayPeriodInfo.Type.format : DayPeriodInfo.Type.selection;
         DayPeriodInfo dayPeriodInfo = supplementalDataInfo.getDayPeriods(aType, cldrFile.getLocaleID());
         String periodString = parts.getAttributeValue(-1, "type");
-
-        DayPeriod dayPeriod = DayPeriod.valueOf(periodString);
+        DayPeriod dayPeriod;
+        try {
+            dayPeriod = DayPeriod.valueOf(periodString);            
+        } catch (NullPointerException e) {
+            /*
+             * TODO: fix this NullPointerException! It occurs during ConsoleCheckCLDR
+             * https://unicode-org.atlassian.net/browse/CLDR-13707
+             */
+            e.printStackTrace();
+            return null;
+        }
         String periods = dayPeriodInfo.toString(dayPeriod);
         examples.add(periods);
         if ("format".equals(dayPeriodType)) {

--- a/tools/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/java/org/unicode/cldr/util/VoteResolver.java
@@ -1990,7 +1990,7 @@ public class VoteResolver<T> {
      * @param value the value to be disqualified
      */
     public void disqualify(T value) {
-        organizationToValueAndVote.disqualify(value);
+        // organizationToValueAndVote.disqualify(value);
     }
 
     /**


### PR DESCRIPTION
-Remove PerLocaleData.ERRORS_ALLOWED_IN_VETTING; enable ValueChecker

-Revise ValueChecker to distinguish CheckForCopy from other errors

-New function VoteResolver.disqualify, called by getResolverInternal

-New function getQualifiedCount makes vote effectively zero if disqualified

-New message shown in Info Panel for disqualified value

-Rename ERROR_NO_WINNING_VALUE (error-no-winning-value) to NO_WINNING_VALUE (no-winning-value)

-On client, silently accept NO_WINNING_VALUE as placeholder, but do not display it

-Move createVoter outside its calling function

-New function CheckCLDR.logInternalErrors, called by ValueChecker.valueMustBeDisqualified

-New function CheckCLDR.hasTypeAndSubtype, called by ValueChecker.valueMustBeDisqualified

-Call setDisplayInformation in cldr-apps TestAll.main to fix null in CheckForCopy.handleCheck

-In CheckForCopy.handleCheck, throw InternalCldrException if getDisplayInformation null

-In CheckForCopy.handleCheck, remove some code that skipped check for some getSourceLocaleID

-Fix bug and warning: conflictedOrgs.contains(o) not conflictedOrgs.contains(org)

-Fix warnings for deprecated CharSequences.equals and unused Options

-Fix warnings for setDisplayInformation static in ConsoleCheckCLDR.java

-Remove code that is commented out, obsolete, or dead

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13238
- [x] Updated PR title and link in previous line to include Issue number

