### PR TITLE
CLDR-13807 Emoji: Add "rofl" annotation to 🤣

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -220,7 +220,7 @@ annotations.
 		<annotation cp="😆" type="tts">grinning squinting face</annotation>
 		<annotation cp="😅">cold | face | grinning face with sweat | open | smile | sweat</annotation>
 		<annotation cp="😅" type="tts">grinning face with sweat</annotation>
-		<annotation cp="🤣">face | floor | laugh | rolling | rolling on the floor laughing</annotation>
+		<annotation cp="🤣">face | floor | laugh | rolling | rolling on the floor laughing | rofl | rotfl</annotation>
 		<annotation cp="🤣" type="tts">rolling on the floor laughing</annotation>
 		<annotation cp="😂">face | face with tears of joy | joy | laugh | tear</annotation>
 		<annotation cp="😂" type="tts">face with tears of joy</annotation>


### PR DESCRIPTION
Added "rofl" and "rotfl" as keyword/annotation to the "rolling on the floor laughing" emoji 🤣 (U+1F923)

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13807
- [x] Updated PR title and link in previous line to include Issue number
- [x] CLA signed
