### PR TITLE
CLDR-13739 Changed some tzdata files to rear-guard version.

### DIFF
--- a/tools/java/org/unicode/cldr/util/data/africa
+++ b/tools/java/org/unicode/cldr/util/data/africa
@@ -930,7 +930,7 @@ Rule	Morocco	2012	only	-	Aug	20	 2:00	1:00	-
 Rule	Morocco	2012	only	-	Sep	30	 3:00	0	-
 Rule	Morocco	2013	only	-	Jul	 7	 3:00	0	-
 Rule	Morocco	2013	only	-	Aug	10	 2:00	1:00	-
-Rule	Morocco	2013	2018	-	Oct	lastSun	 3:00	0	-
+Rule	Morocco	2013	2017	-	Oct	lastSun	 3:00	0	-
 Rule	Morocco	2014	2018	-	Mar	lastSun	 2:00	1:00	-
 Rule	Morocco	2014	only	-	Jun	28	 3:00	0	-
 Rule	Morocco	2014	only	-	Aug	 2	 2:00	1:00	-
@@ -942,148 +942,148 @@ Rule	Morocco	2017	only	-	May	21	 3:00	0	-
 Rule	Morocco	2017	only	-	Jul	 2	 2:00	1:00	-
 Rule	Morocco	2018	only	-	May	13	 3:00	0	-
 Rule	Morocco	2018	only	-	Jun	17	 2:00	1:00	-
