### PR TITLE
CLDR-13761 fix typo of language to region

### DIFF
--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -1149,9 +1149,9 @@
               <li>Five special deprecated grandfathered codes (such as <em>i-default</em>) are in  type attributes, and are also replaced.</li>
             </ol>
           </li>
-          <li>If the  region subtag matches the <i>type</i> attribute of a <i>territoryAlias</i> element in <a href=
+          <li>If the region subtag matches the <i>type</i> attribute of a <i>territoryAlias</i> element in <a href=
       "tr35-info.html#Supplemental_Data">Supplemental Data</a>,
-            replace the language subtag with the <i>replacement</i> value, as follows:
+            replace the region subtag with the <i>replacement</i> value, as follows:
             <ol>
               <li>If there is a single territory in the replacement,
                 use it.</li>
@@ -1286,7 +1286,7 @@
       <li>If the BCP 47 region subtag matches the <i>type</i>
       attribute of a <i>territoryAlias</i> element in <a href=
       "tr35-info.html#Supplemental_Data">Supplemental Data</a>,
-      replace the language subtag with the <i>replacement</i>
+      replace the region subtag with the <i>replacement</i>
       value, as follows:
         <ol>
           <li>If there is a single territory in the replacement,


### PR DESCRIPTION
By the context, the one to be replaced should be region subtag, not language subtag.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13761
- [X] Updated PR title and link in previous line to include Issue number

