### PR TITLE
CLDR-13781 update CLDR version, readme; update ICU4J libs to release-67-1

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -46,7 +46,7 @@ $Revision$
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "37" >
+<!ATTLIST version cldrVersion CDATA #FIXED "38" >
     <!--@MATCH:any-->
     <!--@VALUE-->
 <!ATTLIST version draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/dtd/ldmlBCP47.dtd
+++ b/common/dtd/ldmlBCP47.dtd
@@ -16,7 +16,7 @@ $Revision$
 <!ATTLIST version number CDATA #REQUIRED >
 	<!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "37" >
+<!ATTLIST version cldrVersion CDATA #FIXED "38" >
 	<!--@MATCH:version-->
     <!--@VALUE-->
 

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -17,7 +17,7 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "37" >
+<!ATTLIST version cldrVersion CDATA #FIXED "38" >
     <!--@MATCH:version-->
     <!--@VALUE-->
 <!ATTLIST version unicodeVersion CDATA #FIXED "13.0.0" >

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -21,7 +21,7 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "37" >
+<!ATTLIST version cldrVersion CDATA #FIXED "38" >
     <!--@MATCH:version-->
     <!--@METADATA-->
 

--- a/readme.html
+++ b/readme.html
@@ -11,17 +11,17 @@
 
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
-    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 37</h3>
-    <p>Last updated: 2020-Apr-14</p>
+    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 38</h3>
+    <p>Last updated: 2020-May-18</p>
 
-    <!--<p><b>Note:</b> CLDR 37 is in development and not recommended for use at this stage.</p>-->
-    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 37, intended for those wishing to do pre-release testing.
+    <p><b>Note:</b> CLDR 38 is in development and not recommended for use at this stage.</p>
+    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 38, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a preliminary version of CLDR 37, intended for those wishing to do pre-release testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 38, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 37, intended for testing.
+    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 38, intended for testing.
     It is not recommended for production use.</p>-->
-    <p>This is the final release version of CLDR 37.</p>
+    <!--<p>This is the final release version of CLDR 38.</p>-->
     
     <p><strong>Important notes for CLDR 36 and later:</strong></p>
     <ul>

--- a/tools/java/libs/icu4j-src.jar
+++ b/tools/java/libs/icu4j-src.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93a42723c6fb064ec346badfee031c7a8cc56e4f8e9c8242f9753409002314f4
-size 2402332
+oid sha256:72fe9807e2e10abfd3232b7428f81cd1c4e69ca5143df7a6ec46460ff5d2c1b7
+size 2402379

--- a/tools/java/libs/icu4j-version.txt
+++ b/tools/java/libs/icu4j-version.txt
@@ -1,1 +1,1 @@
-icu4j b9d1ba87f545744f2b81f1f413484f55a0da3d2f 2020-04-14 (from maint/maint-67, ICU 67 post rc)
+icu4j 125e29d54990e74845e1546851b5afa3efab06ce 2020-05-18 (from maint/maint-67, = tag: release-67-1)

--- a/tools/java/libs/icu4j.jar
+++ b/tools/java/libs/icu4j.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09941bcbc82d3bba0bb165a17b1f85e6a1aa19897c1a660336846a219d49a317
-size 23400340
+oid sha256:697c21eca5d2b31effe52f19f1cd6c1981f3e9f107c3b6fcb8cee7d53b85bcd0
+size 13106772

--- a/tools/java/libs/utilities-src.jar
+++ b/tools/java/libs/utilities-src.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b181349ed8ae2a0672499a3bcb14fc36b6a05d315d8b6a42b4bfe36b8f6876b4
+oid sha256:03f1788a37f1c0ee022368d749e6a5147723111b888ace25d058b162add7a610
 size 21708

--- a/tools/java/libs/utilities.jar
+++ b/tools/java/libs/utilities.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3d387d932da9fb80e37f65d947848ff2029623aac16d7e5400026cb21902436
+oid sha256:1b7f628b858c3b6a4ac085700186ebfe7a74ea4252abf9807436b4b8c4f122cf
 size 36681

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -128,7 +128,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String> {
     public static final String SUPPLEMENTAL_NAME = "supplementalData";
     public static final String SUPPLEMENTAL_METADATA = "supplementalMetadata";
     public static final String SUPPLEMENTAL_PREFIX = "supplemental";
-    public static final String GEN_VERSION = "37";
+    public static final String GEN_VERSION = "38";
     public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "grammaticalFeatures", "languageInfo",
         "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "plurals", "postalCodeData", "rgScope", "supplementalData",
         "supplementalMetadata", "telephoneCodeData", "units", "windowsZones");


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13781
- [x] Updated PR title and link in previous line to include Issue number

* Update dtd cldrVersion to 38
* Update CLDRFile.java GEN_VERSION to 38
* Update readme for v38 development version
* Update ICU4J libs to version release-67-1

