### PR TITLE
CLDR-13857 Fix BufferedInputStream

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -46,9 +46,9 @@ import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
+import org.unicode.cldr.util.StripUTF8BOMInputStream;
 import org.unicode.cldr.util.SupplementalDataInfo.AttributeValidityInfo;
 import org.unicode.cldr.util.Validity;
-import org.unicode.cldr.util.XMLFileReader.FilterBomInputStream;
 import org.unicode.cldr.util.XPathParts;
 import org.xml.sax.Attributes;
 
@@ -171,7 +171,7 @@ public class TestAttributeValues extends TestFmwk {
         try {
             // should convert these over to new io.
             try (InputStream fis0 = new FileInputStream(fullFile);
-                InputStream fis = new FilterBomInputStream(fis0);
+                InputStream fis = new StripUTF8BOMInputStream(fis0);
                 InputStreamReader inputStreamReader = new InputStreamReader(fis, Charset.forName("UTF-8"));
                 BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
                 ) {

--- a/tools/java/org/unicode/cldr/util/StripUTF8BOMInputStream.java
+++ b/tools/java/org/unicode/cldr/util/StripUTF8BOMInputStream.java
@@ -10,11 +10,11 @@ package org.unicode.cldr.util;
 import java.io.IOException;
 import java.io.InputStream;
 
-class StripUTF8BOMInputStream extends InputStream {
+public class StripUTF8BOMInputStream extends InputStream {
     InputStream base;
 
-    StripUTF8BOMInputStream(InputStream base) {
-        this.base = base;
+    public StripUTF8BOMInputStream(InputStream base) {
+        this.base = InputStreamFactory.buffer(base);
     }
 
     boolean checkForUTF8BOM = true;
@@ -36,6 +36,15 @@ class StripUTF8BOMInputStream extends InputStream {
         result = base.read();
         result = base.read();
         return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        if (base != null) {
+            base.close();
+            base = null;
+        }
     }
 
 }

--- a/tools/java/org/unicode/cldr/util/XMLFileReader.java
+++ b/tools/java/org/unicode/cldr/util/XMLFileReader.java
@@ -92,7 +92,7 @@ public class XMLFileReader {
      */
     public XMLFileReader read(String fileName, int handlers, boolean validating) {
         try (InputStream fis0 = new FileInputStream(fileName);
-            InputStream fis = new FilterBomInputStream(fis0);
+            InputStream fis = new StripUTF8BOMInputStream(fis0);
             ) {
             return read(fileName, fis, handlers, validating);
         } catch (IOException e) {
@@ -502,39 +502,40 @@ public class XMLFileReader {
         }
     }
 
-    public static final class FilterBomInputStream extends InputStream {
-        InputStream contents;
-        boolean first = true;
-
-        @Override
-        public void close() throws IOException {
-            contents.close();
-        }
-
-        public FilterBomInputStream(InputStream fis) {
-            contents = fis;
-        }
-
-        @Override
-        public int read() throws IOException {
-            int x = contents.read();
-            if (first) {
-                first = false;
-                // 0xEF,0xBB,0xBF
-                // SKIP bom
-                if (x == 0xEF) {
-                    int y = contents.read();
-                    if (y == 0xBB) {
-                        int z = contents.read();
-                        if (z == 0xBF) {
-                            x = contents.read();
-                        }
-                    }
-                }
-            }
-            return x;
-        }
-    }
+// class StripUTF8BOMInputStream does the same thing
+//    public static final class FilterBomInputStream extends InputStream {
+//        InputStream contents;
+//        boolean first = true;
+//
+//        @Override
+//        public void close() throws IOException {
+//            contents.close();
+//        }
+//
+//        public FilterBomInputStream(InputStream fis) {
+//            contents = fis;
+//        }
+//
+//        @Override
+//        public int read() throws IOException {
+//            int x = contents.read();
+//            if (first) {
+//                first = false;
+//                // 0xEF,0xBB,0xBF
+//                // SKIP bom
+//                if (x == 0xEF) {
+//                    int y = contents.read();
+//                    if (y == 0xBB) {
+//                        int z = contents.read();
+//                        if (z == 0xBF) {
+//                            x = contents.read();
+//                        }
+//                    }
+//                }
+//            }
+//            return x;
+//        }
+//    }
 
     public static List<Pair<String, String>> loadPathValues(String filename, List<Pair<String, String>> data, boolean validating) {
         return loadPathValues(filename, data, validating, false);


### PR DESCRIPTION
- Remove FilterBomInputStream and use existing StripUTF8BOMInputStream as they do the same thing
- Faster XML reading by using BufferedInputStream in StripUTF8BOMInputStream
- Remove XML read code in CLDRFile.loadFromInputStream and use existing XMLFileReader.read

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13857
- [ ] Updated PR title and link in previous line to include Issue number

