### PR TITLE
CLDR-13306 Generate disruptive data churn report

### DIFF
--- a/tools/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -31,7 +31,7 @@ public final class SubmissionLocales {
         );
 
     // have to have a lazy eval because otherwise CLDRConfig is called too early in the boot process
-    static Set<String> CLDR_LOCALES = ImmutableSet.<String>builder()
+    public static Set<String> CLDR_LOCALES = ImmutableSet.<String>builder()
         .addAll(HIGH_LEVEL_LOCALES)
         .addAll(NEW_CLDR_LOCALES)
         .addAll(StandardCodes.make().getLocaleToLevel(Organization.cldr).keySet()).build();


### PR DESCRIPTION
-Replace DO_CHURN with highLevelOnly in MyOptions

-Encapsulate Delta vs Churn per highLevelOnly: dirName, chartNameCap

-New inner class HighLevelPaths determines which paths are high-level

-Match some paths exactly

-Match other paths with special functions like isHighLevelTerritoryName

-Check only locales in SubmissionLocales.CLDR_LOCALES; make that public

-Report on usage of highLevelPaths, with highLevelPathMatched

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13306
- [x] Updated PR title and link in previous line to include Issue number

