### PR TITLE
CLDR-13857 Fix XPathParts.getInstance

### DIFF
--- a/tools/cldr-apps/WebContent/tc-mzfix.jsp
+++ b/tools/cldr-apps/WebContent/tc-mzfix.jsp
@@ -61,7 +61,7 @@ boolean reallymove = request.getParameter("reallymove")!=null;
 		if(good==null) {
 			if(badString==null) badString=xpt.getById(bad);
 			if(badString==null) return XPathTable.NO_XPATH;
-			XPathParts xpp = XPathParts.getInstance(badString); // not frozen, for putAttributeValue
+			XPathParts xpp = XPathParts.getFrozenInstance(badString).cloneAsThawed(); // not frozen, for putAttributeValue
 			
 			// is it an intact metazone?
 			String mz = xpp.getElement(3);

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyAjax.java
@@ -2983,7 +2983,7 @@ public class SurveyAjax extends HttpServlet {
         try {
             for (String x : all) {
                 String full = cf.getFullXPath(x);
-                XPathParts xppMine = XPathParts.getInstance(full); // not frozen, for xPathPartsToBase
+                XPathParts xppMine = XPathParts.getFrozenInstance(full).cloneAsThawed(); // not frozen, for xPathPartsToBase
                 String valOrig = cf.getStringValue(x);
                 Exception exc[] = new Exception[1];
                 final String val0 = processor.processInput(x, valOrig, exc);
@@ -3005,7 +3005,7 @@ public class SurveyAjax extends HttpServlet {
                     style = "opacity: 0.9;";
                 }
 
-                XPathParts xpp = XPathParts.getInstance(base); // not frozen, for removeAttribute
+                XPathParts xpp = XPathParts.getFrozenInstance(base).cloneAsThawed(); // not frozen, for removeAttribute
                 xpp.removeAttribute(-1, LDMLConstants.ALT);
 
                 String result = "";

--- a/tools/cldr-apps/src/org/unicode/cldr/web/XPathTable.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/XPathTable.java
@@ -449,7 +449,7 @@ public class XPathTable {
      * Called by handlePathValue and makeProposedFile
      */
     public static String removeAlt(String path) {
-        XPathParts xpp = XPathParts.getInstance(path); // not frozen, for removeAttribute
+        XPathParts xpp = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeAttribute
         xpp.removeAttribute(-1, LDMLConstants.ALT);
         return xpp.toString();
     }
@@ -463,7 +463,7 @@ public class XPathTable {
      * @return
      */
     public static String removeDraftAltProposed(String path) {
-        XPathParts xpp = XPathParts.getInstance(path); // not frozen, for removeAttribute
+        XPathParts xpp = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeAttribute
         Map<String, String> lastAtts = xpp.getAttributes(-1);
 
         // Remove alt proposed, but leave the type
@@ -511,7 +511,7 @@ public class XPathTable {
      * This is NOT the same as the two-parameter xpathToBaseXpath elsewhere in this file
      */
     public static String xpathToBaseXpath(String xpath) {
-        XPathParts xpp = XPathParts.getInstance(xpath); // not frozen, for removeAttribute
+        XPathParts xpp = XPathParts.getFrozenInstance(xpath);
         Map<String, String> lastAtts = xpp.getAttributes(-1);
         String oldAlt = lastAtts.get(LDMLConstants.ALT);
         if (oldAlt == null) {
@@ -520,10 +520,12 @@ public class XPathTable {
 
         String newAlt = LDMLUtilities.parseAlt(oldAlt)[0]; // #0 : altType
         if (newAlt == null) {
+            xpp = xpp.cloneAsThawed();
             xpp.removeAttribute(-1, LDMLConstants.ALT); // alt dropped out existence
         } else if (newAlt.equals(oldAlt)) {
             return xpath; // No change
         } else {
+            xpp = xpp.cloneAsThawed();
             xpp.putAttributeValue(-1, LDMLConstants.ALT, newAlt);
         }
         String newXpath = xpp.toString();
@@ -562,7 +564,7 @@ public class XPathTable {
      * @return the type as a string
      */
     private String whatFromPathToTinyXpath(String path, String what) {
-        XPathParts xpp = XPathParts.getInstance(path); // not frozen, for removeAttribute
+        XPathParts xpp = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeAttribute
         Map<String, String> lastAtts = xpp.getAttributes(-1);
         String type = lastAtts.get(what);
         if (type != null) {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBCP47.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBCP47.java
@@ -46,20 +46,20 @@ public class TestBCP47 extends TestFmwk {
         String.class);
     static {
         for (String path : With.in(ENGLISH.iterator("//ldml/localeDisplayNames/keys/key"))) {
-            XPathParts parts = XPathParts.getInstance(path);
+            XPathParts parts = XPathParts.getFrozenInstance(path);
             String value = ENGLISH.getStringValue(path);
             String key = parts.getAttributeValue(-1, "type");
             keyTypeTranslations.put(key, "", value);
         }
         for (String path : With.in(ENGLISH.iterator("//ldml/localeDisplayNames/types/type"))) {
-            XPathParts parts = XPathParts.getInstance(path);
+            XPathParts parts = XPathParts.getFrozenInstance(path);
             String value = ENGLISH.getStringValue(path);
             String key = parts.getAttributeValue(-1, "key");
             String type = parts.getAttributeValue(-1, "type");
             keyTypeTranslations.put(key, type, value);
         }
         for (String path : With.in(ENGLISH.iterator("//ldml/localeDisplayNames/transformNames/transformName"))) {
-            XPathParts parts = XPathParts.getInstance(path);
+            XPathParts parts = XPathParts.getFrozenInstance(path);
             String value = ENGLISH.getStringValue(path);
             String type = parts.getAttributeValue(-1, "type");
             keyTypeTranslations.put("d0", type, value);
@@ -181,7 +181,7 @@ public class TestBCP47 extends TestFmwk {
         return "key: " + key + "\taliases: " + keyAliases + (type.isEmpty() ? "" : "\ttype: " + type + "\taliases: " + typeAliases) + "\tbcp: "
             + bcp47Description + ",\teng: " + eng;
     }
-    
+
     static final Set<String> BOGUS_TZIDS = ImmutableSet.of(
         "ACT", "AET", "AGT", "ART", "AST", "BET", "BST", "CAT", "CET", "CNT", "CST", "CTT", "EAT", "ECT", "EET", "Factory", "IET", "IST", "JST", "MET", "MIT",
         "NET", "NST", "PLT", "PNT", "PRT", "PST", "SST", "SystemV/AST4", "SystemV/AST4ADT", "SystemV/CST6", "SystemV/CST6CDT", "SystemV/EST5",
@@ -212,7 +212,7 @@ public class TestBCP47 extends TestFmwk {
                 }
             }
         }
-        
+
         warnln("CLDR deprecated bcp47 ids: " + deprecatedBcp47s);
         warnln("CLDR deprecated tzids: " + deprecatedAliases);
 
@@ -250,7 +250,7 @@ public class TestBCP47 extends TestFmwk {
         } else if (!bcp47IdsNotUsed.isEmpty()) {
             warnln("CLDR has unused (but deprecated) bcp47 ids: " + bcp47IdsNotUsed);
         }
-        
+
         diff = new LinkedHashSet<>(missingAliases);
         diff.removeAll(deprecatedAliases);
         if (!diff.isEmpty()) {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
@@ -399,7 +399,7 @@ public class TestPaths extends TestFmwkPlus {
                     for (Pair<String, String> pathValue : XMLFileReader.loadPathValues(fullName, new ArrayList<Pair<String, String>>(), true)) {
                         String path = pathValue.getFirst();
                         final String value = pathValue.getSecond();
-                        XPathParts parts = XPathParts.getInstance(path); // not frozen, for removeNonDistinguishing
+                        XPathParts parts = XPathParts.getFrozenInstance(path);
                         if (dtdData == null) {
                             type = DtdType.valueOf(parts.getElement(0));
                             dtdData = DtdData.getInstance(type);
@@ -449,6 +449,7 @@ public class TestPaths extends TestFmwkPlus {
                         if (!normalizedPath.equals(path) && !normalizedPath[0].equals(dpath)) {
                             checkParts(normalizedPath[0], dtdData);
                         }
+                        parts = parts.cloneAsThawed();
                         counter = removeNonDistinguishing(parts, dtdData, counter, removed, nonFinalValues);
                         String cleaned = parts.toString();
                         Pair<String, String> pair = Pair.of(type == DtdType.ldml ? file : type.toString(), cleaned);

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPerf.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPerf.java
@@ -123,7 +123,7 @@ public class TestPerf extends TestFmwkPlus {
         int size = 0;
         for (String p : testPaths) {
             for (int i = 0; i < ITERATIONS; ++i) {
-                XPathParts xpp = XPathParts.getInstance(p);
+                XPathParts xpp = XPathParts.getFrozenInstance(p);
                 size += xpp.size();
             }
         }

--- a/tools/java/org/unicode/cldr/draft/ExtractCountItems.java
+++ b/tools/java/org/unicode/cldr/draft/ExtractCountItems.java
@@ -159,7 +159,7 @@ public class ExtractCountItems {
             }
             String value = cldr.getStringValue(path).toLowerCase(Locale.ENGLISH);
             // get the path without the count = basepath
-            XPathParts parts = XPathParts.getInstance(path); // not frozen, setAttribute
+            XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, setAttribute
             Count count = PluralInfo.Count.valueOf(parts.getAttributeValue(-1, "count"));
             parts.setAttribute(-1, "count", null);
             String basePath = parts.toString();

--- a/tools/java/org/unicode/cldr/draft/JsonConverter.java
+++ b/tools/java/org/unicode/cldr/draft/JsonConverter.java
@@ -64,7 +64,7 @@ public class JsonConverter {
                 final String xpath = it.next();
                 final String fullXpath = file.getFullXPath(xpath);
                 String value = file.getStringValue(xpath);
-                XPathParts oldParts = XPathParts.getInstance(fullXpath); // not frozen, rewrite can modify
+                XPathParts oldParts = XPathParts.getFrozenInstance(fullXpath).cloneAsThawed(); // not frozen, rewrite can modify
                 if (dtdType == null) {
                     dtdType = DtdType.valueOf(parts.getElement(0));
                 }

--- a/tools/java/org/unicode/cldr/json/CldrItem.java
+++ b/tools/java/org/unicode/cldr/json/CldrItem.java
@@ -229,10 +229,10 @@ public class CldrItem implements Comparable<CldrItem> {
                 String[] words = null;
                 words = wordString.trim().split("\\s+");
                 for (String word : words) {
-                    XPathParts newxpp = XPathParts.getInstance(xpp.toString());
-                    XPathParts newfullxpp = XPathParts.getInstance(fullxpp.toString());
-                    XPathParts untransformednewxpp = XPathParts.getInstance(untransformedxpp.toString());
-                    XPathParts untransformednewfullxpp = XPathParts.getInstance(untransformedfullxpp.toString());
+                    XPathParts newxpp = xpp.cloneAsThawed();
+                    XPathParts newfullxpp = fullxpp.cloneAsThawed();
+                    XPathParts untransformednewxpp = untransformedxpp.cloneAsThawed();
+                    XPathParts untransformednewfullxpp = untransformedfullxpp.cloneAsThawed();
 
                     newxpp.setAttribute(s.element, s.attribute, word);
                     newfullxpp.setAttribute(s.element, s.attribute, word);

--- a/tools/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -294,7 +294,7 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
             if (!path.contains("[@count=") || "0".equals(value)) {
                 return this;
             }
-            XPathParts parts = XPathParts.getInstance(path); // not frozen, for removeElement
+            XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeElement
             String type = parts.getAttributeValue(-1, "type");
             myPrefix = parts.removeElement(-1).toString();
             matcher = PatternCache.get(myPrefix.replaceAll("\\[", "\\\\[") +

--- a/tools/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/java/org/unicode/cldr/test/CheckNumbers.java
@@ -202,7 +202,7 @@ public class CheckNumbers extends FactoryCheckCLDR {
         if (type == NumericType.NOT_NUMERIC) {
             return this; // skip
         }
-        XPathParts parts = XPathParts.getInstance(path); // can't be frozen because some of the following code modifies it!
+        XPathParts parts = XPathParts.getFrozenInstance(path);
 
         boolean isPositive = true;
         for (String patternPart : SEMI_SPLITTER.split(value)) {
@@ -280,6 +280,7 @@ public class CheckNumbers extends FactoryCheckCLDR {
         // Tests that assume that the value is a valid number pattern.
         // Notice that we pick up any exceptions, so that we can
         // give a reasonable error message.
+        parts = parts.cloneAsThawed();
         try {
             if (type == NumericType.DECIMAL_ABBREVIATED || type == NumericType.CURRENCY_ABBREVIATED) {
                 // Check for consistency in short/long decimal formats.

--- a/tools/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -342,7 +342,7 @@ public class ExampleGenerator {
          * Need getInstance, not getFrozenInstance here: some functions such as handleNumberSymbol
          * expect to call functions like parts.addRelative which throw exceptions if parts is frozen.
          */
-        XPathParts parts = XPathParts.getInstance(xpath);
+        XPathParts parts = XPathParts.getFrozenInstance(xpath).cloneAsThawed();
         if (parts.contains("dateRangePattern")) { // {0} - {1}
             result = handleDateRangePattern(value);
         } else if (parts.contains("timeZoneNames")) {

--- a/tools/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/java/org/unicode/cldr/test/TestMisc.java
@@ -640,10 +640,11 @@ public class TestMisc {
             String path = it.next();
             String value = supp.getStringValue(path);
             String fullPath = supp.getFullXPath(path);
-            XPathParts parts = XPathParts.getInstance(fullPath); // not frozen, for putAttributeValue
+            XPathParts parts = XPathParts.getFrozenInstance(fullPath);
             String type = parts.getAttributeValue(-1, "type");
             String pop = language_territory_hack_map.get(type);
             if (pop != null) {
+                parts = parts.cloneAsThawed();
                 parts.putAttributeValue(-1, "mostPopulousTerritory", pop);
                 fullPath = parts.toString();
             }

--- a/tools/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/java/org/unicode/cldr/tool/CLDRModify.java
@@ -1112,7 +1112,7 @@ public class CLDRModify {
                 }
                 String oldFullXPath = cldrFileToFilter.getFullXPath(xpath);
                 String value = cldrFileToFilter.getStringValue(xpath);
-                XPathParts fullparts = XPathParts.getInstance(oldFullXPath); // not frozen, for removeAttribute
+                XPathParts fullparts = XPathParts.getFrozenInstance(oldFullXPath).cloneAsThawed(); // not frozen, for removeAttribute
                 fullparts.removeAttribute("pattern", "alt");
                 fullparts.setAttribute("currencyFormat", "type", "accounting");
                 String newFullXPath = fullparts.toString();
@@ -1203,12 +1203,13 @@ public class CLDRModify {
                 if (!xpath.contains("/language")) {
                     return;
                 }
-                XPathParts parts = XPathParts.getInstance(xpath); // not frozen, for setAttribute
+                XPathParts parts = XPathParts.getFrozenInstance(xpath);
                 String languageCode = parts.findAttributeValue("language", "type");
                 String v = resolved.getStringValue(xpath);
                 if (!languageCode.equals("swc")) {
                     return;
                 }
+                parts = parts.cloneAsThawed();
                 parts.setAttribute("language", "type", "sw_CD");
                 replace(xpath, parts.toString(), v);
             }
@@ -1291,7 +1292,7 @@ public class CLDRModify {
                     return;
                 }
                 String fullpath = cldrFileToFilter.getFullXPath(xpath);
-                XPathParts parts = XPathParts.getInstance(fullpath); // not frozen, for setAttribute
+                XPathParts parts = XPathParts.getFrozenInstance(fullpath).cloneAsThawed(); // not frozen, for setAttribute
                 String countValue = parts.getAttributeValue(-1, "count");
                 if (!DIGITS.containsAll(countValue)) {
                     return;
@@ -1328,7 +1329,7 @@ public class CLDRModify {
                 String userID = options[USER].value;
                 String fullpath = cldrFileToFilter.getFullXPath(xpath);
                 String value = cldrFileToFilter.getStringValue(xpath);
-                XPathParts parts = XPathParts.getInstance(fullpath); // not frozen, for addAttribute
+                XPathParts parts = XPathParts.getFrozenInstance(fullpath).cloneAsThawed(); // not frozen, for addAttribute
                 parts.addAttribute("draft", "unconfirmed");
                 parts.addAttribute("alt", "proposed-u" + userID + "-implicit1.8");
                 String newPath = parts.toString();
@@ -1499,7 +1500,7 @@ public class CLDRModify {
             public void handlePath(String xpath) {
                 if (xpath.indexOf("proposed") < 0) return;
                 String fullXPath = cldrFileToFilter.getFullXPath(xpath);
-                XPathParts parts = XPathParts.getInstance(fullXPath); // not frozen, for removeProposed
+                XPathParts parts = XPathParts.getFrozenInstance(fullXPath).cloneAsThawed(); // not frozen, for removeProposed
                 String newFullXPath = parts.removeProposed().toString();
                 // now see if there is an uninherited value
                 String value = cldrFileToFilter.getStringValue(xpath);
@@ -1727,7 +1728,7 @@ public class CLDRModify {
                 String fullpath = cldrFileToFilter.getFullXPath(xpath);
                 if (!fullpath.contains("reference")) return;
                 String value = cldrFileToFilter.getStringValue(xpath);
-                XPathParts fullparts = XPathParts.getInstance(fullpath); // can't be frozen
+                XPathParts fullparts = XPathParts.getFrozenInstance(fullpath).cloneAsThawed(); // can't be frozen
                 if ("reference".equals(fullparts.getElement(-1))) {
                     fixType(value, "type", fullpath, fullparts);
                 } else if (fullparts.getAttributeValue(-1, "references") != null) {
@@ -1772,13 +1773,14 @@ public class CLDRModify {
                     return;
                 }
                 String fullpath = cldrFileToFilter.getFullXPath(xpath);
-                XPathParts parts = XPathParts.getInstance(fullpath); // not frozen, for putAttributeValue
+                XPathParts parts = XPathParts.getFrozenInstance(fullpath);
                 String cp = parts.getAttributeValue(2, "cp");
                 String tts = parts.getAttributeValue(2, "tts");
                 String type = parts.getAttributeValue(2, "type");
                 if ("tts".equals(type)) {
                     return; // ok, skip
                 }
+                parts = parts.cloneAsThawed();
                 String hex = "1F600";
                 if (cp.startsWith("[")) {
                     UnicodeSet us = new UnicodeSet(cp);
@@ -2269,7 +2271,7 @@ public class CLDRModify {
                         continue;
                     }
 
-                    XPathParts fullparts = XPathParts.getInstance(fullPath); // not frozen, for setAttribute
+                    XPathParts fullparts = XPathParts.getFrozenInstance(fullPath).cloneAsThawed(); // not frozen, for setAttribute
                     fullparts.setAttribute(-1, "draft", worstStatus.toString());
                     replace(fullPath, fullparts.toString(), value, "Fleshing out bailey to " + worstStatus);
                 }

--- a/tools/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/java/org/unicode/cldr/tool/ChartDelta.java
@@ -472,7 +472,7 @@ public class ChartDelta extends Chart {
         // NEW:     <annotation cp="😀">face | grin</annotation>
         //          <annotation cp="😀" type="tts">grinning face</annotation>
         // from the NEW paths, get the OLD values
-        XPathParts parts = XPathParts.getInstance(path); // not frozen, for removeAttribute
+        XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeAttribute
         boolean isTts = parts.getAttributeValue(-1, "type") != null;
         if (isTts) {
             parts.removeAttribute(-1, "type");

--- a/tools/java/org/unicode/cldr/tool/FilterFactory.java
+++ b/tools/java/org/unicode/cldr/tool/FilterFactory.java
@@ -159,9 +159,10 @@ public class FilterFactory extends Factory {
             String value = rawFile.getStringValue(xpath);
             // Remove count="x" if the value is equivalent to count="other".
             if (xpath.contains("[@count=")) {
-                XPathParts parts = XPathParts.getInstance(xpath); // not frozen, for setAttribute
+                XPathParts parts = XPathParts.getFrozenInstance(xpath);
                 String count = parts.getAttributeValue(-1, "count");
                 if (!count.equals("other")) {
+                    parts = parts.cloneAsThawed();
                     parts.setAttribute(-1, "count", "other");
                     String otherPath = parts.toString();
                     if (value.equals(rawFile.getStringValue(otherPath))) {

--- a/tools/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -214,7 +214,7 @@ public class GenerateCoverageLevels {
         }
 
         private XPathParts setNewParts(String path) {
-            XPathParts parts = XPathParts.getInstance(path); // not frozen, for removeElement
+            XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeElement
             if (path.startsWith("//ldml/dates/timeZoneNames/metazone")
                 || path.startsWith("//ldml/dates/timeZoneNames/zone")) {
                 String element = nextParts.getElement(-1);

--- a/tools/java/org/unicode/cldr/tool/GenerateItemCounts.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateItemCounts.java
@@ -676,7 +676,10 @@ public class GenerateItemCounts {
         }
 
         private String fixKeyPath(String path) {
-            XPathParts parts = XPathParts.getInstance(path); // not frozen, for addAttribute
+            XPathParts parts = XPathParts.getFrozenInstance(path);
+            if (!SKIP_ORDERING) {
+                parts = parts.cloneAsThawed();
+            }
             for (int i = 0; i < parts.size(); ++i) {
                 String element = parts.getElement(i);
                 if (!SKIP_ORDERING) {

--- a/tools/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -699,7 +699,7 @@ public class GenerateSidewaysView {
     }
 
     private static String removeAttributes(String xpath, Set<String> skipAttributes) {
-        XPathParts parts = XPathParts.getInstance(xpath); // not frozen, for removeAttributes
+        XPathParts parts = XPathParts.getFrozenInstance(xpath).cloneAsThawed(); // not frozen, for removeAttributes
         removeAttributes(parts, skipAttributes);
         return parts.toString();
     }
@@ -740,7 +740,7 @@ public class GenerateSidewaysView {
             return value;
         }
         if (value.length() == 0) {
-            XPathParts parts = XPathParts.getInstance(fullPath); // not frozen, for removeAttributes
+            XPathParts parts = XPathParts.getFrozenInstance(fullPath).cloneAsThawed(); // not frozen, for removeAttributes
             removeAttributes(parts, skipSet);
             int limit = parts.size();
             value = parts.toString(limit - 1, limit);

--- a/tools/java/org/unicode/cldr/tool/XMLModify.java
+++ b/tools/java/org/unicode/cldr/tool/XMLModify.java
@@ -85,7 +85,7 @@ public class XMLModify {
                         out.println("<!--" + value + " -->");
                         continue;
                     }
-                    XPathParts parts = XPathParts.getInstance(path); // not frozen, for setAttribute
+                    XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for setAttribute
                     if (pathMatcher.reset(path).matches()) {
                         String type = parts.getAttributeValue(-1, "type");
                         parts.setAttribute(-1, "type", type.toLowerCase(Locale.ROOT).replaceAll("-", ""));

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -502,7 +502,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             if (isResolved && xpath.contains("/alias")) {
                 continue;
             }
-            XPathParts current = XPathParts.getInstance(xpath);
+            XPathParts current = XPathParts.getFrozenInstance(xpath).cloneAsThawed();
             current.writeDifference(pw, current, last, "", tempComments);
             last = current;
         }
@@ -527,12 +527,12 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
              * The difference between "filtered" (currentFiltered) and "not filtered" (current) is that
              * current uses getFullXPath(xpath), while currentFiltered uses xpath.
              */
-            XPathParts currentFiltered = XPathParts.getInstance(xpath);
+            XPathParts currentFiltered = XPathParts.getFrozenInstance(xpath).cloneAsThawed();
             if (currentFiltered.size() >= 2
                 && currentFiltered.getElement(1).equals("identity")) {
                 continue;
             }
-            XPathParts current = XPathParts.getInstance(getFullXPath(xpath));
+            XPathParts current = XPathParts.getFrozenInstance(getFullXPath(xpath)).cloneAsThawed();
             current.writeDifference(pw, currentFiltered, last, v, tempComments);
             last = current;
             wroteAtLeastOnePath = true;
@@ -883,7 +883,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                     && !key.startsWith("//ldml/identity")) {
                     for (int i = 0;; ++i) {
                         String prop = "proposed" + (i == 0 ? "" : String.valueOf(i));
-                        XPathParts parts = XPathParts.getInstance(other.getFullXPath(key)); // not frozen, for addAttribut
+                        XPathParts parts = XPathParts.getFrozenInstance(other.getFullXPath(key)).cloneAsThawed(); // not frozen, for addAttribut
                         String fullPath = parts.addAttribute("alt", prop).toString();
                         String path = getDistinguishingXPath(fullPath, null);
                         if (dataSource.getValueAtPath(path) != null) {
@@ -1338,7 +1338,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             return xpath;
         }
         synchronized (syncObject) {
-            XPathParts parts = XPathParts.getInstance(xpath); // can't be frozen since we call removeAttributes
+            XPathParts parts = XPathParts.getFrozenInstance(xpath).cloneAsThawed(); // can't be frozen since we call removeAttributes
             String restore;
             HashSet<String> toRemove = new HashSet<>();
             for (int i = 0; i < parts.size(); ++i) {
@@ -2744,7 +2744,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         if (locked) throw new UnsupportedOperationException("Attempt to modify locked object");
         for (Iterator<String> it = dataSource.iterator(); it.hasNext();) {
             String path = it.next();
-            XPathParts parts = XPathParts.getInstance(dataSource.getFullPath(path)); // not frozen, for addAttribute
+            XPathParts parts = XPathParts.getFrozenInstance(dataSource.getFullPath(path)).cloneAsThawed(); // not frozen, for addAttribute
             parts.addAttribute("draft", draftStatus.toString());
             dataSource.putValueAtPath(parts.toString(), dataSource.getValueAtPath(path));
         }
@@ -2888,7 +2888,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             //     synchronized (distinguishingMap) {
             String result = distinguishingMap.get(xpath);
             if (result == null) {
-                XPathParts distinguishingParts = XPathParts.getInstance(xpath); // not frozen, for removeAttributes
+                XPathParts distinguishingParts = XPathParts.getFrozenInstance(xpath).cloneAsThawed(); // not frozen, for removeAttributes
 
                 DtdType type = distinguishingParts.getDtdData().dtdType;
                 Set<String> toRemove = new HashSet<>();
@@ -3587,7 +3587,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
      */
     public String getCountPathWithFallback(String xpath, Count count, boolean winning) {
         String result;
-        XPathParts parts = XPathParts.getInstance(xpath); // not frozen, addAttribute in getCountPathWithFallback2
+        XPathParts parts = XPathParts.getFrozenInstance(xpath).cloneAsThawed(); // not frozen, addAttribute in getCountPathWithFallback2
 
         // In theory we should do all combinations of gender, case, count (and eventually definiteness), but for simplicity
         // we just successively try "zeroing" each one in a set order.

--- a/tools/java/org/unicode/cldr/util/LogicalGrouping.java
+++ b/tools/java/org/unicode/cldr/util/LogicalGrouping.java
@@ -104,7 +104,7 @@ public class LogicalGrouping {
         XPathParts parts = null;
         PathType pathType = null;
         if (GET_TYPE_FROM_PARTS) {
-            parts = XPathParts.getInstance(path); // can't always be frozen, some addPath do setAttribute
+            parts = XPathParts.getFrozenInstance(path);
             pathType = PathType.getPathTypeFromParts(parts);
         } else {
             /*
@@ -128,7 +128,9 @@ public class LogicalGrouping {
         }
 
         if (!GET_TYPE_FROM_PARTS) {
-            parts = XPathParts.getInstance(path);
+            parts = XPathParts.getFrozenInstance(path).cloneAsThawed();
+        } else {
+            parts = parts.cloneAsThawed();
         }
 
         if (PathType.isLocaleDependent(pathType)) {
@@ -171,7 +173,7 @@ public class LogicalGrouping {
      *         that it belongs to.
      */
     public static boolean isOptional(CLDRFile cldrFile, String path) {
-        XPathParts parts = XPathParts.getInstance(path);
+        XPathParts parts = XPathParts.getFrozenInstance(path);
 
         if (parts.containsElement("relative")) {
             String fieldType = parts.findAttributeValue("field", "type");
@@ -188,6 +190,7 @@ public class LogicalGrouping {
         if (pluralType.equals("0") || pluralType.equals("1")) return true;
         if (!pluralType.equals("zero") && !pluralType.equals("one")) return false;
 
+        parts = parts.cloneAsThawed();
         PluralRules pluralRules = getPluralInfo(cldrFile).getPluralRules();
         parts.setAttribute(-1, "count", "0");
         Set<Double> explicits = new HashSet<>();

--- a/tools/java/org/unicode/cldr/util/PathStarrer.java
+++ b/tools/java/org/unicode/cldr/util/PathStarrer.java
@@ -28,7 +28,7 @@ public class PathStarrer implements Transform<String, String> {
     private final StringBuilder starredPathOld = new StringBuilder();
 
     public String set(String path) {
-        XPathParts parts = XPathParts.getInstance(path);
+        XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed();
         return set(parts, Collections.<String> emptySet());
     }
 

--- a/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4118,7 +4118,7 @@ public class SupplementalDataInfo {
 
     public boolean isDeprecated(DtdType type, String path) {
 
-        XPathParts parts = XPathParts.getInstance(path);
+        XPathParts parts = XPathParts.getFrozenInstance(path);
         for (int i = 0; i < parts.size(); ++i) {
             String element = parts.getElement(i);
             if (isDeprecated(type, element, "*", "*")) {

--- a/tools/java/org/unicode/cldr/util/WikiSubdivisionLanguages.java
+++ b/tools/java/org/unicode/cldr/util/WikiSubdivisionLanguages.java
@@ -343,7 +343,7 @@ public final class WikiSubdivisionLanguages {
             R2<List<String>, String> replacement = SUBDIVISION_ALIASES.get(type);
             if (replacement != null) {
                 String fullPath = oldFileSubdivisions.getFullXPath(path);
-                XPathParts parts2 = XPathParts.getInstance(fullPath);
+                XPathParts parts2 = XPathParts.getFrozenInstance(fullPath).cloneAsThawed();
                 for (String replacementType : replacement.get0()) {
                     parts2.setAttribute(-1, "type", replacementType);
                     toRemove.add(path);

--- a/tools/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/java/org/unicode/cldr/util/XMLSource.java
@@ -847,7 +847,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 // find the differences, and add them into xpath
                 // we do this by walking through each element, adding the corresponding attribute values.
                 // we add attributes FROM THE END, in case the lengths are different!
-                XPathParts xpathParts = XPathParts.getInstance(xpath); // not frozen, for putAttributeValue
+                XPathParts xpathParts = XPathParts.getFrozenInstance(xpath).cloneAsThawed(); // not frozen, for putAttributeValue
                 XPathParts fullPathWhereFoundParts = XPathParts.getFrozenInstance(fullPathWhereFound);
                 XPathParts pathWhereFoundParts = XPathParts.getFrozenInstance(fullStatus.pathWhereFound);
                 int offset = xpathParts.size() - pathWhereFoundParts.size();

--- a/tools/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/java/org/unicode/cldr/util/XPathParts.java
@@ -1272,10 +1272,6 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
         return result;
     }
 
-    public static XPathParts getInstance(String path) {
-        return getFrozenInstance(path).cloneAsThawed();
-    }
-
     public DtdData getDtdData() {
         return dtdData;
     }
@@ -1310,7 +1306,7 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
     }
 
     public static String getPathWithoutAlt(String xpath) {
-        XPathParts xpp = getInstance(xpath);
+        XPathParts xpp = getFrozenInstance(xpath).cloneAsThawed();
         xpp.removeAttribute("alt");
         return xpp.toString();
     }


### PR DESCRIPTION
- Inline method XPathParts.getInstance() 
- XPathParts.getInstance() is expensive as it calls getFrozenInstance().cloneAsThawed(); Postpone calling cloneAsThawed() until needed to save time.

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13857
- [x] Updated PR title and link in previous line to include Issue number

