### PR TITLE
CLDR-14067 Make forum visible even when ST is read-only

### DIFF
--- a/tools/cldr-apps/WebContent/js/CldrStForum.js
+++ b/tools/cldr-apps/WebContent/js/CldrStForum.js
@@ -55,6 +55,11 @@ const cldrStForum = (function() {
 	let threadHash = {};
 
 	/**
+	 * Whether the current user can make posts
+	 */
+	let userCanPost = false;
+
+	/**
 	 * Fetch the Forum data from the server, and "load" it
 	 *
 	 * @param locale the locale string, like "fr_CA" (surveyCurrentLocale)
@@ -76,6 +81,13 @@ const cldrStForum = (function() {
 				}
 				return;
 			}
+			/*
+			 * The server has already confirmed that the user is logged in and has permission to view the forum.
+			 * Note: the criteria (here) for posting in the main forum window are less strict than in the info
+			 * panel; see the other call to setUserCanPost. Here, we have no "json.canModify" set by the server.
+			 */
+			setUserCanPost(true);
+
 			// set up the 'right sidebar'
 			showInPop2(forumStr(params.name + "Guidance"), null, null, null, true); /* show the box the first time */
 
@@ -108,6 +120,13 @@ const cldrStForum = (function() {
 			error: errorHandler
 		};
 		cldrStAjax.sendXhr(xhrArgs);
+	}
+
+	/**
+	 * Set whether the user is allowed to make posts
+	 */
+	function setUserCanPost(canPost) {
+		userCanPost = canPost ? true : false;
 	}
 
 	/**
@@ -649,6 +668,9 @@ const cldrStForum = (function() {
 	 * @param topicDivs the map from threadId to DOM elements
 	 */
 	function addReplyButtonsToEachTopic(topicDivs) {
+		if (!userCanPost) {
+			return;
+		}
 		Object.keys(topicDivs).forEach(function(threadId) {
 			const rootPost = getRootPostFromThreadId(threadId);
 			if (rootPost) {
@@ -668,6 +690,9 @@ const cldrStForum = (function() {
 	 * @param value the value the current user voted for, or null
 	 */
 	function addNewPostButtons(el, locale, couldFlag, xpstrid, code, value) {
+		if (!userCanPost) {
+			return;
+		}
 		const options = getPostTypeOptions(false /* isReply */, null /* rootPost */, value);
 
 		Object.keys(options).forEach(function(postType) {
@@ -682,6 +707,9 @@ const cldrStForum = (function() {
 	 * @param rootPost the original post in the thread
 	 */
 	function addReplyButtons(el, rootPost) {
+		if (!userCanPost) {
+			return;
+		}
 		const options = getPostTypeOptions(true /* isReply */, rootPost, rootPost.value);
 
 		Object.keys(options).forEach(function(postType) {
@@ -1213,6 +1241,7 @@ const cldrStForum = (function() {
 		loadForum: loadForum,
 		reload: reload,
 		addNewPostButtons: addNewPostButtons,
+		setUserCanPost: setUserCanPost,
 		/*
 		 * The following are meant to be accessible for unit testing only:
 		 */

--- a/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
+++ b/tools/cldr-apps/WebContent/js/CldrSurveyVettingTable.js
@@ -900,7 +900,7 @@ const cldrSurveyTable = (function() {
 			codeStr = codeStr + " (optional)";
 		}
 		cell.appendChild(createChunk(codeStr));
-		if (tr.theTable.json.canModify) { // pointless if can't modify.
+		if (surveyUserPerms.userExist) {
 			cell.className = "d-code codecell";
 			if (!tr.forumDiv) {
 				tr.forumDiv = document.createElement("div");

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -2042,6 +2042,9 @@ function updateInfoPanelForumPosts(tr) {
  * @param {Node} forumDiv
  */
 function appendForumStuff(tr, theRow, forumDiv) {
+
+	cldrStForum.setUserCanPost(tr.theTable.json.canModify);
+
 	removeAllChildNodes(forumDiv); // we may be updating.
 	var theForum = locmap.getLanguage(surveyCurrentLocale);
 	forumDiv.replyStub = contextPath + "/survey?forum=" + theForum + "&_=" + surveyCurrentLocale + "&replyto=";

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyForum.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyForum.java
@@ -263,6 +263,9 @@ public class SurveyForum {
      * @throws SurveyException
      */
     private boolean userCanUsePostType(User user, PostType postType, int replyTo) throws SurveyException {
+        if (SurveyMain.isPhaseReadonly()) {
+            return false;
+        }
         if (postType != PostType.CLOSE) {
             return true;
         }


### PR DESCRIPTION
-Show forum posts in info panel if user is logged in (userExist)

-Hide info panel forum buttons if userCanPost (json.canModify) is false

-Do not hide buttons in main forum window (no change; possible TO-DO)

-On server, prevent post if SurveyMain.isPhaseReadonly

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14067
- [x] Updated PR title and link in previous line to include Issue number

