### PR TITLE
CLDR-13750 Replace custom comparison logic with JDK comparators

### DIFF
--- a/tools/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -1,8 +1,9 @@
 package org.unicode.cldr.tool;
 
+import static com.google.common.collect.Comparators.lexicographical;
+
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
@@ -30,7 +31,6 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.TempPrintWriter;
 
 import com.google.common.base.Joiner;
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.MessageFormat;
@@ -221,15 +221,14 @@ public class GeneratePluralRanges {
     private final SupplementalDataInfo SUPPLEMENTAL;
     private final PluralRulesFactory prf;
 
-    public static final Comparator<Set<String>> STRING_SET_COMPARATOR = new SetComparator<>();
-    public static final Comparator<Set<Count>> COUNT_SET_COMPARATOR = new SetComparator<>();
-
-    static final class SetComparator<T extends Comparable<T>, U extends Set<T>> implements Comparator<U> {
-        @Override
-        public int compare(U o1, U o2) {
-            return CollectionUtilities.compare((Collection<T>) o1, (Collection<T>) o2);
-        }
-    }
+    // Ordering by size-of-set first, and then lexicographically, with a final tie-break on the
+    // string representation.
+    private static final Comparator<Set<String>> STRING_SET_COMPARATOR =
+        Comparator.<Set<String>, Integer>comparing(Set::size)
+            .thenComparing(lexicographical(Comparator.<String>naturalOrder()));
+    private static final Comparator<Set<Count>> COUNT_SET_COMPARATOR =
+        Comparator.<Set<Count>, Integer>comparing(Set::size)
+            .thenComparing(lexicographical(Comparator.<Count>naturalOrder()));
 
     public void reformatPluralRanges() {
         Map<Set<Count>, Relation<Set<String>, String>> seen = new TreeMap<>(COUNT_SET_COMPARATOR);

--- a/tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
+++ b/tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
@@ -1,18 +1,21 @@
 package org.unicode.cldr.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Comparators.lexicographical;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.ibm.icu.dev.util.CollectionUtilities;
 
 public final class PreferredAndAllowedHour implements Comparable<PreferredAndAllowedHour> {
-
+    // DO NOT change enum item names, they are mapped directly from data values via "valueOf".
     public enum HourStyle {
         H, Hb(H), HB(H), k, h, hb(h), hB(h), K;
         public final HourStyle base;
@@ -29,77 +32,77 @@ public final class PreferredAndAllowedHour implements Comparable<PreferredAndAll
             try {
                 HourStyle.valueOf(c);
                 return true;
-            } catch (Exception e) {
+            } catch (IllegalArgumentException e) {
                 return false;
             }
         }
     }
 
+    // For splitting the style ID string.
+    private static final Splitter SPACE_SPLITTER = Splitter.on(' ').trimResults();
+
+    // If this used "getter" method references it wouldn't need so much explicit generic typing.
+    private static final Comparator<PreferredAndAllowedHour> COMPARATOR =
+        Comparator.<PreferredAndAllowedHour, HourStyle>comparing(t -> t.preferred)
+            .thenComparing(t -> t.allowed, lexicographical(Comparator.<HourStyle>naturalOrder()));
+
     public final HourStyle preferred;
-    public final List<HourStyle> allowed;
+    /** Unique allowed styles, in the order they were specified during construction. */
+    public final ImmutableList<HourStyle> allowed;
 
-    public PreferredAndAllowedHour(char preferred, Collection<Character> allowed) {
-        this(HourStyle.valueOf(String.valueOf(preferred)), mungeSet(allowed));
+    /**
+     * Creates a PreferredAndAllowedHour instance with "allowed" styles derived from single
+     * character IDs in the given collection. Note that the iteration order of the allowed
+     * styles is retained.
+     *
+     * <p>This constructor is limiting, since some styles are identified by two character
+     * strings, which cannot be referenced via this constructor.
+     */
+    public PreferredAndAllowedHour(char preferred, Set<Character> allowed) {
+        this(String.valueOf(preferred), allowed.stream().map(String::valueOf));
     }
 
-    public PreferredAndAllowedHour(Collection<HourStyle> allowed) {
-        this(allowed.iterator().next(), allowed);
+    /**
+     * Creates a PreferredAndAllowedHour instance with "allowed" styles derived from a space
+     * separated list of unique IDs. Note that the iteration order of the allowed styles is
+     * retained, since in some situations it is necessary that the preferred style should
+     * also be the first allowed style. The list of allowed style IDs must not contain
+     * duplicates.
+     */
+    public PreferredAndAllowedHour(String preferred, String allowedString) {
+        this(preferred, SPACE_SPLITTER.splitToList(allowedString).stream());
     }
 
-    public PreferredAndAllowedHour(HourStyle preferred, Collection<HourStyle> allowed) {
-        if (preferred == null) {
-            throw new NullPointerException();
-        }
-        if (!allowed.contains(preferred)) {
-            throw new IllegalArgumentException("Allowed (" + allowed +
-                ") must contain preferred(" + preferred +
-                ")");
-        }
-        this.preferred = preferred;
-        this.allowed = ImmutableList.copyOf(new LinkedHashSet<>(allowed));
-    }
-
-    public PreferredAndAllowedHour(String preferred2, String allowedString) {
-        this(HourStyle.valueOf(preferred2), mungeOperands(allowedString));
-    }
-
-    private static EnumSet<HourStyle> mungeSet(Collection<Character> allowed) {
-        EnumSet<HourStyle> temp = EnumSet.noneOf(HourStyle.class);
-        for (char c : allowed) {
-            temp.add(HourStyle.valueOf(String.valueOf(c)));
-        }
-        return temp;
-    }
-
-    static final Splitter SPACE_SPLITTER = Splitter.on(' ').trimResults();
-
-    private static LinkedHashSet<HourStyle> mungeOperands(String allowedString) {
-        LinkedHashSet<HourStyle> allowed = new LinkedHashSet<>();
-        for (String s : SPACE_SPLITTER.split(allowedString)) {
-            allowed.add(HourStyle.valueOf(s));
-        }
-        return allowed;
+    private PreferredAndAllowedHour(String preferredStyle, Stream<String> allowedStyles) {
+        this.preferred = checkNotNull(HourStyle.valueOf(preferredStyle));
+        this.allowed = allowedStyles.map(HourStyle::valueOf).collect(toImmutableList());
+        checkArgument(allowed.stream().distinct().count() == allowed.size(),
+                "Allowed (%s) must not contain duplicates", allowed);
+        // Note: In *some* cases the preferred style is required to be the first style in
+        // the allowed set, but not always (thus we cannot do a better check here).
+        // TODO: Figure out if we can enforce preferred == first(allowed) here.
+        checkArgument(allowed.contains(preferred),
+                "Allowed (%s) must contain preferred (%s)", allowed, preferred);
     }
 
     @Override
-    public int compareTo(PreferredAndAllowedHour arg0) {
-        int diff = preferred.compareTo(arg0.preferred);
-        if (diff != 0) return diff;
-        return CollectionUtilities.compare(allowed.iterator(), arg0.allowed.iterator());
+    public int compareTo(PreferredAndAllowedHour other) {
+        return COMPARATOR.compare(this, other);
     }
 
     @Override
     public String toString() {
-        return toString(Collections.singleton("?"));
+        return toString(ImmutableList.of("?"));
     }
 
     public String toString(Collection<String> regions) {
+        Joiner withSpaces = Joiner.on(" ");
         return "<hours preferred=\""
             + preferred
             + "\" allowed=\""
-            + Joiner.on(" ").join(allowed)
+            + withSpaces.join(allowed)
             + "\" regions=\""
-            + Joiner.on(" ").join(regions)
+            + withSpaces.join(regions)
             + "\"/>";
     }
 


### PR DESCRIPTION
This replaces the custom logic for the CollectionUtilities methods with the recently added JDK Comparator(s) functionality. This method probably needs to be double checked against the com.ibm classes to ensure it's equivalent.

See: https://github.com/unicode-org/cldr/blob/master/tools/java/libs/utilities-src.jar

IMPORTANT: This is a clone of https://github.com/unicode-org/cldr/pull/462 which I had to abandon because of conflicting changes caused in the time that this PR has been awaiting review (a combination of the requirement to force squash branches and inability to cleanly merge recent changes).

This is one of the more subtle refactorings since it relies on human understanding of the existing (undocumented, non-trivial) comparison code. Luckily it has only a few uses, and the JDK Comparator API is nice and readable, so the intent of the new code should be clear.

As far as I can tell, the existing comparator code for iterables is equivalent to lexicographical ordering of the “natural” order with the exception that “null” should always be sorted first.
Then the ordering of collections is that, but preceded by a check on the size first.

Note that while the examples in:
tools/java/org/unicode/cldr/tool/GeneratePluralRanges.java
previously passed collections, and thus get a size comparison in the new code, the example in:
tools/java/org/unicode/cldr/util/PreferredAndAllowedHour.java
explicitly passes just the iterator for comparison, bypassing the size check.

Somewhat strangely, the example in:
tools/java/org/unicode/cldr/tool/WritePluralRules.java
does the collection comparison (with size check) and then falls back to a tie-break on the "toString()" of the instances being compared. I've no idea why it's doing this, but I've replicated it.

Note that while I’ve copied this behaviour, I’m not actually sure that in the places it's used you actually expect null at all, so some call sites could possibly be simplified.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13750
- [x] Updated PR title and link in previous line to include Issue number

