### PR TITLE
CLDR-13695 Define stages of a forum thread

### DIFF
--- a/tools/cldr-apps/WebContent/css/CldrStForum.css
+++ b/tools/cldr-apps/WebContent/css/CldrStForum.css
@@ -1,13 +1,37 @@
-.postTypeLabel {
-	font-size: larger;
-	text-align: right;
+.forumThreadStatus {
 	color: red;
+	clear: left;
+}
+
+.postTypeComboLabel {
+	float: right;
+	clear: right;
+}
+
+.postTypeLabel {
+	color: red;
+	text-align: right;
+	clear: right;
 }
 
 .postTextBorder {
 	border-style: solid;
-	padding: 0.5em;
-	margin: 0.5em;
+	padding: 0.25em;
+	margin: 0.25em;
 	border-color: #3399f3;
 	border-width: 2px;
+}
+
+.postTextArea {
+	width: 100%;
+	box-sizing: border-box;
+	margin-bottom: 1em;
+}
+
+.addPostButton {
+	margin: 0.5em !important; /* override bootstrap btn margin-bottom 0 */
+}
+
+hr.postRule {
+	border-top: 1px solid #3399f3;
 }

--- a/tools/cldr-apps/WebContent/js/review.js
+++ b/tools/cldr-apps/WebContent/js/review.js
@@ -90,10 +90,10 @@ function showReviewPage(json, showFn) {
 			element.description + '"></span></div></a></li>';
 	});
 
