### PR TITLE
CLDR-13725 Skip units/grammaticalFeatures and add subdivisionAliases

### DIFF
--- a/tools/java/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/java/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -17,7 +17,6 @@ section=languageMatching ; path=//cldr/supplemental/languageMatching/.* ; packag
 section=territoryInfo ; path=//cldr/supplemental/territoryInfo/.* ; package=core
 section=calendarData ; path=//cldr/supplemental/calendarData/.* ; package=core
 section=calendarPreferenceData ; path=//cldr/supplemental/calendarPreferenceData/.* ; package=core
-section=unitPreferenceData ; path=//cldr/supplemental/unitPreferenceData/.* ; package=core
 section=weekData ; path=//cldr/supplemental/weekData/.* ; package=core
 section=timeData ; path=//cldr/supplemental/timeData/.* ; package=core
 section=measurementData ; path=//cldr/supplemental/measurementData/.* ; package=core
@@ -26,4 +25,4 @@ section=parentLocales ; path=//cldr/supplemental/parentLocales/.* ; package=core
 section=references ; path=//cldr/supplemental/references/.* ; package=core
 section=telephoneCodeData ; path=//cldr/supplemental/telephoneCodeData/.* ; package=core
 section=windowsZones ; path=//cldr/supplemental/windowsZones/.* ; package=core
-section=aliases ; path=//cldr/supplemental/metadata/alias/(language|script|territory|variant|zone)Alias.* ; package=core
+section=aliases ; path=//cldr/supplemental/metadata/alias/(language|script|subdivision|territory|variant|zone)Alias.* ; package=core

--- a/tools/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -13,8 +13,8 @@ import com.google.common.collect.ImmutableSet;
 class LdmlConvertRules {
 
     /** File sets that will not be processed in JSON transformation. */
-    public static final ImmutableSet<String> IGNORE_FILE_SET = ImmutableSet.of("attributeValueValidity", "coverageLevels", "postalCodeData", "pluralRanges",
-        "subdivisions");
+    public static final ImmutableSet<String> IGNORE_FILE_SET = ImmutableSet.of("attributeValueValidity", "coverageLevels", "grammaticalFeatures", "postalCodeData", "pluralRanges",
+        "subdivisions", "units");
 
     /**
      * The attribute list that should become part of the name in form of
@@ -423,6 +423,7 @@ class LdmlConvertRules {
         new PathTransformSpec("(.*/languageAlias)\\[@type=\"([^\"]*)\"\\](.*)", "$1/$2$3"),
         new PathTransformSpec("(.*/scriptAlias)\\[@type=\"([^\"]*)\"\\](.*)", "$1/$2$3"),
         new PathTransformSpec("(.*/territoryAlias)\\[@type=\"([^\"]*)\"\\](.*)", "$1/$2$3"),
+        new PathTransformSpec("(.*/subdivisionAlias)\\[@type=\"([^\"]*)\"\\](.*)", "$1/$2$3"),
         new PathTransformSpec("(.*/variantAlias)\\[@type=\"([^\"]*)\"\\](.*)", "$1/$2$3"),
         new PathTransformSpec("(.*/zoneAlias)\\[@type=\"([^\"]*)\"\\](.*)", "$1/$2$3"),
         new PathTransformSpec("(.*/alias)(.*)", "$1/alias$2"),

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -124,10 +124,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
     public static final String SUPPLEMENTAL_METADATA = "supplementalMetadata";
     public static final String SUPPLEMENTAL_PREFIX = "supplemental";
     public static final String GEN_VERSION = "37";
-    public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "languageInfo",
+    public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "grammaticalFeatures", "languageInfo",
         "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "plurals", "postalCodeData", "rgScope", "supplementalData",
-        "supplementalMetadata",
-        "telephoneCodeData", "windowsZones");
+        "supplementalMetadata", "telephoneCodeData", "units", "windowsZones");
 
     private Collection<String> extraPaths = null;
 


### PR DESCRIPTION
[CLDR-13725]

Update for JSON conversion utilities for 37

1. Skip units and grammaticalFeatures stuff for now.  There is just too much there. If someone needs this in JSON format then the tools will need to be modified to accommodate that, but it will take more than the one day that I have now.  Side effect is that the unitPreferenceData goes away, but the structure is so different now that this will have to be addressed later.

2). Add subdivisionAlias from supplementalMetadata.


[CLDR-13725]: https://unicode-org.atlassian.net/browse/CLDR-13725