### PR TITLE
CLDR-13994 stop propagation of events from the .hide-review button to body

### DIFF
--- a/tools/cldr-apps/WebContent/js/review.js
+++ b/tools/cldr-apps/WebContent/js/review.js
@@ -377,9 +377,9 @@ function toggleFix(event) {
 /**
  * Hide or show line for the review (Dashboard) page
  *
- * Called only by the Startup function at the top of this file
+ * This function is the click handler for the .hide-review button.
  */
-function toggleReviewLine() {
+function toggleReviewLine(event) {
 	var line = $(this).closest('tr');
 	var next = line.next();
 
@@ -425,6 +425,8 @@ function toggleReviewLine() {
 		table.find('tr:first').addClass('hidden-line');
 	}
 	refreshAffix();
+	event.preventDefault();
+	event.stopPropagation();
 }
 
 /**


### PR DESCRIPTION
CLDR-13994

- To fix a performance issue
- Semantic change: you can now hide unrelated review items without dismissing the popover.


