### PR TITLE
CLDR-13750 Removing obsolete comments relating to now unused CollectionUtilities class

### DIFF
--- a/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -578,7 +578,7 @@ public class ConsoleCheckCLDR {
                 showValue(file, null, localeID, null, null, null, null, statusString, status.getSubtype());
             }
             paths.clear();
-            // CollectionUtilities.addAll(file.iterator(pathFilter), paths);
+
             CoverageInfo covInfo = cldrConf.getCoverageInfo();
             for (String path : file.fullIterable()) {
                 if (pathFilter != null && !pathFilter.reset(path).find()) {
@@ -596,7 +596,6 @@ public class ConsoleCheckCLDR {
             // addPrettyPaths(file, file.getExtraPaths(), pathFilter, prettyPathMaker, noaliases, false, paths);
 
             // also add the English paths
-            // CollectionUtilities.addAll(checkCldr.getDisplayInformation().iterator(pathFilter), paths);
             // initialize the first time in.
             if (englishPaths == null) {
                 englishPaths = new HashSet<String>();

--- a/tools/java/org/unicode/cldr/test/TestMetadata.java
+++ b/tools/java/org/unicode/cldr/test/TestMetadata.java
@@ -22,8 +22,7 @@ public class TestMetadata {
     public static void main(String[] args) {
         Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
         CLDRFile metadata = cldrFactory.make("supplementalMetadata", false);
-        // Set allKeys = new TreeSet();
-        // CollectionUtilities.addAll(metadata.iterator(), allKeys);
+        // Set allKeys = new TreeSet(metadata);
         // System.out.println("Keys: " + allKeys);
         // attribute order
 

--- a/tools/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/java/org/unicode/cldr/tool/CountItems.java
@@ -208,9 +208,6 @@ public class CountItems {
                 Collator spaceCol = Collator.getInstance(new ULocale(locale));
                 spaceCol.setStrength(Collator.PRIMARY);
                 out.println(locale + ":\t\u200E" + v + '\u200E');
-                // String fixedFull = CollectionUtilities.prettyPrint(exemplars, col, false);
-                // System.out.println(" =>\t" + fixedFull);
-                // verifyEquality(exemplars, new UnicodeSet(fixedFull));
                 String fixed = new UnicodeSetPrettyPrinter()
                     .setOrdering(col != null ? col : Collator.getInstance(ULocale.ROOT))
                     .setSpaceComparator(spaceCol != null ? spaceCol : ROOT_PRIMARY_COLLATOR)

--- a/tools/java/org/unicode/cldr/tool/GenerateAliases.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateAliases.java
@@ -100,8 +100,6 @@ public class GenerateAliases {
                     System.out.println("missing" + "\t" + localeID);
                 }
             }
-
-            // System.out.println(CollectionUtilities.join(aliasMap.entrySet(), "\n"));
         }
 
         private void addToLikely(Map<String, String> likely) {

--- a/tools/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -293,9 +293,6 @@ public class GenerateLanguageContainment {
         } else {
             newFile.add("//" + DtdType.supplementalData + "/languageGroups/languageGroup[@parent=\"" + base + "\"]",
                 Joiner.on(" ").join(children));
-//            System.out.println("\t<languageGroup parent='" 
-//                + base + "'>" 
-//                + CollectionUtilities.join(children, " ") + "</languageGroup>");
         }
         for (String child : children) {
             printXML(newFile, parentToChild, child);

--- a/tools/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -309,14 +309,6 @@ public class GenerateSidewaysView {
             .format((System.currentTimeMillis() - startTime) / 1000.0));
     }
 
-    // static Comparator UCA;
-    // static {
-    // RuleBasedCollator UCA2 = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
-    // UCA2.setNumericCollation(true);
-    // UCA2.setStrength(UCA2.IDENTICAL);
-    // UCA = new CollectionUtilities.MultiComparator(UCA2, new UTF16.StringComparator(true, false, 0) );
-    // }
-
     static final String[][] EXEMPLARS = {
         { "//ldml/characters/exemplarCharacters", "main", "Main Exemplars" },
         { "//ldml/characters/exemplarCharacters[@type=\"punctuation\"]", "punctuation", "Punctuation Exemplars" },

--- a/tools/java/org/unicode/cldr/tool/LikelySubtags.java
+++ b/tools/java/org/unicode/cldr/tool/LikelySubtags.java
@@ -77,8 +77,6 @@ public class LikelySubtags {
                 }
             }
         }
-        // System.out.println("Currency to Territory:\n\t" +
-        // CollectionUtilities.join(currencyToLikelyTerritory.entrySet(), "\n\t"));
     }
 
     /**

--- a/tools/java/org/unicode/cldr/tool/ListCoverageLevels.java
+++ b/tools/java/org/unicode/cldr/tool/ListCoverageLevels.java
@@ -197,16 +197,6 @@ public class ListCoverageLevels {
 //                getName(map, result);
 //            }            
 //
-//
-////            localeNameToAttributeList.forEach((name,list) -> {
-////                if (result.length() != 0) {
-////                    result.append(' ');
-////                }
-////                result.append(name);
-////                if (!list.isEmpty()) {
-////                    result.append(':').append(CollectionUtilities.join(list, "|"));
-////                }
-////                });
 //            return result;
 //        }
 

--- a/tools/java/org/unicode/cldr/tool/SearchCLDR.java
+++ b/tools/java/org/unicode/cldr/tool/SearchCLDR.java
@@ -106,7 +106,6 @@ public class SearchCLDR {
 
     public static void main(String[] args) {
         myOptions.parse(args, true);
-        // System.out.println("Arguments: " + CollectionUtilities.join(args, " "));
 
         long startTime = System.currentTimeMillis();
 

--- a/tools/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -1048,8 +1048,6 @@ public class ShowLocaleCoverage {
                         .append('\n');
                     }
 
-                    //out2.println(header + "\t" + coreValue + "\t" + CollectionUtilities.join(missing, ", "));
-
                     // Write missing paths (for >99% and specials
 
                     //                if (false) { // checkModernLocales.contains(locale)

--- a/tools/java/org/unicode/cldr/tool/SubdivisionNode.java
+++ b/tools/java/org/unicode/cldr/tool/SubdivisionNode.java
@@ -550,7 +550,7 @@ public class SubdivisionNode {
                 String reason = "deprecated";
                 R2<List<String>, String> aliasInfo = subdivisionAliasesFormer.get(toReplace);
                 if (aliasInfo != null) {
-                    replaceBy = aliasInfo.get0(); //  == null ? null : CollectionUtilities.join(aliasInfo.get0(), " ");
+                    replaceBy = aliasInfo.get0();
                     reason = aliasInfo.get1();
                     System.out.println("Adding former alias: " + toReplace + " => " + replaceBy);
                 } else {

--- a/tools/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -459,10 +459,6 @@ public class ICUServiceBuilder {
             throw new RuntimeException("Internal Error: ICUServiceBuilder.getArray():" + cldrFile.getLocaleID() + " "
                 + prefix + lastType + postfix + " - result.size=" + result.size() + ", less than acceptable minimum "
                 + minimumSize);
-            // Collection s = CollectionUtilities.addAll(cldrFile.iterator(prefix), new
-            // TreeSet());//cldrFile.keySet(".*gregorian.*months.*", );
-            // String item = cldrFile.getWinningValueWithBailey(prefix + lastType + postfix);
-            // throw new IllegalArgumentException("Can't find enough items");
         }
         /*
          * <months>


### PR DESCRIPTION
This is an optional change to remove references to the now unused CollectionUtilities class from legacy comments. I'd be happy to go further and remove more legacy comments in these, or other, files if wanted.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13750
- [x] Updated PR title and link in previous line to include Issue number

