### PR TITLE
CLDR-13238 Disallow winning vote for inheritance from root

### DIFF
--- a/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
+++ b/tools/cldr-apps/WebContent/WEB-INF/tmpl/ajax_status.jsp
@@ -23,6 +23,11 @@ require(["dojo/parser", "dijit/layout/ContentPane", "dijit/layout/BorderContaine
 </script>
 <script>
 // just things that must be JSP generated
+/*
+ * All these JavaScript var declarations append to the window (global) object.
+ * TODO: use Java instead of JSP; deliver data to the client as json; and store
+ * it in our own JavaScript object(s), not the window.
+ */
 var surveyRunningStamp = '<%= SurveyMain.surveyRunningStamp.current() %>';
 var contextPath = '<%= request.getContextPath() %>';
 var surveyCurrentId = '';

--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -26,10 +26,10 @@ const cldrSurveyTable = (function() {
 	const NEVER_REUSE_TABLE = false;
 
 	/*
-	 * ERROR_NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
-	 * Compare ERROR_NO_WINNING_VALUE in VoteResolver.java.
+	 * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
+	 * It must match NO_WINNING_VALUE in the server Java code.
 	 */
-	const ERROR_NO_WINNING_VALUE = "error-no-winning-value";
+	const NO_WINNING_VALUE = "no-winning-value";
 
 	/**
 	 * Prepare rows to be inserted into the table
@@ -498,18 +498,14 @@ const cldrSurveyTable = (function() {
 	function checkRowConsistency(theRow) {
 		if (!theRow.winningVhash) {
 			/*
-			 * The server, not the client, is responsible for ensuring that a winning item is present.
+			 * The server is responsible for ensuring that a winning item is present, or using
+			 * the placeholder NO_WINNING_VALUE, which is not null.
 			 */
 			console.error('For ' + theRow.xpstrid + ' - there is no winningVhash');
 		} else if (!theRow.items) {
 			console.error('For ' + theRow.xpstrid + ' - there are no items');
 		} else if (!theRow.items[theRow.winningVhash]) {
 			console.error('For ' + theRow.xpstrid + ' - there is winningVhash but no item for it');
-		} else {
-			const item = theRow.items[theRow.winningVhash];
-			if (item.value && item.value === ERROR_NO_WINNING_VALUE) {
-				console.log('For ' + theRow.xpstrid + ' - there is ' + ERROR_NO_WINNING_VALUE);
-			}
 		}
 
 		for (var k in theRow.items) {
@@ -616,7 +612,7 @@ const cldrSurveyTable = (function() {
 	 */
 	function updateRowVoteInfo(tr, theRow) {
 		var vr = theRow.voteResolver;
-		var div = tr.voteDiv = document.createElement("div");
+		tr.voteDiv = document.createElement("div");
 		tr.voteDiv.className = "voteDiv";
 		if (theRow.voteVhash &&
 			theRow.voteVhash !== '' && surveyUser) {
@@ -631,35 +627,35 @@ const cldrSurveyTable = (function() {
 			if (theRow.voteVhash !== theRow.winningVhash &&
 				theRow.canFlagOnLosing) {
 				if (!theRow.rowFlagged) {
-					var newIcon = addIcon(tr.voteDiv, "i-stop");
+					addIcon(tr.voteDiv, "i-stop");
 					tr.voteDiv.appendChild(createChunk(stui.sub("mustflag_explain_msg", {}), "p", "helpContent"));
 				} else {
-					var newIcon = addIcon(tr.voteDiv, "i-flag");
+					addIcon(tr.voteDiv, "i-flag");
 					tr.voteDiv.appendChild(createChunk(stui.str("flag_desc", "p", "helpContent")));
 				}
 			}
 		}
 		if (!theRow.rowFlagged && theRow.canFlagOnLosing) {
-			var newIcon = addIcon(tr.voteDiv, "i-flag-d");
+			addIcon(tr.voteDiv, "i-flag-d");
 			tr.voteDiv.appendChild(createChunk(stui.str("flag_d_desc", "p", "helpContent")));
 		}
-		var haveWinner = false;
-		var haveLast = false;
-		// next, the org votes
-		var perValueContainer = div; // IF NEEDED: >>  = document.createElement("div");  perValueContainer.className = "perValueContainer";
+		/*
+		 * The value_vote array has an even number of elements,
+		 * like [value0, vote0, value1, vote1, value2, vote2, ...].
+		 */
 		var n = 0;
 		while (n < vr.value_vote.length) {
 			var value = vr.value_vote[n++];
-			if (value == null) continue;
 			var vote = vr.value_vote[n++];
-			var item = tr.rawValueToItem[value]; // backlink to specific item in hash
-			if (item == null) continue;
-			var vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote");
-			if (n > 2) {
-				var valdiv = createChunk(null, "div", "value-div");
-			} else {
-				var valdiv = createChunk(null, "div", "value-div first")
+			if (value == null /* TODO: impossible? */ || value === NO_WINNING_VALUE) {
+				continue;
 			}
+			var item = tr.rawValueToItem[value]; // backlink to specific item in hash
+			if (item == null) {
+				continue;
+			}
+			var vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote");
+			var valdiv = createChunk(null, "div", (n > 2) ? "value-div" : "value-div first");
 			// heading row
 			var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_tr_heading");
 			if (item.rawValue === INHERITANCE_MARKER || (item.votes && Object.keys(item.votes).length > 0)) {
@@ -686,8 +682,13 @@ const cldrSurveyTable = (function() {
 			}
 			setLang(valdiv);
 			if (value === INHERITANCE_MARKER) {
-				appendItem(valdiv, theRow.inheritedValue, item.pClass, tr);
-				valdiv.appendChild(createChunk(stui.str("voteInfo_votesForInheritance"), 'p'));
+				/*
+				 * theRow.inheritedValue can be undefined here; then do not append
+				 */
+				if (theRow.inheritedValue) {
+					appendItem(valdiv, theRow.inheritedValue, item.pClass, tr);
+					valdiv.appendChild(createChunk(stui.str("voteInfo_votesForInheritance"), 'p'));
+				}
 			} else {
 				appendItem(valdiv, value, (value === theRow.winningValue) ? "winner" : "value", tr);
 				if (value === theRow.inheritedValue) {
@@ -713,16 +714,16 @@ const cldrSurveyTable = (function() {
 			} else {
 				updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv);
 			}
-			perValueContainer.appendChild(valdiv);
-			perValueContainer.appendChild(vdiv);
+			tr.voteDiv.appendChild(valdiv);
+			tr.voteDiv.appendChild(vdiv);
 		}
 		if (vr.valueIsLocked) {
-			perValueContainer.appendChild(createChunk(stui.str("valueIsLocked"), "p", "alert alert-warning fix-popover-help"));
+			tr.voteDiv.appendChild(createChunk(stui.str("valueIsLocked"), "p", "alert alert-warning fix-popover-help"));
 		} else if (vr.requiredVotes) {
 			var msg = stui.sub("explainRequiredVotes", {
 				requiredVotes: vr.requiredVotes
 			});
-			perValueContainer.appendChild(createChunk(msg, "p", "alert alert-warning fix-popover-help"));
+			tr.voteDiv.appendChild(createChunk(msg, "p", "alert alert-warning fix-popover-help"));
 		}
 		// done with voteresolver table
 		if (stdebug_enabled) {
@@ -741,16 +742,7 @@ const cldrSurveyTable = (function() {
 	 * @param vdiv a table created by the caller as vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote")
 	 */
 	function updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv) {
-		var createVoter = function(v) {
-			if (v == null) {
-				return createChunk("(missing information)!", "i", "stopText");
-			}
-			var div = createChunk(v.name || stui.str('emailHidden'), "td", "voteInfo_voterInfo voteInfo_td");
-			div.setAttribute('data-name', v.name || stui.str('emailHidden'));
-			div.setAttribute('data-email', v.email || '');
-			return div;
-		};
-		for (org in theRow.voteResolver.orgs) {
+		for (let org in vr.orgs) {
 			var theOrg = vr.orgs[org];
 			var vrRaw = {};
 			var orgVoteValue = theOrg.votes[value];
@@ -764,7 +756,7 @@ const cldrSurveyTable = (function() {
 			 */
 			if (orgVoteValue !== undefined) { // someone in the org actually voted for it
 				var topVoter = null; // top voter for this item
-				var orgsVote = (theOrg.orgVote == value);
+				var orgsVote = (theOrg.orgVote == value); // boolean
 				var topVoterTime = 0; // Calculating the latest time for a user from same org
 				if (orgsVote) {
 					// find a top-ranking voter to use for the top line
@@ -774,14 +766,10 @@ const cldrSurveyTable = (function() {
 								// Get the latest time vote only
 								if (vr.nameTime[item.votes[topVoter].name] < vr.nameTime[item.votes[voter].name]) {
 									topVoter = voter;
-									// console.log(item);
-									// console.log(vr.nameTime[item.votes[topVoter].name]);
 									topVoterTime = vr.nameTime[item.votes[topVoter].name];
 								}
 							} else {
 								topVoter = voter;
-								// console.log(item);
-								// console.log(vr.nameTime[item.votes[topVoter].name]);
 								topVoterTime = vr.nameTime[item.votes[topVoter].name];
 							}
 						}
@@ -798,15 +786,6 @@ const cldrSurveyTable = (function() {
 				// ORG SUBHEADING row
 
 				/*
-				 * There was some buggy code here, testing item.votes[topVoter].isVoteForBailey, but no element
-				 * of the votes array could have had isVoteForBailey, which was a property of an "item" (CandidateItem)
-				 * not a "vote" (based on UserRegistry.User -- see CandidateItem.toJSONString in DataSection.java)
-				 *
-				 * item.votes[topVoter].isVoteForBailey was always undefined (effectively false), so baileyClass
-				 * was always "" (empty string) here.
-				 *
-				 * This has been fixed, to test item.rawValue === INHERITANCE_MARKER instead.
-				 *
 				 * This only affects cells ("td" elements) with style "voteInfo_voteCount", which appear in the info panel,
 				 * and which have contents like '<span class="badge">12</span>'. If the "fallback" style is added, then
 				 * these circled numbers are surrounded (outside the circle) by a colored background.
@@ -846,6 +825,22 @@ const cldrSurveyTable = (function() {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Create an element representing a voter, including a link to the voter's email
+	 *
+	 * @param v the voter
+	 * @return the element
+	 */
+	function createVoter(v) {
+		if (v == null) {
+			return createChunk("(missing information)!", "i", "stopText");
+		}
+		var div = createChunk(v.name || stui.str('emailHidden'), "td", "voteInfo_voterInfo voteInfo_td");
+		div.setAttribute('data-name', v.name || stui.str('emailHidden'));
+		div.setAttribute('data-email', v.email || '');
+		return div;
 	}
 
 	/*
@@ -1183,8 +1178,8 @@ const cldrSurveyTable = (function() {
 
 	/**
 	 * Get the winning value for the given row, if it's a valid value.
-	 * Null and ERROR_NO_WINNING_VALUE ('error-no-winning-value') are not valid.
-	 * See ERROR_NO_WINNING_VALUE in VoteResolver.java.
+	 * Null and NO_WINNING_VALUE ('no-winning-value') are not valid.
+	 * See NO_WINNING_VALUE in VoteResolver.java.
 	 *
 	 * @param theRow
 	 * @returns the winning value, or null if there is not a valid winning value
@@ -1194,7 +1189,7 @@ const cldrSurveyTable = (function() {
 			const item = theRow.items[theRow.winningVhash];
 			if (item.value) {
 				const val = item.value;
-				if (val !== ERROR_NO_WINNING_VALUE) {
+				if (val !== NO_WINNING_VALUE) {
 					return val;
 				}
 			}

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -2587,7 +2587,10 @@ function checkLRmarker(field, dir, value) {
  * @return {DOM} the new span
  */
 function appendItem(div, value, pClass, tr) {
-	var text = document.createTextNode(value ? value : stui.str("no value"));
+	if (!value) {
+		return;
+	}
+	var text = document.createTextNode(value);
 	var span = document.createElement("span");
 	span.appendChild(text);
 	if (!value) {
@@ -2904,16 +2907,19 @@ function appendExample(parent, text, loc) {
  * @param {DOM} newButton	 button prototype object
  */
 function addVitem(td, tr, theRow, item, newButton) {
+	var displayValue = item.value;
+	if (displayValue === INHERITANCE_MARKER) {
+		displayValue = theRow.inheritedValue;
+		if (displayValue == null) {
+			return;
+		}
+	}
 	var div = document.createElement("div");
 	var isWinner = (td == tr.proposedcell);
 	var testKind = getTestKind(item.tests);
 	setDivClass(div, testKind);
 	item.div = div; // back link
 
-	var displayValue = item.value;
-	if (item.value === INHERITANCE_MARKER) {
-		displayValue = theRow.inheritedValue; // TODO: what if theRow.inheritedValue is undefined, as it sometimes is?
-	}
 
 	var choiceField = document.createElement("div");
 	var wrap;

--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -203,6 +203,7 @@ define({
 		StatusAction_FORBID_NULL:      "The item has no value.",
 		StatusAction_FORBID_ROOT:      "The item is a root annotation code.",
 		StatusAction_FORBID_PERMANENT_WITHOUT_FORUM: "A forum entry is required to make a Permanent vote.",
+		StatusAction_FORBID_CODE:      "The item is the same as the code.",
 
 		// v.jsp
 		"v-title2_desc": "Locale title",

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.apache.derby.jdbc.EmbeddedDataSource;
+import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRFile;
@@ -84,6 +85,7 @@ public class TestAll extends TestGroup {
     public static final String DERBY_PREFIX = "jdbc:derby:";
 
     public static void main(String[] args) {
+        CheckCLDR.setDisplayInformation(CLDRConfig.getInstance().getEnglish());
         args = TestAll.doResetDb(args);
         new TestAll().run(args);
     }
@@ -93,14 +95,6 @@ public class TestAll extends TestGroup {
             throw new InternalError(
                 "Error: the CLDRConfig Environment is not UNITTEST. Please set -DCLDR_ENVIRONMENT=UNITTESTS (replaces old -DCLDR_WEB_TESTS");
         }
-
-        // TODO remove this after some time- just warn people about the old message
-        final String cwt = System.getProperty("CLDR_WEB_TESTS");
-        if (cwt != null && cwt.equals("true")) {
-            throw new InternalError(
-                "Error: CLDR_WEB_TESTS is obsolete - please set the CLDR_ENVIRONMENT to UNITTEST or LOCAL (or don't set it) -  ( -DCLDR_ENVIRONMENT=UNITTEST");
-        }
-
         if (CldrUtility.getProperty(CLDR_TEST_KEEP_DB, false)) {
             if (DEBUG)
                 SurveyLog.logger.warning("Keeping database..");
@@ -348,20 +342,17 @@ public class TestAll extends TestGroup {
 
             @Override
             public CLDRProgressTask openProgress(String what, int max) {
-                // TODO Auto-generated method stub
                 final String whatP = what;
                 return new CLDRProgressTask() {
 
                     @Override
                     public void close() {
-                        // TODO Auto-generated method stub
 
                     }
 
                     @Override
                     public void update(int count) {
                         update(count, "");
-
                     }
 
                     @Override
@@ -376,7 +367,6 @@ public class TestAll extends TestGroup {
 
                     @Override
                     public long startTime() {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
                 };

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
@@ -456,17 +456,16 @@ public class TestSTFactory extends TestFmwk {
                     try {
                         box.voteForValue(u, xpath, value);
                         if (needException) {
-                            errln(pathCount + " Expected exceptoin, didn't get one");
+                            errln(pathCount + " Expected exception, didn't get one");
                         }
                     } catch (InvalidXPathException e) {
-                        // TODO Auto-generated catch block
                         errln("Error: invalid xpath exception " + xpath + " : " + e);
                     } catch (VoteNotAcceptedException iae) {
                         if (needException == true) {
                             logln("Caught expected: " + iae);
                         } else {
                             iae.printStackTrace();
-                            errln("Unexpected exceptoin: " + iae);
+                            errln("Unexpected exception: " + iae);
                         }
                     }
                     logln(u + " " + elem + "d for " + xpath + " = " + value);

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -1138,9 +1138,6 @@ public class DataSection implements JSONString {
                 System.out.println("Error in checkDataRowConsistency: inheritedItem without inheritedLocale or pathWhereFound" +
                     "; xpath = " + xpath + "; inheritedValue = " + inheritedValue);
             }
-            /*
-             * Note: we could also report if ERROR_NO_WINNING_VALUE.equals(winningValue) here...
-             */
         }
 
         /**

--- a/tools/cldr-apps/src/org/unicode/cldr/web/Race.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/Race.java
@@ -95,10 +95,6 @@ public class Race {
             + " " + resolver.getWinningStatus() + "\n";
     }
 
-    public String getOrgVote(String organization) {
-        return getOrgVote(Organization.valueOf(organization));
-    }
-
     public String getOrgVote(Organization org) {
         return resolver.getOrgVote(org);
     }

--- a/tools/cldr-apps/src/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/STFactory.java
@@ -852,12 +852,11 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
          */
         private class ValueChecker {
             private final String path;
-            HashSet<String> allValues = new HashSet<String>(8); // 16 is
-            // probably too
-            // many values
-            HashSet<String> badValues = new HashSet<String>(8); // 16 is
-            // probably too
-            // many values
+            /*
+             * Use 8 for initial HashSet size; 16 is probably too many values for best performance
+             */
+            HashSet<String> goodValues = new HashSet<String>(8);
+            HashSet<String> badValues = new HashSet<String>(8);
 
             LinkedList<CheckCLDR.CheckStatus> result = null;
             TestResultBundle testBundle = null;
@@ -867,7 +866,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             }
 
             boolean canUseValue(String value) {
-                if (value == null || allValues.contains(value)) {
+                if (value == null || goodValues.contains(value)) {
                     return true;
                 } else if (badValues.contains(value)) {
                     return false;
@@ -885,7 +884,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                         badValues.add(value);
                         return false;
                     } else {
-                        allValues.add(value);
+                        goodValues.add(value);
                         return true; // OK
                     }
                 }
@@ -893,6 +892,9 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
 
         }
 
+        /**
+         * Disable ValueChecker
+         */
         private static final boolean ERRORS_ALLOWED_IN_VETTING = true;
 
         /**

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -33,6 +33,7 @@ import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.test.CheckForCopy;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
@@ -1716,14 +1717,12 @@ public class SurveyAjax extends HttpServlet {
             translationHintsFile = sm.getTranslationHintsFile();
         }
         XMLSource diskData = (XMLSource) sm.getDiskFactory().makeSource(locale.getBaseName()).freeze(); // trunk
+        CLDRFile cldrFile = fac.make(loc, true, true);
 
         Set<String> validPaths = fac.getPathsForFile(locale);
         CoverageInfo covInfo = CLDRConfig.getInstance().getCoverageInfo();
         long viewableVoteCount = 0;
         for (Map<String, Object> m : rows) {
-            // TODO: clarify which exceptions should be caught here, such as invalid xpathString.
-            // For now, catch all silently and skip old votes that generate exceptions -- they're
-            // invalid; neither winning nor losing, but invisible as far as import is concerned.
             try {
                 String value = m.get("value").toString();
                 if (value == null) {
@@ -1741,6 +1740,9 @@ public class SurveyAjax extends HttpServlet {
                 }
                 if (covInfo.getCoverageValue(xpathString, loc) > Level.COMPREHENSIVE.getLevel()) {
                     continue; // out of coverage
+                }
+                if (CheckForCopy.sameAsCode(value, xpathString, cldrFile)) {
+                    continue; // not allowed
                 }
                 String curValue = diskData.getValueAtDPath(xpathString);
                 boolean isWinning = equalsOrInheritsCurrentValue(value, curValue, diskData, xpathString);
@@ -1774,6 +1776,15 @@ public class SurveyAjax extends HttpServlet {
                    }
                }
             } catch (Exception e) {
+                /*
+                 * Skip old votes that generate exceptions -- they're invalid; neither winning nor
+                 * losing, but invisible as far as import is concerned.
+                 *
+                 * Log any exception that we don't want to ignore completely.
+                 * InvalidXPathException and VoteNotAcceptedException would be OK to ignore, but
+                 * they can't happen here.
+                 */
+                SurveyLog.logException(e, "Viewing old votes");
                 continue;
             }
         }
@@ -2183,13 +2194,7 @@ public class SurveyAjax extends HttpServlet {
                 if (curValue == null) {
                     continue;
                 }
-                /*
-                 * Import if the value is winning (equalsOrInheritsCurrentValue), or is null (abstain).
-                 * By importing null (abstain) votes, we fix a problem where, for example, the user
-                 * voted for a value "x" in one old version, then voted to abstain in a later version,
-                 * and then the "x" still got imported into an even later version. 
-                 */
-                if (value == null || equalsOrInheritsCurrentValue(value, curValue, diskData, xpathString)) {
+                if (valueCanBeAutoImported(value, curValue, diskData, xpathString, fac, loc)) {
                     BallotBox<User> box = fac.ballotBoxForLocale(locale);
                     /*
                      * Only import the most recent vote (or abstention) for the given user and xpathString.
@@ -2210,8 +2215,39 @@ public class SurveyAjax extends HttpServlet {
                 /* Silently catch IllegalByDtdException, otherwise logs grow too fast with useless warnings */
             }
         }
-        // System.out.println("importAllOldWinningVotes: imported " + confirmations + " votes in " + oldVotesTable);
         return confirmations;
+    }
+
+    /**
+     * Can the value be auto-imported?
+     *
+     * Import if the value is null (abstain), or is winning (equalsOrInheritsCurrentValue) and
+     * is not a code-copy failure (sameAsCode).
+     *
+     * By importing null (abstain) votes, we fix a problem where, for example, the user
+     * voted for a value "x" in one old version, then voted to abstain in a later version,
+     * and then the "x" still got imported into an even later version.
+     *
+     * @param value the value in question
+     * @param curValue the current value, that is, file.getStringValue(xpathString)
+     * @param diskData the XMLSource for getBaileyValue
+     * @param xpathString the path identifier
+     * @param fac the STFactory
+     * @param loc the locale string
+     * @return true if OK to import, else false
+     */
+    private boolean valueCanBeAutoImported(String value, String curValue, XMLSource diskData, String xpathString, STFactory fac, String loc) {
+        if (value == null) {
+            return true;
+        }
+        if (!equalsOrInheritsCurrentValue(value, curValue, diskData, xpathString)) {
+            return false;
+        }
+        CLDRFile cldrFile = fac.make(loc, true, true);
+        if (CheckForCopy.sameAsCode(value, xpathString, cldrFile)) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -2224,7 +2260,7 @@ public class SurveyAjax extends HttpServlet {
      * 
      * @param value the value in question
      * @param curValue the current value, that is, file.getStringValue(xpathString)
-     * @param file the CLDRFile for getBaileyValue
+     * @param diskData the XMLSource for getBaileyValue
      * @param xpathString the path identifier
      * @return true if it matches or inherits, else false
      */
@@ -2464,8 +2500,15 @@ public class SurveyAjax extends HttpServlet {
 
         DataRow pvi = section.getDataRow(xp);
         CheckCLDR.StatusAction showRowAction = pvi.getStatusAction();
-        if (CldrUtility.INHERITANCE_MARKER.equals(val) && pvi.wouldInheritNull()) {
-            showRowAction = CheckCLDR.StatusAction.FORBID_NULL;
+        if (CldrUtility.INHERITANCE_MARKER.equals(val)) {
+            if (pvi.wouldInheritNull()) {
+                showRowAction = CheckCLDR.StatusAction.FORBID_NULL;
+            } else {
+                CLDRFile cldrFile = stf.make(locale.getBaseName(), true, true);
+                if (CheckForCopy.sameAsCode(val, xp, cldrFile)) {
+                    showRowAction = CheckCLDR.StatusAction.FORBID_CODE;
+                }
+            }
         } else if (pvi.isUnvotableRoot(val)) {
             showRowAction = CheckCLDR.StatusAction.FORBID_ROOT;
         }
@@ -2508,8 +2551,11 @@ public class SurveyAjax extends HttpServlet {
                     System.err.println("Voting for::  " + val);
                 Integer withVote = null;
                 try {
-                    withVote = Integer.parseInt(request.getParameter("voteLevelChanged"));
-                } catch (Throwable t) {
+                    String voteLevelParam = request.getParameter("voteLevelChanged");
+                    if (voteLevelParam != null) {
+                        withVote = Integer.parseInt(voteLevelParam);
+                    }
+                } catch (NumberFormatException e) {
                     withVote = null;
                 }
                 boolean badNoForum = false;
@@ -2951,6 +2997,9 @@ public class SurveyAjax extends HttpServlet {
                     DataSection.DataRow pvi = section.getDataRow(base);
                     CheckCLDR.StatusAction showRowAction = pvi.getStatusAction();
 
+                    if (CheckForCopy.sameAsCode(val0, x, baseFile)) {
+                        showRowAction = CheckCLDR.StatusAction.FORBID_CODE;
+                    }
                     if (showRowAction.isForbidden()) {
                         result = "Item may not be modified. ("
                                 + showRowAction + ")";

--- a/tools/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/CheckCLDR.java
@@ -109,6 +109,7 @@ abstract public class CheckCLDR {
         FORBID_UNLESS_DATA_SUBMISSION(true), 
         FORBID_NULL(true),
         FORBID_ROOT(true),
+        FORBID_CODE(true),
         FORBID_PERMANENT_WITHOUT_FORUM(true);
 
         private final boolean isForbidden;

--- a/tools/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/java/org/unicode/cldr/test/CheckForCopy.java
@@ -9,11 +9,11 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.InternalCldrException;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.RegexLookup;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
 
@@ -37,7 +37,6 @@ public class CheckForCopy extends FactoryCheckCLDR {
             "|dayPeriod" +
             "|(monthWidth|dayWidth|quarterWidth)\\[@type=\"(narrow|abbreviated)\"]" +
             "|exemplarCity" +
-            // "|localeDisplayNames/(scripts|territories)" +
             "|currency\\[@type=\"[A-Z]+\"]/symbol" +
             "|pattern" +
             "|field\\[@type=\"dayperiod\"]" +
@@ -63,162 +62,135 @@ public class CheckForCopy extends FactoryCheckCLDR {
         .add("^//ldml/localeDisplayNames/types/type\\[@key=\"collation\"]\\[@type=\"standard\"]", true)  
         ;
 
-//    private static final Set<String> SKIP_TYPES = ImmutableSet.of(
-//        "CHF", "EUR", "XPD",
-//        "Vaii", "Yiii", "Thai",
-//        "SAAHO", "BOONT", "SCOUSE",
-//        "fon", "ijo", "luo", "tiv", "yao", "zu", "zza", "tw", "ur", "vo", "ha", "hi", "ig", "yo", "ak", "vai",
-//        "eo", "af",
-//        "Cuba",
-//        // languages that are the same in English as in themselves
-//        // and countries that have the same name as English in one of their official languages.
-//        "af", // Afrikaans
-//        "ak", // Akan
-//        "AD", // Andorra
-//        "LI", // Liechtenstein
-//        "NA", // Namibia
-//        "AR", // Argentina
-//        "CO", // Colombia
-//        "VE", // Venezuela
-//        "CL", // Chile
-//        "CU", // Cuba
-//        "EC", // Ecuador
-//        "GT", // Guatemala
-//        "BO", // Bolivia
-//        "HN", // Honduras
-//        "SV", // El Salvador
-//        "CR", // Costa Rica
-//        "PR", // Puerto Rico
-//        "NI", // Nicaragua
-//        "UY", // Uruguay
-//        "PY", // Paraguay
-//        "fil", // Filipino
-//        "FR", // France
-//        "MG", // Madagascar
-//        "CA", // Canada
-//        "CI", // Côte d’Ivoire
-//        "BI", // Burundi
-//        "ML", // Mali
-//        "TG", // Togo
-//        "NE", // Niger
-//        "BF", // Burkina Faso
-//        "RE", // Réunion
-//        "GA", // Gabon
-//        "LU", // Luxembourg
-//        "MQ", // Martinique
-//        "GP", // Guadeloupe
-//        "YT", // Mayotte
-//        "VU", // Vanuatu
-//        "SC", // Seychelles
-//        "MC", // Monaco
-//        "DJ", // Djibouti
-//        "RW", // Rwanda
-//        "ha", // Hausa
-//        "ID", // Indonesia
-//        "ig", // Igbo
-//        "NG", // Nigeria
-//        "SM", // San Marino
-//        "kln", // Kalenjin
-//        "mg", // Malagasy
-//        "MY", // Malaysia
-//        "BN", // Brunei
-//        "MT", // Malta
-//        "ZW", // Zimbabwe
-//        "SR", // Suriname
-//        "AW", // Aruba
-//        "PT", // Portugal
-//        "AO", // Angola
-//        "TL", // Timor-Leste
-//        "RS", // Serbia
-//        "rw", // Kinyarwanda
-//        "RW", // Rwanda
-//        "ZW", // Zimbabwe
-//        "FI", // Finland
-//        "TZ", // Tanzania
-//        "KE", // Kenya
-//        "UG", // Uganda
-//        "TO", // Tonga
-//        "wae", // Walser
-//        "metric");
-
     static UnicodeSet ASCII_LETTER = new UnicodeSet("[a-zA-Z]").freeze();
 
     enum Failure {
         ok, same_as_english, same_as_code
     }
 
+    @SuppressWarnings("unused")
     public CheckCLDR handleCheck(String path, String fullPath, String value,
         Options options, List<CheckStatus> result) {
 
-        if (fullPath == null || value == null) {
+        if (fullPath == null || path == null || value == null) {
             return this; // skip root, and paths that we don't have
         }
-        if (value.contentEquals("Hanb")) {
-            int debug = 0;
-        }
+        Failure failure = sameAsCodeOrEnglish(value, path, getCldrFileToCheck(), false);
+        addFailure(result, failure);
+        return this;
+    }
+
+    /**
+     * Check the given path and value, and return true if it has a same_as_code failure
+
+     * @param value the value
+     * @param path the path
+     * @param cldrFile the CLDRFile
+     * @return true or false
+     */
+    public static boolean sameAsCode(String value, String path, CLDRFile cldrFile) {
+        return sameAsCodeOrEnglish(value, path, cldrFile, true) == Failure.same_as_code;
+    }
+
+    /**
+     * Check the given path and value for same_as_code and same_as_english failures
+     *
+     * @param value the value
+     * @param path the path
+     * @param cldrFile the CLDRFile
+     * @param contextIsVoteSubmission true when a new or imported vote is in question, else false
+     * @return the Failure object
+     */
+    private static Failure sameAsCodeOrEnglish(String value, String path, CLDRFile cldrFile, boolean contextIsVoteSubmission) {
 
         Status status = new Status();
 
-        // don't check inherited values unless they are from ^^^
-        String topStringValue = getCldrFileToCheck().getUnresolved().getStringValue(path);
+        /*
+         * Don't check inherited values unless they are from ^^^
+         *
+         * In the context of vote submission, we must check inherited values,
+         * otherwise nothing prevents voting to inherit the code value.
+         *
+         * TODO: clarify the purpose of using topStringValue and getConstructedValue here;
+         * cf. getConstructedBaileyValue. This code is confusing and warrants explanation.
+         * The meaning of "explicit" here seems to be the opposite of its meaning elsewhere.
+         */
+        String topStringValue = cldrFile.getUnresolved().getStringValue(path);
         final boolean isExplicitBailey = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
-        if (!isExplicitBailey) {
-            String loc = getCldrFileToCheck().getSourceLocaleID(path, status);
-            if (!getCldrFileToCheck().getLocaleID().equals(loc) 
+        if (!contextIsVoteSubmission && !isExplicitBailey) {
+            String loc = cldrFile.getSourceLocaleID(path, status);
+            if (!cldrFile.getLocaleID().equals(loc)
                 || !path.equals(status.pathWhereFound)) {
-                return this;
+                return Failure.ok;
             }
-        }       
+        }
 
-
+        /*
+         * Since get() may return null here, comparison with Boolean.TRUE prevents NullPointerException.
+         */
         if (Boolean.TRUE == skip.get(path)) {
-            return this;
+            return Failure.ok;
         }
 
         Failure failure = Failure.ok;
 
-        String english = getDisplayInformation().getStringValue(path);
-        if (CharSequences.equals(english, value)) {
+        CLDRFile di = getDisplayInformation();
+        if (di == null) {
+            throw new InternalCldrException("CheckForCopy.sameAsCodeOrEnglish error: getDisplayInformation is null");
+        }
+        String english = di.getStringValue(path);
+        if (value.equals(english)) {
             if (ASCII_LETTER.containsSome(english)) {
                 failure = Failure.same_as_english;
             }
         }
 
-        // Check for attributes.
-        // May override English test
-        if (Boolean.TRUE != SKIP_CODE_CHECK.get(path)) {
-            String value2 = value;
-            if (isExplicitBailey) {
-                value2 = getCldrFileToCheck().getConstructedValue(path);
-                if (value2 == null) { // no special constucted value
-                    value2 = value;
-                }
-            }
-
-            XPathParts parts = XPathParts.getFrozenInstance(path);
-
-            int elementCount = parts.size();
-            for (int i = 2; i < elementCount; ++i) {
-                Map<String, String> attributes = parts.getAttributes(i);
-                for (Entry<String, String> attributeEntry : attributes.entrySet()) {
-                    final String attributeValue = attributeEntry.getValue();
-                    //                    if (SKIP_TYPES.contains(attributeValue)) {
-                    //                        failure = Failure.ok; // override English test
-                    //                        break;
-                    //                    }
-                    try {
-                        if (value2.equals(attributeValue)) {
-                            failure = Failure.same_as_code;
-                            break;
-                        }
-                    } catch (NullPointerException e) {
-                        throw new ICUException("Value: " + value + "\nattributeValue: " + attributeValue
-                            + "\nPath: " + path, e);
-                    }                
-                }
+        /*
+         * Check for attributes. May override English test.
+         * Since get() may return null here, comparison with Boolean.TRUE prevents NullPointerException.
+         */
+        if (Boolean.TRUE == SKIP_CODE_CHECK.get(path)) {
+            return Failure.ok;
+        }
+        if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
+            value = cldrFile.getConstructedBaileyValue(path, null, null);
+        }
+        String value2 = value;
+        if (isExplicitBailey) {
+            value2 = cldrFile.getConstructedValue(path);
+            if (value2 == null) { // no special constructed value
+                value2 = value;
             }
         }
 
+        XPathParts parts = XPathParts.getFrozenInstance(path);
+
+        int elementCount = parts.size();
+        for (int i = 2; i < elementCount; ++i) {
+            Map<String, String> attributes = parts.getAttributes(i);
+            for (Entry<String, String> attributeEntry : attributes.entrySet()) {
+                final String attributeValue = attributeEntry.getValue();
+                try {
+                    if (value2.equals(attributeValue)) {
+                        failure = Failure.same_as_code;
+                        break;
+                    }
+                } catch (NullPointerException e) {
+                    throw new ICUException("Value: " + value + "\nattributeValue: " + attributeValue
+                        + "\nPath: " + path, e);
+                }
+            }
+        }
+        return failure;
+    }
+
+    /**
+     * If there is a failure, add it to the list
+     *
+     * @param result the list of CheckStatus objects
+     * @param failure the Failure object
+     */
+    private void addFailure(List<CheckStatus> result, Failure failure) {
         switch (failure) {
         case same_as_english:
             result
@@ -244,21 +216,22 @@ public class CheckForCopy extends FactoryCheckCLDR {
             break;
         default:
         }
-        return this;
     }
 
     @Override
     public CheckCLDR setCldrFileToCheck(CLDRFile cldrFileToCheck, Options options,
         List<CheckStatus> possibleErrors) {
-        
-        if (cldrFileToCheck == null) return this;
+
+        if (cldrFileToCheck == null) {
+            return this;
+        }
 
         final String localeID = cldrFileToCheck.getLocaleID();
-        
+
         LanguageTagParser ltp = new LanguageTagParser().set(localeID);
         String lang = ltp.getLanguage();
 
-        setSkipTest(false);        
+        setSkipTest(false);
         if (lang.equals("en") || localeID.equals("root")) {// || exemplars != null && ASCII_LETTER.containsNone(exemplars)) {
             setSkipTest(true);
             if (DEBUG) {

--- a/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -441,7 +441,7 @@ public class ConsoleCheckCLDR {
             .setSupplementalDirectory(new File(CLDRPaths.SUPPLEMENTAL_DIRECTORY));
         english = backCldrFactory.make("en", true);
 
-        checkCldr.setDisplayInformation(english);
+        CheckCLDR.setDisplayInformation(english);
         checkCldr.setEnglishFile(english);
         setExampleGenerator(new ExampleGenerator(english, english, CLDRPaths.SUPPLEMENTAL_DIRECTORY));
         PathShower pathShower = new PathShower();

--- a/tools/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
+++ b/tools/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
@@ -91,9 +91,22 @@ public class EmojiSubdivisionNames {
                 _nameToSubdivisionId = getNameToSubdivisionPath(parentLocaleId);
                 _subdivisionIdToName = localeToSubdivisionIdToName.get(parentLocaleId);
             }
-            localeToNameToSubdivisionId.put(localeID, _nameToSubdivisionId);
-            localeToSubdivisionIdToName.put(localeID, _subdivisionIdToName);
-        } catch (Exception e) {}
+            /*
+             * In practice _subdivisionIdToName == null actually happens here.
+             * Check for null rather than triggering NullPointerException.
+             */
+            if (_nameToSubdivisionId != null) {
+                localeToNameToSubdivisionId.put(localeID, _nameToSubdivisionId);
+            }
+            if (_subdivisionIdToName != null) {
+                localeToSubdivisionIdToName.put(localeID, _subdivisionIdToName);
+            }
+        } catch (Exception e) {
+            /*
+             * TODO: If there is a valid rationale for catching and ignoring all exceptions here,
+             * document it. Otherwise it should be avoided since it tends to hide programming errors.
+             */
+        }
     }
 
     static Set<String> SUBDIVISIONS = ImmutableSet.of("gbeng", "gbsct", "gbwls");

--- a/tools/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -305,6 +305,13 @@ public class ExampleGenerator {
         try {
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
                 value = cldrFile.getConstructedBaileyValue(xpath, null, null);
+                if (value == null) {
+                    /*
+                     * This can happen for some paths, such as
+                     * //ldml/dates/timeZoneNames/metazone[@type="Mawson"]/short/daylight
+                     */
+                    return null;
+                }
             }
             ExampleCache.ExampleCacheItem cacheItem = exCache.new ExampleCacheItem(xpath, value);
             result = cacheItem.getExample();
@@ -576,8 +583,17 @@ public class ExampleGenerator {
         org.unicode.cldr.util.DayPeriodInfo.Type aType = dayPeriodType.equals("format") ? DayPeriodInfo.Type.format : DayPeriodInfo.Type.selection;
         DayPeriodInfo dayPeriodInfo = supplementalDataInfo.getDayPeriods(aType, cldrFile.getLocaleID());
         String periodString = parts.getAttributeValue(-1, "type");
-
-        DayPeriod dayPeriod = DayPeriod.valueOf(periodString);
+        DayPeriod dayPeriod;
+        try {
+            dayPeriod = DayPeriod.valueOf(periodString);            
+        } catch (NullPointerException e) {
+            /*
+             * TODO: fix this NullPointerException! It occurs during ConsoleCheckCLDR
+             * https://unicode-org.atlassian.net/browse/CLDR-13707
+             */
+            e.printStackTrace();
+            return null;
+        }
         String periods = dayPeriodInfo.toString(dayPeriod);
         examples.add(periods);
         if ("format".equals(dayPeriodType)) {


### PR DESCRIPTION
-Split CheckForCopy.handleCheck into subroutines sameAsCodeOrEnglish, addFailure

-New function CheckForCopy.sameAsCode, called by submitVoteOrAbstention, valueCanBeAutoImported, viewOldVotes, handleBulkSubmit

-New CheckCLDR.StatusAction.FORBID_CODE

-Rename ERROR_NO_WINNING_VALUE (error-no-winning-value) to NO_WINNING_VALUE (no-winning-value)

-On client, silently accept NO_WINNING_VALUE as placeholder, but do not display it

-Also do not display [no value] as was displayed for undefined value or inheritedValue

-Move createVoter outside its calling function; misc. js clean-up

-Call setDisplayInformation in cldr-apps TestAll.main to fix null in CheckForCopy.handleCheck

-In CheckForCopy.handleCheck, throw InternalCldrException if getDisplayInformation null

-Fix bug and warning: conflictedOrgs.contains(o) not conflictedOrgs.contains(org)

-Fix warnings for deprecated CharSequences.equals and unused Options

-Fix warnings for setDisplayInformation static in ConsoleCheckCLDR.java

-Remove code that is commented out, obsolete, or dead

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13238
- [x] Updated PR title and link in previous line to include Issue number

