### PR TITLE
CLDR-13836 fix script for dogri, the generation program, and default …

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -592,8 +592,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Dan; ?; ? } => { Dan; Latin; Côte d’Ivoire }-->
 		<likelySubtag from="dob" to="dob_Latn_ZZ"/>
 		<!--{ Dobu; ?; ? } => { Dobu; Latin; Unknown Region }-->
-		<likelySubtag from="doi" to="doi_Arab_IN"/>
-		<!--{ Dogri; ?; ? } => { Dogri; Arabic; India }-->
+		<likelySubtag from="doi" to="doi_Deva_IN"/>
+		<!--{ Dogri; ?; ? } => { Dogri; Devanagari; India }-->
 		<likelySubtag from="dop" to="dop_Latn_ZZ"/>
 		<!--{ Lukpa; ?; ? } => { Lukpa; Latin; Unknown Region }-->
 		<likelySubtag from="dow" to="dow_Latn_ZZ"/>
@@ -3014,8 +3014,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; ?; Spain } => { Spanish; Latin; Spain }-->
 		<likelySubtag from="und_ET" to="am_Ethi_ET"/>
 		<!--{ ?; ?; Ethiopia } => { Amharic; Ethiopic; Ethiopia }-->
-		<likelySubtag from="und_EU" to="en_Latn_GB"/>
-		<!--{ ?; ?; European Union } => { English; Latin; United Kingdom }-->
+		<likelySubtag from="und_EU" to="en_Latn_IE"/>
+		<!--{ ?; ?; European Union } => { English; Latin; Ireland }-->
 		<likelySubtag from="und_EZ" to="de_Latn_EZ"/>
 		<!--{ ?; ?; Eurozone } => { German; Latin; Eurozone }-->
 		<likelySubtag from="und_FI" to="fi_Latn_FI"/>

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -936,8 +936,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Hoyahoya; ?; ? } => { Hoyahoya; Latin; Unknown Region }-->
 		<likelySubtag from="hi" to="hi_Deva_IN"/>
 		<!--{ Hindi; ?; ? } => { Hindi; Devanagari; India }-->
-		<likelySubtag from="hi_Latn" to="hi_Latn_IN"/>
-		<!--{ Hindi; Latin; ? } => { Hindi; Latin; India }-->
 		<likelySubtag from="hia" to="hia_Latn_ZZ"/>
 		<!--{ Lamang; ?; ? } => { Lamang; Latin; Unknown Region }-->
 		<likelySubtag from="hif" to="hif_Latn_FJ"/>
@@ -1290,8 +1288,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Kurukh; ?; ? } => { Kurukh; Devanagari; India }-->
 		<likelySubtag from="ks" to="ks_Arab_IN"/>
 		<!--{ Kashmiri; ?; ? } => { Kashmiri; Arabic; India }-->
-		<likelySubtag from="ks_Deva" to="ks_Deva_IN"/>
-		<!--{ Kashmiri; Devanagari; ? } => { Kashmiri; Devanagari; India }-->
 		<likelySubtag from="ksb" to="ksb_Latn_TZ"/>
 		<!--{ Shambala; ?; ? } => { Shambala; Latin; Tanzania }-->
 		<likelySubtag from="ksd" to="ksd_Latn_ZZ"/>
@@ -1692,8 +1688,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Malay; ?; ? } => { Malay; Latin; Malaysia }-->
 		<likelySubtag from="ms_CC" to="ms_Arab_CC"/>
 		<!--{ Malay; ?; Cocos (Keeling) Islands } => { Malay; Arabic; Cocos (Keeling) Islands }-->
-		<likelySubtag from="ms_ID" to="ms_Latn_ID"/>
-		<!--{ Malay; ?; Indonesia } => { Malay; Latin; Indonesia }-->
 		<likelySubtag from="mt" to="mt_Latn_MT"/>
 		<!--{ Maltese; ?; ? } => { Maltese; Latin; Malta }-->
 		<likelySubtag from="mtc" to="mtc_Latn_ZZ"/>

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -18,7 +18,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <!-- 2: one,other -->
 
-        <pluralRules locales="am as bn fa gu hi kn pcm zu">
+        <pluralRules locales="am as bn doi fa gu hi kn pcm zu">
             <pluralRule count="one">i = 0 or n = 1 @integer 0, 1 @decimal 0.0~1.0, 0.00~0.04</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 1.1~2.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1499,8 +1499,8 @@ XXX Code for transations where no currency is involved
 		<language type="dng" scripts="Cyrl"/>
 		<language type="dnj" scripts="Latn"/>
 		<language type="dnj" territories="CI" alt="secondary"/>
-		<language type="doi" scripts="Arab"/>
-		<language type="doi" scripts="Takr" territories="IN" alt="secondary"/>
+		<language type="doi" scripts="Deva"/>
+		<language type="doi" scripts="Arab Takr" territories="IN" alt="secondary"/>
 		<language type="dsb" scripts="Latn"/>
 		<language type="dtm" scripts="Latn"/>
 		<language type="dtp" scripts="Latn"/>
@@ -3143,7 +3143,8 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="gv" populationPercent="1.9" officialStatus="official"/>	<!--Manx-->
 		</territory>
 		<territory type="IN" gdp="9474000000000" literacyPercent="62.8" population="1296830000">	<!--India-->
-			<languagePopulation type="hi" populationPercent="41" officialStatus="official" references="R1066"/>	<!--Hindi-->
+            <languagePopulation type="hi" populationPercent="41" officialStatus="official" references="R1066"/> <!--Hindi-->
+            <languagePopulation type="hi_Latn" populationPercent="1"/> <!-- Hinglish -->
 			<languagePopulation type="en" populationPercent="19" officialStatus="official" references="R1033"/>	<!--English-->
 			<languagePopulation type="bn" populationPercent="8.1" officialStatus="official_regional" references="R1195"/>	<!--Bangla-->
 			<languagePopulation type="te" populationPercent="7.2" officialStatus="official_regional" references="R1195"/>	<!--Telugu-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1337,7 +1337,7 @@ XXX Code for transations where no currency is involved
 		<language type="ba" scripts="Cyrl"/>
 		<language type="ba" territories="RU" alt="secondary"/>
 		<language type="bal" scripts="Arab"/>