-	if (cldrStForum) {
-		const userId = (surveyUser && surveyUser.id) ? surveyUser.id : 0;
+	if (cldrStForum && surveyCurrentLocale && surveyUser && surveyUser.id) {
+		const forumSummary = cldrStForum.getForumSummaryText(surveyCurrentLocale, surveyUser.id, true /* table */);
 		sidebarHtml += "<li><a id='dashToForum' onclick='cldrStForum.reload();'>Forum</a></li>\n";
-		sidebarHtml += "<li>" + cldrStForum.getForumSummaryHtml(surveyCurrentLocale, userId) + "</li>\n";
+		sidebarHtml += "<li>" + forumSummary + "</li>\n";
 	}
 	const menuDom = document.createElement('ul');
 	menuDom.className = 'nav nav-pills nav-stacked affix menu-review';

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -627,7 +627,7 @@ function createLinkToFn(strid, fn, tag) {
 function createGravitar(user) {
 	if (user.emailHash) {
 		var gravatar = document.createElement("img");
-		gravatar.src = 'http://www.gravatar.com/avatar/' + user.emailHash + '?d=identicon&r=g&s=32';
+		gravatar.src = 'https://www.gravatar.com/avatar/' + user.emailHash + '?d=identicon&r=g&s=32';
 		gravatar.title = 'gravatar - http://www.gravatar.com';
 		return gravatar;
 	} else {
@@ -3986,6 +3986,11 @@ function refreshCounterVetting() {
 	}
 	document.getElementById('progress-voted').style.width = voted * 100 / total + '%';
 	document.getElementById('progress-abstain').style.width = abstain * 100 / total + '%';
+
+	if (cldrStForum && surveyCurrentLocale && surveyUser && surveyUser.id) {
+		const forumSummary = cldrStForum.getForumSummaryHtml(surveyCurrentLocale, surveyUser.id, false);
+		document.getElementById('vForum').innerHTML = forumSummary;
+	}
 }
 
 /**

--- a/tools/cldr-apps/WebContent/surveytool.css
+++ b/tools/cldr-apps/WebContent/surveytool.css
@@ -1440,25 +1440,6 @@ div.forumDiv .adminUserUser i {
 		margin:  0.25em !important;
 }
 
-div.postHeaderInfoGroup, .postHeaderItem {
-	display:  block;
-}
-
-
-div.postHeaderLine {
-	display:  table-row;
-	font-size: small;
-}
-
-div.postHeaderLine div {
-	display:  table-row;
-}
-
-div.postHeaderLine div.postHeaderItem {
-	display:  table-row;
-	font-size: smaller;
-}
-
 div.forumDiv div.subpost div.postContent {	
 	padding-top:  0.5em;
 	font: small Georgia, "Times New Roman", Times, serif;

--- a/tools/cldr-apps/WebContent/v.jsp
+++ b/tools/cldr-apps/WebContent/v.jsp
@@ -427,8 +427,11 @@ surveyUser =  <%=ctx.session.user.toJSONString()%>;
 						  <div id="progress-abstain" class="progress-bar progress-bar-warning tip-log" title='Abstain' style="width: 0%">
 						  </div>
 					</div>
-					<div class='counter-infos'>Votes: <span id='count-voted'></span> - Abstain: <span id='count-abstain'></span> - Total: <span id='count-total'></span>
-			    	
+					<div class='counter-infos'><a onclick='cldrStForum.reload();'>Forum:</a>
+						<span id='vForum'>...</span> ●
+						Votes: <span id='count-voted'></span>
+						- Abstain: <span id='count-abstain'></span>
+						- Total: <span id='count-total'></span>
 			    	</div>
 		    </div>
        </div>

--- a/tools/cldr-apps/js-unittest/TestCldrStForum.js
+++ b/tools/cldr-apps/js-unittest/TestCldrStForum.js
@@ -27,40 +27,40 @@
 
 			assert(content.firstChild != null, "first child is not null");
 			assert.equal(content.firstChild.id, "fthr_fr_CA|45347");
-			const s1 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:26Closetest"
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:28Closetest reply blah!Discuss";
+			const s1 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:26ClosedClosetest"
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:28Closetest reply blah!";
 			assert.equal(normalizeWhitespace(content.firstChild.textContent), normalizeWhitespace(s1));
 
 			const firstSibling = content.firstChild.nextSibling;
 			assert(firstSibling != null, "first sibling is not null");
 			assert.equal(firstSibling.id, "fthr_fr_CA|45346");
-			const s2 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:20CloseFUrthermoreDiscuss";
+			const s2 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:20ClosedCloseFUrthermore";
 			assert.equal(normalizeWhitespace(firstSibling.textContent), normalizeWhitespace(s2));
 
 			const secondSibling = firstSibling.nextSibling;
 			assert(secondSibling != null, "second sibling is not null");
 			assert.equal(secondSibling.id, "fthr_fr_CA|45343");
-			const s3 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:17Closetest"
+			const s3 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:17ClosedClosetest"
 				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:18CloseOK, replying to test in Dashboard"
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:19CloseAnd replying to replyDiscuss";
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:19CloseAnd replying to reply";
 			assert.equal(normalizeWhitespace(secondSibling.textContent), normalizeWhitespace(s3));
 
 			const thirdSibling = secondSibling.nextSibling;
 			assert(thirdSibling != null, "third sibling is not null");
 			assert.equal(thirdSibling.id, "fthr_fr_CA|45341");
-			const s4 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:12CloseAnd another post from Dashboard."
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:14CloseAnd another reply, this time from Dashboard Fix pop-up!!!Discuss";
+			const s4 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:12ClosedCloseAnd another post from Dashboard."
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:14CloseAnd another reply, this time from Dashboard Fix pop-up!!!";
 			assert.equal(normalizeWhitespace(thirdSibling.textContent), normalizeWhitespace(s4));
 
 			assert(content.lastChild != null, "last child is not null");
 			assert.equal(content.lastChild.id, "fthr_fr|363");
-			const sLast = "n (Microsoft) userlevel_vetter[v28] 2015-05-19 11:58Close...Discuss";
+			const sLast = "n (Microsoft) userlevel_vetter[v28] 2015-05-19 11:58ClosedClose...";
 			assert.equal(normalizeWhitespace(content.lastChild.textContent), normalizeWhitespace(sLast));
 		});
 	});
 
 	describe('cldrStForum.getForumSummaryHtml', function() {
-		const html = cldrStForum.getForumSummaryHtml();
+		const html = cldrStForum.getForumSummaryHtml('aa', 1, true);
 
 		it('should not return null or empty', function() {
 			assert((html != null && html !== ''), "html is neither null nor empty");

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -1031,11 +1031,27 @@ public class SurveyAjax extends HttpServlet {
 
         final String subj = SurveyForum.HTMLSafe(request.getParameter("subj"));
         final String text = SurveyForum.HTMLSafe(request.getParameter("text"));
-        final String postType = SurveyForum.HTMLSafe(request.getParameter("postType"));
+        final String postTypeStr = SurveyForum.HTMLSafe(request.getParameter("postType"));
+        final String openStr = SurveyForum.HTMLSafe(request.getParameter("open"));
+        final String value = SurveyForum.HTMLSafe(request.getParameter("value"));
 
         final int replyTo = getIntParameter(request, "replyTo", SurveyForum.NO_PARENT);
+        final int root = getIntParameter(request, "root", SurveyForum.NO_PARENT);
 
-        final int postId = sm.fora.doPost(mySession, xpath, l, subj, text, postType, replyTo);
+        final boolean open = !"false".equals(openStr);
+
+        SurveyForum.PostInfo postInfo = sm.fora.new PostInfo(l, postTypeStr, text);
+        postInfo.setSubj(subj);
+        postInfo.setPathString(xpath);
+        postInfo.setReplyTo(replyTo);
+        postInfo.setUser(mySession.user);
+        postInfo.setRoot(root);
+        postInfo.setOpen(open);
+        if (value != null) {
+            postInfo.setValue(value);
+        }
+
+        final int postId = sm.fora.doPost(mySession, postInfo);
 
         r.put("postId", postId);
         if (postId > 0) {


### PR DESCRIPTION
-Votes cause auto-generated Agree post(s)

-Revise prefill texts for post types

-Disable editing of subject (path-header)

-Display status Open or Closed at top of thread

-Separate posts in thread with horizontal rules; no lines along left

-New replies always have parent == root (original) post

-New filters: Needing action; Open requests by you; remove most other filters

-Show Summary at top of Section window (progress area)

-Space between buttons with margin in css; other css improvements

-Add four columns to the FORUM_POSTS table: root, type, open, value

-Remove the FORUM_TYPES table, revise related code to use FORUM_POSTS

-New object SurveyForum.PostInfo for encapsulation, fewer function params

-Set open=false for all posts in thread when get PostType.CLOSE

-Move doPostInternal and savePostToDb below their callers

-Change http to https for www.gravatar.com to fix security warning

-Move code from long functions into subroutines

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13695
- [x] Updated PR title and link in previous line to include Issue number

