### PR TITLE
CLDR-13937 es-419: Attempting to open provisional item via dashboard causes E_UNKNOWN

### DIFF
--- a/tools/cldr-apps/WebContent/js/review.js
+++ b/tools/cldr-apps/WebContent/js/review.js
@@ -638,8 +638,16 @@ function insertFixInfo(theDiv, xpath, session, json) {
 		}
 	}
 
-	var k = theTable.json.displaySets[theTable.curSortMode].rows[0];
-	var theRow = theTable.json.section.rows[k];
+	const k = theTable.json.displaySets[theTable.curSortMode].rows[0];
+	if (!k) {
+		console.log("k is null or undefined in insertFixInfo");
+		return;
+	}
+	const theRow = theTable.json.section.rows[k];
+	if (!theRow) {
+		console.log("theRow is null or undefined in insertFixInfo; k = " + k);
+		return;
+	}
 	removeAllChildNodes(tbody);
 	/*
 	 * Caution: in spite of the name here in the JavaScript, "tr" isn't a
@@ -652,9 +660,6 @@ function insertFixInfo(theDiv, xpath, session, json) {
 	}
 	tr.rowHash = k;
 	tr.theTable = theTable;
-	if (!theRow) {
-		console.log("Missing row " + k);
-	}
 
 	cldrSurveyTable.updateRow(tr,theRow);
 


### PR DESCRIPTION
-Fix front end only to prevent crash; back end will be fixed separately

-If json has empty array, log message to console and return from insertFixInfo early

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13937
- [x] Updated PR title and link in previous line to include Issue number

