### PR TITLE
Russian / Territory 001 should be capitilzed

### DIFF
--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -733,7 +733,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Zzzz">неизвестная письменность</script>
 		</scripts>
 		<territories>
-			<territory type="001">весь мир</territory>
+			<territory type="001">Весь Мир</territory>
 			<territory type="002">Африка</territory>
 			<territory type="003">Северная Америка</territory>
 			<territory type="005">Южная Америка</territory>


### PR DESCRIPTION
Hello!

The territory "001" in Russian should be capitalized as other territories and countries
Here is fix.

P.S. I created account at `unicode-org.atlassian.net` but i decided to make patch here because there is a very difficult ticket system (many fields). I will create there a ticket and will post there this issue.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-_____
- [ ] Updated PR title and link in previous line to include Issue number

