### PR TITLE
CLDR-13750 Refactoring joiner and equals utilities.

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/CheckYear.java
@@ -25,7 +25,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.With;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -365,7 +365,7 @@ public class CheckYear {
         PrintWriter out = FileUtilities.openUTF8Writer(CLDRPaths.GEN_DIRECTORY
             + "datecheck/", filename);
         out.println("Name\tid\t"
-            + CollectionUtilities.join(Category.values(), "\t"));
+            + Joiner.on("\t").join(Category.values()));
         for (Entry<String, String> entry : sorted.entrySet()) {
             String localeId = entry.getValue();
             boolean priority = getPriority(localeId);
@@ -378,7 +378,7 @@ public class CheckYear {
             for (Category item : Category.values()) {
                 Set<String> items = localeInfo.category2base.get(item);
                 if (items != null) {
-                    out.print("\t" + CollectionUtilities.join(items, " "));
+                    out.print("\t" + Joiner.on(" ").join(items));
                 } else {
                     out.print("\t");
                 }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/DataDrivenTestHelper.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/DataDrivenTestHelper.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 import org.unicode.cldr.draft.FileUtilities;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.util.ICUUncheckedIOException;
 
 abstract public class DataDrivenTestHelper {
@@ -44,7 +44,7 @@ abstract public class DataDrivenTestHelper {
                 } else {
                     String first = components.iterator().next();
                     String sep = first.startsWith("@") ? "=" : SEPARATOR;
-                    out.append(CollectionUtilities.join(components, sep));
+                    out.append(Joiner.on(sep).join(components));
                     if (!comment.isEmpty()) {
                         out.append("\t# ").append(comment);
                     }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAlt.java
@@ -14,10 +14,10 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R4;
 import com.ibm.icu.util.Output;
@@ -70,7 +70,7 @@ public class TestAlt extends TestFmwk {
             }
         }
         for (Entry<String, Collection<R4<String, String, String, String>>> entry : altStarred.asMap().entrySet()) {
-            System.out.println(entry.getKey() + "\t" + CollectionUtilities.join(entry.getValue(), "\t"));
+            System.out.println(entry.getKey() + "\t" + Joiner.on("\t").join(entry.getValue()));
         }
     }
     

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAnnotations.java
@@ -30,12 +30,12 @@ import org.unicode.cldr.util.XListFormatter;
 import org.unicode.cldr.util.XListFormatter.ListTypeLength;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R3;
@@ -154,7 +154,7 @@ public class TestAnnotations extends TestFmwkPlus {
                 final Set<String> keywords = eng.getKeywords(emoji);
                 System.out.println("{\"" + emoji
                     + "\",\"" + shortName
-                    + "\",\"" + CollectionUtilities.join(keywords, " | ")
+                    + "\",\"" + Joiner.on(" | ").join(keywords)
                     + "\"},");
             }
         }
@@ -189,7 +189,8 @@ public class TestAnnotations extends TestFmwkPlus {
             }
             String minorCategory = Emoji.getMinorCategory(emoji);
             long emojiOrder = Emoji.getEmojiToOrder(emoji);
-            R3<String, String, String> row2 = Row.of(emoji, annotations.getShortName(), CollectionUtilities.join(annotations.getKeywords(), " | "));
+            R3<String, String, String> row2 = Row.of(emoji, annotations.getShortName(),
+                Joiner.on(" | ").join(annotations.getKeywords()));
             R4<PageId, Long, String, R3<String, String, String>> row = Row.of(majorCategory, emojiOrder, minorCategory, row2);
             sorted.add(row);
         }
@@ -250,7 +251,7 @@ public class TestAnnotations extends TestFmwkPlus {
             if (emojis.size() > 1) {
                 synchronized(problems) {
                     problems.add("Duplicate name in " + locale + ": “" + name + "” for "
-                        + CollectionUtilities.join(emojis, " & "));
+                        + Joiner.on(" & ").join(emojis));
                 }
                 if (duplicateNameToEmoji == null) {
                     duplicateNameToEmoji = TreeMultimap.create();

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -59,7 +59,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row.R3;
 import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.Output;
@@ -346,7 +345,7 @@ public class TestAttributeValues extends TestFmwk {
                             + "\t" + attributeName 
                             + "\t" + (matchValue == null ? "" : matchValue)
                             + "\t" + validFound.size()
-                            + "\t" + CollectionUtilities.join(validFound, ", ")
+                            + "\t" + Joiner.on(", ").join(validFound)
                             + "\n"
                             );
                         if (valueStatus == ValueStatus.valid) try {
@@ -372,7 +371,7 @@ public class TestAttributeValues extends TestFmwk {
                                         + "\t" + attributeName 
                                         + "\t" + "" 
                                         + "\t" + "" 
-                                        + "\t" + CollectionUtilities.join(missing, ", ")
+                                        + "\t" + Joiner.on(", ").join(missing)
                                         + "\n"
                                     );
                             }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBasic.java
@@ -61,12 +61,12 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -895,9 +895,9 @@ public class TestBasic extends TestFmwkPlus {
                     int debug = 0;
                 }
                 if (leaves.size() == 1) {
-                    System.out.println(prefix + CollectionUtilities.join(presentation, " "));
+                    System.out.println(prefix + Joiner.on(" ").join(presentation));
                 } else {
-                    System.out.println(prefix + "{" + CollectionUtilities.join(presentation, " ") + "}");
+                    System.out.println(prefix + "{" + Joiner.on(" ").join(presentation) + "}");
                 }
             }
             for (String parent : parents) {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -28,13 +28,13 @@ import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.text.UnicodeSet;
 
 public class TestCLDRLocaleCoverage extends TestFmwkPlus {
@@ -179,7 +179,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             for (String locale : temp) {
                 temp2.add(locale + "\t" + ENGLISH.getName(locale));
             }
-            warnln("Missing:\t" + temp.size() + "\n\t" + CollectionUtilities.join(temp2, "\n\t"));
+            warnln("Missing:\t" + temp.size() + "\n\t" + Joiner.on("\n\t").join(temp2));
         }
         return result;
     }
@@ -231,7 +231,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             diff2.removeAll(skip);
             if (!diff2.isEmpty()) {
                 String diffString = diff2.toString();
-                String levelString = CollectionUtilities.join(level, "+");
+                String levelString = Joiner.on("+").join(level);
                 for (String localeId : diff2) {
                     diffString += "\n\t" + localeId + "\t" + CLDRConfig.getInstance().getEnglish().getName(localeId);
                 }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -40,10 +40,10 @@ import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.text.CompactDecimalFormat;
@@ -135,11 +135,10 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 + "\t"
                 + starred
                 + "\t"
-                + CollectionUtilities.join(levelsFound, ", ")
+                + Joiner.on(", ").join(levelsFound)
                 + "\t"
                 + (maxLevelCount == 1 ? "all" : localesWithUniqueLevels
-                    .size() == 0 ? "none" : CollectionUtilities.join(
-                        localesWithUniqueLevels, ", ")));
+                    .size() == 0 ? "none" : Joiner.on(", ").join(localesWithUniqueLevels)));
         }
     }
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestDtdData.java
@@ -30,10 +30,10 @@ import org.unicode.cldr.util.Validity.Status;
 import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public class TestDtdData extends TestFmwk {
     private static final String COMMON_DIR = CLDRPaths.BASE_DIRECTORY + "common/";
@@ -284,7 +284,7 @@ public class TestDtdData extends TestFmwk {
     }
 
     private String showPath(List<Element> parents) {
-        return "!//" + CollectionUtilities.join(parents, "/");
+        return "!//" + Joiner.on("/").join(parents);
     }
 
     public void TestNewDtdData() {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestFmwkPlus.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestFmwkPlus.java
@@ -7,8 +7,8 @@ import java.util.Set;
 
 import org.unicode.cldr.util.CldrUtility;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.text.Transform;
 import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.text.UnicodeSet;
@@ -160,7 +160,7 @@ public class TestFmwkPlus extends TestFmwk {
 
         @Override
         public String toString() {
-            return CollectionUtilities.join(others, " and ");
+            return Joiner.on(" and ").join(others);
         }
     }
 
@@ -185,7 +185,7 @@ public class TestFmwkPlus extends TestFmwk {
 
         @Override
         public String toString() {
-            return CollectionUtilities.join(others, " or ");
+            return Joiner.on(" or ").join(others);
         }
     }
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestInheritance.java
@@ -36,8 +36,8 @@ import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData.Type;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 
@@ -540,7 +540,7 @@ public class TestInheritance extends TestFmwk {
         }
         if (additionalDefaultContents.size() != 0) {
             errln("Suggested additions to supplementalMetadata/../defaultContent:\n"
-                + CollectionUtilities.join(additionalDefaultContents, " "));
+                + Joiner.on(" ").join(additionalDefaultContents));
         }
     }
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
@@ -43,7 +43,6 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -726,7 +725,7 @@ public class TestLocale extends TestFmwkPlus {
     private void showItem(LanguageTagParser ltp, String extension, String key, String gorp, String... values) {
 
         String locale = "en-GB-" + extension + (extension.equals("t") ? "-hi" : "")
-            + "-" + key + "-" + CollectionUtilities.join(values, "-") + gorp;
+            + "-" + key + "-" + String.join("-", values) + gorp;
         ltp.set(locale);
 
         logln(ltp.toString(Format.bcp47) 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
@@ -53,12 +53,12 @@ import org.unicode.cldr.util.With;
 import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -724,7 +724,7 @@ public class TestPathHeader extends TestFmwkPlus {
                     data = Relation.of(new TreeMap<String, Set<String>>(),
                         TreeSet.class));
             }
-            data.put(starred, CollectionUtilities.join(attr, "|"));
+            data.put(starred, Joiner.on("|").join(attr));
         }
         for (Entry<SurveyToolStatus, Relation<String, String>> entry : info2
             .entrySet()) {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -24,7 +24,7 @@ import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.With;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.lang.UCharacter;
@@ -69,11 +69,11 @@ public class TestScriptMetadata extends TestFmwkPlus {
             if (ScriptMetadata.errors.size() == 1) {
                 logln("ScriptMetadata initialization errors\t"
                     + ScriptMetadata.errors.size() + "\t"
-                    + CollectionUtilities.join(ScriptMetadata.errors, "\n"));
+                    + Joiner.on("\n").join(ScriptMetadata.errors));
             } else {
                 errln("ScriptMetadata initialization errors\t"
                     + ScriptMetadata.errors.size() + "\t"
-                    + CollectionUtilities.join(ScriptMetadata.errors, "\n"));
+                    + Joiner.on("\n").join(ScriptMetadata.errors));
             }
         }
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -72,7 +72,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -389,7 +388,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         PluralInfo pluralInfo = SUPPLEMENTAL.getPlurals(
             PluralType.valueOf(row[1]), row[0]);
         Count count = pluralInfo.getCount(new FixedDecimal(row[2]));
