### PR TITLE
CLDR-13750 Refactoring collection utilities (part 2, addAll and asMap)

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCldrFactory.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCldrFactory.java
@@ -24,7 +24,6 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public class TestCldrFactory extends TestFmwkPlus {
     private static final boolean DEBUG = false;
@@ -138,8 +137,8 @@ public class TestCldrFactory extends TestFmwkPlus {
     private String differentPathValue(CLDRFile a, CLDRFile b) {
         int debugCount = 0;
         Set<String> paths = new TreeSet<>();
-        CollectionUtilities.addAll(a.iterator(), paths);
-        CollectionUtilities.addAll(b.iterator(), paths);
+        a.forEach(paths::add);
+        b.forEach(paths::add);
         for (String xpath : paths) {
             if (++debugCount < 100) {
                 logln(debugCount + "\t" + xpath);

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestExampleDependencies.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestExampleDependencies.java
@@ -26,7 +26,6 @@ import org.unicode.cldr.util.XMLSource;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public class TestExampleDependencies extends TestFmwk {
 
@@ -99,7 +98,8 @@ public class TestExampleDependencies extends TestFmwk {
         cldrFile.disableCaching();
 
         Set<String> paths = new TreeSet<String>(cldrFile.getComparator());
-        CollectionUtilities.addAll(cldrFile.iterator(), paths); // time-consuming
+        // time-consuming
+        cldrFile.forEach(paths::add);
 
         ExampleGenerator egTest = new ExampleGenerator(cldrFile, englishFile, CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY);
         egTest.setCachingEnabled(false); // will not employ a cache -- this should save some time, since cache would be wasted
@@ -157,7 +157,8 @@ public class TestExampleDependencies extends TestFmwk {
         cldrFile.disableCaching();
 
         Set<String> paths = new TreeSet<String>(cldrFile.getComparator());
-        CollectionUtilities.addAll(cldrFile.iterator(), paths); // time-consuming
+        // time-consuming
+        cldrFile.forEach(paths::add);
 
         ExampleGenerator egBase = new ExampleGenerator(cldrFile, englishFile, CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY);
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -18,7 +18,6 @@ import org.unicode.cldr.util.With;
 
 import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.dev.test.TestFmwk;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public class TestExampleGenerator extends TestFmwk {
     CLDRConfig info = CLDRConfig.getInstance();
@@ -212,8 +211,9 @@ public class TestExampleGenerator extends TestFmwk {
         PathStarrer ps = new PathStarrer();
         Set<String> seen = new HashSet<String>();
         CLDRFile cldrFile = exampleGenerator.getCldrFile();
-        for (String path : CollectionUtilities.addAll(cldrFile.fullIterable()
-            .iterator(), new TreeSet<String>(cldrFile.getComparator()))) {
+        TreeSet<String> target = new TreeSet<String>(cldrFile.getComparator());
+        cldrFile.fullIterable().forEach(target::add);
+        for (String path : target) {
             String plainStarred = ps.set(path);
             String value = cldrFile.getStringValue(path);
             if (value == null || path.endsWith("/alias")

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
@@ -36,7 +36,6 @@ import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.collect.ImmutableSet;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public class TestPaths extends TestFmwkPlus {
     static CLDRConfig testInfo = CLDRConfig.getInstance();
@@ -46,11 +45,10 @@ public class TestPaths extends TestFmwkPlus {
     }
 
     public void VerifyEnglishVsRoot() {
-        Set<String> rootPaths = CollectionUtilities.addAll(testInfo
-            .getRoot().iterator(),
-            new HashSet<String>());
-        Set<String> englishPaths = CollectionUtilities.addAll(testInfo
-            .getEnglish().iterator(), new HashSet<String>());
+        HashSet<String> rootPaths = new HashSet<String>();
+        testInfo.getRoot().forEach(rootPaths::add);
+        HashSet<String> englishPaths = new HashSet<String>();
+        testInfo.getEnglish().forEach(englishPaths::add);
         englishPaths.removeAll(rootPaths);
         if (englishPaths.size() == 0) {
             return;

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPerf.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPerf.java
@@ -15,7 +15,6 @@ import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Timer;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.util.Output;
 
 public class TestPerf extends TestFmwkPlus {
@@ -33,8 +32,8 @@ public class TestPerf extends TestFmwkPlus {
 
     static {
         Set<String> testPaths_ = new HashSet<String>();
-        CollectionUtilities.addAll(CLDRConfig.getInstance().getEnglish()
-            .iterator(), testPaths_);
+        CLDRConfig.getInstance().getEnglish()
+            .forEach(testPaths_::add);
         testPaths = Collections.unmodifiableSet(testPaths_);
         Set<String> sorted = new TreeSet<String>(
             CLDRFile.getComparator(DtdType.ldml));

--- a/tools/java/org/unicode/cldr/icu/CheckIBMCoverage.java
+++ b/tools/java/org/unicode/cldr/icu/CheckIBMCoverage.java
@@ -315,7 +315,7 @@ public class CheckIBMCoverage extends CLDRConverterTool {
         coverage.setCldrFileToCheck(file, options, result);
         CLDRFile resolved = coverage.getResolvedCldrFileToCheck();
         Set<String> paths = new TreeSet<String>(resolved.getComparator());
-        com.ibm.icu.dev.util.CollectionUtilities.addAll(resolved.iterator(), paths);
+        resolved.forEach(paths::add);
         int ret = 0;
         if (level != null) {
             coverage.setRequiredLevel(level);

--- a/tools/java/org/unicode/cldr/tool/CLDRCompare.java
+++ b/tools/java/org/unicode/cldr/tool/CLDRCompare.java
@@ -11,8 +11,6 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PatternCache;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
-
 public class CLDRCompare {
     public static void main(String[] args) throws Exception {
         String filter = CldrUtility.getProperty("filter", ".*");
@@ -62,13 +60,13 @@ public class CLDRCompare {
                 CLDRFile newCldrFile = null;
                 try {
                     newCldrFile = cldrFactory.make(file, false);
-                    CollectionUtilities.addAll(newCldrFile.iterator(), paths);
+                    newCldrFile.forEach(paths::add);
                 } catch (Exception e) {
                 }
                 CLDRFile oldCldrFile = null;
                 try {
                     oldCldrFile = oldFactory.make(file, false);
-                    CollectionUtilities.addAll(oldCldrFile.iterator(), paths);
+                    oldCldrFile.forEach(paths::add);
                 } catch (Exception e1) {
                 }
 

--- a/tools/java/org/unicode/cldr/tool/CLDRFormat.java
+++ b/tools/java/org/unicode/cldr/tool/CLDRFormat.java
@@ -16,8 +16,6 @@ import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SimpleFactory;
 //import org.unicode.cldr.util.XPathParts.Comments;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
-
 public class CLDRFormat {
     public static void main(String[] args) throws Exception {
         // TODO - make these parameters
@@ -83,8 +81,8 @@ public class CLDRFormat {
     private static String findFirstDifference(CLDRFile cldrFile, CLDRFile regenFile) {
         keys1.clear();
         keys2.clear();
-        CollectionUtilities.addAll(cldrFile.iterator(), keys1);
-        CollectionUtilities.addAll(regenFile.iterator(), keys2);
+        cldrFile.forEach(keys1::add);
+        regenFile.forEach(keys2::add);
         if (!keys1.equals(keys2)) {
             Set<String> missing = new TreeSet<String>(keys1);
             missing.removeAll(keys2);

--- a/tools/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/java/org/unicode/cldr/tool/CLDRModify.java
@@ -69,7 +69,6 @@ import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.ibm.icu.dev.tool.UOption;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.DateTimePatternGenerator;
@@ -525,13 +524,13 @@ public class CLDRModify {
                         testPath = "//ldml/dates/calendars/calendar[@type=\"persian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"abbreviated\"]/alias";
                         System.out.println(k.getStringValue(testPath));
                         // System.out.println(k.getFullXPath(testPath));
-                        Iterator it4 = k.iterator();
-                        Set s = CollectionUtilities.addAll(it4, new TreeSet());
+                        TreeSet s = new TreeSet();
+                        k.forEach(s::add);
 
                         System.out.println(k.getStringValue(testPath));
                         // if (true) return;
                         Set orderedSet = new TreeSet(k.getComparator());
-                        CollectionUtilities.addAll(k.iterator(), orderedSet);
+                        k.forEach(orderedSet::add);
                         for (Iterator it3 = orderedSet.iterator(); it3.hasNext();) {
                             String path = (String) it3.next();
                             // System.out.println(path);
@@ -2283,7 +2282,7 @@ public class CLDRModify {
         Map<String, ValuePair> haveSameValues = new TreeMap<String, ValuePair>();
         CLDRFile resolvedFile = cldrFactory.make(key, true);
         // get only those paths that are not in "root"
-        CollectionUtilities.addAll(resolvedFile.iterator(), skipPaths);
+        resolvedFile.forEach(skipPaths::add);
 
         // first, collect all the paths
         for (String locale : availableChildren) {

--- a/tools/java/org/unicode/cldr/tool/CompareEn.java
+++ b/tools/java/org/unicode/cldr/tool/CompareEn.java
@@ -16,8 +16,6 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
-
 public class CompareEn {
 
     enum MyOptions {
@@ -72,7 +70,8 @@ public class CompareEn {
 
             // walk through all the new paths and values to check them.
 
-            Set<String> paths = CollectionUtilities.addAll(en_GB.iterator(), new TreeSet<>());
+            TreeSet<String> paths = new TreeSet<>();
+            en_GB.forEach(paths::add);
 
             for (String path : paths) {
                 if (path.startsWith("//ldml/identity")) {
@@ -130,8 +129,9 @@ public class CompareEn {
 
                 // walk through all the new paths and values to check them.
 
-                Set<String> paths = CollectionUtilities.addAll(en_GB.iterator(), new TreeSet<>());
-                paths = CollectionUtilities.addAll(en_001.iterator(), paths);
+                TreeSet<String> paths = new TreeSet<>();
+                en_GB.forEach(paths::add);
+                en_001.forEach(paths::add);
 
                 for (String path : paths) {
                     if (path.startsWith("//ldml/identity")) {

--- a/tools/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/java/org/unicode/cldr/tool/CountItems.java
@@ -51,7 +51,7 @@ import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.props.ICUPropertyFactory;
 
 import com.google.common.base.Joiner;
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.collect.ImmutableMap;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.dev.util.UnicodeMapIterator;
 import com.ibm.icu.impl.Relation;
@@ -85,35 +85,36 @@ public class CountItems {
         + " America/Los_Angeles America/Phoenix America/Denver America/Chicago America/Indianapolis"
         + " America/New_York";
 
-    static final Map<String, String> country_map = CollectionUtilities.asMap(new String[][] {
-        { "AQ", "http://www.worldtimezone.com/time-antarctica24.php" },
-        { "AR", "http://www.worldtimezone.com/time-south-america24.php" },
-        { "AU", "http://www.worldtimezone.com/time-australia24.php" },
-        { "BR", "http://www.worldtimezone.com/time-south-america24.php" },
-        { "CA", "http://www.worldtimezone.com/time-canada24.php" },
-        { "CD", "http://www.worldtimezone.com/time-africa24.php" },
-        { "CL", "http://www.worldtimezone.com/time-south-america24.php" },
-        { "CN", "http://www.worldtimezone.com/time-cis24.php" },
-        { "EC", "http://www.worldtimezone.com/time-south-america24.php" },
-        { "ES", "http://www.worldtimezone.com/time-europe24.php" },
-        { "FM", "http://www.worldtimezone.com/time-oceania24.php" },
-        { "GL", "http://www.worldtimezone.com/index24.php" },
-        { "ID", "http://www.worldtimezone.com/time-asia24.php" },
-        { "KI", "http://www.worldtimezone.com/time-oceania24.php" },
-        { "KZ", "http://www.worldtimezone.com/time-cis24.php" },
-        { "MH", "http://www.worldtimezone.com/time-oceania24.php" },
-        { "MN", "http://www.worldtimezone.com/time-cis24.php" },
-        { "MX", "http://www.worldtimezone.com/index24.php" },
-        { "MY", "http://www.worldtimezone.com/time-asia24.php" },
-        { "NZ", "http://www.worldtimezone.com/time-oceania24.php" },
-        { "PF", "http://www.worldtimezone.com/time-oceania24.php" },
-        { "PT", "http://www.worldtimezone.com/time-europe24.php" },
-        { "RU", "http://www.worldtimezone.com/time-russia24.php" },
-        { "SJ", "http://www.worldtimezone.com/index24.php" },
-        { "UA", "http://www.worldtimezone.com/time-cis24.php" },
-        { "UM", "http://www.worldtimezone.com/time-oceania24.php" },
-        { "US", "http://www.worldtimezone.com/time-usa24.php" },
-        { "UZ", "http://www.worldtimezone.com/time-cis24.php" }, });
+    static final ImmutableMap<String, String> country_map = ImmutableMap.<String, String>builder()
+        .put("AQ", "http://www.worldtimezone.com/time-antarctica24.php")
+        .put("AR", "http://www.worldtimezone.com/time-south-america24.php")
+        .put("AU", "http://www.worldtimezone.com/time-australia24.php")
+        .put("BR", "http://www.worldtimezone.com/time-south-america24.php")
+        .put("CA", "http://www.worldtimezone.com/time-canada24.php")
+        .put("CD", "http://www.worldtimezone.com/time-africa24.php")
+        .put("CL", "http://www.worldtimezone.com/time-south-america24.php")
+        .put("CN", "http://www.worldtimezone.com/time-cis24.php")
+        .put("EC", "http://www.worldtimezone.com/time-south-america24.php")
+        .put("ES", "http://www.worldtimezone.com/time-europe24.php")
+        .put("FM", "http://www.worldtimezone.com/time-oceania24.php")
+        .put("GL", "http://www.worldtimezone.com/index24.php")
+        .put("ID", "http://www.worldtimezone.com/time-asia24.php")
+        .put("KI", "http://www.worldtimezone.com/time-oceania24.php")
+        .put("KZ", "http://www.worldtimezone.com/time-cis24.php")
+        .put("MH", "http://www.worldtimezone.com/time-oceania24.php")
+        .put("MN", "http://www.worldtimezone.com/time-cis24.php")
+        .put("MX", "http://www.worldtimezone.com/index24.php")
+        .put("MY", "http://www.worldtimezone.com/time-asia24.php")
+        .put("NZ", "http://www.worldtimezone.com/time-oceania24.php")
+        .put("PF", "http://www.worldtimezone.com/time-oceania24.php")
+        .put("PT", "http://www.worldtimezone.com/time-europe24.php")
+        .put("RU", "http://www.worldtimezone.com/time-russia24.php")
+        .put("SJ", "http://www.worldtimezone.com/index24.php")
+        .put("UA", "http://www.worldtimezone.com/time-cis24.php")
+        .put("UM", "http://www.worldtimezone.com/time-oceania24.php")
+        .put("US", "http://www.worldtimezone.com/time-usa24.php")
+        .put("UZ", "http://www.worldtimezone.com/time-cis24.php")
+        .build();
 
     /**
      * Count the data.
@@ -1043,7 +1044,7 @@ public class CountItems {
 
             CLDRFile itemResolved = cldrFactory.make(locale, true);
             temp.clear();
-            CollectionUtilities.addAll(itemResolved.iterator(), temp);
+            itemResolved.forEach(temp::add);
             int resolvedCurrent = temp.size();
 
             System.out.println(locale + "\tPlain:\t" + current + "\tResolved:\t"

--- a/tools/java/org/unicode/cldr/tool/GenerateCasingChart.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateCasingChart.java
@@ -22,7 +22,6 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Splitter;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.text.DisplayContext;
 import com.ibm.icu.text.LocaleDisplayNames;
 import com.ibm.icu.text.UnicodeSet;
@@ -101,7 +100,7 @@ public class GenerateCasingChart {
             Level level = CLDRConfig.getInstance().getStandardCodes().getLocaleCoverageLevel("cldr", locale);
             boolean hasCasedLetters = changesUpper.containsSome(exemplars);
             Set<String> items = new LinkedHashSet<>();
-            CollectionUtilities.addAll(cldrFile.iterator("//ldml/contextTransforms"), items);
+            cldrFile.iterator("//ldml/contextTransforms").forEachRemaining(items::add);
             if (!hasCasedLetters) {
                 if (items.size() != 0) {
                     System.out.println(locale + "Uncased language has context!!!");

--- a/tools/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -20,7 +20,6 @@ import org.unicode.cldr.util.PrettyPath;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.Timer;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.text.Collator;
@@ -163,11 +162,11 @@ public class GenerateComparison {
             Set<String> paths;
             try {
                 paths = new HashSet<String>();
-                CollectionUtilities.addAll(oldFile.iterator(), paths);
+                oldFile.forEach(paths::add);
                 if (oldList.contains(locale)) {
                     paths.addAll(oldFile.getExtraPaths());
                 }
-                CollectionUtilities.addAll(newFile.iterator(), paths);
+                newFile.forEach(paths::add);
                 if (newList.contains(locale)) {
                     paths.addAll(newFile.getExtraPaths());
                 }

--- a/tools/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -33,7 +33,7 @@ import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 import org.unicode.cldr.util.XPathParts;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.collect.ImmutableMap;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.Collator;
@@ -570,15 +570,14 @@ public class GenerateEnums {
     Set<String> corrigendum = new TreeSet<String>(Arrays.asList(new String[] { "QE", "833",
         "830", "172" })); // 003, 419
 
-    private Map extraNames = CollectionUtilities.asMap(new String[][] {
-        { "BU", "Burma" }, { "TP", "East Timor" }, { "YU", "Yugoslavia" },
-        { "ZR", "Zaire" }, { "CD", "Congo (Kinshasa, Democratic Republic)" },
-        { "CI", "Ivory Coast (Cote d'Ivoire)" },
-        { "FM", "Micronesia (Federated States)" },
-        { "TL", "East Timor (Timor-Leste)" },
-        // {"155","Western Europe"},
-
-    });
+    private ImmutableMap<String, String> extraNames = ImmutableMap.<String, String>builder()
+        .put("BU", "Burma").put("TP", "East Timor").put("YU", "Yugoslavia")
+        .put("ZR", "Zaire").put("CD", "Congo (Kinshasa, Democratic Republic)")
+        .put("CI", "Ivory Coast (Cote d'Ivoire)")
+        .put("FM", "Micronesia (Federated States)")
+        .put("TL", "East Timor (Timor-Leste)")
+        // .put("155", "Western Europe")
+        .build();
 
     private Set<String> currencyCodes;
 

--- a/tools/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/java/org/unicode/cldr/tool/ShowData.java
@@ -40,7 +40,6 @@ import org.unicode.cldr.util.TransliteratorUtilities;
 
 import com.google.common.base.Joiner;
 import com.ibm.icu.dev.tool.UOption;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.Collator;
@@ -179,13 +178,13 @@ public class ShowData {
 
                 // get all of the paths
                 Set<String> allPaths = new HashSet<>();
-                CollectionUtilities.addAll(file.iterator(), allPaths);
+                file.forEach(allPaths::add);
 
                 if (!locale.equals("root")) {
                     for (String childLocale : children) {
                         CLDRFile childCldrFile = cldrFactory.make(childLocale, false);
                         if (childCldrFile != null) {
-                            CollectionUtilities.addAll(childCldrFile.iterator(), allPaths);
+                            childCldrFile.forEach(allPaths::add);
                         }
                         sublocales.put(childLocale, childCldrFile);
                     }

--- a/tools/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -64,10 +64,10 @@ import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.TreeMultimap;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Row.R4;
@@ -569,13 +569,13 @@ public class ShowLanguages {
         .finishRow();
     }
 
-    static Map<String, String> fixScriptGif = CollectionUtilities.asMap(new String[][] {
-        { "hangul", "hangulsyllables" },
-        { "japanese", "hiragana" },
-        { "unknown or invalid script", "unknown" },
-        { "Hant", "Hant" },
-        { "Hans", "Hans" },
-    });
+    static ImmutableMap<String, String> fixScriptGif = ImmutableMap.<String, String>builder()
+        .put("hangul", "hangulsyllables")
+        .put("japanese", "hiragana")
+        .put("unknown or invalid script", "unknown")
+        .put("Hant", "Hant")
+        .put("Hans", "Hans")
+        .build();
 
     private static String getGifName(String script) {
         String temp = fixScriptGif.get(script);

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -64,7 +64,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -412,7 +411,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
      */
     public boolean write(PrintWriter pw, Map<String, ?> options) {
         Set<String> orderedSet = new TreeSet<String>(getComparator());
-        CollectionUtilities.addAll(dataSource.iterator(), orderedSet);
+        dataSource.forEach(orderedSet::add);
 
         String firstPath = null;
         String firstFullPath = null;
@@ -1259,10 +1258,10 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
         Iterator<String> it = (prefix == null || prefix.length() == 0)
             ? dataSource.iterator()
                 : dataSource.iterator(prefix);
-            if (comparator == null) return it;
-            Set<String> orderedSet = new TreeSet<String>(comparator);
-            CollectionUtilities.addAll(it, orderedSet);
-            return orderedSet.iterator();
+        if (comparator == null) return it;
+        Set<String> orderedSet = new TreeSet<String>(comparator);
+        it.forEachRemaining(orderedSet::add);
+        return orderedSet.iterator();
     }
 
     public Iterable<String> fullIterable() {

--- a/tools/java/org/unicode/cldr/util/DtdDataCheck.java
+++ b/tools/java/org/unicode/cldr/util/DtdDataCheck.java
@@ -20,7 +20,6 @@ import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdData.ElementType;
 
 import com.google.common.base.Joiner;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -202,7 +201,7 @@ public class DtdDataCheck {
                 Comparator<String> comp = dtdData.getDtdComparator(null);
                 CLDRFile test = ToolConfig.getToolInstance().getEnglish();
                 Set<String> sorted = new TreeSet(test.getComparator());
-                CollectionUtilities.addAll(test.iterator(), sorted);
+                test.forEach(sorted::add);
                 String[] sortedArray = sorted.toArray(new String[sorted.size()]);
 
                 // compare for identity

--- a/tools/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/java/org/unicode/cldr/util/MatchValue.java
@@ -24,7 +24,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
@@ -633,7 +632,7 @@ public abstract class MatchValue implements Predicate<String> {
         final List<MatchValue> subtests;
 
         private OrMatchValue(Iterator<MatchValue> iterator) {
-            this.subtests = ImmutableList.copyOf(CollectionUtilities.addAll(iterator, new ArrayList<>()));
+            this.subtests = ImmutableList.copyOf(iterator);
         }
 
         @Override

--- a/tools/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/java/org/unicode/cldr/util/PathHeader.java
@@ -25,7 +25,6 @@ import org.unicode.cldr.util.RegexLookup.Finder;
 import org.unicode.cldr.util.With.SimpleIterator;
 
 import com.google.common.base.Splitter;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.lang.UCharacter;
@@ -1874,7 +1873,8 @@ public class PathHeader implements Comparable<PathHeader> {
          */
         public Set<String> pathsForFile(CLDRFile file) {
             // make sure we cache all the path headers
-            Set<String> filePaths = CollectionUtilities.addAll(file.fullIterable().iterator(), new HashSet<String>());
+            HashSet<String> filePaths = new HashSet<String>();
+            file.fullIterable().forEach(filePaths::add);
             for (String path : filePaths) {
                 try {
                     fromPath(path); // call to make sure cached


### PR DESCRIPTION
Mostly automatic via IntelliJ and inlining of methods for addAll(), but some changes needed since it’s better to say:
    iterable.forEach(thing::add)
than:
    iterator.forEachRemaining(thing::add)
where possible (and the original utilities class took iterators rather than iterables).

The asMap() changes were manual since there were so few.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13750
- [x] Updated PR title and link in previous line to include Issue number

