### PR TITLE
CLDR-13868 NullPointerException in CheckDisplayCollisions

### DIFF
--- a/tools/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/java/org/unicode/cldr/util/XMLSource.java
@@ -1628,11 +1628,11 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             String norm = null;
             for (String alias : aliases) {
                 if (alias.startsWith(pathPrefix)) {
-                    if (norm == null) {
+                    if (norm == null && valueToMatch != null) {
                         norm = SimpleXMLSource.normalize(valueToMatch);
                     }
                     String value = getValueAtDPath(alias);
-                    if (SimpleXMLSource.normalize(value).equals(norm)) {
+                    if (value != null && SimpleXMLSource.normalize(value).equals(norm)) {
                         filteredPaths.add(alias);
                     }
                 }


### PR DESCRIPTION
-Avoid calling SimpleXMLSource.normalize with null param

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13868
- [x] Updated PR title and link in previous line to include Issue number

