### PR TITLE
CLDR-13306 Data churn report: Fix ChartDelta CLDR_BASE_DIR bug

### DIFF
--- a/tools/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/java/org/unicode/cldr/tool/ChartDelta.java
@@ -191,7 +191,7 @@ public class ChartDelta extends Chart {
 
     private static final CLDRFile EMPTY_CLDR = new CLDRFile(new SimpleXMLSource("und").freeze());
 
-    private static final String CLDR_BASE_DIR = CLDRConfig.getInstance().getCldrBaseDirectory().toString();
+    private static final File CLDR_BASE_DIR = CLDRConfig.getInstance().getCldrBaseDirectory();
 
     private enum ChangeType {
         added, deleted, changed, same;


### PR DESCRIPTION
-CLDR_BASE_DIR must be File not String to prevent mixup between two versions of DtdData.getInstance

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13306
- [x] Updated PR title and link in previous line to include Issue number

