### PR TITLE
CLDR-13939 zh_Hant_HK, add aux exemplars with chars in zh_Hant aux + 106 more from Big5/HKSCS

### DIFF
--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -1405,7 +1405,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters draft="contributed">↑↑↑</exemplarCharacters>
-		<exemplarCharacters type="auxiliary" draft="contributed">↑↑↑</exemplarCharacters>
+		<exemplarCharacters type="auxiliary" draft="contributed">[㩒 乍 乒 乓 乞 乳 仂 仗 伏 佐 侖 侶 俏 倉 倦 偽 傅 傘 僳 兆 兌 兹 冇 冥 凋 凍 凸 划 刨 别 刮 券 剃 剔 勳 勾 匕 匙 匣 匯 卑 卞 占 卹 叉 叮 叶 吻 呔 咗 哺 唇 唵 啤 啲 喪 喲 喺 嘅 嘔 嘟 嘢 噁 噓 噘 嚏 嚿 坑 埋 堤 墅 墎 墓 墟 墳 壤 壩 壺 奥 妖 娥 嬰 嬲 孕 孜 孵 宴 寺 尬 尷 尿 屍 屎 屑 峇 嶼 巽 巾 帆 帚 幟 廁 廈 廊 廚 廟 弋 弓 循 忡 恤 憊 憤 懨 懸 戚 戟 扒 扮 扳 扶 拎 拐 捂 捏 捧 掠 掩 掰 揹 搏 摀 摔 撅 撕 撲 撳 擘 攀 攤 敞 斑 斜 斧 暈 暮 曇 曬 曳 朔 杆 杖 枯 柄 柑 栓 栗 栽 框 桶 桿 梘 梳 棍 棕 棺 椒 楔 榚 槌 樽 橄 橇 橘 橙 檬 檳 檸 櫃 櫚 櫻 欖 欠 残 殭 汁 沫 沮 泣 津 浣 浴 浸 涅 涎 涮 淇 淋 渣 温 渾 湘 溜 漿 潤 澎 澡 濕 灑 灘 烘 烙 烹 焊 焗 焙 焰 煎 煨 煮 燕 燙 燦 燭 爍 牡 犀 犬 狄 狡 狸 猩 猾 猿 獺 獾 珀 珈 琳 瑚 璃 瓢 甕 甩 甫 畿 疊 疲 疾 瘦 瘧 皂 皺 皿 盆 盈 盒 盔 盥 眨 眩 着 睏 睜 瞇 瞌 瞓 瞪 瞰 矮 碌 碑 磚 礁 礫 祈 禱 禿 稻 穀 穗 窄 竿 筒 筷 箏 箔 篤 篷 簍 籠 粒 粟 粥 糖 糰 紉 紋 紗 紮 紳 綁 綽 綿 縫 繃 繡 繩 纏 纖 纜 罈 罐 罩 羮 羯 羹 聳 聾 肌 肖 肺 脈 脖 脷 腐 腕 腸 腹 膏 膚 膠 臂 臟 舔 艇 芒 芙 芭 芽 苗 苣 茄 茨 茵 茸 莓 莖 菇 菌 菓 菠 菱 萎 萵 葵 蒜 蒸 蓄 蓉 蓬 蔔 蔥 蔬 蕃 蕉 蕾 薑 薯 蘋 蘑 蘿 虹 蚊 蚓 蚩 蚯 蛛 蜀 蜘 蜥 蜴 蝙 蝟 蝠 蝦 蝴 蝸 螂 螃 螞 螺 蟀 蟄 蟋 蟑 蟳 蟻 蠅 蠔 蠕 蠟 蠣 衫 袍 裏 裘 裙 裱 裹 褐 褸 襪 襯 訝 診 諜 謎 謠 謬 豎 豔 豚 豹 賊 賬 贛 跆 跨 跪 踩 踭 躬 軸 輻 轆 轎 辜 辣 遞 鄙 酋 酪 醬 釘 鈔 鈕 鉅 鉛 鉤 鋁 鋤 錨 錶 鍊 鎚 鎬 鏈 鏢 鐺 鑊 鑰 鑽 鑿 閂 閩 阱 隴 雀 雌 霄 霜 静 靴 鞠 鞭 頌 頸 顛 颱 飆 飪 餃 餌 餚 餡 餵 餾 駝 駱 騮 騰 驕 骰 骷 骹 髀 髏 髒 鬍 鬚 魷 鮑 鯉 鯊 鯨 鱷 鳩 鳶 鴨 鴿 鵑 鵡 鶴 鸚 鹽 麪 黛 黯 鼬 龐]</exemplarCharacters>
 		<exemplarCharacters type="index" draft="contributed">↑↑↑</exemplarCharacters>
 		<exemplarCharacters type="numbers" draft="contributed">↑↑↑</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="contributed">↑↑↑</exemplarCharacters>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13939
- [x] Updated PR title and link in previous line to include Issue number

zh_Hant_HK was just inheriting the aux exemplars from zh_Hant (it also inherits main exemplars from zh_Hant). Add its own aux exemplars which consist of all of the characters in zh_Hant aux exemplars plus 106 more from Big5 (90) and HKSCS (16) which are used in CLDR data. See discussion in JIRA ticket.

