### PR TITLE
CLDR-13750 Replace custom comparison logic with JDK comparators

### DIFF
--- a/tools/java/org/unicode/cldr/tool/WritePluralRules.java
+++ b/tools/java/org/unicode/cldr/tool/WritePluralRules.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.tool;
 
+import static java.util.Comparator.naturalOrder;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,15 +15,26 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
 import com.google.common.base.Joiner;
-import com.ibm.icu.dev.util.CollectionUtilities;
+import com.google.common.collect.Comparators;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.PluralRules;
 
 public class WritePluralRules {
+    // Ordering by size-of-set first, and then lexicographically, with a final tie-break on the
+    // string representation.
+    // Note: This code was refactored from a legacy utility method (which allowed null) but it's
+    // not actually clear if nulls need to be allowed in this case.
+    private static final Comparator<PluralRules> PLURAL_RULES_COMPARATOR =
+        Comparator.<PluralRules, Integer>comparing(r -> r.getKeywords().size())
+            .thenComparing(PluralRules::getKeywords,
+                Comparators.lexicographical(Comparator.<String>nullsFirst(naturalOrder())))
+            .thenComparing(Object::toString);
+
     static SupplementalDataInfo sInfo = CLDRConfig.getInstance().getSupplementalDataInfo();
 
     public static void main(String[] args) {
-        Relation<PluralRules, String> rulesToLocales = Relation.of(new TreeMap<PluralRules, Set<String>>(new PluralRulesComparator()), TreeSet.class);
+        Relation<PluralRules, String> rulesToLocales =
+            Relation.of(new TreeMap<>(PLURAL_RULES_COMPARATOR), TreeSet.class);
         for (String locale : sInfo.getPluralLocales(PluralType.cardinal)) {
             if (locale.equals("root")) {
                 continue;
@@ -126,8 +139,6 @@ public class WritePluralRules {
 
     static class HackComparator implements Comparator<Entry<PluralRules, Set<String>>> {
         // we get the order of the first items in each of the old rules, and use that order where we can.
-        PluralRulesComparator prc = new PluralRulesComparator();
-
         @Override
         public int compare(Entry<PluralRules, Set<String>> o1, Entry<PluralRules, Set<String>> o2) {
             Integer firstLocale1 = HACK_ORDER_PLURALS.get(o1.getValue().iterator().next());
@@ -140,7 +151,7 @@ public class WritePluralRules {
             } else if (firstLocale2 != null) {
                 return 1;
             } else { // only if BOTH are null, use better comparison
-                return prc.compare(o1.getKey(), o2.getKey());
+                return PLURAL_RULES_COMPARATOR.compare(o1.getKey(), o2.getKey());
             }
         }
     }
@@ -157,21 +168,6 @@ public class WritePluralRules {
 //        for (String s : "af fil hu sv en it ca mr gu hi bn zu".split(" ")) {
 //            HACK_ORDER_ORDINALS.put(s, i++);
 //        }
-    }
-
-    static class PluralRulesComparator implements Comparator<PluralRules> {
-        CollectionUtilities.CollectionComparator<String> comp = new CollectionUtilities.CollectionComparator<String>();
-
-        @Override
-        public int compare(PluralRules arg0, PluralRules arg1) {
-            Set<String> key0 = arg0.getKeywords();
-            Set<String> key1 = arg1.getKeywords();
-            int diff = comp.compare(key0, key1);
-            if (diff != 0) {
-                return diff;
-            }
-            return arg0.toString().compareTo(arg1.toString());
-        }
     }
 
     static PluralRules forLocale(String locale) {

--- a/tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
+++ b/tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
@@ -1,18 +1,22 @@
 package org.unicode.cldr.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Comparators.lexicographical;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public final class PreferredAndAllowedHour implements Comparable<PreferredAndAllowedHour> {
-
+    // DO NOT change enum item names, they are mapped directly from data values via "valueOf".
     public enum HourStyle {
         H, Hb(H), HB(H), k, h, hb(h), hB(h), K;
         public final HourStyle base;
@@ -29,77 +33,77 @@ public final class PreferredAndAllowedHour implements Comparable<PreferredAndAll
             try {
                 HourStyle.valueOf(c);
                 return true;
-            } catch (Exception e) {
+            } catch (IllegalArgumentException e) {
                 return false;
             }
         }
     }
 
+    // For splitting the style ID string.
+    private static final Splitter SPACE_SPLITTER = Splitter.on(' ').trimResults();
+
+    // If this used "getter" method references it wouldn't need so much explicit generic typing.
+    private static final Comparator<PreferredAndAllowedHour> COMPARATOR =
+        Comparator.<PreferredAndAllowedHour, HourStyle>comparing(t -> t.preferred)
+            .thenComparing(t -> t.allowed, lexicographical(Comparator.<HourStyle>naturalOrder()));
+
     public final HourStyle preferred;
-    public final List<HourStyle> allowed;
+    /** Unique allowed styles, in the order they were specified during construction. */
+    public final ImmutableList<HourStyle> allowed;
 
-    public PreferredAndAllowedHour(char preferred, Collection<Character> allowed) {
-        this(HourStyle.valueOf(String.valueOf(preferred)), mungeSet(allowed));
+    /**
+     * Creates a PreferredAndAllowedHour instance with "allowed" styles derived from single
+     * character IDs in the given collection. Note that the iteration order of the allowed
+     * styles is retained.
+     *
+     * <p>This constructor is limiting, since some styles are identified by two character
+     * strings, which cannot be referenced via this constructor.
+     */
+    public PreferredAndAllowedHour(char preferred, Set<Character> allowed) {
+        this(String.valueOf(preferred), allowed.stream().map(String::valueOf));
     }
 
-    public PreferredAndAllowedHour(Collection<HourStyle> allowed) {
-        this(allowed.iterator().next(), allowed);
+    /**
+     * Creates a PreferredAndAllowedHour instance with "allowed" styles derived from a space
+     * separated list of unique IDs. Note that the iteration order of the allowed styles is
+     * retained, since in some situations it is necessary that the preferred style should
+     * also be the first allowed style. The list of allowed style IDs must not contain
+     * duplicates.
+     */
+    public PreferredAndAllowedHour(String preferred, String allowedString) {
+        this(preferred, SPACE_SPLITTER.splitToList(allowedString).stream());
     }
 
-    public PreferredAndAllowedHour(HourStyle preferred, Collection<HourStyle> allowed) {
-        if (preferred == null) {
-            throw new NullPointerException();
-        }
-        if (!allowed.contains(preferred)) {
-            throw new IllegalArgumentException("Allowed (" + allowed +
-                ") must contain preferred(" + preferred +
-                ")");
-        }
-        this.preferred = preferred;
-        this.allowed = ImmutableList.copyOf(new LinkedHashSet<>(allowed));
-    }
-
-    public PreferredAndAllowedHour(String preferred2, String allowedString) {
-        this(HourStyle.valueOf(preferred2), mungeOperands(allowedString));
-    }
-
-    private static EnumSet<HourStyle> mungeSet(Collection<Character> allowed) {
-        EnumSet<HourStyle> temp = EnumSet.noneOf(HourStyle.class);
-        for (char c : allowed) {
-            temp.add(HourStyle.valueOf(String.valueOf(c)));
-        }
-        return temp;
-    }
-
-    static final Splitter SPACE_SPLITTER = Splitter.on(' ').trimResults();
-
-    private static LinkedHashSet<HourStyle> mungeOperands(String allowedString) {
-        LinkedHashSet<HourStyle> allowed = new LinkedHashSet<>();
-        for (String s : SPACE_SPLITTER.split(allowedString)) {
-            allowed.add(HourStyle.valueOf(s));
-        }
-        return allowed;
+    private PreferredAndAllowedHour(String preferredStyle, Stream<String> allowedStyles) {
+        this.preferred = checkNotNull(HourStyle.valueOf(preferredStyle));
+        this.allowed = allowedStyles.map(HourStyle::valueOf).collect(toImmutableList());
+        checkArgument(allowed.stream().distinct().count() == allowed.size(),
+                "Allowed (%s) must not contain duplicates", allowed);
+        // Note: In *some* cases the preferred style is required to be the first style in
+        // the allowed set, but not always (thus we cannot do a better check here).
+        // TODO: Figure out if we can enforce preferred == first(allowed) here.
+        checkArgument(allowed.contains(preferred),
+                "Allowed (%s) must contain preferred (%s)", allowed, preferred);
     }
 
     @Override
-    public int compareTo(PreferredAndAllowedHour arg0) {
-        int diff = preferred.compareTo(arg0.preferred);
-        if (diff != 0) return diff;
-        return CollectionUtilities.compare(allowed.iterator(), arg0.allowed.iterator());
+    public int compareTo(PreferredAndAllowedHour other) {
+        return COMPARATOR.compare(this, other);
     }
 
     @Override
     public String toString() {
-        return toString(Collections.singleton("?"));
+        return toString(ImmutableList.of("?"));
     }
 
     public String toString(Collection<String> regions) {
+        Joiner withSpaces = Joiner.on(" ");
         return "<hours preferred=\""
             + preferred
             + "\" allowed=\""
-            + Joiner.on(" ").join(allowed)
+            + withSpaces.join(allowed)
             + "\" regions=\""
-            + Joiner.on(" ").join(regions)
+            + withSpaces.join(regions)
             + "\"/>";
     }
 


### PR DESCRIPTION
This replaces the custom logic for the CollectionUtilities methods with the recently added JDK Comparator(s) functionality. This method probably needs to be double checked against the com.ibm classes to ensure it's equivalent.

See: https://github.com/unicode-org/cldr/blob/master/tools/java/libs/utilities-src.jar

This is one of the more subtle refactorings since it relies on human understanding of the existing (undocumented, non-trivial) comparison code. Luckily it has only a few uses, and the JDK Comparator API is nice and readable, so the intent of the new code should be clear.

As far as I can tell, the existing comparator code for *iterables* is equivalent to lexicographical ordering of the “natural” order with the exception that “null” should always be sorted first.
Then the ordering of *collections* is that, but preceded by a check on the size first.

Note that while the examples in:
    tools/java/org/unicode/cldr/tool/GeneratePluralRanges.java
previously passed collections, and thus get a size comparison in the new code, the example in:
    tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
explicitly passes just the iterator for comparison, bypassing the size check.

Somewhat strangely, the example in:
    tools/java/org/unicode/cldr/tool/WritePluralRules.java
does the collection comparison (with size check) and then falls back to a tie-break on the "toString()" of the instances being compared. I've no idea why it's doing this, but I've replicated it.

Note that while I’ve copied this behaviour, I’m not actually sure that in the places it's used you actually expect null at all, so some call sites could possibly be simplified.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13750
- [x] Updated PR title and link in previous line to include Issue number

