### PR TITLE
CLDR-6746 TestPaths to include seed and exemplars

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3089,7 +3089,6 @@ $Revision$
     <!--@MATCH:literal/NumberingSystemRules, OrdinalRules, SpelloutRules-->
 <!ATTLIST rulesetGrouping draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
     <!--@METADATA-->
-    <!--@DEPRECATED-->
 
 <!ELEMENT ruleset ( alias | ( rbnfrule*, special* ) ) >
     <!--@ORDERED-->

--- a/seed/collation/sa.xml
+++ b/seed/collation/sa.xml
@@ -12,9 +12,8 @@
 <collation type="standard"
 references="Monier-Williams: Sanskrit-English Dictionary ISBN:8120800656"
 draft="unconfirmed" alt="proposed">
-<settings normalization="on"/>
 <cr><![CDATA[
-
+[normalization on]
 #
 # The following tailoring is an adjustment of the
 # DUCET collation order for ANUSVARA, CANDRABINDU,
@@ -50,8 +49,8 @@ Monier-Williams: Sanskrit-English Dictionary
 http://www.ibiblio.org/sripedia/ebooks/mw/
 http://www.ibiblio.org/sripedia/ebooks/mw/0000/mw__0033.html"
 draft="unconfirmed" alt="proposed">
-<settings normalization="on"/>
 <cr><![CDATA[
+[normalization on]
 &औ<ं<<ँ<ः<क्<ख्<ग्<घ्<ङ्<च्<छ्<ज्<झ्<ञ्<ट्<ठ्<ड्<ढ्<ण्<त्<थ्<द्<ध्<न्<प्<फ्<ब्<भ्
 <म्<य्<र्<ल्<ळ्<व्<श्<ष्<स्<ह्
 &क्अ=क

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPaths.java
@@ -278,11 +278,20 @@ public class TestPaths extends TestFmwkPlus {
                 for (Entry<String, String> attributeNValue : parts.getAttributes(i).entrySet()) {
                     String attributeName = attributeNValue.getKey();
                     if (dtdData.isDeprecated(elementName, attributeName, "*")) {
-                        testPaths.errln("Deprecated attribute in data: "
-                            + dtdData.dtdType
-                            + ":" + elementName
-                            + ":" + attributeName
-                            + " \t;" + fullName);
+                        if (attributeName.equals("draft")) {
+                            testPaths.errln("Deprecated attribute in data: "
+                                            + dtdData.dtdType
+                                            + ":" + elementName
+                                            + ":" + attributeName
+                                            + " \t;" + fullName +
+                                            " - consider adding to DtdData.DRAFT_ON_NON_LEAF_ALLOWED if you are sure this is ok.");
+                        } else {
+                            testPaths.errln("Deprecated attribute in data: "
+                                            + dtdData.dtdType
+                                            + ":" + elementName
+                                            + ":" + attributeName
+                                            + " \t;" + fullName);
+                        }
                         return true;
                     }
                     String attributeValue = attributeNValue.getValue();
@@ -367,7 +376,7 @@ public class TestPaths extends TestFmwkPlus {
         String[] normalizedPath = { "" };
 
         int counter = 0;
-        for (String directory : Arrays.asList("keyboards/", "common/")) {
+        for (String directory : Arrays.asList("keyboards/", "common/", "seed/", "exemplars/")) {
             String dirPath = CLDRPaths.BASE_DIRECTORY + directory;
             for (String fileName : new File(dirPath).list()) {
                 File dir2 = new File(dirPath + fileName);

--- a/tools/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/java/org/unicode/cldr/util/DtdData.java
@@ -99,7 +99,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         CDATA, ID, IDREF, IDREFS, ENTITY, ENTITIES, NMTOKEN, NMTOKENS, ENUMERATED_TYPE
     }
 
-    static final Set<String> DRAFT_ON_NON_LEAF_ALLOWED = ImmutableSet.of("collation", "transform", "unitPreferenceData");
+    static final Set<String> DRAFT_ON_NON_LEAF_ALLOWED = ImmutableSet.of("collation", "transform", "unitPreferenceData", "rulesetGrouping");
 
     public static class Attribute implements Named {
         public final String name;


### PR DESCRIPTION
CLDR-6746

- TestPaths needed to include seed and exemplars
- two files had deprecate formats, fixed.

I moved the normalization mode out of the deprecated options, and removed the deprecated draftiness on RBNF.

- [ ] Open Q for @macchiati in Jira, should the test enforce deprecation on the deprecated postalcode elements? (could be a separate PR)