### PR TITLE
CLDR-13810 add zh-(gan|wuu|yue) to languageAlias

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -139,6 +139,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="myd" replacement="aog" reason="deprecated"/> <!-- Maramba ⇒ Angoram -->
 			<languageAlias type="nns" replacement="nbr" reason="deprecated"/> <!-- Ningye ⇒ Numana -->            <!-- miscellaneous deprecated -->
 
+			<!-- redundant deprecated -->
+			<languageAlias type="zh-gan" replacement="gan" reason="deprecated"/> <!-- Kan or Gan -->
+			<languageAlias type="zh-wuu" replacement="wuu" reason="deprecated"/> <!-- Shanghaiese or Wu -->
+			<languageAlias type="zh-yue" replacement="yue" reason="deprecated"/> <!-- Cantonese -->
 			<!-- miscellaneous deprecated -->
             <languageAlias type="no_BOKMAL" replacement="nb" reason="deprecated"/>
             <languageAlias type="no_NYNORSK" replacement="nn" reason="deprecated"/>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13810
- [X] Updated PR title and link in previous line to include Issue number

This part is tricky because zh-gan / zh-wuu / zh-yue are primary language tag and secondary language tag but  UTS35 said
```
If the BCP 47 primary language subtag matches the type attribute of a languageAlias 
element in Supplemental Data, replace the language subtag with the replacement value.
```
So even if we land this PR to the file the UTS35 algorithm should not look into them.
