### PR TITLE
CLDR-13417 Fix invalid XML characters in annotations

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -382,4 +382,14 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         }
         return "?";
     }
+
+    /**
+     * Test whether DisplayAndInputProcessor.processInput removes backspaces
+     */
+    public void TestBackspaceFilter() {
+        DisplayAndInputProcessor daip = new DisplayAndInputProcessor(info.getEnglish(), false);
+        String xpath = "//ldml/localeDisplayNames/languages/language[@type=\"fr\"]";
+        String value = daip.processInput(xpath, "\btest\bTEST\b", null);
+        assertEquals("Backspaces are filtered out", "testTEST", value);
+    }
 }

--- a/tools/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -314,6 +314,7 @@ public class DisplayAndInputProcessor {
      */
     public synchronized String processInput(String path, String value, Exception[] internalException) {
         String original = value;
+        value = stripProblematicControlCharacters(value);
         value = Normalizer.compose(value, false); // Always normalize all input to NFC.
         if (internalException != null) {
             internalException[0] = null;
@@ -471,6 +472,23 @@ public class DisplayAndInputProcessor {
             }
             return original;
         }
+    }
+
+    /**
+     * Strip out all code points less than U+0020 except for U+0009 tab,
+     * U+000A line feed, and U+000D carriage return.
+     *
+     * @param s the string
+     * @return the resulting string
+     */
+    private String stripProblematicControlCharacters(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        return s.codePoints()
+            .filter(c -> (c >= 0x20 || c == 9 || c == 0xA || c == 0xD))
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
     }
 
     private static final boolean REMOVE_COVERED_KEYWORDS = true;


### PR DESCRIPTION
-New function DisplayAndInputProcessor.stripProblematicControlCharacters

-Strip out all code points less than U+0020 except for tab, line feed, and carriage return

-New test function TestDisplayAndInputProcessor.TestBackspaceFilter

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13417
- [x] Updated PR title and link in previous line to include Issue number

