### PR TITLE
CLDR-13750 Refactoring collection utilities (part 4, contains/iterators)

### DIFF
--- a/tools/java/org/unicode/cldr/test/CoverageLevel2.java
+++ b/tools/java/org/unicode/cldr/test/CoverageLevel2.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.test;
 
+import static java.util.Collections.disjoint;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -20,7 +22,6 @@ import org.unicode.cldr.util.SupplementalDataInfo.CoverageLevelInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.CoverageVariableInfo;
 import org.unicode.cldr.util.Timer;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
 
@@ -61,8 +62,10 @@ public class CoverageLevel2 {
         public MyRegexFinder(String pattern, String additionalMatch, CoverageLevelInfo ci) {
             super(pattern);
             // remove the ${ and the }, and change - to _.
-            this.additionalMatch = additionalMatch == null ? null : SetMatchType.valueOf(additionalMatch.substring(2,
-                additionalMatch.length() - 1).replace('-', '_'));
+            this.additionalMatch = additionalMatch == null
+                ? null
+                : SetMatchType.valueOf(
+                    additionalMatch.substring(2, additionalMatch.length() - 1).replace('-', '_'));
             this.ci = ci;
         }
 
@@ -78,10 +81,10 @@ public class CoverageLevel2 {
                 && ci.inLanguage.matcher(localeSpecificInfo.targetLanguage).matches()) {
                 lstOK = true;
             } else if (ci.inScriptSet != null
-                && CollectionUtilities.containsSome(ci.inScriptSet, localeSpecificInfo.cvi.targetScripts)) {
+                && !disjoint(ci.inScriptSet, localeSpecificInfo.cvi.targetScripts)) {
                 lstOK = true;
             } else if (ci.inTerritorySet != null
-                && CollectionUtilities.containsSome(ci.inTerritorySet, localeSpecificInfo.cvi.targetTerritories)) {
+                && !disjoint(ci.inTerritorySet, localeSpecificInfo.cvi.targetTerritories)) {
                 lstOK = true;
             }
 

--- a/tools/java/org/unicode/cldr/tool/GenerateCldrTests.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateCldrTests.java
@@ -445,18 +445,6 @@ public class GenerateCldrTests {
     };
 
     /*
-     * public interface Equator { public boolean equals(Object o1, Object o2); }
-     */
-    @SuppressWarnings("rawtypes")
-    static boolean intersects(Collection a, Collection b) {
-        for (Iterator it = a.iterator(); it.hasNext();) {
-            if (b.contains(it.next()))
-                return true;
-        }
-        return false;
-    }
-
-    /*
      * static Collection extract(Object x, Collection a, Equator e, Collection
      * output) { List itemsToRemove = new ArrayList(); for (Iterator it =
      * a.iterator(); it.hasNext();) { Object item = it.next(); if (e.equals(x,

--- a/tools/java/org/unicode/cldr/util/LenientDateParser.java
+++ b/tools/java/org/unicode/cldr/util/LenientDateParser.java
@@ -24,7 +24,6 @@ import org.unicode.cldr.util.Dictionary.Matcher.Filter;
 import org.unicode.cldr.util.Dictionary.Matcher.Status;
 import org.unicode.cldr.util.LenientDateParser.Token.Type;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.OlsonTimeZone;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UCharacter;
@@ -400,8 +399,8 @@ public class LenientDateParser {
             if (firstType != null) {
                 // skip
             } else {
-                boolean hasDate = CollectionUtilities.containsSome(dateTypes, set);
-                boolean hasTime = CollectionUtilities.containsSome(timeTypes, set);
+                boolean hasDate = !Collections.disjoint(dateTypes, set);
+                boolean hasTime = !Collections.disjoint(timeTypes, set);
                 if (hasDate != hasTime) {
                     firstType = hasDate ? Type.YEAR : Type.HOUR;
                 }

--- a/tools/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/java/org/unicode/cldr/util/XMLSource.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import org.unicode.cldr.util.XPathParts.Comments;
 
+import com.google.common.collect.Iterators;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.util.Freezable;
 import com.ibm.icu.util.Output;
@@ -620,12 +621,12 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
      */
     public Iterator<String> iterator(String prefix) {
         if (prefix == null || prefix.length() == 0) return iterator();
-        return new com.ibm.icu.dev.util.CollectionUtilities.PrefixIterator().set(iterator(), prefix);
+        return Iterators.filter(iterator(), s -> s.startsWith(prefix));
     }
 
     public Iterator<String> iterator(Matcher pathFilter) {
         if (pathFilter == null) return iterator();
-        return new com.ibm.icu.dev.util.CollectionUtilities.RegexIterator().set(iterator(), pathFilter);
+        return Iterators.filter(iterator(), s -> pathFilter.reset(s).matches());
     }
 
     /**


### PR DESCRIPTION
Replace "containsSome()" and the FilteredIterator class with JDK utilities.

* containsSome() is just equivalent to a "disjoint" check.
* FilteredIterator is now trivially doable inline with streams and lambdas.

The “containsSome()” method is interesting because the old implementation went to great lengths to handle ordered sets efficiently, but in reality none of the sets given to it now were ordered, so that code was unused. Simply replaced with a check for “disjoint” from the JDK Sets class.
PrefixIterator was easy to change manually. The change does not appear to have made anything slower (e.g. running all unit tests).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13750
- [x] Updated PR title and link in previous line to include Issue number

