### PR TITLE
CLDR-14085 sv script translation

### DIFF
--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -708,9 +708,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hang">hangul</script>
 			<script type="Hani">han</script>
 			<script type="Hano">hanunó’o</script>
-			<script type="Hans">förenklade</script>
+			<script type="Hans">förenklad</script>
 			<script type="Hans" alt="stand-alone">förenklade han-tecken</script>
-			<script type="Hant">traditionella</script>
+			<script type="Hant">traditionell</script>
 			<script type="Hant" alt="stand-alone">traditionella han-tecken</script>
 			<script type="Hatr">hatran</script>
 			<script type="Hebr">hebreiska</script>


### PR DESCRIPTION
sv: simplified and traditional translated out of context - is plural, should be singular

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14085
- [ ] Updated PR title and link in previous line to include Issue number

