### PR TITLE
CLDR-13873 in En_GB, vote to inherit month gets Same as Code error

### DIFF
--- a/tools/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/java/org/unicode/cldr/test/CheckForCopy.java
@@ -118,8 +118,8 @@ public class CheckForCopy extends FactoryCheckCLDR {
          */
         String topStringValue = cldrFile.getUnresolved().getStringValue(path);
         final boolean isExplicitBailey = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
+        String loc = cldrFile.getSourceLocaleID(path, status);
         if (!contextIsVoteSubmission && !isExplicitBailey) {
-            String loc = cldrFile.getSourceLocaleID(path, status);
             if (!cldrFile.getLocaleID().equals(loc)
                 || !path.equals(status.pathWhereFound)) {
                 return Failure.ok;
@@ -155,6 +155,9 @@ public class CheckForCopy extends FactoryCheckCLDR {
         }
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
             value = cldrFile.getConstructedBaileyValue(path, null, null);
+        }
+        if ("en".equals(loc) && ("year".equals(value) || "month".equals(value) || "day".equals(value) || "hour".equals(value))) {
+            return Failure.ok;
         }
         String value2 = value;
         if (isExplicitBailey) {


### PR DESCRIPTION
-Treat year, month, day, and hour as exceptions to the rule

-Only if getSourceLocaleID is en

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13873
- [x] Updated PR title and link in previous line to include Issue number

