### PR TITLE
CLDR-13749 Clarify language/region/script

### DIFF
--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -5277,9 +5277,13 @@ root</pre>
       return it.</li>
       <li style="margin-top: 0.5em; margin-bottom: 0.5em">Remove
       the variants from max.</li>
+      <li style="margin-top: 0.5em; margin-bottom: 0.5em">Get the 
+	      components of the max (<em>language<sub>max</sub></em>, 
+	      <em>script<sub>max</sub></em>, <em>region<sub>max</sub></em>).</li>
       <li style="margin-top: 0.5em; margin-bottom: 0.5em">Then for
-      <i>trial</i> in {language, language _ region, language _
-      script}
+      <i>trial</i> in {<em>language<sub>max</sub></em>, 
+	      <em>language<sub>max</sub>_region<sub>max</sub></em>, 
+	      <em>language<sub>max</sub>_script<sub>max</sub></em>}
         <ul>
           <li style="margin-top: 0.5em; margin-bottom: 0.5em">If
           AddLikelySubtags(<i>trial</i>) = max, then return


### PR DESCRIPTION
Clarify the language, region and script in the RemoveLikelySubtags are referring to the one inside the max by using 
subscript max. 
close https://unicode-org.atlassian.net/browse/CLDR-13749

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13749
- [X] Updated PR title and link in previous line to include Issue number

