### PR TITLE
remove wrong legacy

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -155,7 +155,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     		<languageAlias type="ha_Latn_NG" replacement="ha_NG" reason="legacy"/>
     		<languageAlias type="kk_Cyrl_KZ" replacement="kk_KZ"  reason="legacy"/>
     		<languageAlias type="ky_Cyrl_KG" replacement="ky_KG"  reason="legacy"/>
-    		<languageAlias type="ks_Arab_IN" replacement="ks_IN"  reason="legacy"/>
     		<languageAlias type="mn_Cyrl_MN" replacement="mn_MN" reason="legacy"/>
     		<languageAlias type="ms_Latn_BN" replacement="ms_BN" reason="legacy"/>
     		<languageAlias type="ms_Latn_MY" replacement="ms_MY" reason="legacy"/>


### PR DESCRIPTION
CLDR 37 added `ks_IN` and `ks_Arab_IN`
Removes this wrong legacy line:
````
<languageAlias type="ks_Arab_IN" replacement="ks_IN"  reason="legacy"/>
````