### PR TITLE
CLDR-13919 Error E_UNKNOWN interrupts data entry

### DIFF
--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -500,6 +500,10 @@ const cldrSurveyTable = (function() {
 	 * for automated testing with WebDriver.
 	 */
 	function checkRowConsistency(theRow) {
+		if (!theRow) {
+			console.error('theRow is null or undefined in checkRowConsistency');
+			return;
+		}
 		if (!theRow.winningVhash) {
 			/*
 			 * The server is responsible for ensuring that a winning item is present, or using
@@ -615,6 +619,10 @@ const cldrSurveyTable = (function() {
 	 * TODO: shorten this function by using subroutines.
 	 */
 	function updateRowVoteInfo(tr, theRow) {
+		if (!theRow) {
+			console.error('theRow is null or undefined in updateRowVoteInfo');
+			return;
+		}
 		var vr = theRow.voteResolver;
 		tr.voteDiv = document.createElement("div");
 		tr.voteDiv.className = "voteDiv";
@@ -992,7 +1000,7 @@ const cldrSurveyTable = (function() {
 		listenToPop(null, tr, cell, cell.showFn);
 	}
 
-	/*
+	/**
 	 * Update the "Others" cell (column) of this row
 	 *
 	 * @param tr the table row
@@ -1189,6 +1197,10 @@ const cldrSurveyTable = (function() {
 	 * @returns the winning value, or null if there is not a valid winning value
 	 */
 	function getValidWinningValue(theRow) {
+		if (!theRow) {
+			console.error('theRow is null or undefined in getValidWinningValue');
+			return null;
+		}
 		if (theRow.items && theRow.winningVhash && theRow.items[theRow.winningVhash]) {
 			const item = theRow.items[theRow.winningVhash];
 			if (item.value) {

--- a/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/DataSection.java
@@ -282,7 +282,7 @@ public class DataSection implements JSONString {
              * All return values: "winner", "alias", "fallback", "fallback_code", "fallback_root", "loser".
              *
              * Called by CandidateItem.toJSONString (for item.pClass)
-             * 
+             *
              * Relationships between class, color, and inheritance (http://cldr.unicode.org/translation/getting-started/guide#TOC-Inheritance):
              * "The inherited values are color coded:
              *  1.  Darker [blue] The original is from a parent locale, such as if you are working in
@@ -1100,7 +1100,7 @@ public class DataSection implements JSONString {
          *
          * JSON sent from server to client must be COMPLETE and CONSISTENT
          * Establish and test rules like:
-         *   winningVHash cannot be empty;
+         *   winningVhash cannot be empty;
          *   There must be an item that corresponds to the winningValue;
          *   There must be an item with INHERITANCE_MARKER;
          *   ...


### PR DESCRIPTION
-Guard against accessing theRow.winningVhash if theRow is null or undefined

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13919
- [x] Updated PR title and link in previous line to include Issue number

