### PR TITLE
CLDR-13695 Define stages of a forum thread

### DIFF
--- a/tools/cldr-apps/WebContent/css/CldrStForum.css
+++ b/tools/cldr-apps/WebContent/css/CldrStForum.css
@@ -19,7 +19,7 @@
 	padding: 0.25em;
 	margin: 0.25em;
 	border-color: #3399f3;
-	border-width: 2px;
+	border-width: 1px;
 }
 
 .postTextArea {

--- a/tools/cldr-apps/WebContent/js/CldrStForumFilter.js
+++ b/tools/cldr-apps/WebContent/js/CldrStForumFilter.js
@@ -22,8 +22,8 @@ const cldrStForumFilter = (function() {
 	const filters = [
 		{name: 'Needing action', func: passIfNeedingAction, keepCount: true},
 		{name: 'Open requests by you', func: passIfOpenRequestYouStarted, keepCount: true},
-		{name: 'Open threads', func: passIfOpen, keepCount: true},
-		{name: 'All threads', func: passAll, keepCount: false},
+		{name: 'Open topics', func: passIfOpen, keepCount: true},
+		{name: 'All topics', func: passAll, keepCount: false},
 	];
 
 	/**

--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
@@ -1256,6 +1256,14 @@ function showV() {
 					isLoading = false;
 
 					/*
+					 * Scroll back to top when loading a new page, to avoid a bug where, for
+					 * example, having scrolled towards bottom, we switch from a Section page
+					 * to the Forum page and the scrollbar stays where it was, making the new
+					 * content effectively invisible.
+					 */
+					window.scrollTo(0, 0);
+
+					/*
 					 * TODO: explain code related to "showers".
 					 */
 					showers[flipper.get(pages.data).id] = function() {

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -3965,8 +3965,8 @@ function showstats(hname) {
  * Update the counter on top of the vetting page
  */
 function refreshCounterVetting() {
-	if (isVisitor) {
-		// if the user is a visitor, don't display the counter informations
+	if (isVisitor || isDashboard()) {
+		// if the user is a visitor, or this is the Dashboard, don't display the counter informations
 		$('#nav-page .counter-infos, #nav-page .nav-progress').hide();
 		return;
 	}


### PR DESCRIPTION
-Change border-width from 2px to 1px for postTextBorder

-For Request, default text includes My reasons are:

-For Request, add a topic heading Requesting (value)

-Show disabled Request button if value is null

-For replies, show Comment instead of Discuss

-Show reply buttons only if opts.showReplyButton true

-Remove horizontal rule separating posts in thread

-Refer to topics instead of threads in UI

-Scroll to top when load page, to avoid Forum page invisibility bug

-Hide counters in refreshCounterVetting if Dashboard, to avoid forum summary bug

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13695
- [x] Updated PR title and link in previous line to include Issue number