-Rule	Morocco	2019	only	-	May	 5	 3:00	-1:00	-
-Rule	Morocco	2019	only	-	Jun	 9	 2:00	0	-
-Rule	Morocco	2020	only	-	Apr	19	 3:00	-1:00	-
-Rule	Morocco	2020	only	-	May	31	 2:00	0	-
-Rule	Morocco	2021	only	-	Apr	11	 3:00	-1:00	-
-Rule	Morocco	2021	only	-	May	16	 2:00	0	-
-Rule	Morocco	2022	only	-	Mar	27	 3:00	-1:00	-
-Rule	Morocco	2022	only	-	May	 8	 2:00	0	-
-Rule	Morocco	2023	only	-	Mar	19	 3:00	-1:00	-
-Rule	Morocco	2023	only	-	Apr	23	 2:00	0	-
-Rule	Morocco	2024	only	-	Mar	10	 3:00	-1:00	-
-Rule	Morocco	2024	only	-	Apr	14	 2:00	0	-
-Rule	Morocco	2025	only	-	Feb	23	 3:00	-1:00	-
-Rule	Morocco	2025	only	-	Apr	 6	 2:00	0	-
-Rule	Morocco	2026	only	-	Feb	15	 3:00	-1:00	-
-Rule	Morocco	2026	only	-	Mar	22	 2:00	0	-
-Rule	Morocco	2027	only	-	Feb	 7	 3:00	-1:00	-
-Rule	Morocco	2027	only	-	Mar	14	 2:00	0	-
-Rule	Morocco	2028	only	-	Jan	23	 3:00	-1:00	-
-Rule	Morocco	2028	only	-	Mar	 5	 2:00	0	-
-Rule	Morocco	2029	only	-	Jan	14	 3:00	-1:00	-
-Rule	Morocco	2029	only	-	Feb	18	 2:00	0	-
-Rule	Morocco	2029	only	-	Dec	30	 3:00	-1:00	-
-Rule	Morocco	2030	only	-	Feb	10	 2:00	0	-
-Rule	Morocco	2030	only	-	Dec	22	 3:00	-1:00	-
-Rule	Morocco	2031	only	-	Jan	26	 2:00	0	-
-Rule	Morocco	2031	only	-	Dec	14	 3:00	-1:00	-
-Rule	Morocco	2032	only	-	Jan	18	 2:00	0	-
-Rule	Morocco	2032	only	-	Nov	28	 3:00	-1:00	-
-Rule	Morocco	2033	only	-	Jan	 9	 2:00	0	-
-Rule	Morocco	2033	only	-	Nov	20	 3:00	-1:00	-
-Rule	Morocco	2033	only	-	Dec	25	 2:00	0	-
-Rule	Morocco	2034	only	-	Nov	 5	 3:00	-1:00	-
-Rule	Morocco	2034	only	-	Dec	17	 2:00	0	-
-Rule	Morocco	2035	only	-	Oct	28	 3:00	-1:00	-
-Rule	Morocco	2035	only	-	Dec	 9	 2:00	0	-
-Rule	Morocco	2036	only	-	Oct	19	 3:00	-1:00	-
-Rule	Morocco	2036	only	-	Nov	23	 2:00	0	-
-Rule	Morocco	2037	only	-	Oct	 4	 3:00	-1:00	-
-Rule	Morocco	2037	only	-	Nov	15	 2:00	0	-
-Rule	Morocco	2038	only	-	Sep	26	 3:00	-1:00	-
-Rule	Morocco	2038	only	-	Oct	31	 2:00	0	-
-Rule	Morocco	2039	only	-	Sep	18	 3:00	-1:00	-
-Rule	Morocco	2039	only	-	Oct	23	 2:00	0	-
-Rule	Morocco	2040	only	-	Sep	 2	 3:00	-1:00	-
-Rule	Morocco	2040	only	-	Oct	14	 2:00	0	-
-Rule	Morocco	2041	only	-	Aug	25	 3:00	-1:00	-
-Rule	Morocco	2041	only	-	Sep	29	 2:00	0	-
-Rule	Morocco	2042	only	-	Aug	10	 3:00	-1:00	-
-Rule	Morocco	2042	only	-	Sep	21	 2:00	0	-
-Rule	Morocco	2043	only	-	Aug	 2	 3:00	-1:00	-
-Rule	Morocco	2043	only	-	Sep	13	 2:00	0	-
-Rule	Morocco	2044	only	-	Jul	24	 3:00	-1:00	-
-Rule	Morocco	2044	only	-	Aug	28	 2:00	0	-
-Rule	Morocco	2045	only	-	Jul	 9	 3:00	-1:00	-
-Rule	Morocco	2045	only	-	Aug	20	 2:00	0	-
-Rule	Morocco	2046	only	-	Jul	 1	 3:00	-1:00	-
-Rule	Morocco	2046	only	-	Aug	 5	 2:00	0	-
-Rule	Morocco	2047	only	-	Jun	23	 3:00	-1:00	-
-Rule	Morocco	2047	only	-	Jul	28	 2:00	0	-
-Rule	Morocco	2048	only	-	Jun	 7	 3:00	-1:00	-
-Rule	Morocco	2048	only	-	Jul	19	 2:00	0	-
-Rule	Morocco	2049	only	-	May	30	 3:00	-1:00	-
-Rule	Morocco	2049	only	-	Jul	 4	 2:00	0	-
-Rule	Morocco	2050	only	-	May	15	 3:00	-1:00	-
-Rule	Morocco	2050	only	-	Jun	26	 2:00	0	-
-Rule	Morocco	2051	only	-	May	 7	 3:00	-1:00	-
-Rule	Morocco	2051	only	-	Jun	18	 2:00	0	-
-Rule	Morocco	2052	only	-	Apr	28	 3:00	-1:00	-
-Rule	Morocco	2052	only	-	Jun	 2	 2:00	0	-
-Rule	Morocco	2053	only	-	Apr	13	 3:00	-1:00	-
-Rule	Morocco	2053	only	-	May	25	 2:00	0	-
-Rule	Morocco	2054	only	-	Apr	 5	 3:00	-1:00	-
-Rule	Morocco	2054	only	-	May	10	 2:00	0	-
-Rule	Morocco	2055	only	-	Mar	28	 3:00	-1:00	-
-Rule	Morocco	2055	only	-	May	 2	 2:00	0	-
-Rule	Morocco	2056	only	-	Mar	12	 3:00	-1:00	-
-Rule	Morocco	2056	only	-	Apr	23	 2:00	0	-
-Rule	Morocco	2057	only	-	Mar	 4	 3:00	-1:00	-
-Rule	Morocco	2057	only	-	Apr	 8	 2:00	0	-
-Rule	Morocco	2058	only	-	Feb	17	 3:00	-1:00	-
-Rule	Morocco	2058	only	-	Mar	31	 2:00	0	-
-Rule	Morocco	2059	only	-	Feb	 9	 3:00	-1:00	-
-Rule	Morocco	2059	only	-	Mar	23	 2:00	0	-
-Rule	Morocco	2060	only	-	Feb	 1	 3:00	-1:00	-
-Rule	Morocco	2060	only	-	Mar	 7	 2:00	0	-
-Rule	Morocco	2061	only	-	Jan	16	 3:00	-1:00	-
-Rule	Morocco	2061	only	-	Feb	27	 2:00	0	-
-Rule	Morocco	2062	only	-	Jan	 8	 3:00	-1:00	-
-Rule	Morocco	2062	only	-	Feb	12	 2:00	0	-
-Rule	Morocco	2062	only	-	Dec	31	 3:00	-1:00	-
-Rule	Morocco	2063	only	-	Feb	 4	 2:00	0	-
-Rule	Morocco	2063	only	-	Dec	16	 3:00	-1:00	-
-Rule	Morocco	2064	only	-	Jan	27	 2:00	0	-
-Rule	Morocco	2064	only	-	Dec	 7	 3:00	-1:00	-
-Rule	Morocco	2065	only	-	Jan	11	 2:00	0	-
-Rule	Morocco	2065	only	-	Nov	22	 3:00	-1:00	-
-Rule	Morocco	2066	only	-	Jan	 3	 2:00	0	-
-Rule	Morocco	2066	only	-	Nov	14	 3:00	-1:00	-
-Rule	Morocco	2066	only	-	Dec	26	 2:00	0	-
-Rule	Morocco	2067	only	-	Nov	 6	 3:00	-1:00	-
-Rule	Morocco	2067	only	-	Dec	11	 2:00	0	-
-Rule	Morocco	2068	only	-	Oct	21	 3:00	-1:00	-
-Rule	Morocco	2068	only	-	Dec	 2	 2:00	0	-
-Rule	Morocco	2069	only	-	Oct	13	 3:00	-1:00	-
-Rule	Morocco	2069	only	-	Nov	17	 2:00	0	-
-Rule	Morocco	2070	only	-	Oct	 5	 3:00	-1:00	-
-Rule	Morocco	2070	only	-	Nov	 9	 2:00	0	-
-Rule	Morocco	2071	only	-	Sep	20	 3:00	-1:00	-
-Rule	Morocco	2071	only	-	Nov	 1	 2:00	0	-
-Rule	Morocco	2072	only	-	Sep	11	 3:00	-1:00	-
-Rule	Morocco	2072	only	-	Oct	16	 2:00	0	-
-Rule	Morocco	2073	only	-	Aug	27	 3:00	-1:00	-
-Rule	Morocco	2073	only	-	Oct	 8	 2:00	0	-
-Rule	Morocco	2074	only	-	Aug	19	 3:00	-1:00	-
-Rule	Morocco	2074	only	-	Sep	30	 2:00	0	-
-Rule	Morocco	2075	only	-	Aug	11	 3:00	-1:00	-
-Rule	Morocco	2075	only	-	Sep	15	 2:00	0	-
-Rule	Morocco	2076	only	-	Jul	26	 3:00	-1:00	-
-Rule	Morocco	2076	only	-	Sep	 6	 2:00	0	-
-Rule	Morocco	2077	only	-	Jul	18	 3:00	-1:00	-
-Rule	Morocco	2077	only	-	Aug	22	 2:00	0	-
-Rule	Morocco	2078	only	-	Jul	10	 3:00	-1:00	-
-Rule	Morocco	2078	only	-	Aug	14	 2:00	0	-
-Rule	Morocco	2079	only	-	Jun	25	 3:00	-1:00	-
-Rule	Morocco	2079	only	-	Aug	 6	 2:00	0	-
-Rule	Morocco	2080	only	-	Jun	16	 3:00	-1:00	-
-Rule	Morocco	2080	only	-	Jul	21	 2:00	0	-
-Rule	Morocco	2081	only	-	Jun	 1	 3:00	-1:00	-
-Rule	Morocco	2081	only	-	Jul	13	 2:00	0	-
-Rule	Morocco	2082	only	-	May	24	 3:00	-1:00	-
-Rule	Morocco	2082	only	-	Jun	28	 2:00	0	-
-Rule	Morocco	2083	only	-	May	16	 3:00	-1:00	-
-Rule	Morocco	2083	only	-	Jun	20	 2:00	0	-
-Rule	Morocco	2084	only	-	Apr	30	 3:00	-1:00	-
-Rule	Morocco	2084	only	-	Jun	11	 2:00	0	-
-Rule	Morocco	2085	only	-	Apr	22	 3:00	-1:00	-
-Rule	Morocco	2085	only	-	May	27	 2:00	0	-
-Rule	Morocco	2086	only	-	Apr	14	 3:00	-1:00	-
-Rule	Morocco	2086	only	-	May	19	 2:00	0	-
-Rule	Morocco	2087	only	-	Mar	30	 3:00	-1:00	-
-Rule	Morocco	2087	only	-	May	11	 2:00	0	-
+Rule	Morocco	2019	only	-	May	 5	 3:00	0	-
+Rule	Morocco	2019	only	-	Jun	 9	 2:00	1:00	-
+Rule	Morocco	2020	only	-	Apr	19	 3:00	0	-
+Rule	Morocco	2020	only	-	May	31	 2:00	1:00	-
+Rule	Morocco	2021	only	-	Apr	11	 3:00	0	-
+Rule	Morocco	2021	only	-	May	16	 2:00	1:00	-
+Rule	Morocco	2022	only	-	Mar	27	 3:00	0	-
+Rule	Morocco	2022	only	-	May	 8	 2:00	1:00	-
+Rule	Morocco	2023	only	-	Mar	19	 3:00	0	-
+Rule	Morocco	2023	only	-	Apr	23	 2:00	1:00	-
+Rule	Morocco	2024	only	-	Mar	10	 3:00	0	-
+Rule	Morocco	2024	only	-	Apr	14	 2:00	1:00	-
+Rule	Morocco	2025	only	-	Feb	23	 3:00	0	-
+Rule	Morocco	2025	only	-	Apr	 6	 2:00	1:00	-
+Rule	Morocco	2026	only	-	Feb	15	 3:00	0	-
+Rule	Morocco	2026	only	-	Mar	22	 2:00	1:00	-
+Rule	Morocco	2027	only	-	Feb	 7	 3:00	0	-
+Rule	Morocco	2027	only	-	Mar	14	 2:00	1:00	-
+Rule	Morocco	2028	only	-	Jan	23	 3:00	0	-
+Rule	Morocco	2028	only	-	Mar	 5	 2:00	1:00	-
+Rule	Morocco	2029	only	-	Jan	14	 3:00	0	-
+Rule	Morocco	2029	only	-	Feb	18	 2:00	1:00	-
+Rule	Morocco	2029	only	-	Dec	30	 3:00	0	-
+Rule	Morocco	2030	only	-	Feb	10	 2:00	1:00	-
+Rule	Morocco	2030	only	-	Dec	22	 3:00	0	-
+Rule	Morocco	2031	only	-	Jan	26	 2:00	1:00	-
+Rule	Morocco	2031	only	-	Dec	14	 3:00	0	-
+Rule	Morocco	2032	only	-	Jan	18	 2:00	1:00	-
+Rule	Morocco	2032	only	-	Nov	28	 3:00	0	-
+Rule	Morocco	2033	only	-	Jan	 9	 2:00	1:00	-
+Rule	Morocco	2033	only	-	Nov	20	 3:00	0	-
+Rule	Morocco	2033	only	-	Dec	25	 2:00	1:00	-
+Rule	Morocco	2034	only	-	Nov	 5	 3:00	0	-
+Rule	Morocco	2034	only	-	Dec	17	 2:00	1:00	-
+Rule	Morocco	2035	only	-	Oct	28	 3:00	0	-
+Rule	Morocco	2035	only	-	Dec	 9	 2:00	1:00	-
+Rule	Morocco	2036	only	-	Oct	19	 3:00	0	-
+Rule	Morocco	2036	only	-	Nov	23	 2:00	1:00	-
+Rule	Morocco	2037	only	-	Oct	 4	 3:00	0	-
+Rule	Morocco	2037	only	-	Nov	15	 2:00	1:00	-
+Rule	Morocco	2038	only	-	Sep	26	 3:00	0	-
+Rule	Morocco	2038	only	-	Oct	31	 2:00	1:00	-
+Rule	Morocco	2039	only	-	Sep	18	 3:00	0	-
+Rule	Morocco	2039	only	-	Oct	23	 2:00	1:00	-
+Rule	Morocco	2040	only	-	Sep	 2	 3:00	0	-
+Rule	Morocco	2040	only	-	Oct	14	 2:00	1:00	-
+Rule	Morocco	2041	only	-	Aug	25	 3:00	0	-
+Rule	Morocco	2041	only	-	Sep	29	 2:00	1:00	-
+Rule	Morocco	2042	only	-	Aug	10	 3:00	0	-
+Rule	Morocco	2042	only	-	Sep	21	 2:00	1:00	-
+Rule	Morocco	2043	only	-	Aug	 2	 3:00	0	-
+Rule	Morocco	2043	only	-	Sep	13	 2:00	1:00	-
+Rule	Morocco	2044	only	-	Jul	24	 3:00	0	-
+Rule	Morocco	2044	only	-	Aug	28	 2:00	1:00	-
+Rule	Morocco	2045	only	-	Jul	 9	 3:00	0	-
+Rule	Morocco	2045	only	-	Aug	20	 2:00	1:00	-
+Rule	Morocco	2046	only	-	Jul	 1	 3:00	0	-
+Rule	Morocco	2046	only	-	Aug	 5	 2:00	1:00	-
+Rule	Morocco	2047	only	-	Jun	23	 3:00	0	-
+Rule	Morocco	2047	only	-	Jul	28	 2:00	1:00	-
+Rule	Morocco	2048	only	-	Jun	 7	 3:00	0	-
+Rule	Morocco	2048	only	-	Jul	19	 2:00	1:00	-
+Rule	Morocco	2049	only	-	May	30	 3:00	0	-
+Rule	Morocco	2049	only	-	Jul	 4	 2:00	1:00	-
+Rule	Morocco	2050	only	-	May	15	 3:00	0	-
+Rule	Morocco	2050	only	-	Jun	26	 2:00	1:00	-
+Rule	Morocco	2051	only	-	May	 7	 3:00	0	-
+Rule	Morocco	2051	only	-	Jun	18	 2:00	1:00	-
+Rule	Morocco	2052	only	-	Apr	28	 3:00	0	-
+Rule	Morocco	2052	only	-	Jun	 2	 2:00	1:00	-
+Rule	Morocco	2053	only	-	Apr	13	 3:00	0	-
+Rule	Morocco	2053	only	-	May	25	 2:00	1:00	-
+Rule	Morocco	2054	only	-	Apr	 5	 3:00	0	-
+Rule	Morocco	2054	only	-	May	10	 2:00	1:00	-
+Rule	Morocco	2055	only	-	Mar	28	 3:00	0	-
+Rule	Morocco	2055	only	-	May	 2	 2:00	1:00	-
+Rule	Morocco	2056	only	-	Mar	12	 3:00	0	-
+Rule	Morocco	2056	only	-	Apr	23	 2:00	1:00	-
+Rule	Morocco	2057	only	-	Mar	 4	 3:00	0	-
+Rule	Morocco	2057	only	-	Apr	 8	 2:00	1:00	-
+Rule	Morocco	2058	only	-	Feb	17	 3:00	0	-
+Rule	Morocco	2058	only	-	Mar	31	 2:00	1:00	-
+Rule	Morocco	2059	only	-	Feb	 9	 3:00	0	-
+Rule	Morocco	2059	only	-	Mar	23	 2:00	1:00	-
+Rule	Morocco	2060	only	-	Feb	 1	 3:00	0	-
+Rule	Morocco	2060	only	-	Mar	 7	 2:00	1:00	-
+Rule	Morocco	2061	only	-	Jan	16	 3:00	0	-
+Rule	Morocco	2061	only	-	Feb	27	 2:00	1:00	-
+Rule	Morocco	2062	only	-	Jan	 8	 3:00	0	-
+Rule	Morocco	2062	only	-	Feb	12	 2:00	1:00	-
+Rule	Morocco	2062	only	-	Dec	31	 3:00	0	-
+Rule	Morocco	2063	only	-	Feb	 4	 2:00	1:00	-
+Rule	Morocco	2063	only	-	Dec	16	 3:00	0	-
+Rule	Morocco	2064	only	-	Jan	27	 2:00	1:00	-
+Rule	Morocco	2064	only	-	Dec	 7	 3:00	0	-
+Rule	Morocco	2065	only	-	Jan	11	 2:00	1:00	-
+Rule	Morocco	2065	only	-	Nov	22	 3:00	0	-
+Rule	Morocco	2066	only	-	Jan	 3	 2:00	1:00	-
+Rule	Morocco	2066	only	-	Nov	14	 3:00	0	-
+Rule	Morocco	2066	only	-	Dec	26	 2:00	1:00	-
+Rule	Morocco	2067	only	-	Nov	 6	 3:00	0	-
+Rule	Morocco	2067	only	-	Dec	11	 2:00	1:00	-
+Rule	Morocco	2068	only	-	Oct	21	 3:00	0	-
+Rule	Morocco	2068	only	-	Dec	 2	 2:00	1:00	-
+Rule	Morocco	2069	only	-	Oct	13	 3:00	0	-
+Rule	Morocco	2069	only	-	Nov	17	 2:00	1:00	-
+Rule	Morocco	2070	only	-	Oct	 5	 3:00	0	-
+Rule	Morocco	2070	only	-	Nov	 9	 2:00	1:00	-
+Rule	Morocco	2071	only	-	Sep	20	 3:00	0	-
+Rule	Morocco	2071	only	-	Nov	 1	 2:00	1:00	-
+Rule	Morocco	2072	only	-	Sep	11	 3:00	0	-
+Rule	Morocco	2072	only	-	Oct	16	 2:00	1:00	-
+Rule	Morocco	2073	only	-	Aug	27	 3:00	0	-
+Rule	Morocco	2073	only	-	Oct	 8	 2:00	1:00	-
+Rule	Morocco	2074	only	-	Aug	19	 3:00	0	-
+Rule	Morocco	2074	only	-	Sep	30	 2:00	1:00	-
+Rule	Morocco	2075	only	-	Aug	11	 3:00	0	-
+Rule	Morocco	2075	only	-	Sep	15	 2:00	1:00	-
+Rule	Morocco	2076	only	-	Jul	26	 3:00	0	-
+Rule	Morocco	2076	only	-	Sep	 6	 2:00	1:00	-
+Rule	Morocco	2077	only	-	Jul	18	 3:00	0	-
+Rule	Morocco	2077	only	-	Aug	22	 2:00	1:00	-
+Rule	Morocco	2078	only	-	Jul	10	 3:00	0	-
+Rule	Morocco	2078	only	-	Aug	14	 2:00	1:00	-
+Rule	Morocco	2079	only	-	Jun	25	 3:00	0	-
+Rule	Morocco	2079	only	-	Aug	 6	 2:00	1:00	-
+Rule	Morocco	2080	only	-	Jun	16	 3:00	0	-
+Rule	Morocco	2080	only	-	Jul	21	 2:00	1:00	-
+Rule	Morocco	2081	only	-	Jun	 1	 3:00	0	-
+Rule	Morocco	2081	only	-	Jul	13	 2:00	1:00	-
+Rule	Morocco	2082	only	-	May	24	 3:00	0	-
+Rule	Morocco	2082	only	-	Jun	28	 2:00	1:00	-
+Rule	Morocco	2083	only	-	May	16	 3:00	0	-
+Rule	Morocco	2083	only	-	Jun	20	 2:00	1:00	-
+Rule	Morocco	2084	only	-	Apr	30	 3:00	0	-
+Rule	Morocco	2084	only	-	Jun	11	 2:00	1:00	-
+Rule	Morocco	2085	only	-	Apr	22	 3:00	0	-
+Rule	Morocco	2085	only	-	May	27	 2:00	1:00	-
+Rule	Morocco	2086	only	-	Apr	14	 3:00	0	-
+Rule	Morocco	2086	only	-	May	19	 2:00	1:00	-
+Rule	Morocco	2087	only	-	Mar	30	 3:00	0	-
+Rule	Morocco	2087	only	-	May	11	 2:00	1:00	-
 # For dates after the somewhat-arbitrary cutoff of 2087, assume that
 # Morocco will no longer observe DST.  At some point this table will
 # need to be extended, though quite possibly Morocco will change the