-        assertEquals(CollectionUtilities.join(row, ", "),
+        assertEquals(String.join(", ", row),
             Count.valueOf(row[3]), count);
     }
 
@@ -627,7 +626,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                         c.toString());
                     ruleToExceptions.put(countRules == null ? "" : countRules,
                         "{\"" + locale + "\", \"" + c + "\", \""
-                            + CollectionUtilities.join(compose, ",")
+                            + Joiner.on(",").join(compose)
                             + "\"},");
                 }
             }
@@ -750,7 +749,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             addName(CLDRFile.SCRIPT_NAME, ltp.getScript(), b);
             addName(CLDRFile.TERRITORY_NAME, ltp.getRegion(), b);
         }
-        return CollectionUtilities.join(b, "; ");
+        return Joiner.on("; ").join(b);
     }
 
     private void addName(int languageName, String code, Set<String> b) {
@@ -1027,7 +1026,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                     errln(code + "\t=>\t" + oldReplacement + "\tshould be:\n\t"
                         + "<" + type + "Alias type=\"" + code
                         + "\" replacement=\""
-                        + CollectionUtilities.join(newReplacement, " ")
+                        + Joiner.on(" ").join(newReplacement)
                         + "\" reason=\"XXX\"/> <!-- YYY -->\n");
                 }
             }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestTransforms.java
@@ -27,7 +27,7 @@ import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Normalizer2;
@@ -130,9 +130,9 @@ public class TestTransforms extends TestFmwkPlus {
                 }
             }
             logln("Success! " + latinFromCyrillicSucceeds.size() + "\n"
-                + CollectionUtilities.join(latinFromCyrillicSucceeds, "\n"));
+                + Joiner.on("\n").join(latinFromCyrillicSucceeds));
             logln("\nFAILS!" + latinFromCyrillicFails.size() + "\n"
-                + CollectionUtilities.join(latinFromCyrillicFails, "\n"));
+                + Joiner.on("\n").join(latinFromCyrillicFails));
         }
     }
 

