### PR TITLE
CLDR-13838 adjust root currencySpacing to avoid double space

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3657,12 +3657,12 @@ for derived annotations.
 		<currencyFormats numberSystem="latn">
 			<currencySpacing>
 				<beforeCurrency>
-					<currencyMatch>[:^S:]</currencyMatch>
+					<currencyMatch>[[:^S:]&amp;[:^Z:]]</currencyMatch>
 					<surroundingMatch>[:digit:]</surroundingMatch>
 					<insertBetween> </insertBetween>
 				</beforeCurrency>
 				<afterCurrency>
-					<currencyMatch>[:^S:]</currencyMatch>
+					<currencyMatch>[[:^S:]&amp;[:^Z:]]</currencyMatch>
 					<surroundingMatch>[:digit:]</surroundingMatch>
 					<insertBetween> </insertBetween>
 				</afterCurrency>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13838
- [x] Updated PR title and link in previous line to include Issue number

Adjust root currencySpacing to avoid inserting additional space if the currency symbol text already includes space  (e.g. "EUR ", which some clients have done).