-		<language type="bal" scripts="Latn" territories="AF IR PK" alt="secondary"/>
+		<language type="bal" scripts="Latn" territories="IR PK" alt="secondary"/>
 		<language type="ban" scripts="Latn"/>
 		<language type="ban" scripts="Bali" territories="ID" alt="secondary"/>
 		<language type="bap" scripts="Deva"/>
@@ -1637,7 +1637,7 @@ XXX Code for transations where no currency is involved
 		<language type="haz" territories="AF" alt="secondary"/>
 		<language type="he" scripts="Hebr" territories="IL"/>
 		<language type="hi" scripts="Deva" territories="IN"/>
-		<language type="hi" scripts="Latn Mahj" territories="FJ ZA" alt="secondary"/>
+		<language type="hi" scripts="Latn Mahj" territories="FJ IN ZA" alt="secondary"/>
 		<language type="hif" scripts="Deva Latn" territories="FJ"/>
 		<language type="hil" scripts="Latn"/>
 		<language type="hil" territories="PH" alt="secondary"/>
@@ -2246,7 +2246,7 @@ XXX Code for transations where no currency is involved
 		<language type="tru" scripts="Latn"/>
 		<language type="tru" scripts="Syrc" alt="secondary"/>
 		<language type="trv" scripts="Latn"/>
-                <language type="trw" scripts="Arab"/>
+		<language type="trw" scripts="Arab"/>
 		<language type="ts" scripts="Latn"/>
 		<language type="ts" territories="MZ ZA" alt="secondary"/>
 		<language type="tsd" scripts="Grek"/>
@@ -2400,7 +2400,6 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="uz_Arab" populationPercent="4.7" officialStatus="official_regional"/>	<!--Uzbek (Arabic)-->
 			<languagePopulation type="tk" populationPercent="1.7" officialStatus="official_regional"/>	<!--Turkmen-->
 			<languagePopulation type="prd" populationPercent="1.2"/>	<!--Parsi-Dari-->
-			<languagePopulation type="bal" populationPercent="0.67" officialStatus="official_regional"/>	<!--Baluchi-->
 			<languagePopulation type="bgn" writingPercent="5" populationPercent="0.63" references="R1209"/>	<!--Western Balochi-->
 			<languagePopulation type="ug" populationPercent="0.0086" references="R1165"/>	<!--Uyghur-->
 			<languagePopulation type="kk_Arab" populationPercent="0.0057" references="R1119"/>	<!--Kazakh (Arabic)-->
@@ -3143,8 +3142,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="gv" populationPercent="1.9" officialStatus="official"/>	<!--Manx-->
 		</territory>
 		<territory type="IN" gdp="9474000000000" literacyPercent="62.8" population="1296830000">	<!--India-->
-            <languagePopulation type="hi" populationPercent="41" officialStatus="official" references="R1066"/> <!--Hindi-->
-            <languagePopulation type="hi_Latn" populationPercent="1"/> <!-- Hinglish -->
+			<languagePopulation type="hi" populationPercent="41" officialStatus="official" references="R1066"/>	<!--Hindi-->
 			<languagePopulation type="en" populationPercent="19" officialStatus="official" references="R1033"/>	<!--English-->
 			<languagePopulation type="bn" populationPercent="8.1" officialStatus="official_regional" references="R1195"/>	<!--Bangla-->
 			<languagePopulation type="te" populationPercent="7.2" officialStatus="official_regional" references="R1195"/>	<!--Telugu-->
@@ -3192,6 +3190,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="bhb" populationPercent="0.12"/>	<!--Bhili-->
 			<languagePopulation type="mni" populationPercent="0.11"/>	<!--Manipuri-->
 			<languagePopulation type="raj" populationPercent="0.1"/>	<!--Rajasthani-->
+			<languagePopulation type="hi_Latn" populationPercent="0.1" references="R1317"/>	<!--Hindi (Latin)-->
 			<languagePopulation type="hoc" populationPercent="0.099" references="R1195"/>	<!--Ho-->
 			<languagePopulation type="mtr" populationPercent="0.097"/>	<!--Mewari-->
 			<languagePopulation type="unr" populationPercent="0.094"/>	<!--Mundari-->
@@ -3465,7 +3464,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="en" populationPercent="93" officialStatus="official"/>	<!--English-->
 			<languagePopulation type="mh" populationPercent="73" officialStatus="official"/>	<!--Marshallese-->
 		</territory>
-		<territory type="MK" gdp="30590000000" literacyPercent="97" population="2082960">	<!--North Macedonia-->
+		<territory type="MK" gdp="31030000000" literacyPercent="97.4" population="2118950">	<!--North Macedonia-->
 			<languagePopulation type="mk" populationPercent="67" officialStatus="official"/>	<!--Macedonian-->
 			<languagePopulation type="sq" populationPercent="25" officialStatus="official_regional" references="R1053"/>	<!--Albanian-->
 			<languagePopulation type="tr" populationPercent="3.5"/>	<!--Turkish-->
@@ -3765,7 +3764,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="kxp" populationPercent="0.11"/>	<!--Wadiyara Koli-->
 			<languagePopulation type="gjk" populationPercent="0.11"/>	<!--Kachi Koli-->
 			<languagePopulation type="ks" populationPercent="0.069"/>	<!--Kashmiri-->
-                        <languagePopulation type="trw" populationPercent="0.053"/>	<!--Torwali-->
+			<languagePopulation type="trw" populationPercent="0.053"/>	<!--Torwali-->
 			<languagePopulation type="btv" populationPercent="0.019"/>	<!--Bateri-->
 		</territory>
 		<territory type="PL" gdp="1126000000000" literacyPercent="99.7" population="38420700">	<!--Poland-->