@@ -1094,7 +1094,7 @@ Zone Africa/Casablanca	-0:30:20 -	LMT	1913 Oct 26
 			 0:00	Morocco	+00/+01	1984 Mar 16
 			 1:00	-	+01	1986
 			 0:00	Morocco	+00/+01	2018 Oct 28  3:00
-			 1:00	Morocco	+01/+00
+			 0:00	Morocco	+00/+01
 
 # Western Sahara
 #
@@ -1110,7 +1110,7 @@ Zone Africa/Casablanca	-0:30:20 -	LMT	1913 Oct 26
 Zone Africa/El_Aaiun	-0:52:48 -	LMT	1934 Jan # El Aaiún
 			-1:00	-	-01	1976 Apr 14
 			 0:00	Morocco	+00/+01	2018 Oct 28  3:00
-			 1:00	Morocco	+01/+00
+			 0:00	Morocco	+00/+01
 
 # Mozambique
 #
@@ -1182,13 +1182,13 @@ Link Africa/Maputo Africa/Lusaka	# Zambia
 
 # RULE	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 # Vanguard section, for zic and other parsers that support negative DST.
-Rule	Namibia	1994	only	-	Mar	21	0:00	-1:00	WAT
-Rule	Namibia	1994	2017	-	Sep	Sun>=1	2:00	0	CAT
-Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	-1:00	WAT
+#Rule	Namibia	1994	only	-	Mar	21	0:00	-1:00	WAT
+#Rule	Namibia	1994	2017	-	Sep	Sun>=1	2:00	0	CAT
+#Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	-1:00	WAT
 # Rearguard section, for parsers lacking negative DST; see ziguard.awk.
