### PR TITLE
CLDR-13906 show a stack trace for loading: section

### DIFF
--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingLoader.js
@@ -467,7 +467,7 @@ function showV() {
 							});
 						} catch (e) {
 							console.log("Error in ajax post [" + message + "]  " + e.message + " / " + e.name);
-							handleDisconnect("Exception while  loading: " + message + " - " + e.message + ", n=" + e.name, null); // in case the 2nd line doesn't work
+							handleDisconnect("Exception while loading: " + message + " - " + e.message + ", n=" + e.name + ' \nStack:\n' + (e.stack || '[none]'), null); // in case the 2nd line doesn't work
 						}
 					};
 					var xhrArgs = {


### PR DESCRIPTION
CLDR-13906

Not a fix, but adds a stack trace.

- show a stack trace for errors in the dreaded 'Exception while loading: section' message
- use error.stack where available to include a stack trace