@@ -5626,6 +5625,7 @@ XXX Code for transations where no currency is involved
 		<reference type="R1314" uri="http://www.axl.cefan.ulaval.ca/afrique/soudan.htm">[missing]</reference>
 		<reference type="R1315" uri="https://en.wikipedia.org/wiki/Languages_of_Brazil">[missing]</reference>
 		<reference type="R1316" uri="http://www.bfs.admin.ch/bfs/portal/en/index/themen/01/05/blank/key/sprachen.html">[missing]</reference>
+		<reference type="R1317">No hard figures for this yet, so this is a placeholder figure.</reference>
 		<reference type="R1318" uri="https://en.wikipedia.org/wiki/Bavarian_language">Widely spoken less written, and most speakers know standard German as well</reference>
 		<reference type="R1319" uri="http://nso.gov.mt/en/publicatons/Publications_by_Unit/Documents/C1_Living_Conditions_and_Culture_Statistics/Culture_Participation_Survey_2011.pdf">[missing]</reference>
 		<reference type="R1320" uri="https://www.cia.gov/library/publications/the-world-factbook/geos/hk.html">and https://www.ethnologue.com/language/yue</reference>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1593,7 +1593,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			bo_CN br_FR brx_IN bs_Cyrl_BA bs_Latn bs_Latn_BA bss_CM byn_ER
 			ca_ES cad_US cch_NG ccp_BD ce_RU ceb_PH cgg_UG chr_US cic_US ckb_IQ co_FR cs_CZ
 			cu_RU cv_RU cy_GB
-			da_DK dav_KE de_DE dje_NE dsb_DE dua_CM dv_MV dyo_SN dz_BT
+			da_DK dav_KE de_DE dje_NE doi_IN dsb_DE dua_CM dv_MV dyo_SN dz_BT
 			ebu_KE ee_GH el_GR en_Dsrt_US en_US eo_001 es_ES et_EE eu_ES ewo_CM
 			fa_IR ff_Adlm_GN ff_Latn ff_Latn_SN fi_FI fil_PH fo_FO fr_FR fur_IT fy_NL
 			ga_IE gaa_GH gd_GB gez_ET gl_ES gn_PY gsw_CH gu_IN guz_KE gv_IM
@@ -1608,7 +1608,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			mn_Mong_CN mni_Beng mni_Beng_IN mni_Mtei_IN moh_CA mr_IN ms_Arab_MY ms_MY mt_MT
 			mua_CM mus_US my_MM myv_RU mzn_IR
 			naq_NA nb_NO nd_ZW nds_DE ne_NP nl_NL nmg_CM nn_NO nnh_CM nqo_GN nr_ZA nso_ZA
-			nus_SS ny_MW nyn_UG
+			nus_SS nv_US ny_MW nyn_UG
 			oc_FR om_ET or_IN os_GE osa_US
 			pa_Arab_PK pa_Guru pa_Guru_IN pcm_NG pl_PL prg_001 ps_AF pt_BR
 			qu_PE quc_GT

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1591,9 +1591,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 			az_Arab_IR az_Cyrl_AZ az_Latn az_Latn_AZ
 			ba_RU bas_CM be_BY bem_ZM bez_TZ bg_BG bgn_PK blt_VN bm_ML bm_Nkoo_ML bn_BD
 			bo_CN br_FR brx_IN bs_Cyrl_BA bs_Latn bs_Latn_BA bss_CM byn_ER
-			ca_ES cad_US cch_NG ccp_BD ce_RU ceb_PH cgg_UG chr_US cic_US ckb_IQ co_FR cs_CZ cu_RU
-			cv_RU cy_GB
-			da_DK dav_KE de_DE dje_NE doi_IN dsb_DE dua_CM dv_MV dyo_SN dz_BT
+			ca_ES cad_US cch_NG ccp_BD ce_RU ceb_PH cgg_UG chr_US cic_US ckb_IQ co_FR cs_CZ
+			cu_RU cv_RU cy_GB
+			da_DK dav_KE de_DE dje_NE dsb_DE dua_CM dv_MV dyo_SN dz_BT
 			ebu_KE ee_GH el_GR en_Dsrt_US en_US eo_001 es_ES et_EE eu_ES ewo_CM
 			fa_IR ff_Adlm_GN ff_Latn ff_Latn_SN fi_FI fil_PH fo_FO fr_FR fur_IT fy_NL
 			ga_IE gaa_GH gd_GB gez_ET gl_ES gn_PY gsw_CH gu_IN guz_KE gv_IM
@@ -1601,24 +1601,25 @@ For terms of use, see http://www.unicode.org/copyright.html
 			ia_001 id_ID ife_TG ig_NG ii_CN io_001 is_IS it_IT iu_CA iu_Latn_CA
 			ja_JP jbo_001 jgo_CM jmc_TZ jv_ID
 			ka_GE kab_DZ kaj_NG kam_KE kcg_NG kde_TZ kea_CV ken_CM khq_ML ki_KE kk_KZ
-			kkj_CM kl_GL kln_KE km_KH kn_IN ko_KR kok_IN kpe_LR ks_Arab ks_Arab_IN ks_Deva_IN ksb_TZ ksf_CM ksh_DE
-			ku_TR kw_GB ky_KG
+			kkj_CM kl_GL kln_KE km_KH kn_IN ko_KR kok_IN kpe_LR ks_Arab ks_Arab_IN
+			ks_Deva_IN ksb_TZ ksf_CM ksh_DE ku_TR kw_GB ky_KG
 			lag_TZ lb_LU lg_UG lkt_US ln_CD lo_LA lrc_IR lt_LT lu_CD luo_KE luy_KE lv_LV
-			mai_IN mas_KE mer_KE mfe_MU mg_MG mgh_MZ mgo_CM mi_NZ mk_MK ml_IN mn_MN mn_Mong_CN
-			mni_Beng mni_Beng_IN mni_Mtei_IN moh_CA mr_IN ms_Arab_MY ms_MY mt_MT mua_CM mus_US my_MM myv_RU mzn_IR
+			mai_IN mas_KE mer_KE mfe_MU mg_MG mgh_MZ mgo_CM mi_NZ mk_MK ml_IN mn_MN
+			mn_Mong_CN mni_Beng mni_Beng_IN mni_Mtei_IN moh_CA mr_IN ms_Arab_MY ms_MY mt_MT
+			mua_CM mus_US my_MM myv_RU mzn_IR
 			naq_NA nb_NO nd_ZW nds_DE ne_NP nl_NL nmg_CM nn_NO nnh_CM nqo_GN nr_ZA nso_ZA
