### PR TITLE
CLDR-14004 fix error for unique plural forms

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -185,6 +185,7 @@ public class TestCheckCLDR extends TestFmwk {
     public void testPlaceholderSamples() {
         CLDRFile root = cldrFactory.make("root", true);
         String[][] tests = {
+            {"he", "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"one\"]", "שנה"},
             // test edge cases
             // locale, path, value, 0..n Subtype errors
             {"en", "//ldml/localeDisplayNames/localeDisplayPattern/localePattern", "{0}huh?{1}"},
@@ -213,6 +214,11 @@ public class TestCheckCLDR extends TestFmwk {
             {"ar", "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-hour\"]/unitPattern[@count=\"one\"]", "ساعة"},
             {"ar", "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-hour\"]/unitPattern[@count=\"one\"]", "{0} ساعة"},
             {"ar", "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-hour\"]/unitPattern[@count=\"one\"]", "{1}{0} ساعة", "extraPlaceholders"},
+
+            {"he", "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"one\"]", "שנה"},
+            {"he", "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"two\"]", "שנתיים"},
+            {"he", "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"many\"]", "שנה", "missingPlaceholders"},
+            {"he", "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"other\"]", "שנים", "missingPlaceholders"},
         };
         for (String[] row : tests) {
             String localeId = row[0];

--- a/tools/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -478,7 +478,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         int minimum = placeholderInfo.size();
         int maximum = placeholderInfo.size();
 
-        if (placeholderStatus == PlaceholderStatus.LOCALE_DEPENDENT) {
+        if (placeholderStatus == PlaceholderStatus.LOCALE_DEPENDENT || placeholderStatus == PlaceholderStatus.MULTIPLE) {
             // if locale dependent, it is because of count= or ordinal=. Figure out what the values are, and whether we are allowed to have none or one
             PluralRules rules = PluralRules.forLocale(new ULocale(getCldrFileToCheck().getLocaleID()));
             if (rules != null) {

--- a/tools/java/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/java/org/unicode/cldr/util/data/Placeholders.txt
@@ -3,7 +3,7 @@
 # The default for everything in this file is REQUIRED, meaning that the number of placeholders has to match the number in the final field.
 # That default is overridden if the line has as the X parameter: locale or multiple.
 #	locale: there is a count= or ordinal=, so the value is subject to the locale; may be zero or one.
-#	multiple: there may be zero or more placeholders (normally only in minimalPairs)
+#	multiple: there may be zero or more placeholders (normally only in count or ordinal minimalPairs)
 
 %A = [^"]*+
 %L = (long|short|narrow)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14004
- [ ] Updated PR title and link in previous line to include Issue number


Problem was that "multiple" also needs to count as "locale dependent". Only used in count/orginal minimal pairs.