### PR TITLE
CLDR-8383 fix some SQL issues with mail

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyLog.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyLog.java
@@ -96,7 +96,7 @@ public class SurveyLog {
         sb.append(FIELD_SEP).append(LogField.LOGSITE).append(' ').append(StackTracker.currentStack()).append('\n');
         Throwable t = exception;
         while (t != null) {
-            sb.append(FIELD_SEP).append(LogField.MESSAGE).append(' ').append(t.toString()).append(' ').append(t.getMessage())
+            sb.append(FIELD_SEP).append(LogField.MESSAGE).append(' ').append(t.toString())
                 .append('\n');
             sb.append(FIELD_SEP).append(LogField.STACK).append(' ').append(StackTracker.stackToString(t.getStackTrace(), 0))
                 .append('\n');


### PR DESCRIPTION
CLDR-8383
- cannot use first() on a forward only updateable resultset, changed to next()
- cleaned up SurveyLog so that error messages aren't repeated.
 (Exception.toString() includes Exception.getMessage(), so do not need a separate getMessage())

fyi @btangmu

SQL err was `java.sql.SQLException: Result set type is TYPE_FORWARD_ONLY`