--- a/tools/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -19,7 +19,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.text.NumberFormat;
 
 public class GenerateLanguageData {
@@ -131,8 +131,8 @@ public class GenerateLanguageData {
 
                 String lang = entry.getKey();
                 out.println(fixLang(lang)
-                    + "\t" + (top.size() < 6 ? CollectionUtilities.join(top, ", ")
-                        : CollectionUtilities.join(top.subList(0, 5), ", ") + ", …"));
+                    + "\t" + (top.size() < 6 ? Joiner.on(", ").join(top)
+                        : Joiner.on(", ").join(top.subList(0, 5)) + ", …"));
                 missing.remove(lang);
             }
             for (String lang : missing) {

--- a/tools/java/org/unicode/cldr/draft/Keyboard.java
+++ b/tools/java/org/unicode/cldr/draft/Keyboard.java
@@ -22,7 +22,7 @@ import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XMLFileReader.SimpleHandler;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.text.UnicodeSet;
 
 /**
@@ -183,7 +183,7 @@ public class Keyboard {
                 .read(fileName, -1, true);
             return keyboardHandler.getKeyboard();
         } catch (Exception e) {
-            throw new KeyboardException(fileName + "\n" + CollectionUtilities.join(errors, ", "), e);
+            throw new KeyboardException(fileName + "\n" + Joiner.on(", ").join(errors), e);
         }
     }
 

--- a/tools/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/java/org/unicode/cldr/draft/Misc.java
@@ -26,7 +26,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData;
 import org.unicode.cldr.util.Timer;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.lang.UCharacter;
@@ -88,7 +88,7 @@ public class Misc {
             } else if (locale.equals("zh_Hant")) {
                 scripts.add("Hant");
             }
-            System.out.println(locale + "\t" + CollectionUtilities.join(scripts, " "));
+            System.out.println(locale + "\t" + Joiner.on(" ").join(scripts));
         }
 
         StringTransform unicode = Transliterator.getInstance("hex/unicode");

--- a/tools/java/org/unicode/cldr/draft/ScriptMetadata.java
+++ b/tools/java/org/unicode/cldr/draft/ScriptMetadata.java
@@ -19,7 +19,7 @@ import org.unicode.cldr.util.SemiFileReader;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.With;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.Transform;
@@ -299,7 +299,7 @@ public class ScriptMetadata {
 
         private Map<String, Info> getData() {
             if (!errors.isEmpty()) {
-                throw new RuntimeException(CollectionUtilities.join(errors, "\n\t"));
+                throw new RuntimeException(Joiner.on("\n\t").join(errors));
             }
             return Collections.unmodifiableMap(data);
         }

--- a/tools/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -20,6 +20,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
@@ -30,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R4;
 import com.ibm.icu.util.Output;
@@ -69,7 +69,8 @@ public class XLocaleDistance {
 
         for (String container : SDI.getContainers()) {
             Set<String> contained = SDI.getContained(container);
-            System.out.println(".putAll(\"" + container + "\", \"" + CollectionUtilities.join(contained, "\", \"") + "\")");
+            System.out.println(".putAll(\"" + container + "\", \"" + Joiner.on("\", \"")
+                .join(contained) + "\")");
         }
 
         ImmutableMultimap.Builder<String, String> containerToFinalContainedBuilder = new ImmutableMultimap.Builder<>();
@@ -778,7 +779,8 @@ public class XLocaleDistance {
         }
         if (PRINT_OVERRIDES) {
             System.out.println("\t\t<languageMatches type=\"written\" alt=\"enhanced\">");
-            System.out.println("\t\t\t<paradigmLocales locales=\"" + CollectionUtilities.join(paradigmRegions, " ")
+            System.out.println("\t\t\t<paradigmLocales locales=\"" + String
+                .join(" ", paradigmRegions)
                 + "\"/>");
             for (String[] variableRule : variableOverrides) {
                 System.out.println("\t\t\t<matchVariable id=\"" + variableRule[0]
@@ -879,8 +881,8 @@ public class XLocaleDistance {
 
     private static void printMatchXml(List<String> desired, List<String> supported, Integer distance, Boolean oneway) {
         if (PRINT_OVERRIDES) {
-            String desiredStr = CollectionUtilities.join(desired, "_");
-            String supportedStr = CollectionUtilities.join(supported, "_");
+            String desiredStr = Joiner.on("_").join(desired);
+            String supportedStr = Joiner.on("_").join(supported);
             String desiredName = fixedName(desired);
             String supportedName = fixedName(supported);
             System.out.println("\t\t\t<languageMatch"
@@ -918,7 +920,7 @@ public class XLocaleDistance {
                 result.insert(0, english.getName(CLDRFile.TERRITORY_NAME, language));
             }
         }
-        return CollectionUtilities.join(alt, "; ");
+        return Joiner.on("; ").join(alt);
     }
 
     static public void add(StringDistanceTable languageDesired2Supported, List<String> desired, List<String> supported, int percentage) {

--- a/tools/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -38,13 +38,13 @@ import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.stream.JsonWriter;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 /**
  * Utility methods to extract data from CLDR repository and export it in JSON
@@ -767,7 +767,7 @@ public class Ldml2JsonConverter {
             scriptInfo.put(script, i);
         }
         if (ScriptMetadata.errors.size() > 0) {
-            System.err.println(CollectionUtilities.join(ScriptMetadata.errors, "\n\t"));
+            System.err.println(Joiner.on("\n\t").join(ScriptMetadata.errors));
             //throw new IllegalArgumentException();
         }
 

--- a/tools/java/org/unicode/cldr/test/CheckConsistentCasing.java
+++ b/tools/java/org/unicode/cldr/test/CheckConsistentCasing.java
@@ -21,7 +21,7 @@ import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.RegexLookup;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.util.ULocale;
@@ -287,7 +287,7 @@ public class CheckConsistentCasing extends FactoryCheckCLDR {
             info.put(category, type);
         }
         if (DEBUG && missing.size() != 0) {
-            System.out.println("Paths skipped:\n" + CollectionUtilities.join(missing, "\n"));
+            System.out.println("Paths skipped:\n" + Joiner.on("\n").join(missing));
         }
         return info;
     }

--- a/tools/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/java/org/unicode/cldr/test/CheckDates.java
@@ -43,7 +43,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.props.UnicodeProperty.PatternMatcher;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.DateTimePatternGenerator;
@@ -662,7 +662,7 @@ public class CheckDates extends FactoryCheckCLDR {
                 results.add(stringValue);
             }
         }
-        return "{" + CollectionUtilities.join(results, "},{") + "}";
+        return "{" + Joiner.on("},{").join(results) + "}";
     }
 
     static final Pattern HACK_CONFLICTING = PatternCache.get("Conflicting fields:\\s+M+,\\s+l");
@@ -981,7 +981,7 @@ public class CheckDates extends FactoryCheckCLDR {
                     result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.warningType)
                         .setSubtype(Subtype.missingDatePattern)
                         .setMessage(msg,
-                            dateTimeLength, dateOrTime, value, CollectionUtilities.join(bases, ", ")));
+                            dateTimeLength, dateOrTime, value, Joiner.on(", ").join(bases)));
                 }
             }
         }

--- a/tools/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/java/org/unicode/cldr/tool/CLDRModify.java
@@ -66,6 +66,7 @@ import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.XPathParts.Comments;
 import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.ibm.icu.dev.tool.UOption;
 import com.ibm.icu.dev.util.CollectionUtilities;
@@ -1845,7 +1846,7 @@ public class CLDRModify {
                     int debug = 0;
                 }
                 DisplayAndInputProcessor.filterCoveredKeywords(sorted);
-                String newKeywordValue = CollectionUtilities.join(sorted, " | ");
+                String newKeywordValue = Joiner.on(" | ").join(sorted);
                 if (!newKeywordValue.equals(keywordValue)) {
                     replace(keywordPath, keywordPath, newKeywordValue);
                 }

--- a/tools/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -23,9 +23,9 @@ import org.unicode.cldr.util.LanguageGroup;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R3;
@@ -212,7 +212,7 @@ public class ChartAnnotations extends Chart {
                             }
                         }
                         for (Entry<String, Collection<String>> entry : valueToSub.asMap().entrySet()) {
-                            baseAnnotation += "<hr><i>" + CollectionUtilities.join(entry.getValue(), ", ") + "</i>: " + entry.getKey();
+                            baseAnnotation += "<hr><i>" + Joiner.on(", ").join(entry.getValue()) + "</i>: " + entry.getKey();
                         }
                     }
                     tablePrinter.addCell(baseAnnotation);
@@ -333,7 +333,7 @@ public class ChartAnnotations extends Chart {
                 + "The keywords plus the words in the short name are typically used for search and predictive typing.<p>\n"
                 + "<p>Most short names and keywords that can be constructed with the mechanism in " + LDML_ANNOTATIONS + " are omitted. "
                 + "However, a few are included for comparison: "
-                + CollectionUtilities.join(EXTRAS.addAllTo(new TreeSet<>()), ", ") + ". "
+                + Joiner.on(", ").join(EXTRAS.addAllTo(new TreeSet<>())) + ". "
                 + "In this chart, missing items are marked with “" + Annotations.MISSING_MARKER + "”, "
                 + "‘fallback’ constructed items with “" + Annotations.BAD_MARKER + "”, "
                 + "substituted English values with “" + Annotations.ENGLISH_MARKER + "”, and "

--- a/tools/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/java/org/unicode/cldr/tool/ChartCollation.java
@@ -29,8 +29,8 @@ import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.Transliterator;
@@ -210,7 +210,7 @@ public class ChartCollation extends Chart {
         if (dataItem == null) {
             data.put(type, dataItem = new Data());
         }
-        dataItem.settings.add(leaf + ":" + CollectionUtilities.join(settings, ";"));
+        dataItem.settings.add(leaf + ":" + Joiner.on(";").join(settings));
     }
 
     private void addCollator(Map<String, Data> data, String type, RuleBasedCollator col) {
@@ -311,7 +311,7 @@ public class ChartCollation extends Chart {
                 Set<String> settings = entry.getValue().settings;
                 StringBuilder list = new StringBuilder();
                 if (!settings.isEmpty()) {
-                    list.append(CollectionUtilities.join(settings, "<br>"));
+                    list.append(Joiner.on("<br>").join(settings));
                     list.append("<br><b><i>plus</i></b><br>");
                 }
                 if (col == null) {

--- a/tools/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/java/org/unicode/cldr/tool/ChartDelta.java
@@ -47,10 +47,10 @@ import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Row.R3;
@@ -118,7 +118,7 @@ public class ChartDelta extends Chart {
             String rawOrg = MyOptions.orgFilter.option.getValue();
             Organization org = Organization.fromString(rawOrg);
             Set<String> locales = StandardCodes.make().getLocaleCoverageLocales(org);
-            fileFilter = PatternCache.get("^(main|annotations)/(" + CollectionUtilities.join(locales, "|") + ")$").matcher("");
+            fileFilter = PatternCache.get("^(main|annotations)/(" + Joiner.on("|").join(locales) + ")$").matcher("");
         }
         Level coverage = !MyOptions.coverageFilter.option.doesOccur() ? null : Level.fromString(MyOptions.coverageFilter.option.getValue());
         boolean verbose = MyOptions.verbose.option.doesOccur();
@@ -722,7 +722,7 @@ public class ChartDelta extends Chart {
             .addCell(ph.getPageId())
             .addCell(ph.getHeader())
             .addCell(ph.getCode())
-            .addCell(CollectionUtilities.join(locales, " "))
+            .addCell(Joiner.on(" ").join(locales))
             .finishRow();
         }
     }
@@ -933,11 +933,11 @@ public class ChartDelta extends Chart {
 //                        Set<String> s2M1 = new LinkedHashSet<>(set2);
 //                        s2M1.removeAll(set1);
                             if (s1MOld.isEmpty()) {
-                                addRow(target, key, "▷missing◁", CollectionUtilities.join(s2M1, ", "));
+                                addRow(target, key, "▷missing◁", Joiner.on(", ").join(s2M1));
                                 addChange(parentAndFile, ChangeType.added, s2M1.size());
                                 countAdded.add(key, 1);
                             } else if (s2M1.isEmpty()) {
-                                addRow(target, key, CollectionUtilities.join(s1MOld, ", "), "▷removed◁");
+                                addRow(target, key, Joiner.on(", ").join(s1MOld), "▷removed◁");
                                 addChange(parentAndFile, ChangeType.deleted, s1MOld.size());
                                 countDeleted.add(key, 1);
                             } else {

--- a/tools/java/org/unicode/cldr/tool/ChartDtdDelta.java
+++ b/tools/java/org/unicode/cldr/tool/ChartDtdDelta.java
@@ -21,11 +21,11 @@ import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.util.VersionInfo;
 
@@ -262,8 +262,8 @@ public class ChartDtdDelta extends Chart {
             }
             dtdType = dtdCurrent.dtdType;
             this.newPath = fix(newPath);
-            this.attributeNames = attributeNames2.isEmpty() ? NONE :  
-                START_ATTR + CollectionUtilities.join(attributeNames2, END_ATTR + START_ATTR) + END_ATTR;
+            this.attributeNames = attributeNames2.isEmpty() ? NONE :
+                START_ATTR + Joiner.on(END_ATTR + START_ATTR).join(attributeNames2) + END_ATTR;
             this.newElement = newElement;
         }
 

--- a/tools/java/org/unicode/cldr/tool/ChartLanguageMatching.java
+++ b/tools/java/org/unicode/cldr/tool/ChartLanguageMatching.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.unicode.cldr.util.CLDRFile;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row.R4;
 
 public class ChartLanguageMatching extends Chart {
@@ -97,7 +96,7 @@ public class ChartLanguageMatching extends Chart {
                 parts[2] = "XY";
             }
         }
-        String result = ENGLISH.getName(CollectionUtilities.join(parts, "_"), true, CLDRFile.SHORT_ALTS);
+        String result = ENGLISH.getName(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
         if (user) {
             result = result
                 .replace("Xxxx", "any-script")

--- a/tools/java/org/unicode/cldr/tool/ChartSubdivisions.java
+++ b/tools/java/org/unicode/cldr/tool/ChartSubdivisions.java
@@ -16,7 +16,7 @@ import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 
@@ -116,7 +116,8 @@ public class ChartSubdivisions extends Chart {
             tablePrinter.addRow()
                 .addCell(ENGLISH.getName(CLDRFile.TERRITORY_NAME, region))
                 .addCell(region)
-                .addCell(regionAliases == null ? "«none»" : "=" + CollectionUtilities.join(regionAliases, ", "))
+                .addCell(regionAliases == null ? "«none»" : "=" + Joiner.on(", ")
+                    .join(regionAliases))
                 //.addCell(type)
                 .addCell("")
                 .addCell("")

--- a/tools/java/org/unicode/cldr/tool/CheckHtmlFiles.java
+++ b/tools/java/org/unicode/cldr/tool/CheckHtmlFiles.java
@@ -44,8 +44,8 @@ import org.unicode.cldr.util.SimpleHtmlParser;
 import org.unicode.cldr.util.SimpleHtmlParser.Type;
 import org.unicode.cldr.util.TransliteratorUtilities;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R4;
 import com.ibm.icu.text.BreakIterator;
@@ -879,7 +879,7 @@ public class CheckHtmlFiles {
             }
             if (!captionWarnings.isEmpty()) {
                 System.out.println("WARNING: Missing <caption> on the following lines: "
-                    + "\n    " + CollectionUtilities.join(captionWarnings, ", ")
+                    + "\n    " + Joiner.on(", ").join(captionWarnings)
                     + "\n\tTo fix, add <caption> after the <table>, such as:"
                     + "\n\t\t<table>"
                     + "\n\t\t\t<caption>Private Use Codes in CLDR</a></caption>"

--- a/tools/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -54,9 +54,9 @@ import org.unicode.cldr.util.Validity.Status;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.XPathParts.Comments;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.math.DoubleMath;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -2177,7 +2177,7 @@ public class ConvertLanguageData {
             return "* " + this
                 + " *\t" + problem + ":"
                 + "\t" + details
-                + (row != null && row.size() > 0 ? "\t" + CollectionUtilities.join(row, "\t") : "");
+                + (row != null && row.size() > 0 ? "\t" + Joiner.on("\t").join(row) : "");
         }
     }
 

--- a/tools/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/java/org/unicode/cldr/tool/CountItems.java
@@ -50,6 +50,7 @@ import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.props.ICUPropertyFactory;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.dev.util.UnicodeMapIterator;
@@ -633,7 +634,7 @@ public class CountItems {
             bad3letter.add(alpha3);
             String targetAliased;
             if (languageAliasInfo.containsKey(target)) {
-                targetAliased = CollectionUtilities.join(languageAliasInfo.get(target).get0(), " ");
+                targetAliased = Joiner.on(" ").join(languageAliasInfo.get(target).get0());
             } else {
                 targetAliased = target;
             }
@@ -805,7 +806,7 @@ public class CountItems {
         }
         System.out.println("    </codeMappings>");
         System.out.println("<!-- end of Code Mappings generated with CountItems tool ...");
-        System.out.println(CollectionUtilities.join(warnings, CldrUtility.LINE_SEPARATOR));
+        System.out.println(Joiner.on(CldrUtility.LINE_SEPARATOR).join(warnings));
     }
 
     enum VariableType {
@@ -894,7 +895,7 @@ public class CountItems {
             Map<String, R2<List<String>, String>> territoryAliasInfo = supplementalData.getLocaleAliasInfo().get("territory");
             String result;
             if (territoryAliasInfo.containsKey(region)) {
-                result = CollectionUtilities.join(territoryAliasInfo.get(region).get0(), " ");
+                result = Joiner.on(" ").join(territoryAliasInfo.get(region).get0());
             } else {
                 result = region;
             }

--- a/tools/java/org/unicode/cldr/tool/DiffCldr.java
+++ b/tools/java/org/unicode/cldr/tool/DiffCldr.java
@@ -25,10 +25,10 @@ import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.With;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.util.Output;
 
 public class DiffCldr {
@@ -217,6 +217,6 @@ public class DiffCldr {
                 cleanedValues.add(item);
             }
         }
-        return CollectionUtilities.join(DtdData.CR_SPLITTER.split(CollectionUtilities.join(values, " ␍ ")), " ␍ ");
+        return Joiner.on(" ␍ ").join(DtdData.CR_SPLITTER.split(Joiner.on(" ␍ ").join(values)));
     }
 }

--- a/tools/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -22,7 +22,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 import org.unicode.cldr.util.With;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.DateTimePatternGenerator.FormatParser;
 import com.ibm.icu.text.DateTimePatternGenerator.VariableField;
@@ -244,7 +244,7 @@ public class FindPreferredHours {
             }
             String subcontinent = Containment.getSubcontinent(region);
             String continent = Containment.getContinent(region);
-            String tag = CollectionUtilities.join(preferredSet.keySet(), ",");
+            String tag = Joiner.on(",").join(preferredSet.keySet());
             if (tag.equals("h")) {
                 tag += "*";
             }
@@ -270,9 +270,9 @@ public class FindPreferredHours {
                 + preferredAndAllowedHour.preferred
                 + "\""
                 + " allowed=\""
-                + CollectionUtilities.join(preferredAndAllowedHour.allowed, " ")
+                + Joiner.on(" ").join(preferredAndAllowedHour.allowed)
                 + "\""
-                + " regions=\"" + CollectionUtilities.join(regions, " ") + "\""
+                + " regions=\"" + Joiner.on(" ").join(regions) + "\""
                 + "/>");
         }
         System.out.println("    </timeData>");

--- a/tools/java/org/unicode/cldr/tool/GenerateBcp47Text.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateBcp47Text.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -90,7 +90,7 @@ public class GenerateBcp47Text {
     }
 
     private void showField(PrintWriter out, String title, Collection<String> set) {
-        showField(out, title, set == null || set.isEmpty() ? null : CollectionUtilities.join(set, ", "));
+        showField(out, title, set == null || set.isEmpty() ? null : Joiner.on(", ").join(set));
     }
 
     private void showField(PrintWriter out, String title, String item) {

--- a/tools/java/org/unicode/cldr/tool/GenerateItemCounts.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateItemCounts.java
@@ -42,8 +42,8 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -280,7 +280,7 @@ public class GenerateItemCounts {
                     + "\t" + noOccur);
             }
             out.println("\nERRORS/WARNINGS");
-            out.println(CollectionUtilities.join(errors, "\n"));
+            out.println(Joiner.on("\n").join(errors));
         }
     }
 
@@ -563,7 +563,7 @@ public class GenerateItemCounts {
         summary2.println("#Countries:\t" + countries.size());
         summary2.println("#Locales:\t" + localesToPaths.size());
         for (Entry<String, Set<String>> entry : localesToPaths.keyValuesSet()) {
-            summary2.println(entry.getKey() + "\t" + CollectionUtilities.join(entry.getValue(), "\t"));
+            summary2.println(entry.getKey() + "\t" + Joiner.on("\t").join(entry.getValue()));
         }
         summary2.close();
     }

--- a/tools/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -33,6 +33,7 @@ import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -42,7 +43,6 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.util.ICUUncheckedIOException;
 
@@ -291,7 +291,8 @@ public class GenerateLanguageContainment {
         if (base.equals("und")) {
             // skip, no good info
         } else {
-            newFile.add("//" + DtdType.supplementalData + "/languageGroups/languageGroup[@parent=\"" + base + "\"]", CollectionUtilities.join(children, " "));
+            newFile.add("//" + DtdType.supplementalData + "/languageGroups/languageGroup[@parent=\"" + base + "\"]",
+                Joiner.on(" ").join(children));
 //            System.out.println("\t<languageGroup parent='" 
 //                + base + "'>" 
 //                + CollectionUtilities.join(children, " ") + "</languageGroup>");

--- a/tools/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -43,9 +43,9 @@ import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData.Type;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -366,7 +366,7 @@ public class GenerateMaximalLocales {
         Map<String, String> oldLikely = SupplementalDataInfo.getInstance().getLikelySubtags();
         Set<String> changes = compareMapsAndFixNew("*WARNING* Likely Subtags: ", oldLikely, toMaximized, "ms_Arab",
             "ms_Arab_ID");
-        System.out.println(CollectionUtilities.join(changes, "\n"));
+        System.out.println(Joiner.on("\n").join(changes));
 
         if (OUTPUT_STYLE == OutputStyle.C_ALT) {
             doAlt(toMaximized);
@@ -2057,24 +2057,24 @@ public class GenerateMaximalLocales {
         Map<String, String> oldDefaultContent = SupplementalDataInfo.makeLocaleToDefaultContents(
             ConvertLanguageData.supplementalData.getDefaultContentLocales(), new TreeMap<String, String>(), errors);
         if (!errors.isEmpty()) {
-            System.out.println(CollectionUtilities.join(errors, "\n"));
+            System.out.println(Joiner.on("\n").join(errors));
             errors.clear();
         }
         Map<String, String> newDefaultContent = SupplementalDataInfo.makeLocaleToDefaultContents(defaultLocaleContent,
             new TreeMap<String, String>(), errors);
         if (!errors.isEmpty()) {
-            System.out.println("Default Content errors: " + CollectionUtilities.join(errors, "\n"));
+            System.out.println("Default Content errors: " + Joiner.on("\n").join(errors));
             errors.clear();
         }
         Set<String> changes = compareMapsAndFixNew("*WARNING* Default Content: ", oldDefaultContent, newDefaultContent,
             "ar", "ar_001");
-        System.out.println(CollectionUtilities.join(changes, "\n"));
+        System.out.println(Joiner.on("\n").join(changes));
         defaultLocaleContent.clear();
         defaultLocaleContent.addAll(newDefaultContent.values());
         newDefaultContent = SupplementalDataInfo.makeLocaleToDefaultContents(defaultLocaleContent,
             new TreeMap<String, String>(), errors);
         if (!errors.isEmpty()) {
-            System.out.println("***New Errors: " + CollectionUtilities.join(errors, "\n"));
+            System.out.println("***New Errors: " + Joiner.on("\n").join(errors));
         }
     }
 

--- a/tools/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -29,6 +29,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.TempPrintWriter;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.DecimalFormat;
@@ -258,9 +259,10 @@ public class GeneratePluralRanges {
                 item.put(s, locale);
             }
             for (Entry<Set<Count>, Relation<Set<String>, String>> entry0 : seen.entrySet()) {
-                out.println("\n<!-- " + CollectionUtilities.join(entry0.getKey(), ", ") + " -->");
+                out.println("\n<!-- " + Joiner.on(", ").join(entry0.getKey()) + " -->");
                 for (Entry<Set<String>, Set<String>> entry : entry0.getValue().keyValuesSet()) {
-                    out.println("\t\t<pluralRanges locales=\"" + CollectionUtilities.join(entry.getValue(), " ") + "\">");
+                    out.println("\t\t<pluralRanges locales=\"" + Joiner.on(" ")
+                        .join(entry.getValue()) + "\">");
                     for (String line : entry.getKey()) {
                         out.println("\t\t\t" + line);
                     }

--- a/tools/java/org/unicode/cldr/tool/GenerateScriptMetadata.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateScriptMetadata.java
@@ -11,7 +11,7 @@ import org.unicode.cldr.draft.ScriptMetadata.Info;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.FileCopier;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R3;
 import com.ibm.icu.impl.Utility;
@@ -32,7 +32,7 @@ public class GenerateScriptMetadata {
             sorted.add(r);
         }
         if (ScriptMetadata.errors.size() > 0) {
-            System.err.println(CollectionUtilities.join(ScriptMetadata.errors, "\n\t"));
+            System.err.println(Joiner.on("\n\t").join(ScriptMetadata.errors));
             //throw new IllegalArgumentException();
         }
         VersionInfo currentUnicodeVersion = UCharacter.getUnicodeVersion();

--- a/tools/java/org/unicode/cldr/tool/GenerateXMB.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateXMB.java
@@ -67,7 +67,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -316,7 +316,7 @@ public class GenerateXMB {
         }
         String skipPath = pathFindRemover.get(path, null, matches, matcherFound, myFailures);
         if (myFailures != null && failures.size() != 0) {
-            System.out.println("Failures\n\t" + CollectionUtilities.join(failures, "\n\t"));
+            System.out.println("Failures\n\t" + Joiner.on("\n\t").join(failures));
             failures.clear();
         }
         if (skipPath == null || skipPath.equals("MAYBE")) {

--- a/tools/java/org/unicode/cldr/tool/GeneratedPluralSamples.java
+++ b/tools/java/org/unicode/cldr/tool/GeneratedPluralSamples.java
@@ -25,7 +25,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 import org.unicode.cldr.util.TempPrintWriter;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.FixedDecimal;
@@ -609,7 +609,8 @@ public class GeneratedPluralSamples {
 
                     if (fileFormat) {
                         if (!keywords.equals(oldKeywords)) {
-                            out.println("\n        <!-- " + keywords.size() + ": " + CollectionUtilities.join(keywords, ",") + " -->\n");
+                            out.println("\n        <!-- " + keywords.size() + ": " + Joiner.on(",")
+                                .join(keywords) + " -->\n");
                             oldKeywords = keywords;
                         }
                         out.println(WritePluralRules.formatPluralRuleHeader(equivalentLocales));
@@ -662,7 +663,8 @@ public class GeneratedPluralSamples {
                         Set<String> remainder = new LinkedHashSet<String>(entry.getValue());
                         String first = remainder.iterator().next();
                         remainder.remove(first);
-                        System.err.println(type + "\tEQUIV:\t\t" + first + "\t≣\t" + CollectionUtilities.join(remainder, ", "));
+                        System.err.println(type + "\tEQUIV:\t\t" + first + "\t≣\t" + Joiner.on(", ")
+                            .join(remainder));
                     }
                     System.out.println();
                 }

--- a/tools/java/org/unicode/cldr/tool/ListCoverageLevels.java
+++ b/tools/java/org/unicode/cldr/tool/ListCoverageLevels.java
@@ -30,6 +30,7 @@ import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Comparators;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
@@ -37,7 +38,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public class ListCoverageLevels {
     public static void main(String[] args) {
@@ -137,7 +137,7 @@ public class ListCoverageLevels {
                 String localeName = getLocaleName(ALL, locales);
                 items.add(level + ":" + (mixed ? "" : "°") + localeName);
             }
-            System.out.println(starred + "\t" + items.size() + "\t" + CollectionUtilities.join(items, " "));
+            System.out.println(starred + "\t" + items.size() + "\t" + Joiner.on(" ").join(items));
         }
         for (Level level : data.keySet()) {
             M3<String, Attributes, Boolean> data2 = data.get(level);
@@ -160,12 +160,12 @@ public class ListCoverageLevels {
         Function<Set<CLDRLocale>,String> remainderName = x -> {
             Set<CLDRLocale> y = new LinkedHashSet<>(all);
             y.removeAll(x);
-            return "AllLcs-(" + CollectionUtilities.join(y, "|") + ")";
+            return "AllLcs-(" + Joiner.on("|").join(y) + ")";
         };
-        return all == null ? CollectionUtilities.join(locales, "|")
+        return all == null ? Joiner.on("|").join(locales)
             : locales.equals(all) ? "AllLcs" 
                 : locales.size()*2 > all.size() ? remainderName.apply(locales)
-                    : CollectionUtilities.join(locales, "|");
+                    : Joiner.on("|").join(locales);
     }
 
     static class Attributes implements Comparable<Attributes>{
@@ -285,7 +285,8 @@ public class ListCoverageLevels {
         }
         @Override
         public String toString() {
-            return attributes.isEmpty() ? cLoc.toString() : cLoc + "|" + CollectionUtilities.join(attributes, "|");
+            return attributes.isEmpty() ? cLoc.toString() : cLoc + "|" + Joiner.on("|")
+                .join(attributes);
         }
     }
 }

--- a/tools/java/org/unicode/cldr/tool/LocaleReplacements.java
+++ b/tools/java/org/unicode/cldr/tool/LocaleReplacements.java
@@ -20,7 +20,7 @@ import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -218,7 +218,7 @@ public class LocaleReplacements {
                 String key = replacementAndReason.get0();
                 Set<String> replacements = replacementAndReason.get1();
                 final String message = type + "\t" + reason + "\t" + key + "\t"
-                    + CollectionUtilities.join(replacements, " ");
+                    + Joiner.on(" ").join(replacements);
                 // System.out.println(message);
                 newStuff.add(message);
             }
@@ -235,7 +235,7 @@ public class LocaleReplacements {
                 List<String> replacements = replacementAndReason.get0();
                 String reason = replacementAndReason.get1();
                 oldStuff.add(type + "\t" + reason + "\t" + item
-                    + "\t" + (replacements == null ? "" : CollectionUtilities.join(replacements, " ")));
+                    + "\t" + (replacements == null ? "" : Joiner.on(" ").join(replacements)));
             }
         }
         Set<Row.R2<String, String>> merged = new TreeSet<Row.R2<String, String>>();

--- a/tools/java/org/unicode/cldr/tool/MinimizeRegex.java
+++ b/tools/java/org/unicode/cldr/tool/MinimizeRegex.java
@@ -9,9 +9,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Output;
@@ -39,7 +39,7 @@ public class MinimizeRegex {
         System.out.println(defaultArg + "\n");
         Output<Set<String>> flattenedOut = new Output<>();
         String recompressed = compressWith(regexString, set, flattenedOut);
-        System.out.println(CollectionUtilities.join(flattenedOut.value,"|") + "\n");
+        System.out.println(Joiner.on("|").join(flattenedOut.value) + "\n");
         System.out.println(recompressed + "\n");
     }
 
@@ -50,12 +50,12 @@ public class MinimizeRegex {
     public static String simplePattern(Collection<String> strings) {
         TreeSet<String> temp = new TreeSet<>(LENGTH_FIRST_COMPARE);
         temp.addAll(strings);
-        return CollectionUtilities.join(temp,"|");
+        return Joiner.on("|").join(temp);
     }
     
     public static String compressWith(String regexString, UnicodeSet set, Output<Set<String>> flattenedOut) {
         Set<String> flattened = flatten(Pattern.compile(regexString), "", set);
-        String regexString2 = CollectionUtilities.join(flattened,"|");
+        String regexString2 = Joiner.on("|").join(flattened);
         Set<String> flattened2 = flatten(Pattern.compile(regexString2), "", set);
         if (!flattened2.equals(flattened)) {
             throw new IllegalArgumentException("Failed to compress: " + regexString + " using " + set + ", got " + regexString2);
@@ -139,7 +139,7 @@ public class MinimizeRegex {
             isSingle.value = true;
             return strings.iterator().next() + (hasEmpty ? "?" : "");
         default:
-            String result = CollectionUtilities.join(strings, "|");
+            String result = Joiner.on("|").join(strings);
             if (hasEmpty) {
                 isSingle.value = true;
                 return '(' + result + ")?";

--- a/tools/java/org/unicode/cldr/tool/Option.java
+++ b/tools/java/org/unicode/cldr/tool/Option.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 import org.unicode.cldr.util.CLDRTool;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 
 /**
  * Simpler mechanism for handling options, where everything can be defined in one place.
@@ -162,7 +162,7 @@ public class Option {
         } else if (match instanceof Class) {
             try {
                 Enum[] valuesMethod = (Enum[]) ((Class) match).getMethod("values").invoke(null);
-                return Pattern.compile(CollectionUtilities.join(valuesMethod, "|"));
+                return Pattern.compile(Joiner.on("|").join(valuesMethod));
             } catch (Exception e) {
                 throw new IllegalArgumentException(e);
             }

--- a/tools/java/org/unicode/cldr/tool/SearchCLDR.java
+++ b/tools/java/org/unicode/cldr/tool/SearchCLDR.java
@@ -34,7 +34,6 @@ import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes;
 
 import com.google.common.collect.ImmutableSet;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.util.ICUUncheckedIOException;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.VersionInfo;
@@ -399,7 +398,7 @@ public class SearchCLDR {
             + locale 
             + "\t⟪" + value + "⟫"
             + (showEnglish ? "\t⟪" + englishValue + "⟫" : "")
-            + (!showParent ? "" : CollectionUtilities.equals(value, parentValue) ? "\t≣" : "\t⟪" + parentValue + "⟫")
+            + (!showParent ? "" : Objects.equals(value, parentValue) ? "\t≣" : "\t⟪" + parentValue + "⟫")
             + "\t" + shortPath
             + (showPath ? "\t" + fullPath : "")
             + (resolved ? "\t" + resolvedSource : "")

--- a/tools/java/org/unicode/cldr/tool/ShowChildren.java
+++ b/tools/java/org/unicode/cldr/tool/ShowChildren.java
@@ -15,13 +15,12 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.PrettyPath;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 
 public class ShowChildren {
 
     public static void main(String[] args) {
-        System.out.println("Arguments: " + CollectionUtilities.join(args, " "));
+        System.out.println("Arguments: " + String.join(" ", args));
 
         long startTime = System.currentTimeMillis();
 

--- a/tools/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/java/org/unicode/cldr/tool/ShowData.java
@@ -38,6 +38,7 @@ import org.unicode.cldr.util.PathHeader.SectionId;
 import org.unicode.cldr.util.StringId;
 import org.unicode.cldr.util.TransliteratorUtilities;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.tool.UOption;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
@@ -410,7 +411,7 @@ public class ShowData {
                         .append("</td><td class='v'>")
                         .append(DataShower.getPrettyValue(value.substring(breakPoint + 2)))
                         .append("</td><td>")
-                        .append(CollectionUtilities.join(s.getValue(), ", "))
+                        .append(Joiner.on(", ").join(s.getValue()))
                         .append("</td></tr>")
                         .append(System.lineSeparator());
                     addRow = true;
@@ -429,7 +430,7 @@ public class ShowData {
         final boolean noLocales = locales == null || locales.isEmpty();
         pw.println("<td"
             + (isExemplar ? " style='max-width:20%'" : "")
-            + (noLocales ? "" : " title='" + CollectionUtilities.join(locales, ", ") + "'")
+            + (noLocales ? "" : " title='" + Joiner.on(", ").join(locales) + "'")
             + (value == null ? "></i>n/a</i>" : " class='v'" + DataShower.getBidiStyle(value) + ">" + DataShower.getPrettyValue(value))
             + "</td>");
     }

--- a/tools/java/org/unicode/cldr/tool/ShowDtdDiffs.java
+++ b/tools/java/org/unicode/cldr/tool/ShowDtdDiffs.java
@@ -17,7 +17,7 @@ import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 
 public class ShowDtdDiffs {
     static final SupplementalDataInfo SDI = CLDRConfig.getInstance().getSupplementalDataInfo();
@@ -153,7 +153,7 @@ public class ShowDtdDiffs {
             }
             names.add(name);
         }
-        return names.isEmpty() ? "" : CollectionUtilities.join(names, ", ");
+        return names.isEmpty() ? "" : Joiner.on(", ").join(names);
     }
 
     private static boolean isDeprecated(DtdType dtdType, String elementName, String attributeName) {

--- a/tools/java/org/unicode/cldr/tool/ShowKeyboards.java
+++ b/tools/java/org/unicode/cldr/tool/ShowKeyboards.java
@@ -42,7 +42,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -153,7 +153,8 @@ public class ShowKeyboards {
             }
         }
         if (totalErrors.size() != 0) {
-            System.out.println("Errors\t" + CollectionUtilities.join(totalErrors, System.lineSeparator() + "\t"));
+            System.out.println("Errors\t" + Joiner.on(System.lineSeparator() + "\t")
+                .join(totalErrors));
         }
         for (String item : totalModifiers) {
             System.out.println(item);
@@ -407,7 +408,7 @@ public class ShowKeyboards {
                 String keyString = key == Gesture.LONGPRESS ? "LP" : key.toString();
                 final V value = entry.getValue();
                 String valueString = value instanceof Collection
-                    ? CollectionUtilities.join((Collection) value, " ")
+                    ? Joiner.on(" ").join((Collection) value)
                     : value.toString();
                 hover.append(TransliteratorUtilities.toHTML.transform(keyString)).append("→")
                     .append(TransliteratorUtilities.toHTML.transform(valueString));

--- a/tools/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -63,6 +63,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.TreeMultimap;
@@ -881,8 +882,8 @@ public class ShowLanguages {
                     String type = entry2.getKey();
                     R2<List<String>, String> replacementReason = entry2.getValue();
                     List<String> replacementList = replacementReason.get0();
-                    String replacement = replacementList == null ? null : CollectionUtilities
-                        .join(replacementList, " ");
+                    String replacement = replacementList == null ? null :
+                        Joiner.on(" ").join(replacementList);
                     String reason = replacementReason.get1();
                     if (element.equals("timezone")) {
                         element = "zone";
@@ -1137,7 +1138,7 @@ public class ShowLanguages {
             pw2.close();
             try (PrintWriter pw21plain = FileUtilities.openUTF8Writer(ffw.getDir(), ffw.getBaseFileName() + ".txt")) {
                 for (Comparable[] row : plainData) {
-                    pw21plain.println(CollectionUtilities.join(row, "\t"));
+                    pw21plain.println(Joiner.on("\t").join(row));
                 }
             }
         }

--- a/tools/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -66,6 +66,7 @@ import org.unicode.cldr.util.VettingViewer.MissingStatus;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -73,7 +74,6 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.lang.UCharacter;
@@ -340,7 +340,7 @@ public class ShowLocaleCoverage {
                 out.println();
                 first = false;
             }
-            out.println(entry.getKey() + "\t" + CollectionUtilities.join(entry.getValue(), "\t"));
+            out.println(entry.getKey() + "\t" + Joiner.on("\t").join(entry.getValue()));
         }
     }
 
@@ -597,7 +597,7 @@ public class ShowLocaleCoverage {
 
             fixCommonLocales();
 
-            System.out.println(CollectionUtilities.join(languageToRegion.keyValuesSet(), "\n"));
+            System.out.println(Joiner.on("\n").join(languageToRegion.keyValuesSet()));
 
             System.out.println("# Checking: " + availableLanguages);
 
@@ -1034,8 +1034,8 @@ public class ShowLocaleCoverage {
                         //                            ;
                         //                    }
                     }
-                    String coreMissingString = 
-                        CollectionUtilities.join(coreMissing, ", ");
+                    String coreMissingString =
+                        Joiner.on(", ").join(coreMissing);
 
                     tablePrinter
                     .addCell(coreMissingString)
@@ -1113,7 +1113,7 @@ public class ShowLocaleCoverage {
                     tsv_missing_summary.println(
                         level 
                         + "\t" + localeSet.size()
-                        + "\t" + CollectionUtilities.join(localeSet, " ")
+                        + "\t" + Joiner.on(" ").join(localeSet)
                         + "\t" + phString
                         );
                 }

--- a/tools/java/org/unicode/cldr/tool/ShowPathHeaderDescriptions.java
+++ b/tools/java/org/unicode/cldr/tool/ShowPathHeaderDescriptions.java
@@ -15,11 +15,11 @@ import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Row.R3;
@@ -139,7 +139,7 @@ public class ShowPathHeaderDescriptions {
 
         process(SphType.sph, sphv, done);
 
-        System.out.println(CollectionUtilities.join(urls, "\n"));
+        System.out.println(Joiner.on("\n").join(urls));
     }
 
     private static void showProgress(Set<String> done, Multimap<String, R3<SectionId, PageId, String>> valueToKey) {

--- a/tools/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -19,7 +19,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.PluralRules;
@@ -221,7 +221,7 @@ public class ShowPlurals {
     }
 
     private String getExamples(FixedDecimalSamples exampleList) {
-        return CollectionUtilities.join(exampleList.getSamples(), ", ") + (exampleList.bounded ? "" : ", …");
+        return Joiner.on(", ").join(exampleList.getSamples()) + (exampleList.bounded ? "" : ", …");
     }
 
     private String getSample(FixedDecimal numb, String samplePattern, NumberFormat nf) {

--- a/tools/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -44,10 +44,10 @@ import org.unicode.cldr.util.SupplementalDataInfo.LengthFirstComparator;
 import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 
@@ -332,7 +332,7 @@ public class ShowStarredCoverage {
             pathHeaders.add(ph);
             SurveyToolStatus stStatus = ph.getSurveyToolStatus();
             String starred = pathStarrer.set(path);
-            String attributes = CollectionUtilities.join(pathStarrer.getAttributes(), "|");
+            String attributes = Joiner.on("|").join(pathStarrer.getAttributes());
             levelToData.put(level, starred + "|" + stStatus + "|" + requiredVotes, attributes, Boolean.TRUE);
             counter.add(level, 1);
         }
@@ -350,7 +350,7 @@ public class ShowStarredCoverage {
                         count = 1;
                     }
                     if (true) {
-                        String samples = CollectionUtilities.join(attributes.keySet(), ", ");
+                        String samples = Joiner.on(", ").join(attributes.keySet());
                         if (samples.length() > 50) samples = samples.substring(0, 50) + "…";
                         System.out.println(count
                             + "\t" + level
@@ -427,12 +427,12 @@ public class ShowStarredCoverage {
                     badLines.add(written
                         + "\t" + name
                         + "\t" + languageFix.get(written).get0()
-                        + "\t" + CollectionUtilities.join(source, " "));
+                        + "\t" + Joiner.on(" ").join(source));
                     source = Collections.singleton(Source.alias);
                 }
                 System.out.println(written
                     + "\t" + name
-                    + "\t" + CollectionUtilities.join(source, " "));
+                    + "\t" + Joiner.on(" ").join(source));
             }
             for (String s : badLines) {
                 System.out.println("BAD:\t" + s);

--- a/tools/java/org/unicode/cldr/tool/SubdivisionNode.java
+++ b/tools/java/org/unicode/cldr/tool/SubdivisionNode.java
@@ -40,7 +40,7 @@ import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Utility;
@@ -180,7 +180,7 @@ public class SubdivisionNode {
             "municipality"
         };
 
-        static final Pattern CRUFT_PATTERN = PatternCache.get("(?i)\\b" + CollectionUtilities.join(CRUFT, "|") + "\\b");
+        static final Pattern CRUFT_PATTERN = PatternCache.get("(?i)\\b" + String.join("|", CRUFT) + "\\b");
         static final Pattern BRACKETED = PatternCache.get("\\[.*\\]");
 
         static String clean(String input) {
@@ -573,7 +573,8 @@ public class SubdivisionNode {
             }
             output.append("<subdivisionAlias"
                 + " type=\"" + toReplace + "\""
-                + " replacement=\"" + (replaceBy == null ? toReplace.substring(0, 2) + "?" : CollectionUtilities.join(replaceBy, " ")) + "\""
+                + " replacement=\"" + (replaceBy == null ? toReplace.substring(0, 2) + "?" :
+                Joiner.on(" ").join(replaceBy)) + "\""
                 + " reason=\"" + reason + "\"/>"
                 + (replaceBy == null ? " <!- - " : " <!-- ")
                 + sdset.getBestName(toReplace, true) + " => " + (replaceBy == null ? "??" : getBestName(replaceBy, true)) + " -->"

--- a/tools/java/org/unicode/cldr/tool/WritePluralRules.java
+++ b/tools/java/org/unicode/cldr/tool/WritePluralRules.java
@@ -12,6 +12,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.PluralRules;
@@ -87,7 +88,7 @@ public class WritePluralRules {
     }
 
     public static String formatPluralRuleHeader(Set<String> values) {
-        String locales = CollectionUtilities.join(values, " ");
+        String locales = Joiner.on(" ").join(values);
         String result = ("        <pluralRules locales=\"" + locales + "\">"
         //+ (comment != null ? comment : "")
         );

--- a/tools/java/org/unicode/cldr/util/Annotations.java
+++ b/tools/java/org/unicode/cldr/util/Annotations.java
@@ -18,11 +18,11 @@ import org.unicode.cldr.tool.ChartAnnotations;
 import org.unicode.cldr.tool.SubdivisionNames;
 import org.unicode.cldr.util.XMLFileReader.SimpleHandler;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
@@ -561,7 +561,7 @@ public class Annotations {
                 keywords = Collections.singleton(EQUIVALENT);
             }
 
-            String result = CollectionUtilities.join(keywords, " |\u00a0");
+            String result = Joiner.on(" |\u00a0").join(keywords);
             if (shortName != null) {
                 String ttsString = (html ? "*<b>" : "*") + shortName + (html ? "</b>" : "*");
                 if (result.isEmpty()) {
@@ -642,7 +642,7 @@ public class Annotations {
             annotations2 = new LinkedHashSet<String>(getKeywords());
             annotations2.remove(getShortName());
         }
-        String result = CollectionUtilities.join(annotations2, " |\u00a0");
+        String result = Joiner.on(" |\u00a0").join(annotations2);
         if (getShortName() != null) {
             String ttsString = (html ? "*<b>" : "*") + getShortName() + (html ? "</b>" : "*");
             if (result.isEmpty()) {
@@ -687,7 +687,7 @@ public class Annotations {
             System.out.println(Utility.hex(key, 4, "_").toLowerCase(Locale.ROOT)
                 + "\t" + key
                 + "\t" + map.get(key).getShortName()
-                + "\t" + CollectionUtilities.join(map.get(key).getKeywords(), " | "));
+                + "\t" + Joiner.on(" | ").join(map.get(key).getKeywords()));
         }
         for (String s : Arrays.asList(
             "💏", "👩‍❤️‍💋‍👩",
@@ -699,7 +699,8 @@ public class Annotations {
             "🚴", "🚴🏿", "🚴‍♂️", "🚴🏿‍♂️", "🚴‍♀️", "🚴🏿‍♀️")) {
             final String shortName = eng.getShortName(s);
             final Set<String> keywords = eng.getKeywords(s);
-            System.out.println("{\"" + s + "\",\"" + shortName + "\",\"" + CollectionUtilities.join(keywords, "|") + "\"},");
+            System.out.println("{\"" + s + "\",\"" + shortName + "\",\"" + Joiner.on("|")
+                .join(keywords) + "\"},");
         }
     }
 
@@ -718,8 +719,8 @@ public class Annotations {
             System.out.println(key + "\tname\t"
                 + "\t" + value.getShortName()
                 + "\t" + (value100 == null ? "" : value100.getShortName())
-                + "\t" + CollectionUtilities.join(value.getKeywords(), " | ")
-                + "\t" + (keywords100 == null ? "" : CollectionUtilities.join(keywords100, " | ")));
+                + "\t" + Joiner.on(" | ").join(value.getKeywords())
+                + "\t" + (keywords100 == null ? "" : Joiner.on(" | ").join(keywords100)));
         }
     }
 }

--- a/tools/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/java/org/unicode/cldr/util/DtdData.java
@@ -23,13 +23,13 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.Transform;
 
@@ -309,7 +309,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         }
 
         public String getMatchString() {
-            return type == AttributeType.ENUMERATED_TYPE ? "⟨" + CollectionUtilities.join(values.keySet(), ", ") + "⟩" 
+            return type == AttributeType.ENUMERATED_TYPE ? "⟨" + Joiner.on(", ")
+                .join(values.keySet()) + "⟩"
                 : matchValue != null ? "⟪" + matchValue.toString() + "⟫"
                     : "";
         }
@@ -1065,7 +1066,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             if (attributeDeprecated) {
                 b.append(COMMENT_PREFIX + "<!--@DEPRECATED-->");
             } else if (!deprecatedValues.isEmpty()) {
-                b.append(COMMENT_PREFIX + "<!--@DEPRECATED:" + CollectionUtilities.join(deprecatedValues, ", ") + "-->");
+                b.append(COMMENT_PREFIX + "<!--@DEPRECATED:" + Joiner.on(", ")
+                    .join(deprecatedValues) + "-->");
             }
         }
         if (current.children.size() > 0) {

--- a/tools/java/org/unicode/cldr/util/DtdDataCheck.java
+++ b/tools/java/org/unicode/cldr/util/DtdDataCheck.java
@@ -19,6 +19,7 @@ import org.unicode.cldr.util.DtdData.AttributeType;
 import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdData.ElementType;
 
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
@@ -266,12 +267,12 @@ public class DtdDataCheck {
             }
             System.out.println("            <distinguishingItems"
                 + " type=\"" + type
-                + "\" elements=\"" + CollectionUtilities.join(areDisting, " ")
+                + "\" elements=\"" + Joiner.on(" ").join(areDisting)
                 + "\" attributes=\"" + attribute
                 + "\"/>"
                 + "\n            <!-- NONDISTINGUISH."
                 + " TYPE=\"" + type
-                + "\" ELEMENTS=\"" + CollectionUtilities.join(areNotDisting, " ")
+                + "\" ELEMENTS=\"" + Joiner.on(" ").join(areNotDisting)
                 + "\" ATTRIBUTES=\"" + attribute
                 + "\" -->");
         }
@@ -294,7 +295,7 @@ public class DtdDataCheck {
         System.out.println("            <distinguishingItems"
             + " type=\"" + type
             + "\" elements=\"*"
-            + "\" attributes=\"" + CollectionUtilities.join(allElements, " ")
+            + "\" attributes=\"" + Joiner.on(" ").join(allElements)
             + "\"/>");
         allElements.clear();
         allElements.add("_q");

--- a/tools/java/org/unicode/cldr/util/IsoRegionData.java
+++ b/tools/java/org/unicode/cldr/util/IsoRegionData.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUUncheckedIOException;
 
@@ -97,7 +97,7 @@ public class IsoRegionData {
                         errors.removeAll(other_internet);
                     }
                     other_internet.removeAll(internetStrings);
-                    internet = CollectionUtilities.join(internetStrings, " ");
+                    internet = Joiner.on(" ").join(internetStrings);
                 }
                 String fips10 = values[4];
                 _numeric.put(alpha2, numeric);
@@ -112,7 +112,7 @@ public class IsoRegionData {
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
-        _internet.put("ZZ", CollectionUtilities.join(other_internet, " "));
+        _internet.put("ZZ", Joiner.on(" ").join(other_internet));
 
         other_internet = Collections.unmodifiableSet(other_internet);
 

--- a/tools/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/java/org/unicode/cldr/util/LanguageGroup.java
@@ -9,7 +9,7 @@ import java.util.TreeMap;
 
 import org.unicode.cldr.util.ChainedMap.M3;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.util.ULocale;
 
 public enum LanguageGroup {
@@ -129,7 +129,7 @@ public enum LanguageGroup {
             Set<ULocale> locales = LanguageGroup.getLocales(languageGroup);
             String englishName = languageGroup.getName(english);
             System.out.print("\t\t<languageGroup id=\"" + languageGroup.iso
-                + "\" code=\"" + CollectionUtilities.join(locales, ", ")
+                + "\" code=\"" + Joiner.on(", ").join(locales)
                 + "\"/>\t<!-- " + englishName + " -->\n");
         }
         System.out.print("\t</languageGroups>"

--- a/tools/java/org/unicode/cldr/util/LanguageTagParser.java
+++ b/tools/java/org/unicode/cldr/util/LanguageTagParser.java
@@ -32,7 +32,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.text.UnicodeSet;
 
@@ -801,7 +800,7 @@ public class LanguageTagParser {
 
     private void appendField(Format format, StringBuilder result, String fieldName, Collection<String> fieldValues) {
         if (!fieldValues.isEmpty()) {
-            appendField(format, result, fieldName, CollectionUtilities.join(fieldValues, ","));
+            appendField(format, result, fieldName, Joiner.on(",").join(fieldValues));
         }
     }
 
@@ -829,35 +828,42 @@ public class LanguageTagParser {
                     if (!haveT) {
                         result.append(format.separator).append('t');
                         if (haveTLang) { // empty is illegal, but just in case
-                            result.append(format.separator).append(CollectionUtilities.join(tLang, format.separator));
+                            result.append(format.separator).append(
+                                Joiner.on(format.separator).join(tLang));
                             haveTLang = false;
                         }
                         haveT = true;
                     }
-                    appendFieldKey(format, result, entry.getKey(), CollectionUtilities.join(entry.getValue(), format.separator));
+                    appendFieldKey(format, result, entry.getKey(),
+                        Joiner.on(format.separator).join(entry.getValue()));
                 } else {
                     if (!haveU) {
                         result2.append(format.separator).append('u');
                         if (haveUSpecial) { // not yet valid, but just in case
-                            result2.append(format.separator).append(CollectionUtilities.join(uSpecial, format.separator));
+                            result2.append(format.separator).append(
+                                Joiner.on(format.separator).join(uSpecial));
                             haveUSpecial = false;
                         }
                         haveU = true;
                     }
-                    appendFieldKey(format, result2, entry.getKey(), CollectionUtilities.join(entry.getValue(), format.separator));
+                    appendFieldKey(format, result2, entry.getKey(),
+                        Joiner.on(format.separator).join(entry.getValue()));
                 }
             }
             if (haveTLang) {
-                result.append(format.separator).append('t').append(format.separator).append(CollectionUtilities.join(tLang, format.separator));
+                result.append(format.separator).append('t').append(format.separator).append(
+                    Joiner.on(format.separator).join(tLang));
             }
             if (haveUSpecial) {
-                result2.append(format.separator).append('u').append(format.separator).append(CollectionUtilities.join(uSpecial, format.separator));
+                result2.append(format.separator).append('u').append(format.separator).append(
+                    Joiner.on(format.separator).join(uSpecial));
             }
             result.append(result2); // put in right order
         } else {
             for (Entry<String, List<String>> entry : fieldValues.entrySet()) {
                 if (match == null || match.contains(entry.getKey())) {
-                    appendFieldKey(format, result, entry.getKey(), CollectionUtilities.join(entry.getValue(), format.separator));
+                    appendFieldKey(format, result, entry.getKey(),
+                        Joiner.on(format.separator).join(entry.getValue()));
                 }
             }
         }

--- a/tools/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/java/org/unicode/cldr/util/MatchValue.java
@@ -478,7 +478,7 @@ public abstract class MatchValue implements Predicate<String> {
 
         @Override
         public String getName() {
-            return "literal/" + CollectionUtilities.join(items, ", ");
+            return "literal/" + Joiner.on(", ").join(items);
         }
 
         private LiteralMatchValue(String key) {
@@ -638,7 +638,7 @@ public abstract class MatchValue implements Predicate<String> {
 
         @Override
         public String getName() {
-            return "or/"+ CollectionUtilities.join(subtests, "||");
+            return "or/"+ Joiner.on("||").join(subtests);
         }
 
         public static OrMatchValue of(String key) {

--- a/tools/java/org/unicode/cldr/util/PathStarrer.java
+++ b/tools/java/org/unicode/cldr/util/PathStarrer.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.Transform;
 
@@ -75,7 +75,7 @@ public class PathStarrer implements Transform<String, String> {
     }
 
     public String getAttributesString(String separator) {
-        return CollectionUtilities.join(attributes, separator);
+        return Joiner.on(separator).join(attributes);
     }
 
     public String getResult() {

--- a/tools/java/org/unicode/cldr/util/PluralSnapshot.java
+++ b/tools/java/org/unicode/cldr/util/PluralSnapshot.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.NumberFormat;
@@ -196,7 +196,7 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
 
     public String toString() {
         StringBuilder result = new StringBuilder();
-        result.append("Plurals: 0, 1, ").append(CollectionUtilities.join(not01, ", "));
+        result.append("Plurals: 0, 1, ").append(Joiner.on(", ").join(not01));
         if (coveredBy01.size() != 0) {
             result.append("\nCovered by {0,1}:\t").append(coveredBy01);
         }

--- a/tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
+++ b/tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
@@ -6,6 +6,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.ibm.icu.dev.util.CollectionUtilities;
@@ -96,9 +97,9 @@ public final class PreferredAndAllowedHour implements Comparable<PreferredAndAll
         return "<hours preferred=\""
             + preferred
             + "\" allowed=\""
-            + CollectionUtilities.join(allowed, " ")
+            + Joiner.on(" ").join(allowed)
             + "\" regions=\""
-            + CollectionUtilities.join(regions, " ")
+            + Joiner.on(" ").join(regions)
             + "\"/>";
     }
 

--- a/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -44,13 +44,13 @@ import org.unicode.cldr.util.SupplementalDataInfo.NumberingSystemInfo.NumberingS
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.Validity.Status;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.IterableComparator;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
@@ -369,8 +369,8 @@ public class SupplementalDataInfo {
 
         public String toString() {
             return "[" + type
-                + (scripts.isEmpty() ? "" : "; scripts=" + CollectionUtilities.join(scripts, " "))
-                + (scripts.isEmpty() ? "" : "; territories=" + CollectionUtilities.join(territories, " "))
+                + (scripts.isEmpty() ? "" : "; scripts=" + Joiner.on(" ").join(scripts))
+                + (scripts.isEmpty() ? "" : "; territories=" + Joiner.on(" ").join(territories))
                 + "]";
         }
 

--- a/tools/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/java/org/unicode/cldr/util/TestUtilities.java
@@ -30,7 +30,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.tool.GenerateAttributeList;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
@@ -303,7 +303,7 @@ public class TestUtilities {
             "comment",
             // collation
             "base", "settings", "suppress_contractions", "optimize", "rules" };
-        String list = CollectionUtilities.join(elements, " ");
+        String list = String.join(" ", elements);
         String prefix = "//supplementalData[@version=\"1.4\"]/metaData/";
         meta.add(prefix + "elementOrder", list);
 
@@ -320,7 +320,7 @@ public class TestUtilities {
             "validSubLocales", "standard", "references", "elements", "element", "attributes", "attribute",
             // these are always at the end
             "alt", "draft", };
-        meta.add(prefix + "attributeOrder", CollectionUtilities.join(attOrder, " "));
+        meta.add(prefix + "attributeOrder", String.join(" ", attOrder));
 
         String[] serialElements = new String[] { "variable", "comment",
             "tRule",
@@ -329,7 +329,7 @@ public class TestUtilities {
             "first_tertiary_ignorable", "last_tertiary_ignorable",
             "first_secondary_ignorable", "last_secondary_ignorable", "first_primary_ignorable",
             "last_primary_ignorable", "first_non_ignorable", "last_non_ignorable", "first_trailing", "last_trailing" };
-        meta.add(prefix + "serialElements", CollectionUtilities.join(serialElements, " "));
+        meta.add(prefix + "serialElements", String.join(" ", serialElements));
         /*
          *
          * <attributeValues elements="weekendStart weekendEnd" attributes="day"
@@ -356,33 +356,33 @@ public class TestUtilities {
                 Set<String>[] valueSets = attribute_valueSet.get(attribute);
                 for (int i = 0; i < 2; ++i) {
                     meta.add(prefix + "valid/attributeValues" + "[@elements=\"" + element + "\"]" + "[@attributes=\""
-                        + attribute + "\"]" + (i == 1 ? "[@x=\"true\"]" : ""), CollectionUtilities.join(
-                            valueSets[i], " "));
+                        + attribute + "\"]" + (i == 1 ? "[@x=\"true\"]" : ""),
+                        Joiner.on(" ").join(valueSets[i]));
                 }
             }
         }
 
         String[] dayValueOrder = new String[] { "sun", "mon", "tue", "wed", "thu", "fri", "sat" };
         meta.add(prefix + "valid/attributeValues[@order=\"given\"][@attributes=\"type\"][@elements=\"" + "day" + "\"]",
-            CollectionUtilities.join(dayValueOrder, " "));
+            String.join(" ", dayValueOrder));
         meta.add(prefix + "valid/attributeValues[@order=\"given\"][@attributes=\"" + "day" + "\"][@elements=\""
-            + "firstDay weekendEnd weekendStart" + "\"]", CollectionUtilities.join(dayValueOrder, " "));
+            + "firstDay weekendEnd weekendStart" + "\"]", String.join(" ", dayValueOrder));
 
         String[] widths = { "monthWidth", "dayWidth", "quarterWidth" };
         String[] widthOrder = new String[] { "abbreviated", "narrow", "wide" };
         meta.add(prefix + "valid/attributeValues[@order=\"given\"][@attributes=\"type\"][@elements=\""
-            + CollectionUtilities.join(widths, " ") + "\"]", CollectionUtilities.join(widthOrder, " "));
+            + String.join(" ", widths) + "\"]", String.join(" ", widthOrder));
 
         String[] formatLengths = { "dateFormatLength", "timeFormatLength", "dateTimeFormatLength",
             "decimalFormatLength", "scientificFormatLength", "percentFormatLength", "currencyFormatLength" };
         String[] lengthOrder = new String[] { "full", "long", "medium", "short" };
         meta.add(prefix + "valid/attributeValues[@order=\"given\"][@attributes=\"type\"][@elements=\""
-            + CollectionUtilities.join(formatLengths, " ") + "\"]", CollectionUtilities.join(lengthOrder, " "));
+            + String.join(" ", formatLengths) + "\"]", String.join(" ", lengthOrder));
 
         String[] dateFieldOrder = new String[] { "era", "year", "month", "week", "day", "weekday", "dayperiod", "hour",
             "minute", "second", "zone" };
         meta.add(prefix + "valid/attributeValues[@order=\"given\"][@attributes=\"type\"][@elements=\"field\"]",
-            CollectionUtilities.join(dateFieldOrder, " "));
+            String.join(" ", dateFieldOrder));
 
         String[][] suppressData = { { "ldml", "version", "*" }, { "orientation", "characters", "left-to-right" },
             { "orientation", "lines", "top-to-bottom" }, { "weekendStart", "time", "00:00" },
@@ -595,7 +595,7 @@ public class TestUtilities {
                 System.out.println("\t\t\t<" + aliasType + "Alias type=\"" + tag + "\" replacement=\"" + preferred
                     + "\"/> <!-- CLDR:" + sdata.get(0) + " -->");
             }
-            String allCodeString = CollectionUtilities.join(allCodes, " ");
+            String allCodeString = Joiner.on(" ").join(allCodes);
             System.out
                 .println("\t\t\t<variable id=\"$" + oldType + "\" type=\"list\">" + allCodeString + "</variable>");
         }

--- a/tools/java/org/unicode/cldr/util/Unlocode.java
+++ b/tools/java/org/unicode/cldr/util/Unlocode.java
@@ -20,7 +20,7 @@ import org.unicode.cldr.tool.CountryCodeConverter;
 import org.unicode.cldr.tool.ToolConfig;
 import org.unicode.cldr.util.ChainedMap.M3;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.Transform;
 import com.ibm.icu.text.Transliterator;
@@ -497,7 +497,7 @@ public class Unlocode {
                 + "-->");
         }
         System.out.println();
-        System.out.println(CollectionUtilities.join(errors, "\n"));
+        System.out.println(Joiner.on("\n").join(errors));
         System.out.println();
         showLocodes("In exemplars already:", already);
         System.out.println();

--- a/tools/java/org/unicode/cldr/util/props/ICUPropertyFactory.java
+++ b/tools/java/org/unicode/cldr/util/props/ICUPropertyFactory.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.base.Joiner;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
@@ -464,7 +464,7 @@ public class ICUPropertyFactory extends UnicodeProperty.Factory {
             // sort by short form
             sorted.put(UScript.getShortName(scriptCode), UScript.getName(scriptCode));
         }
-        return CollectionUtilities.join(sorted.values(), " ");
+        return Joiner.on(" ").join(sorted.values());
     }
 
     private static ICUPropertyFactory singleton = null;


### PR DESCRIPTION
Mostly automated refactoring (via IntelliJ) to replace CollectionUtilities joining and equality methods, which can be trivially replaced with Guava or JDK equivalents.

Basic approach is to replace internals of the method with the Guava/JDK equivalent (a single expression in both cases) and then tell IntelliJ to inline that method everywhere. Then I did a quick manual pass looking for cases where String.join() could be used instead since it's a bit more idiomatic.

Note that while String now has a "join" method, that only works on Strings, so most existing uses were migrated to Guava.

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13750
- [x] Updated PR title and link in previous line to include Issue number