### PR TITLE
CLDR-13817 Missing letter in ru.xml

### DIFF
--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -1060,7 +1060,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<variant type="BOONT" draft="provisional">Бунтлинг</variant>
 			<variant type="FONIPA" draft="contributed">Международный фонетический алфавит</variant>
 			<variant type="FONUPA" draft="provisional">Фонетический алфавит уральских языков</variant>
-			<variant type="KKCOR" draft="provisional">Общая офография</variant>
+			<variant type="KKCOR" draft="provisional">Общая орфография</variant>
 			<variant type="LIPAW" draft="provisional">Липовецкий диалект резьянского языка</variant>
 			<variant type="MONOTON">Монотонный</variant>
 			<variant type="NEDIS" draft="provisional">Надижский диалект</variant>


### PR DESCRIPTION
Add a missing letter 'р' in word 'офография'

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13817
- [x] Updated PR title and link in previous line to include Issue number