-#Rule	Namibia	1994	only	-	Mar	21	0:00	0	WAT
-#Rule	Namibia	1994	2017	-	Sep	Sun>=1	2:00	1:00	CAT
-#Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	0	WAT
+Rule	Namibia	1994	only	-	Mar	21	0:00	0	WAT
+Rule	Namibia	1994	2017	-	Sep	Sun>=1	2:00	1:00	CAT
+Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	0	WAT
 # End of rearguard section.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
@@ -1198,14 +1198,14 @@ Zone	Africa/Windhoek	1:08:24 -	LMT	1892 Feb 8
 			2:00	1:00	SAST	1943 Mar 21  2:00
 			2:00	-	SAST	1990 Mar 21 # independence
 # Vanguard section, for zic and other parsers that support negative DST.
-			2:00	Namibia	%s
+#			2:00	Namibia	%s
 # Rearguard section, for parsers lacking negative DST; see ziguard.awk.
-#			2:00	-	CAT	1994 Mar 21  0:00
+			2:00	-	CAT	1994 Mar 21  0:00
 # From Paul Eggert (2017-04-07):
 # The official date of the 2017 rule change was 2017-10-24.  See:
 # http://www.lac.org.na/laws/annoSTAT/Namibian%20Time%20Act%209%20of%202017.pdf
