### PR TITLE
CLDR-13306 cleanup ChartDelta and ExampleGenerator

### DIFF
--- a/tools/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2091,8 +2091,6 @@ public class ExampleGenerator {
             this.pathDescription = new PathDescription(supplementalDataInfo, englishFile, extras, starredPaths,
                 PathDescription.ErrorHandling.CONTINUE);
 
-            this.pathDescription = new PathDescription(supplementalDataInfo, englishFile, extras, starredPaths,
-                PathDescription.ErrorHandling.CONTINUE);
             if (helpMessages == null) {
                 helpMessages = new HelpMessages("test_help_messages.html");
             }

--- a/tools/java/org/unicode/cldr/tool/Chart.java
+++ b/tools/java/org/unicode/cldr/tool/Chart.java
@@ -100,7 +100,7 @@ public abstract class Chart {
         standardFooter(pw, AnalyticsID.CLDR);
     }
 
-    enum AnalyticsID {
+    private enum AnalyticsID {
         CLDR("UA-7672775-1"), ICU("UA-7670213-1"), ICU_GUIDE("UA-7670256-1"), UNICODE("UA-7670213-1"), UNICODE_UTILITY("UA-8314904-1");
         public final String id;
 
@@ -109,7 +109,7 @@ public abstract class Chart {
         }
     }
 
-    public static void standardFooter(FormattedFileWriter pw, AnalyticsID analytics) throws IOException {
+    private static void standardFooter(FormattedFileWriter pw, AnalyticsID analytics) throws IOException {
         pw.write("<div style='text-align: center; margin-top:2em; margin-bottom: 60em;'><br>\n"
             + "<a href='http://www.unicode.org/unicode/copyright.html'>\n"
             + "<img src='http://www.unicode.org/img/hb_notice.gif' style='border-style: none; width: 216px; height=50px;' alt='Access to Copyright and terms of use'>"


### PR DESCRIPTION
-This PR has only preliminary minor improvements and clean-up

-ChartDelta: report when finished and report file-creation directories

-Remove duplicate new PathDescription from ExampleGenerator.java

-Avoid deprecation warning for DtdData.getInstance; cache getCldrBaseDirectory as CLDR_BASE_DIR

-Refactor to obviate single-line getValueSplitter; call DtdData.getValueSplitter directly instead

-Remove dead/unused code from ChartDelta.java and Chart.java, make private where possible

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13306
- [x] Updated PR title and link in previous line to include Issue number

