### PR TITLE
CLDR-13667 NullPointerException in ExampleGenerator and others

### DIFF
--- a/tools/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/java/org/unicode/cldr/test/CheckExemplars.java
@@ -275,7 +275,14 @@ public class CheckExemplars extends FactoryCheckCLDR {
                     .setMessage("ParseLenient sample not in value: {0} ∌ {1}", us, sampleValue);
                 result.add(message);
             }
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
+            /*
+             * new UnicodeSet(value) throws IllegalArgumentException if, for example, value is null or value = "?".
+             * This can happen during cldr-unittest TestAll.
+             * path = //ldml/characters/parseLenients[@scope="general"][@level="lenient"]/parseLenient[@sample="’"]
+             * or
+             * path = //ldml/characters/parseLenients[@scope="date"][@level="lenient"]/parseLenient[@sample="-"]
+             */
             CheckStatus message = new CheckStatus().setCause(this)
                 .setMainType(CheckStatus.errorType)
                 .setSubtype(Subtype.badParseLenient)

--- a/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -3873,8 +3873,18 @@ public class SupplementalDataInfo {
      */
     public String getDefaultCurrency(String territory) {
 
-        Set<CurrencyDateInfo> targetCurrencyInfo = getCurrencyDateInfo(territory);
         String result = "XXX";
+        Set<CurrencyDateInfo> targetCurrencyInfo = getCurrencyDateInfo(territory);
+        if (targetCurrencyInfo == null) {
+            /*
+             * This happens during ConsoleCheckCLDR
+             * territory = "419"
+             * path = //ldml/numbers/currencyFormats[@numberSystem="latn"]/currencyFormatLength/currencyFormat[@type="accounting"]/pattern[@type="standard"]
+             * value = ¤#,##0.00
+             * Prevent NullPointerException
+             */
+            return result;
+        }
         Date now = new Date();
         for (CurrencyDateInfo cdi : targetCurrencyInfo) {
             if (cdi.getStart().before(now) && cdi.getEnd().after(now) && cdi.isLegalTender()) {


### PR DESCRIPTION
-Revise handleIntervalFormats to choose interval for G like y; and B or b like a

-Fix several other places in the code to return no example rather than throw NullPointerException

-Fix getDefaultCurrency to return XXX rather than throw NullPointerException

-CheckExemplars.checkParse catch IllegalArgumentException but not every Exception

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13667
- [x] Updated PR title and link in previous line to include Issue number

