### PR TITLE
CLDR-13695 Define stages of a forum thread

### DIFF
--- a/tools/cldr-apps/WebContent/css/CldrStForum.css
+++ b/tools/cldr-apps/WebContent/css/CldrStForum.css
@@ -19,7 +19,7 @@
 	padding: 0.25em;
 	margin: 0.25em;
 	border-color: #3399f3;
-	border-width: 2px;
+	border-width: 1px;
 }
 
 .postTextArea {

--- a/tools/cldr-apps/WebContent/js/CldrStForum.js
+++ b/tools/cldr-apps/WebContent/js/CldrStForum.js
@@ -199,7 +199,7 @@ const cldrStForum = (function() {
 			return "I'm closing this thread";
 		} else if (postType === 'Request') {
 			if (value) {
-				return 'Please consider voting for “' + value + '”\n';
+				return 'Please consider voting for “' + value + '”. My reasons are:\n';
 			}
 		} else if (postType === 'Agree') {
 			return 'I agree. I am changing my vote to the requested “' + value + '”';
@@ -366,6 +366,12 @@ const cldrStForum = (function() {
 					}
 					addThreadSubjectSpan(topicInfo, rootPost);
 				}
+				if (opts.createDomElements) {
+					if (rootPost.postType === 'Request' && rootPost.value) {
+						const requestInfo = forumCreateChunk('Requesting “' + post.value + '”', "h4", "postTopicInfo");
+						topicDiv.appendChild(requestInfo);
+					}
+				}
 				topicDivs[post.threadId] = topicDiv;
 				topicDiv.id = "fthr_" + post.threadId;
 			}
@@ -451,7 +457,11 @@ const cldrStForum = (function() {
 				comboChunk.appendChild(forumCreateChunk(post.postType, 'span', 'postTypeComboLabel'));
 				subChunk.appendChild(comboChunk);
 			} else {
-				subChunk.appendChild(forumCreateChunk(post.postType, 'div', 'postTypeLabel'));
+				let typeLabel = post.postType;
+				if (typeLabel === 'Discuss') {
+					typeLabel = 'Comment'; // for replies, label 'Comment' instead of 'Discuss'
+				}
+				subChunk.appendChild(forumCreateChunk(typeLabel, 'div', 'postTypeLabel'));
 			}
 
 			// actual text
@@ -460,7 +470,7 @@ const cldrStForum = (function() {
 			subpost.appendChild(postContent);
 		}
 		appendPostDivsToTopicDivs(posts, topicDivs, postDivs);
-		if (opts.createDomElements) {
+		if (opts.showReplyButton) {
 			addReplyButtonsToEachTopic(topicDivs);
 		}
 		return filterAndAssembleForumThreads(posts, topicDivs, opts.applyFilter, opts.showThreadCount);
@@ -598,16 +608,19 @@ const cldrStForum = (function() {
 	 * @param postDivs the map from post id to DOM elements
 	 */
 	function appendPostDivsToTopicDivs(posts, topicDivs, postDivs) {
-		const USE_HORIZONTAL_RULE = true;
+		const SIMPLE_REPLY_STYLE = true;
+		const USE_HORIZONTAL_RULE = false;
 		for (let i = posts.length - 1; i >= 0; i--) {
 			const post = posts[i];
 			if (post.root === -1) { // this post is the root of its thread, not a reply
 				topicDivs[post.threadId].appendChild(postDivs[post.id]);
 			}
 			else { // this is a reply
-				if (USE_HORIZONTAL_RULE) {
-					const horizontalRule = forumCreateChunk('', 'hr', 'postRule');
-					topicDivs[post.threadId].appendChild(horizontalRule);
+				if (SIMPLE_REPLY_STYLE) {
+					if (USE_HORIZONTAL_RULE) {
+						const horizontalRule = forumCreateChunk('', 'hr', 'postRule');
+						topicDivs[post.threadId].appendChild(horizontalRule);
+					}
 					topicDivs[post.threadId].appendChild(postDivs[post.id]);
 				} else {
 					if (postDivs[post.root]) {
@@ -684,8 +697,9 @@ const cldrStForum = (function() {
 									: "addPostButton forumNewButton btn btn-default btn-sm";
 
 		const newButton = forumCreateChunk(label, "button", buttonClass);
-
-		if (typeof listenFor !== 'undefined') {
+		if (postType === 'Request' && value === null) {
+			newButton.disabled = true;
+		} else if (typeof listenFor !== 'undefined') {
 			listenFor(newButton, "click", function(e) {
 				xpathMap.get({
 					hex: xpstrid
@@ -751,15 +765,20 @@ const cldrStForum = (function() {
 	function getPostTypeOptions(isReply, rootPost, value) {
 		const options = {};
 		if (rootPost === null || rootPost.open) {
-			options['Discuss'] = 'Discuss';
-			if (value) {
-				if (!isReply) {
-					options['Request'] = 'Request';
-				} else if (rootPost && !userIsPoster(rootPost) && rootPost.postType === 'Request') {
-					options['Agree'] = 'Agree';
-					options['Decline'] = 'Decline';
-				}
+			if (!isReply) {
+				/*
+				 * Show Request button even if value is null. It will be visible but disabled if value is null.
+				 */
+				options['Request'] = 'Request';
 			}
+			if (value && isReply && rootPost && !userIsPoster(rootPost) && rootPost.postType === 'Request') {
+				options['Agree'] = 'Agree';
+				options['Decline'] = 'Decline';
+			}
+			/*
+			 * For replies, label 'Comment' instead of 'Discuss'
+			 */
+			options['Discuss'] = isReply ? 'Comment' : 'Discuss';
 			if (userCanClose(isReply, rootPost)) {
 				options['Close'] = 'Close';
 			}
@@ -995,7 +1014,7 @@ const cldrStForum = (function() {
 			}
 		});
 		if (showThreadCount) {
-			countEl.innerHTML = threadCount + ((threadCount === 1) ? ' thread' : ' threads');
+			countEl.innerHTML = threadCount + ((threadCount === 1) ? ' topic' : ' topics');
 		}
 		return forumDiv;
 	}

--- a/tools/cldr-apps/WebContent/js/CldrStForumFilter.js
+++ b/tools/cldr-apps/WebContent/js/CldrStForumFilter.js
@@ -22,8 +22,8 @@ const cldrStForumFilter = (function() {
 	const filters = [
 		{name: 'Needing action', func: passIfNeedingAction, keepCount: true},
 		{name: 'Open requests by you', func: passIfOpenRequestYouStarted, keepCount: true},
-		{name: 'Open threads', func: passIfOpen, keepCount: true},
-		{name: 'All threads', func: passAll, keepCount: false},
+		{name: 'Open topics', func: passIfOpen, keepCount: true},
+		{name: 'All topics', func: passAll, keepCount: false},
 	];
 
 	/**

--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
@@ -1256,6 +1256,14 @@ function showV() {
 					isLoading = false;
 
 					/*
+					 * Scroll back to top when loading a new page, to avoid a bug where, for
+					 * example, having scrolled towards bottom, we switch from a Section page
+					 * to the Forum page and the scrollbar stays where it was, making the new
+					 * content effectively invisible.
+					 */
+					window.scrollTo(0, 0);
+
+					/*
 					 * TODO: explain code related to "showers".
 					 */
 					showers[flipper.get(pages.data).id] = function() {

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -3965,8 +3965,8 @@ function showstats(hname) {
  * Update the counter on top of the vetting page
  */
 function refreshCounterVetting() {
-	if (isVisitor) {
-		// if the user is a visitor, don't display the counter informations
+	if (isVisitor || isDashboard()) {
+		// if the user is a visitor, or this is the Dashboard, don't display the counter informations
 		$('#nav-page .counter-infos, #nav-page .nav-progress').hide();
 		return;
 	}


### PR DESCRIPTION
-Change border-width from 2px to 1px for postTextBorder

-For Request, default text includes My reasons are:

-For Request, add a topic heading Requesting (value)

-Show disabled Request button if value is null

-For replies, show Comment instead of Discuss

-Show reply buttons only if opts.showReplyButton true

-Remove horizontal rule separating posts in thread

-Refer to topics instead of threads in UI

-Scroll to top when load page, to avoid Forum page invisibility bug, cf. CLDR-13826

-Hide counters in refreshCounterVetting if Dashboard, to avoid forum summary bug, cf. CLDR-13827

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13695
- [x] Updated PR title and link in previous line to include Issue number