-#			1:00	Namibia	%s	2017 Oct 24
-#			2:00	-	CAT
+			1:00	Namibia	%s	2017 Oct 24
+			2:00	-	CAT
 # End of rearguard section.
 
 # Niger

--- a/tools/java/org/unicode/cldr/util/data/asia
+++ b/tools/java/org/unicode/cldr/util/data/asia
@@ -2015,7 +2015,7 @@ Zone	Asia/Jerusalem	2:20:54 -	LMT	1880
 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Japan	1948	only	-	May	Sat>=1	24:00	1:00	D
-Rule	Japan	1948	1951	-	Sep	Sat>=8	25:00	0	S
+Rule	Japan	1948	1951	-	Sep	Sun>=9	 1:00	0	S
 Rule	Japan	1949	only	-	Apr	Sat>=1	24:00	1:00	D
 Rule	Japan	1950	1951	-	May	Sat>=1	24:00	1:00	D
 

--- a/tools/java/org/unicode/cldr/util/data/europe
+++ b/tools/java/org/unicode/cldr/util/data/europe
@@ -530,13 +530,13 @@ Link	Europe/London	Europe/Isle_of_Man
 # summer and negative daylight saving time in winter.  It is for when
 # negative SAVE values are used.
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Eire	1971	only	-	Oct	31	 2:00u	-1:00	-
-Rule	Eire	1972	1980	-	Mar	Sun>=16	 2:00u	0	-
-Rule	Eire	1972	1980	-	Oct	Sun>=23	 2:00u	-1:00	-
-Rule	Eire	1981	max	-	Mar	lastSun	 1:00u	0	-
-Rule	Eire	1981	1989	-	Oct	Sun>=23	 1:00u	-1:00	-
-Rule	Eire	1990	1995	-	Oct	Sun>=22	 1:00u	-1:00	-
-Rule	Eire	1996	max	-	Oct	lastSun	 1:00u	-1:00	-
+#Rule	Eire	1971	only	-	Oct	31	 2:00u	-1:00	-
+#Rule	Eire	1972	1980	-	Mar	Sun>=16	 2:00u	0	-
+#Rule	Eire	1972	1980	-	Oct	Sun>=23	 2:00u	-1:00	-
+#Rule	Eire	1981	max	-	Mar	lastSun	 1:00u	0	-
+#Rule	Eire	1981	1989	-	Oct	Sun>=23	 1:00u	-1:00	-
+#Rule	Eire	1990	1995	-	Oct	Sun>=22	 1:00u	-1:00	-
+#Rule	Eire	1996	max	-	Oct	lastSun	 1:00u	-1:00	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Dublin	-0:25:00 -	LMT	1880 Aug  2
@@ -550,11 +550,11 @@ Zone	Europe/Dublin	-0:25:00 -	LMT	1880 Aug  2
 			 0:00	-	GMT	1948 Apr 18  2:00s
 			 0:00	GB-Eire	GMT/IST	1968 Oct 27
 # Vanguard section, for zic and other parsers that support negative DST.
