### PR TITLE
CLDR-11979 Enable assertion in cldr-unittest

### DIFF
--- a/tools/cldr-unittest/build.xml
+++ b/tools/cldr-unittest/build.xml
@@ -35,7 +35,7 @@
 			2) JVM_EXTRA_OPTIONS=xxx in build.properties
 			3) Environment variable - JVM_EXTRA_OPTIONS=xxx
 			4) Final fallback - "-Xmx6g" below -->
-		<property name="env.JVM_EXTRA_OPTIONS" value="-Xmx6g" />
+		<property name="env.JVM_EXTRA_OPTIONS" value="-Xmx6g -enableassertions" />
 		<property name="JVM_EXTRA_OPTIONS" value="${env.JVM_EXTRA_OPTIONS}" />
 		<property name="jvm_options" value="${JVM_OPTIONS} ${JVM_EXTRA_OPTIONS}" />
 


### PR DESCRIPTION
-Add -enableassertions (same as -ea) to JVM_EXTRA_OPTIONS in cldr-unittest/build.xml

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11979
- [x] Updated PR title and link in previous line to include Issue number

