### PR TITLE
CLDR-14044 fix debug output in OutputFileManager

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/web/OutputFileManager.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/OutputFileManager.java
@@ -1145,7 +1145,9 @@ public class OutputFileManager {
             theFile = new Timestamp(lastMod);
         }
         if (theDate == null) {
-            SurveyLog.logger.warning(" .. no data.");
+            if (debugWhyUpdate) {
+                SurveyLog.debug(" .. no data.");
+            }
             return false; // no data (?)
         }
         if (debugWhyUpdate)


### PR DESCRIPTION
CLDR-14044

a log statement wasn't behind the right check, nor did it call debug() as the other  instances did. Check context for related similar  calls.