-			nus_SS nv_US ny_MW nyn_UG
+			nus_SS ny_MW nyn_UG
 			oc_FR om_ET or_IN os_GE osa_US
 			pa_Arab_PK pa_Guru pa_Guru_IN pcm_NG pl_PL prg_001 ps_AF pt_BR
 			qu_PE quc_GT
 			rm_CH rn_BI ro_RO rof_TZ ru_RU rw_RW rwk_TZ
 			sa_IN sah_RU saq_KE sat_Deva_IN sat_Olck sat_Olck_IN sbp_TZ sc_IT scn_IT
-			sd_Arab sd_Arab_PK sd_Deva_IN sdh_IR se_NO seh_MZ ses_ML sg_CF
-			shi_Latn_MA shi_Tfng shi_Tfng_MA si_LK sid_ET sk_SK sl_SI sma_SE smj_SE smn_FI
-			sms_FI sn_ZW so_SO sq_AL sr_Cyrl sr_Cyrl_RS sr_Latn_RS ss_ZA ssy_ER st_ZA
-			su_Latn su_Latn_ID sv_SE sw_TZ syr_IQ szl_PL
-			ta_IN te_IN teo_UG tg_TJ th_TH ti_ET tig_ER tk_TM tn_ZA to_TO tr_TR trv_TW trw_PK
-			ts_ZA tt_RU twq_NE tzm_MA
+			sd_Arab sd_Arab_PK sd_Deva_IN sdh_IR se_NO seh_MZ ses_ML sg_CF shi_Latn_MA
+			shi_Tfng shi_Tfng_MA si_LK sid_ET sk_SK sl_SI sma_SE smj_SE smn_FI sms_FI sn_ZW
+			so_SO sq_AL sr_Cyrl sr_Cyrl_RS sr_Latn_RS ss_ZA ssy_ER st_ZA su_Latn su_Latn_ID
+			sv_SE sw_TZ syr_IQ szl_PL
+			ta_IN te_IN teo_UG tg_TJ th_TH ti_ET tig_ER tk_TM tn_ZA to_TO tr_TR trv_TW
+			trw_PK ts_ZA tt_RU twq_NE tzm_MA
 			ug_CN uk_UA ur_PK uz_Arab_AF uz_Cyrl_UZ uz_Latn uz_Latn_UZ
 			vai_Latn_LR vai_Vaii vai_Vaii_LR ve_ZA vi_VN vo_001 vun_TZ
 			wa_BE wae_CH wal_ET wbp_AU wo_SN

--- a/seed/main/doi.xml
+++ b/seed/main/doi.xml
@@ -11,10 +11,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="doi"/>
 	</identity>
 	<characters>
-		<exemplarCharacters>[\u0951\u0952 \u093C \u0901 \u0902 ः ॐ अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह ऽ ा ि ी \u0941 \u0942 \u0943 \u0944 \u0962 \u0963 \u0947 \u0948 ो ौ \u094D अ, आ, इ, ई, उ, ऊ, ऋ, ऌ, ॡ, ए, ऐ, ओ, औ, अं, अ:, क, ख, ग, घ, डं, च, छ, ज, झ, ञ, ट, ठ, ड , ढ, ण, {ड़ , ढ़} त, थ, द, ध, न, प, फ, ब, भ, म, य, र, ल, व, श, ष, स, ह, क्ष, त्र, ज्ञ, श्र]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[\u200C\u200D ऍ ऑ \u0945 ॉ अ, आ, इ, ई, उ, ऊ, ऋ, ए, ऐ, ओ, औ, अं, अ:]</exemplarCharacters>
+		<exemplarCharacters>[\u0951\u0952 \u093C \u0901 \u0902 ः ॐ अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह ऽ ा ि ी \u0941 \u0942 \u0943 \u0944 \u0962 \u0963 \u0947 \u0948 ो ौ \u094D अ आ इ ई उ ऊ ऋ ऌ ॡ ए ऐ ओ औ अं अ: क ख ग घ डं च छ ज झ ञ ट ठ ड  ढ ण {ड़} {ढ़} त थ द ध न प फ ब भ म य र ल व श ष स ह {क्ष} त्र ज्ञ श्र]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[\u200C\u200D ऍ ऑ \u0945]</exemplarCharacters>
         <exemplarCharacters type="index" draft="contributed">[अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह]</exemplarCharacters>
