### PR TITLE
CLDR-13977 remove duplicate annotation in en.xml

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -3289,7 +3289,6 @@ annotations.
 		<annotation cp="|" type="tts">vertical line</annotation>
 		<annotation cp="~">tilde</annotation>
 		<annotation cp="~" type="tts">tilde</annotation>
-		<annotation cp="⁄">stroke | virgule</annotation>
 		<annotation cp="‾" type="tts">overline</annotation>
 		<annotation cp="‾">vinculum | overstrike</annotation>
 		<annotation cp="‽" type="tts">interrobang</annotation>


### PR DESCRIPTION
This duplicate annotation was removed:
<annotation cp="⁄">stroke | virgule</annotation>
On at least one system, it creates an error.
