### PR TITLE
CLDR-13667 NullPointerException in ExampleGenerator and others

### DIFF
--- a/tools/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/java/org/unicode/cldr/test/CheckExemplars.java
@@ -275,7 +275,14 @@ public class CheckExemplars extends FactoryCheckCLDR {
                     .setMessage("ParseLenient sample not in value: {0} ∌ {1}", us, sampleValue);
                 result.add(message);
             }
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
+            /*
+             * new UnicodeSet(value) throws IllegalArgumentException if, for example, value is null or value = "?".
+             * This can happen during cldr-unittest TestAll.
+             * path = //ldml/characters/parseLenients[@scope="general"][@level="lenient"]/parseLenient[@sample="’"]
+             * or
+             * path = //ldml/characters/parseLenients[@scope="date"][@level="lenient"]/parseLenient[@sample="-"]
+             */
             CheckStatus message = new CheckStatus().setCause(this)
                 .setMainType(CheckStatus.errorType)
                 .setSubtype(Subtype.badParseLenient)

--- a/tools/java/org/unicode/cldr/util/RegexLogger.java
+++ b/tools/java/org/unicode/cldr/util/RegexLogger.java
@@ -473,7 +473,12 @@ public class RegexLogger {
                     break;
                 }
                 if (current.startsWith("org.unicode.cldr.test.CheckCLDR") &&
-                    !lastClass.startsWith("org.unicode.cldr.test.CheckCLDR")) {
+                    /*
+                     * TODO: fix this function to avoid referencing lastClass when it is null.
+                     * The condition lastClass == null here prevents compiler warning/error or possible NullPointerException,
+                     * since lastClass is ALWAYS null here; but this is obviously not the best solution.
+                     */
+                    (lastClass == null || !lastClass.startsWith("org.unicode.cldr.test.CheckCLDR"))) {
                     lastClass = current;
                     // leave out
                     continue;

--- a/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -3873,8 +3873,18 @@ public class SupplementalDataInfo {
      */
     public String getDefaultCurrency(String territory) {
 
-        Set<CurrencyDateInfo> targetCurrencyInfo = getCurrencyDateInfo(territory);
         String result = "XXX";
+        Set<CurrencyDateInfo> targetCurrencyInfo = getCurrencyDateInfo(territory);
+        if (targetCurrencyInfo == null) {
+            /*
+             * This happens during ConsoleCheckCLDR
+             * territory = "419"
+             * path = //ldml/numbers/currencyFormats[@numberSystem="latn"]/currencyFormatLength/currencyFormat[@type="accounting"]/pattern[@type="standard"]
+             * value = ¤#,##0.00
+             * Prevent NullPointerException
+             */
+            return result;
+        }
         Date now = new Date();
         for (CurrencyDateInfo cdi : targetCurrencyInfo) {
             if (cdi.getStart().before(now) && cdi.getEnd().after(now) && cdi.isLegalTender()) {


### PR DESCRIPTION
-Revise handleIntervalFormats to choose interval for B or b like a

-Revise SECOND_INTERVAL to include a date for G

-IntervalFormat.format swap as needed so earlier is earlier than later

-Stop catching NullPointerException in getExampleHtml

-Catch ICU NullPointerException in IntervalFormat.setPattern

-Fix several other places in the code to return no example rather than throw NullPointerException

-Fix getDefaultCurrency to return XXX rather than throw NullPointerException

-CheckExemplars.checkParse catch IllegalArgumentException but not every Exception

-Fix RegexLogger.StringIterableTransformer.transform to avoid NullPointerException

-Fix vararg warning for listFormatter.format

-Make class IntervalFormat private

-Suppress some ICU deprecation warnings, internal but OK for CLDR

-Remove dead code

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13667
- [x] Updated PR title and link in previous line to include Issue number

