### PR TITLE
CLDR-13857 Optimize LikelySubtags initilization

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
@@ -103,7 +103,7 @@ public class CheckLanguageCodeConverter {
             }
         }
 
-        LikelySubtags likely = new LikelySubtags(supplementalDataInfo);
+        LikelySubtags likely = new LikelySubtags();
         LanguageTagParser ltp = new LanguageTagParser();
         // get targets of language aliases for macros
         Map<String, String> macroToEncompassed = new HashMap<String, String>();

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -34,8 +34,7 @@ public class LikelySubtagsTest extends TestFmwk {
         .getInstance().getSupplementalDataInfo();
     static final Map<String, String> likely = SUPPLEMENTAL_DATA_INFO
         .getLikelySubtags();
-    static final LikelySubtags LIKELY = new LikelySubtags(
-        SUPPLEMENTAL_DATA_INFO, likely);
+    static final LikelySubtags LIKELY = new LikelySubtags();
 
     public static void main(String[] args) {
         new LikelySubtagsTest().run(args);

--- a/tools/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/java/org/unicode/cldr/tool/ChartDelta.java
@@ -315,7 +315,7 @@ public class ChartDelta extends Chart {
             Matcher m = fileMatcher.matcher("");
             Set<String> defaultContents = SDI.getDefaultContentLocales();
             LanguageTagParser ltp = new LanguageTagParser();
-            LikelySubtags ls = new LikelySubtags(SDI);
+            LikelySubtags ls = new LikelySubtags();
             for (String file : factories.get(0).getAvailable()) {
                 if (defaultContents.contains(file)) {
                     continue;

--- a/tools/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -112,7 +112,7 @@ public class FindPreferredHours {
         final Relation<String, Hours> lang2Hours = Relation.of(new TreeMap<String, Set<Hours>>(), TreeSet.class);
         final Factory factory = INFO.getCldrFactory();
         final FormatParser formatDateParser = new FormatParser();
-        final LikelySubtags likely2Max = new LikelySubtags(INFO.getSupplementalDataInfo());
+        final LikelySubtags likely2Max = new LikelySubtags();
 
         for (final String locale : factory.getAvailable()) {
             if (locale.equals("root")) {

--- a/tools/java/org/unicode/cldr/util/CoreCoverageInfo.java
+++ b/tools/java/org/unicode/cldr/util/CoreCoverageInfo.java
@@ -30,7 +30,7 @@ public class CoreCoverageInfo {
     private static final CLDRConfig config = CLDRConfig.getInstance();
     private static final String CLDR_BASE_DIRECTORY = config.getCldrBaseDirectory().toString();
     private static final SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
-    private static final LikelySubtags ls = new LikelySubtags(sdi);
+    private static final LikelySubtags ls = new LikelySubtags();
 
     public enum CoreItems {
         // Drop the exemplars, since


### PR DESCRIPTION
Speed up LikelySubtags initialization by making supplementalDataInfo, currencyToLikelyTerritory static, only need to initialize once

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13857
- [ ] Updated PR title and link in previous line to include Issue number

