### PR TITLE
CLDR-13692 Broken links in reports

### DIFF
--- a/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
+++ b/tools/cldr-apps/WebContent/surveyTool/nls/stui.js
@@ -161,7 +161,7 @@ define({
 		winningStatus_msg:  "${1} ${0} Value ",
 		
 		reportGuidance: " ",
-		dataPageInitialGuidance: "Please consult the <a target='_blank' href='http://cldr.unicode.org/index/survey-tool/guide'>Instructions <span class='glyphicon glyphicon-share'></span></a> page.<br/><br/>Briefly, for each row:<br/><ol><li>Click on a cell in the 'Code' column.</li><li>Read the details that appear in the right panel (widen your window to see it).</li><li> Hover over the English and the Winning value to see examples.</li><li>To vote:<ol><li>for an existing item in the Winning or Others column, click on the <input type='radio'/> for that item.</li><li>for a new value, click on the button in the \"Add\" column. A new editing box will open. Enter the new value and hit RETURN.</li><li>for no value (abstain, or retract a vote), click on the  <input type='radio'/> in the Abstain column.</li></ol></li></ol>",
+		dataPageInitialGuidance: "Please consult the <a target='_blank' href='http://cldr.unicode.org/translation/getting-started/guide'>Instructions <span class='glyphicon glyphicon-share'></span></a> page.<br/><br/>Briefly, for each row:<br/><ol><li>Click on a cell in the 'Code' column.</li><li>Read the details that appear in the right panel (widen your window to see it).</li><li> Hover over the English and the Winning value to see examples.</li><li>To vote:<ol><li>for an existing item in the Winning or Others column, click on the <input type='radio'/> for that item.</li><li>for a new value, click on the button in the \"Add\" column. A new editing box will open. Enter the new value and hit RETURN.</li><li>for no value (abstain, or retract a vote), click on the  <input type='radio'/> in the Abstain column.</li></ol></li></ol>",
 		generalPageInitialGuidance: "This area will show details of items as you work with the Survey Tool.",
 		localesInitialGuidance: "Choose a locale to get started.  <ul><li><span class='locked'>locked</span> locales may not be modified by anyone,</li><li><span class='canmodify'>hand icon</span> indicates editing allowed by you</li><li><span class='name_var'>Locales with (Variants)</span> may have specific differences to note.</li></ul><p>Don't see your locale? See: <a href='http://cldr.unicode.org/index/bug-reports#New_Locales'>Adding New Locales</a></p>",
 		
@@ -187,7 +187,7 @@ define({
 		voteInfo_voteTitle_desc: "The total vote score for this value",
 		voteInfo_orgsVote_desc: "This vote is the organization's winning vote",
 		voteInfo_orgsNonVote_desc: "This vote is not the organization's winning vote",
-		voteInfo_baseline_desc: "This is the “baseline” data. See http://cldr.org/index/survey-tool/guide#TOC-Icons",
+		voteInfo_baseline_desc: "This is the “baseline” data. See http://cldr.unicode.org/translation/getting-started/guide#TOC-Icons",
 		voteInfo_winningItem_desc: "This mark shows the item which is currently winning.",
 		voteInfo_winningKey_desc: "This mark shows the item which is currently winning.",
 		voteInfo_perValue_desc: "This shows the state and voters for a particular item.",

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -283,7 +283,7 @@ public class DataSection implements JSONString {
              * 
              * Called by CandidateItem.toJSONString (for item.pClass)
              * 
-             * Relationships between class, color, and inheritance (http://cldr.unicode.org/index/survey-tool/guide#TOC-Inheritance):
+             * Relationships between class, color, and inheritance (http://cldr.unicode.org/translation/getting-started/guide#TOC-Inheritance):
              * "The inherited values are color coded:
              *  1.  Darker [blue] The original is from a parent locale, such as if you are working in
              *      Latin American Spanish (es_419), this value is inherited from European Spanish (es).

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -3273,10 +3273,9 @@ public class SurveyAjax extends HttpServlet {
 
         final String calendarType = "gregorian";
         final String title = com.ibm.icu.lang.UCharacter.toTitleCase(SurveyMain.TRANS_HINT_LOCALE.toLocale(), calendarType, null);
-        final String href = "http://cldr.unicode.org/translation/date-time-review"; // TODO: broken link
 
         out.write("<h3>Review Date/Times : " + title + "</h3>");
-        out.write("<p>Please read the <a target='CLDR-ST-DOCS' href='" + href + "'>instructions</a> before continuing.</p>");
+        writeReportInstructionsLink(out);
 
         STFactory fac = sm.getSTFactory();
         CLDRFile englishFile = fac.make("en", true);
@@ -3299,11 +3298,8 @@ public class SurveyAjax extends HttpServlet {
      * @throws IOException
      */
     private static void generateZonesReport(Writer out, SurveyMain sm, CLDRLocale l) throws IOException {
-
-        final String href = "http://cldr.unicode.org/translation/review-zones"; // TODO: broken link
-
         out.write("<h3>Review Zones</h3>");
-        out.write("<p>Please read the <a target='CLDR-ST-DOCS' href='" + href + "'>instructions</a> before continuing.</p>");
+        writeReportInstructionsLink(out);
 
         CLDRFile englishFile = sm.getDiskFactory().make("en", true);
         CLDRFile nativeFile = sm.getSTFactory().make(l, true);
@@ -3320,15 +3316,24 @@ public class SurveyAjax extends HttpServlet {
      * @throws IOException
      */
     private static void generateNumbersReport(Writer out, SurveyMain sm, CLDRLocale l) throws IOException {
-
-        final String href = "http://cldr.unicode.org/translation/review-numbers"; // TODO: broken link
-
         out.write("<h3>Review Numbers</h3>");
-        out.write("<p>Please read the <a target='CLDR-ST-DOCS' href='" + href + "'>instructions</a> before continuing.</p>");
+        writeReportInstructionsLink(out);
 
         STFactory fac = sm.getSTFactory();
         CLDRFile nativeFile = fac.make(l, true);
 
         org.unicode.cldr.util.VerifyCompactNumbers.showNumbers(nativeFile, true, "EUR", out, fac);
+    }
+
+    /**
+     * Write html including a link to the instructions for using reports
+     *
+     * @param out the Writer
+     * @throws IOException
+     */
+    private static void writeReportInstructionsLink(Writer out) throws IOException {
+        out.write("<p>Please read the <a target='CLDR-ST-DOCS' href='"
+            + "http://cldr.unicode.org/translation/getting-started/review-formats"
+            + "'>instructions</a> before continuing.</p>");
     }
 }

--- a/tools/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/java/org/unicode/cldr/util/VoteResolver.java
@@ -81,8 +81,8 @@ public class VoteResolver<T> {
      * A checkmark means it’s approved and is slated to be used. A cross means it’s a missing value.
      * Green/orange check: The item has enough votes to be used in CLDR.
      * Red/orange/black X: The item does not have enough votes to be used in CLDR, by most implementations (or is completely missing).
-     * Reference: http://cldr.unicode.org/index/survey-tool/guide
-     * 
+     * Reference: http://cldr.unicode.org/translation/getting-started/guide
+     *
      * New January, 2019: When the item is inherited, i.e., winningValue is INHERITANCE_MARKER (↑↑↑),
      * then orange/red X are replaced by orange/red up-arrow. That change is made only on the client.
      * Reference: https://unicode.org/cldr/trac/ticket/11103


### PR DESCRIPTION
-Revise the URLs

-Encapsulate shared links for 3 reports in new writeReportInstructionsLink

-Keep http for now, pending support for https on cldr.unicode.org

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13692
- [x] Updated PR title and link in previous line to include Issue number