-			 1:00	Eire	IST/GMT
+#			 1:00	Eire	IST/GMT
 # Rearguard section, for parsers lacking negative DST; see ziguard.awk.
-#			 1:00	-	IST	1971 Oct 31  2:00u
-#			 0:00	GB-Eire	GMT/IST	1996
-#			 0:00	EU	GMT/IST
+			 1:00	-	IST	1971 Oct 31  2:00u
+			 0:00	GB-Eire	GMT/IST	1996
+			 0:00	EU	GMT/IST
 # End of rearguard section.
 
 
@@ -1018,9 +1018,9 @@ Zone	Europe/Prague	0:57:44 -	LMT	1850
 			1:00	C-Eur	CE%sT	1945 May  9
 			1:00	Czech	CE%sT	1946 Dec  1  3:00
 # Vanguard section, for zic and other parsers that support negative DST.
-			1:00	-1:00	GMT	1947 Feb 23  2:00
+#			1:00	-1:00	GMT	1947 Feb 23  2:00
 # Rearguard section, for parsers lacking negative DST; see ziguard.awk.
-#			0:00	-	GMT	1947 Feb 23  2:00
+			0:00	-	GMT	1947 Feb 23  2:00
 # End of rearguard section.
 			1:00	Czech	CE%sT	1979
 			1:00	EU	CE%sT


### PR DESCRIPTION
Previous PR #440 added tzdata 2020a files, but they include negative offsets from standard time. There is an existing CLDR tool code asserting such data. So when you run CLDR tools with `-ea` (enable assertions), it will stop because of the assertion code.

TZ database provide an option for modifying data not including such negative offsets (`rearguard` version). This PR includes a few modified zone data files produced by the build target, instead of original ones.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13739
- [x] Updated PR title and link in previous line to include Issue number

