### PR TITLE
CLDR-13591 Update spec for deprecated unitPreferences item, fix validation errs

### DIFF
--- a/docs/ldml/tr35-general.html
+++ b/docs/ldml/tr35-general.html
@@ -1562,17 +1562,14 @@ The formal syntax for identifiers is provided below.
    </td>
    <td>product_unit ("-per-" product_unit)*<br>| &quot;per-&quot; product_unit (&quot;-per-&quot; product_unit)*
      <ul>
-
-<li><em>Examples:</em>
-  <ul>
-	<li>foot-per-second-per-second</li>
-	<li>per-second</li>
-  </ul>
-		<li><em>Note: </em>The normalized form will have only one &quot;per&quot;</li>
-
-</li>
+      <li><em>Examples:</em>
+        <ul>
+          <li>foot-per-second-per-second</li>
+          <li>per-second</li>
+        </ul>
+      </li>
+      <li><em>Note: </em>The normalized form will have only one &quot;per&quot;</li>
      </ul>
-
    </td>
   </tr>
   <tr>

--- a/docs/ldml/tr35-info.html
+++ b/docs/ldml/tr35-info.html
@@ -2272,6 +2272,8 @@ The value must be non-negative. For picking negative units (-3 meters), use the 
   </tr>
 </table>
 
+<p><strong>Note:</strong> As of CLDR 37, the &lt;unitPreference&gt; geq attribute replaces
+the now-deprecated &lt;unitPreferences&gt; scope attribute.</p>
 
 <p>
 Example:

--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -102,7 +102,7 @@
       </tr>
       <tr>
         <td>Date</td>
-        <td class="changed">2012-03-23</td>
+        <td class="changed">2012-04-15</td>
       </tr>
       <tr>
         <!-- This link must be made live when posting the final version but is disabled during proposed update stage. -->
@@ -9059,8 +9059,9 @@ decimal?, group?, special*)) &gt;</pre>
     "tr35-info.html#Contents">Supplemental</a> (supplemental
           data)</strong></p>
         <ul>
-              <li ><strong>Section 13 <a href="tr35-info.html#Unit_Conversion" >Unit Conversion</a></strong>: added new section on structure and data for unit conversions</li>
-              <li ><strong>Section 14 <a href="tr35-info.html#Unit_Preferences">Unit Preferences</a></strong>: added new section on structure and data for unit preferences</li>
+              <li ><strong>Section 13 <a href="tr35-info.html#Unit_Conversion" >Unit Conversion</a></strong>: added new section on structure and data for unit conversions.</li>
+              <li ><strong>Section 14 <a href="tr35-info.html#Unit_Preferences">Unit Preferences</a></strong>: added new section on structure and data for unit preferences.
+              Deprecates the &lt;unitPreferences&gt; scope attribute.</li>
         </ul>
         <p><strong>Part 7: <a href=
     "tr35-keyboards.html#Contents">Keyboards</a> (keyboard


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13591
- [x] Updated PR title and link in previous line to include Issue number

Updated spec for deprecated dtd items. There was really only one that affected the spec: The scope attribute for &lt;unitPreferences&gt;, which was deprecated in favor of the geq attribute for &lt;unitPreference&gt;.

Also fixed unrelated validation errors.
