### PR TITLE
CLDR-11045 Restoring no-placeholder Kun in Somali compact decimal.

### DIFF
--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -9648,7 +9648,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="one">0 Kun</pattern>
+					<pattern type="1000" count="one">Kun</pattern>
 					<pattern type="1000" count="other">0 Kun</pattern>
 					<pattern type="10000" count="one">00 Kun</pattern>
 					<pattern type="10000" count="other">00 Kun</pattern>


### PR DESCRIPTION
Reverts c5a208ecace8df07c2c51ee63474dfd587304649

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11045
- [x] Updated PR title and link in previous line to include Issue number

