### PR TITLE
CLDR-13872 Survey Tool en_GB, en_IN cannot load Symbols2

### DIFF
--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -2629,9 +2629,9 @@ function addVitem(td, tr, theRow, item, newButton) {
 	var displayValue = item.value;
 	if (displayValue === INHERITANCE_MARKER) {
 		displayValue = theRow.inheritedValue;
-		if (displayValue == null) {
-			return;
-		}
+	}
+	if (!displayValue) {
+		return;
 	}
 	var div = document.createElement("div");
 	var isWinner = (td == tr.proposedcell);


### PR DESCRIPTION
-Return early from addVitem if displayValue is empty, to prevent exception in setLang

-That happened when appendItem returned undefined given empty displayValue

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13872
- [x] Updated PR title and link in previous line to include Issue number

