### PR TITLE
CLDR-13705 remove redundant currency symbols (will be derived)

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -3252,50 +3252,12 @@ annotations.
 		<annotation cp="$" type="tts">dollar</annotation>
 		<annotation cp="¢">cent</annotation>
 		<annotation cp="¢" type="tts">cent</annotation>
-		<annotation cp="฿">baht | THB</annotation>
-		<annotation cp="฿" type="tts">thai baht</annotation>
-		<annotation cp="₪">shekel | ILS</annotation>
-		<annotation cp="₪" type="tts">sheqel</annotation>
-		<annotation cp="₺">lira | TRY</annotation>
-		<annotation cp="₺" type="tts">turkish lira</annotation>
-		<annotation cp="₫">dong | VND</annotation>
-		<annotation cp="₫" type="tts">Vietnamese dong</annotation>
 		<annotation cp="₱"></annotation>
 		<annotation cp="₱" type="tts">peso</annotation>
-		<annotation cp="₩">KRW | KPW</annotation>
-		<annotation cp="₩" type="tts">won</annotation>
-		<annotation cp="₡">CRC | SVC</annotation>
-		<annotation cp="₡" type="tts">colon currency</annotation>
-		<annotation cp="₦">naira | NGN</annotation>
-		<annotation cp="₦" type="tts">Nigerian naira</annotation>
-		<annotation cp="₮">tugrik | togrog | tögrög | MNT</annotation>
-		<annotation cp="₮" type="tts">Mongolian tugrik</annotation>
-		<annotation cp="৳">taka | BDT</annotation>
-		<annotation cp="৳" type="tts">Bangladeshi taka</annotation>
-		<annotation cp="₴">hryvnia | UAH</annotation>
-		<annotation cp="₴" type="tts">Ukrainian hryvnia</annotation>
-		<annotation cp="₸">tenge | KZT</annotation>
-		<annotation cp="₸" type="tts">Kazakhstani tenge</annotation>
-		<annotation cp="₲">guarani | guaraní | PYG</annotation>
-		<annotation cp="₲" type="tts">Paraguayan guarani</annotation>
-		<annotation cp="₵">cedi | GHS</annotation>
-		<annotation cp="₵" type="tts">Ghanaian cedi</annotation>
-		<annotation cp="៛">riel | KHR</annotation>
-		<annotation cp="៛" type="tts">Cambodian riel</annotation>
-		<annotation cp="₭">kip | LAK</annotation>
-		<annotation cp="₭" type="tts">Lao kip</annotation>
-		<annotation cp="֏">dram | AMD</annotation>
-		<annotation cp="֏" type="tts">Armenian dram</annotation>
 		<annotation cp="₥">mil</annotation>
 		<annotation cp="₥" type="tts">mill</annotation>
-		<annotation cp="₾">lari | GEL</annotation>
-		<annotation cp="₾" type="tts">Georgian lari</annotation>
-		<annotation cp="₼">manat | AZN</annotation>
-		<annotation cp="₼" type="tts">Azerbaijani manat</annotation>
 		<annotation cp="₿">BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
-		<annotation cp="؋">afghani | AFN</annotation>
-		<annotation cp="؋" type="tts">Afghan afghani</annotation>
 		<annotation cp="+">plus  | add</annotation>
 		<annotation cp="+" type="tts">plus sign</annotation>
 		<annotation cp="±">plus-minus</annotation>

--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -3254,6 +3254,8 @@ annotations.
 		<annotation cp="¢" type="tts">cent</annotation>
 		<annotation cp="₱"></annotation>
 		<annotation cp="₱" type="tts">peso</annotation>
+		<annotation cp="₩">KRW | KPW</annotation>
+		<annotation cp="₩" type="tts">won</annotation>
 		<annotation cp="₥">mil</annotation>
 		<annotation cp="₥" type="tts">mill</annotation>
 		<annotation cp="₿">BTC</annotation>

--- a/common/annotations/root.xml
+++ b/common/annotations/root.xml
@@ -3254,6 +3254,8 @@ for derived annotations.
 		<annotation cp="¢" type="tts">E13.1-168</annotation>
 		<annotation cp="₱">E13.1-173</annotation>
 		<annotation cp="₱" type="tts">E13.1-173</annotation>
+		<annotation cp="₩">E13.1-174</annotation>
+		<annotation cp="₩" type="tts">E13.1-174</annotation>
 		<annotation cp="₥">E13.1-186</annotation>
 		<annotation cp="₥" type="tts">E13.1-186</annotation>
 		<annotation cp="₿">E13.1-189</annotation>

--- a/common/annotations/root.xml
+++ b/common/annotations/root.xml
@@ -3252,50 +3252,12 @@ for derived annotations.
 		<annotation cp="$" type="tts">E13.1-167</annotation>
 		<annotation cp="¢">E13.1-168</annotation>
 		<annotation cp="¢" type="tts">E13.1-168</annotation>