-        <exemplarCharacters type="punctuation" draft="contributed">[_ – — , ; : ! ? . … ' ‘ ’ " “ ” ( ) § @ * / &amp; # † ‡ ′ ″]</exemplarCharacters>
+        <exemplarCharacters type="punctuation" draft="contributed">[_ \– \— , ; : ! ? . … ' ‘ ’ " “ ” ( ) § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
 	</characters>
     <numbers>
         <defaultNumberingSystem draft="contributed">latn</defaultNumberingSystem>

--- a/seed/main/doi.xml
+++ b/seed/main/doi.xml
@@ -11,8 +11,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="doi"/>
 	</identity>
 	<characters>
-		<exemplarCharacters>[\u0951\u0952 \u093C \u0901 \u0902 ः ॐ अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह ऽ ा ि ी \u0941 \u0942 \u0943 \u0944 \u0962 \u0963 \u0947 \u0948 ो ौ \u094D]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[\u200C\u200D ऍ ऑ \u0945 ॉ]</exemplarCharacters>
-		<exemplarCharacters type="index" draft="contributed">[अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह]</exemplarCharacters>
+		<exemplarCharacters>[\u0951\u0952 \u093C \u0901 \u0902 ः ॐ अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह ऽ ा ि ी \u0941 \u0942 \u0943 \u0944 \u0962 \u0963 \u0947 \u0948 ो ौ \u094D अ, आ, इ, ई, उ, ऊ, ऋ, ऌ, ॡ, ए, ऐ, ओ, औ, अं, अ:, क, ख, ग, घ, डं, च, छ, ज, झ, ञ, ट, ठ, ड , ढ, ण, {ड़ , ढ़} त, थ, द, ध, न, प, फ, ब, भ, म, य, र, ल, व, श, ष, स, ह, क्ष, त्र, ज्ञ, श्र]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[\u200C\u200D ऍ ऑ \u0945 ॉ अ, आ, इ, ई, उ, ऊ, ऋ, ए, ऐ, ओ, औ, अं, अ:]</exemplarCharacters>
+        <exemplarCharacters type="index" draft="contributed">[अ आ इ ई उ ऊ ऋ ॠ ऌ ॡ ए ऐ ओ औ क ख ग घ ङ च छ ज झ ञ ट ठ ड ढ ण त थ द ध न प फ ब भ म य र ल ळ व श ष स ह]</exemplarCharacters>
+        <exemplarCharacters type="punctuation" draft="contributed">[_ – — , ; : ! ? . … ' ‘ ’ " “ ” ( ) § @ * / &amp; # † ‡ ′ ″]</exemplarCharacters>
 	</characters>
+    <numbers>
+        <defaultNumberingSystem draft="contributed">latn</defaultNumberingSystem>
+        <otherNumberingSystems>
+            <native>deva</native>
+        </otherNumberingSystems>
+	</numbers>
 </ldml>

--- a/seed/main/doi_IN.xml
+++ b/seed/main/doi_IN.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="doi"/>
+		<territory type="IN"/>
+	</identity>
+</ldml>

--- a/seed/main/nv_US.xml
+++ b/seed/main/nv_US.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="nv"/>
+		<territory type="US"/>
+	</identity>
+</ldml>

--- a/tools/java/org/unicode/cldr/draft/ScriptMetadata.java
+++ b/tools/java/org/unicode/cldr/draft/ScriptMetadata.java
@@ -172,7 +172,7 @@ public class ScriptMetadata {
             density = Column.DENSITY.getInt(items, -1);
 
             final String countryRaw = Column.ORIGIN_COUNTRY.getItem(items);
-            String country = CountryCodeConverter.getCodeFromName(countryRaw);
+            String country = CountryCodeConverter.getCodeFromName(countryRaw, false);
             // NAME_TO_REGION_CODE.get(countryRaw.toUpperCase(Locale.ENGLISH));
             if (country == null) {
                 errors.add("Can't map " + countryRaw + " to country/region");

--- a/tools/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/java/org/unicode/cldr/test/CheckExemplars.java
@@ -356,7 +356,7 @@ public class CheckExemplars extends FactoryCheckCLDR {
         } catch (Exception e) {
             result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.errorType)
                 .setSubtype(Subtype.illegalExemplarSet)
-                .setMessage("This field must be a set of the form [a b c-d ...]: ", new Object[] { e.getMessage() }));
+                .setMessage("This field must be a set of the form [a b c-d ...]: {0}", new Object[] { e.getMessage() }));
             return;
         }
 

--- a/tools/java/org/unicode/cldr/tool/AddPopulationData.java
+++ b/tools/java/org/unicode/cldr/tool/AddPopulationData.java
@@ -97,7 +97,7 @@ public class AddPopulationData {
         Set<String> altNames = new TreeSet<String>();
         String oldCode = "";
         for (String display : CountryCodeConverter.names()) {
-            String code = CountryCodeConverter.getCodeFromName(display);
+            String code = CountryCodeConverter.getCodeFromName(display, true);
             String icu = ULocale.getDisplayCountry("und-" + code, "en");
             if (!display.equalsIgnoreCase(icu)) {
                 altNames.add(code + "\t" + display + "\t" + icu);
@@ -201,7 +201,7 @@ public class AddPopulationData {
                     return false;
                 }
                 String[] pieces = line.split("\\s{2,}");
-                String code = CountryCodeConverter.getCodeFromName(FBLine.Country.get(pieces));
+                String code = CountryCodeConverter.getCodeFromName(FBLine.Country.get(pieces), true);
                 if (code == null) {
                     return false;
                 }
@@ -293,7 +293,7 @@ public class AddPopulationData {
         CldrUtility.handleFile(filename, new LineHandler() {
             public boolean handle(String line) {
                 String[] pieces = line.split("\\t");
-                String code = CountryCodeConverter.getCodeFromName(FBLiteracy.Country.get(pieces));
+                String code = CountryCodeConverter.getCodeFromName(FBLiteracy.Country.get(pieces), true);
                 if (code == null) {
                     return false;
                 }
@@ -344,7 +344,7 @@ public class AddPopulationData {
                 if (last == null) {
                     return false;
                 }
-                String country = CountryCodeConverter.getCodeFromName(WBLine.Country_Name.get(pieces));
+                String country = CountryCodeConverter.getCodeFromName(WBLine.Country_Name.get(pieces), true);
                 if (country == null) {
                     return false;
                 }
@@ -383,7 +383,7 @@ public class AddPopulationData {
                 if (pieces.length != 14 || pieces[1].length() == 0 || !DIGITS.containsAll(pieces[1])) {
                     return false;
                 }
-                String code = CountryCodeConverter.getCodeFromName(pieces[0]);
+                String code = CountryCodeConverter.getCodeFromName(pieces[0], true);
                 if (code == null) {
                     return false;
                 }
@@ -437,7 +437,7 @@ public class AddPopulationData {
             }
             if (myErrors.length() != 0) {
                 throw new IllegalArgumentException(
-                    "Missing Country values, the following and add to external/other_country_data to fix:"
+                    "Missing Country values, the following and add to external/other_country_data to fix, chaning the 0 to the real value:"
                         + myErrors);
             }
         } catch (IOException e) {

--- a/tools/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -1978,7 +1978,7 @@ public class ConvertLanguageData {
                 String[] territoryList = parts[4].split("\\s*[;,-]\\s*");
                 for (String territoryName : territoryList) {
                     if (territoryName.equals("ISO/DIS 639") || territoryName.equals("3")) continue;
-                    String territoryCode = CountryCodeConverter.getCodeFromName(territoryName);
+                    String territoryCode = CountryCodeConverter.getCodeFromName(territoryName, true);
                     if (territoryCode == null) {
                         BadItem.ERROR.show("no name found for territory", "<" + territoryName + ">", languageSubtag);
                     } else {

--- a/tools/java/org/unicode/cldr/tool/CountryCodeConverter.java
+++ b/tools/java/org/unicode/cldr/tool/CountryCodeConverter.java
@@ -23,7 +23,7 @@ public class CountryCodeConverter {
     private static Map<String, String> nameToCountryCode = new TreeMap<String, String>(new UTF16.StringComparator(true, true, 0));
     private static Set<String> parseErrors = new LinkedHashSet<String>();
 
-    public static String getCodeFromName(String display) {
+    public static String getCodeFromName(String display, boolean showMissing) {
         String trial = display.trim().toLowerCase(Locale.ENGLISH);
         if (trial.startsWith("\"") && trial.endsWith("\"")) {
             trial = trial.substring(1, trial.length() - 2);
@@ -44,8 +44,8 @@ public class CountryCodeConverter {
                 // }
             }
         }
-        if (SHOW_SKIP && result == null) {
-            System.out.println("Missing code; add to external/alternate_country_names.txt a line like:" +
+        if (result == null && (showMissing || SHOW_SKIP)) {
+            System.err.println("CountryCodeConverter missing code; add to external/alternate_country_names.txt a line like:" +
                 "\t<code>;\t<name>;\t" + display);
         }
         return result;

--- a/tools/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.draft.ScriptMetadata;
 import org.unicode.cldr.draft.ScriptMetadata.Info;
 import org.unicode.cldr.util.Builder;
+import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
@@ -34,6 +35,7 @@ import org.unicode.cldr.util.Iso639Data.Scope;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.Log;
+import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes;
@@ -98,6 +100,7 @@ public class GenerateMaximalLocales {
         new File(CLDRPaths.EXEMPLARS_DIRECTORY) };
 
     private static Factory factory = SimpleFactory.make(list, ".*");
+    private static Factory mainFactory = CLDRConfig.getInstance().getCldrFactory();
     private static SupplementalDataInfo supplementalData = SupplementalDataInfo
         .getInstance(CLDRPaths.SUPPLEMENTAL_DIRECTORY);
     private static StandardCodes standardCodes = StandardCodes.make();
@@ -284,6 +287,7 @@ public class GenerateMaximalLocales {
         { "mis_Medf", "mis_Medf_NG" },
 
         { "ku_Yezi", "ku_Yezi_GE" },
+        { "und_EU", "en_Latn_IE" },
     });
 
     /**
@@ -525,6 +529,7 @@ public class GenerateMaximalLocales {
          *
          * B. X is an exception explicitly approved by the committee or X has minimal
          * language coverage‡ in CLDR itself.
+         * C. The language is in the CLDR-target locales
          */
         OfficialStatus minimalStatus = OfficialStatus.official_regional; // OfficialStatus.de_facto_official;
         Map<String, String> languages = new TreeMap<String, String>();
@@ -539,6 +544,9 @@ public class GenerateMaximalLocales {
             System.out.println(language + "\t" + languages.get(language));
         }
 
+        // also CLDR-target locales
+        final Set<String> CLDRMainLanguages = new TreeSet<>(StandardCodes.make().getLocaleCoverageLocales(Organization.cldr));
+        
         for (String territory : supplementalData.getTerritoriesWithPopulationData()) {
             PopulationData territoryPop = supplementalData.getPopulationDataForTerritory(territory);
             double territoryPopulation = territoryPop.getLiteratePopulation();
@@ -566,6 +574,9 @@ public class GenerateMaximalLocales {
                 // #3
                 if (literatePopulation > minTerritoryPopulation
                     && literatePopulation > minTerritoryPercent * territoryPopulation) {
+                    add = true;
+                }
+                if (add == false && CLDRMainLanguages.contains(language)) {
                     add = true;
                 }
                 if (add) {
@@ -727,7 +738,11 @@ public class GenerateMaximalLocales {
         Set<String> suppressScriptLocales = new HashSet<String>(Arrays.asList(
             "bm_ML", "en_US", "ha_NG", "iu_CA", "ms_MY", "mn_MN",
             "byn_ER", "ff_SN", "dyo_SN", "kk_KZ", "ku_TR", "ky_KG", "ml_IN", "so_SO", "sw_TZ", "wo_SN", "yo_NG", "dje_NE",
-            "blt_VN"));
+            "blt_VN",
+            "hi_IN",
+            "nv_US",
+            "doi_IN"
+            ));
 
         // if any have a script, then throw out any that don't have a script (unless they're specifically included.)
         Set<String> toRemove = new TreeSet<String>();
@@ -740,7 +755,7 @@ public class GenerateMaximalLocales {
                 }
             }
             if (toRemove.size() != 0) {
-                System.out.println("Removing:\t" + locale + "\t" + toRemove + "\tfrom\t" + children);
+                System.out.println("\tRemoving:\t" + locale + "\t" + toRemove + "\tfrom\t" + children);
                 toChildren.removeAll(locale, toRemove);
             }
         }
@@ -1338,7 +1353,7 @@ public class GenerateMaximalLocales {
         String oldValue = toAdd.get(key);
         if (oldValue == null) {
             if (showAction) {
-                System.out.println("Adding:\t\t" + getName(key) + "\t=>\t" + getName(value) + "\t\t\t\t" + kind);
+                System.out.println("\tAdding:\t\t" + getName(key) + "\t=>\t" + getName(value) + "\t\t\t\t" + kind);
             }
         } else if (override == Override.KEEP_EXISTING || value.equals(oldValue)) {
             // if (showAction) {
@@ -1347,7 +1362,7 @@ public class GenerateMaximalLocales {
             return;
         } else {
             if (showAction) {
-                System.out.println("Replacing:\t" + getName(key) + "\t=>\t" + getName(value) + "\t, was\t" + getName(oldValue) + "\t\t" + kind);
+                System.out.println("\tReplacing:\t" + getName(key) + "\t=>\t" + getName(value) + "\t, was\t" + getName(oldValue) + "\t\t" + kind);
             }
         }
         toAdd.put(key, value);

--- a/tools/java/org/unicode/cldr/util/SpreadSheet.java
+++ b/tools/java/org/unicode/cldr/util/SpreadSheet.java
@@ -20,6 +20,9 @@ public class SpreadSheet {
         while (true) {
             String line = r.readLine();
             if (line == null) break;
+            if (line.startsWith("#")) {
+                continue;
+            }
             if (DEBUG) {
                 System.out.println("Spreadsheet:\t" + line);
             }

--- a/tools/java/org/unicode/cldr/util/Unlocode.java
+++ b/tools/java/org/unicode/cldr/util/Unlocode.java
@@ -645,7 +645,7 @@ public class Unlocode {
     static final Transform<String, String> REMOVE_ACCENTS = Transliterator.getInstance("nfd;[:mn:]remove");
 
     static void add(String countryName, String subdivision, String cityName, Relation<String, LocodeData> countryNameToCities, Set<String> errors2) {
-        String countryCode = CountryCodeConverter.getCodeFromName(countryName);
+        String countryCode = CountryCodeConverter.getCodeFromName(countryName, false);
         if (countryCode == null) {
             if (noncountries.contains(countryName)) {
                 return; // skip

--- a/tools/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -69,9 +69,9 @@ public class WikipediaOfficialLanguages {
             //"British Antarctic Territory",
             "British Indian Ocean Territory", "British Virgin Islands", "Cayman Islands", "Falkland Islands", "Gibraltar",
             "Montserrat", "Pitcairn Islands", "Saint Helena", "Ascension Island", "Tristan da Cunha")) {
-            String region = CountryCodeConverter.getCodeFromName(s);
+            String region = CountryCodeConverter.getCodeFromName(s, false);
             if (region == null) {
-                System.out.println("Couldn't parse region: <" + s + ">");
+                System.err.println("Couldn't parse region: <" + s + ">");
             } else {
                 REPLACE_REGIONS.put("United Kingdom and overseas territories", region);
             }
@@ -79,9 +79,9 @@ public class WikipediaOfficialLanguages {
         for (String s : Arrays.asList("French Guiana", "French Polynesia", "Guadeloupe", "Martinique",
             "Mayotte", "New Caledonia", "Réunion", "Saint Barthélemy", "Saint Martin", "Saint Pierre and Miquelon",
             "Wallis and Futuna")) {
-            String region = CountryCodeConverter.getCodeFromName(s);
+            String region = CountryCodeConverter.getCodeFromName(s, false);
             if (region == null) {
-                System.out.println("Couldn't parse region: <" + s + ">");
+                System.err.println("Couldn't parse region: <" + s + ">");
             } else {
                 REPLACE_REGIONS.put("France and overseas departments and territories", region);
             }
@@ -111,9 +111,9 @@ public class WikipediaOfficialLanguages {
                         continue;
                     }
 
-                    String region = CountryCodeConverter.getCodeFromName(items[0]);
+                    String region = CountryCodeConverter.getCodeFromName(items[0], false);
                     if (region == null) {
-                        System.out.println(++count + " Couldn't parse region: <" + items[0] + "> in line: " + line);
+                        System.err.println(++count + " Couldn't parse region: <" + items[0] + "> in line: " + line);
                         regionSet = Collections.emptySet();
                     } else {
                         regionSet = new HashSet<String>();
@@ -194,7 +194,7 @@ public class WikipediaOfficialLanguages {
             if (part.isEmpty() || part.equals("de facto")) {
                 continue;
             }
-            String region = CountryCodeConverter.getCodeFromName(part);
+            String region = CountryCodeConverter.getCodeFromName(part, false);
             if (region == null) {
                 System.err.println("* Can't convert " + region + " in " + part);
             } else {

--- a/tools/java/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/java/org/unicode/cldr/util/data/Locales.txt
@@ -312,7 +312,7 @@ Google	; mai ; basic ; Maithili (Devanagari script)
 Google    ; nn ; Moderate ; Nynorsk
 Google    ; sa ; basic ; Sanskrit
 Google    ; doi ; basic ; Dogri
-Google    ; nv ; basic ; Navajo
+#Google    ; nv ; basic ; Navajo
 
 #Google Tier TR
 Google	;	es_US	;	modern	; TR Spanish (United States)
@@ -452,7 +452,7 @@ Apple	;	yi	;	basic
 
 Apple    ; sa ; basic ; Sanskrit
 Apple    ; doi ; basic ; Dogri
-Apple    ; nv ; basic ; Navajo
+#Apple    ; nv ; basic ; Navajo
 
 Adobe	;	ar	;	basic
 Adobe	;	az	;	basic
@@ -653,7 +653,7 @@ Cldr	; pcm ; basic ; Nigerian Pidgin
 Cldr    ; nn ; Moderate ; Nynorsk
 Cldr    ; sa ; basic ; Sanskrit
 Cldr    ; doi ; basic ; Dogri
-Cldr    ; nv ; basic ; Navajo
+#Cldr    ; nv ; basic ; Navajo
 
 Bangor_Univ ;   cy   ;    modern  ; Welsh
 Bangor_Univ ;   *    ;    moderate  ; All others
@@ -827,7 +827,7 @@ Microsoft	;	yo	;	basic
 Microsoft    ; nn ; Moderate ; Nynorsk
 Microsoft    ; sa ; basic ; Sanskrit
 Microsoft    ; doi ; basic ; Dogri
-Microsoft    ; nv ; basic ; Navajo
+#Microsoft    ; nv ; basic ; Navajo
 
 
 Pakistan	;	ur	;	modern	;	Urdu

--- a/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/java/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -1,4 +1,7 @@
-*	CName	CCode	CPopulation	CLiteracy	CGdp	OfficialStatus	Language	LCode	LPopulation	WritingPop	References	Notes
+#	CName	CCode	CPopulation	CLiteracy	CGdp	OfficialStatus	Language	LCode	LPopulation	WritingPop	References	Notes
+#######
+#WARNING: this file is in TSV format (for pasting from a spreadsheet); make sure you maintain tabs!
+#######
 Afghanistan	AF	"34,940,837"	28%	"69,450,000,000"	official_regional	Baluchi	bal	"233,000"			
 Afghanistan	AF	"34,940,837"	28%	"69,450,000,000"		Hazaragi	haz	5.9%			
 Afghanistan	AF	"34,940,837"	28%	"69,450,000,000"		Kazakh (Arabic)	kk_Arab	"2,000"			"http://en.wikipedia.org/wiki/Kazakh_language - the script is an assumption, needs a reference"
@@ -501,6 +504,7 @@ India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Gujarati	gu	4
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Hadothi	hoj	"1,060,000"			
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Haryanvi	bgc	"15,600,000"	55%		http://en.wikipedia.org/wiki/Haryanvi http://www.indianetzone.com/7/haryanvi.htm little literature mostly folksongs; writers use std Hindi; claim of 55% literacy
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official	Hindi	hi	41%			"http://www.censusindia.net/ Figure for Hindi includes 2nd language users, India Census data."
+India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Hindi (Latn)	hi_Latn	0.1%			"No hard figures for this yet, so this is a placeholder figure."
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Ho	hoc	"1,290,000"			https://www.cia.gov/library/publications/the-world-factbook/geos/in.html
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Kachhi	kfr	"968,000"			
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Kanauji	bjj	"7,200,000"	60%		

--- a/tools/java/org/unicode/cldr/util/data/external/alternate_country_names.txt
+++ b/tools/java/org/unicode/cldr/util/data/external/alternate_country_names.txt
@@ -46,7 +46,7 @@ FM; Micronesia; Fed. Sts. Micronesia
 FM; Micronesia; Federated States of Micronesia
 FM; Micronesia; Micronesia, Fed. Sts.
 FM; Micronesia; Micronesia, Federated States of
-FM; ; Micronesia (Federated States of)
+FM; Micronesia; Micronesia (Federated States of)
 
 FO; Faroe Islands; Faeroe Islands
 
@@ -75,11 +75,14 @@ KP; North Korea; Dem. Rep. Korea
 KP; North Korea; Democratic People's Republic of Korea
 KP; North Korea; Korea, Dem. Rep.
 KP; North Korea; Korea, Democratic People's Republic of
+KP;	North Korea; Korea, North
+KP;	North Korea; Korea, Dem. People’s Rep.
 
 KR; South Korea; Korea, Rep.
 KR; South Korea; Korea, Republic of
 KR; South Korea; Rep. Korea
 KR; South Korea; Republic of Korea
+KR;	South Korea;	Korea, South
 
 LA; Laos; Lao PDR
 LA; Laos; Lao People's Democratic Republic
@@ -97,6 +100,7 @@ MK; Macedonia; Macedonia, The Former Yugoslav Republic of
 MK; Macedonia; The Former Yugoslav Rep. of Macedonia
 MK; Macedonia; The Former Yugoslav Republic of Macedonia
 MK; Macedonia; TFYR of Macedonia
+MK;	Macedonia;	Macedonia
 
 MM; Myanmar; Burma
 
@@ -128,6 +132,7 @@ SK; Slovakia; Slovak Republic
 SY; Syria; Syrian Arab Republic
 
 SZ; Eswatini; eSwatini; Swaziland 
+SZ; Eswatini;	Swaziland
 
 SH; Saint Helena; Saint Helena, Ascension, and Tristan da Cunha
 
@@ -232,3 +237,4 @@ skip;	skip;	Sub-Saharan Africa (all income levels)
 skip;	skip;	Sub-Saharan Africa (developing only)
 skip;	skip;	Sudan (pre-secession)
 skip;	skip;	Upper middle income
+skip;	skip;	Paracel Islands

--- a/tools/java/org/unicode/cldr/util/data/language_script_raw.txt
+++ b/tools/java/org/unicode/cldr/util/data/language_script_raw.txt
@@ -1,4 +1,7 @@
 #Lcode	LanguageName	Status	Scode	ScriptName	References
+#######
+#WARNING: this file is in TSV format (for pasting from a spreadsheet); make sure you maintain tabs!
+#######
 aa	Afar	primary	Latn	Latin
 ab	Abkhazian	primary	Cyrl	Cyrillic
 abq	Abaza	primary	Cyrl	Cyrillic
@@ -183,7 +186,8 @@ din	Dinka	primary	Latn	Latin
 dje	Zarma	primary	Latn	Latin
 dng	Dungan	primary	Cyrl	Cyrillic
 dnj	Dan	primary	Latn	Latin
-doi	Dogri	primary	Arab	Arabic
+doi	Dogri	primary	Deva	Devanagari
+doi	Dogri	secondary	Arab	Arabic
 doi	Dogri	secondary	Takr	Takri
 dsb	Lower Sorbian	primary	Latn	Latin
 dtm	Tomo Kan Dogon	primary	Latn	Latin
@@ -804,7 +808,7 @@ tr	Turkish	secondary	Arab	Arabic
 tru	Turoyo	primary	Latn	Latin
 tru	Turoyo	secondary	Syrc	Syriac
 trv	Taroko	primary	Latn	Latin
-trw     Torwali primary Arab    Arabic
+trw	Torwali	primary	Arab	Arabic
 ts	Tsonga	primary	Latn	Latin
 tsd	Tsakonian	primary	Grek	Greek
 tsg	Tausug	primary	Latn	Latin


### PR DESCRIPTION
…for EU to en-IE (now that GB has left, would change to German if we just went by country, so this restores an en)

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13836
- [ ] Updated PR title and link in previous line to include Issue number