-		<annotation cp="฿">E13.1-169</annotation>
-		<annotation cp="฿" type="tts">E13.1-169</annotation>
-		<annotation cp="₪">E13.1-170</annotation>
-		<annotation cp="₪" type="tts">E13.1-170</annotation>
-		<annotation cp="₺">E13.1-171</annotation>
-		<annotation cp="₺" type="tts">E13.1-171</annotation>
-		<annotation cp="₫">E13.1-172</annotation>
-		<annotation cp="₫" type="tts">E13.1-172</annotation>
 		<annotation cp="₱">E13.1-173</annotation>
 		<annotation cp="₱" type="tts">E13.1-173</annotation>
-		<annotation cp="₩">E13.1-174</annotation>
-		<annotation cp="₩" type="tts">E13.1-174</annotation>
-		<annotation cp="₡">E13.1-175</annotation>
-		<annotation cp="₡" type="tts">E13.1-175</annotation>
-		<annotation cp="₦">E13.1-176</annotation>
-		<annotation cp="₦" type="tts">E13.1-176</annotation>
-		<annotation cp="₮">E13.1-177</annotation>
-		<annotation cp="₮" type="tts">E13.1-177</annotation>
-		<annotation cp="৳">E13.1-178</annotation>
-		<annotation cp="৳" type="tts">E13.1-178</annotation>
-		<annotation cp="₴">E13.1-179</annotation>
-		<annotation cp="₴" type="tts">E13.1-179</annotation>
-		<annotation cp="₸">E13.1-180</annotation>
-		<annotation cp="₸" type="tts">E13.1-180</annotation>
-		<annotation cp="₲">E13.1-181</annotation>
-		<annotation cp="₲" type="tts">E13.1-181</annotation>
-		<annotation cp="₵">E13.1-182</annotation>
-		<annotation cp="₵" type="tts">E13.1-182</annotation>
-		<annotation cp="៛">E13.1-183</annotation>
-		<annotation cp="៛" type="tts">E13.1-183</annotation>
-		<annotation cp="₭">E13.1-184</annotation>
-		<annotation cp="₭" type="tts">E13.1-184</annotation>
-		<annotation cp="֏">E13.1-185</annotation>
-		<annotation cp="֏" type="tts">E13.1-185</annotation>
 		<annotation cp="₥">E13.1-186</annotation>
 		<annotation cp="₥" type="tts">E13.1-186</annotation>
-		<annotation cp="₾">E13.1-187</annotation>
-		<annotation cp="₾" type="tts">E13.1-187</annotation>
-		<annotation cp="₼">E13.1-188</annotation>
-		<annotation cp="₼" type="tts">E13.1-188</annotation>
 		<annotation cp="₿">E13.1-189</annotation>
 		<annotation cp="₿" type="tts">E13.1-189</annotation>
-		<annotation cp="؋">E13.1-190</annotation>
-		<annotation cp="؋" type="tts">E13.1-190</annotation>
 		<annotation cp="+">E13.1-191</annotation>
 		<annotation cp="+" type="tts">E13.1-191</annotation>
 		<annotation cp="±">E13.1-192</annotation>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3760,9 +3760,15 @@ for derived annotations.
 			<alias source="locale" path="../currencyFormats[@numberSystem='latn']"/>
 		</currencyFormats>
 		<currencies>
-			<currency type="AOA">
-				<symbol alt="narrow">Kz</symbol>
-			</currency>
+            <currency type="AFN">
+                <symbol alt="narrow">؋</symbol>
+            </currency>
+            <currency type="AMD">
+                <symbol alt="narrow">֏</symbol>
+            </currency>
+            <currency type="AOA">
+                <symbol alt="narrow">Kz</symbol>
+            </currency>
 			<currency type="ARS">
 				<symbol alt="narrow">$</symbol>
 			</currency>
@@ -3770,6 +3776,9 @@ for derived annotations.
 				<symbol>A$</symbol>
 				<symbol alt="narrow">$</symbol>
 			</currency>
+            <currency type="AZN">
+                <symbol alt="narrow">₼</symbol>
+            </currency>
 			<currency type="BAM">
 				<symbol alt="narrow">KM</symbol>
 			</currency>
@@ -3859,9 +3868,12 @@ for derived annotations.
 			<currency type="GEL">
 				<symbol alt="narrow">₾</symbol>
 			</currency>
-			<currency type="GIP">
-				<symbol alt="narrow">£</symbol>
-			</currency>
+            <currency type="GIP">
+                <symbol alt="narrow">£</symbol>
+            </currency>
+            <currency type="GHS">
+                <symbol alt="narrow">GH₵</symbol>
+            </currency>
 			<currency type="GNF">
 				<symbol alt="narrow">FG</symbol>
 			</currency>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13705
- [x] Updated PR title and link in previous line to include Issue number

