### PR TITLE
CLDR-13771 playbook to include letsencrypt and deploy script

### DIFF
--- a/tools/scripts/ansible/README.md
+++ b/tools/scripts/ansible/README.md
@@ -20,9 +20,11 @@ This is your local system, where you control the others from.
 ansible-galaxy install -r roles.yml
 ```
 
-- Make sure you can `ssh` into all of the needed systems. For example, `ssh cldr-ref.unicode.org` should succeed without needing a password.
+- Make sure you can `ssh` into all of the needed systems. For example,
+`ssh cldr-ref.unicode.org` should succeed without needing a password.
 
-- You should be able to run `ansible all -m ping` and get something back like the following:
+- You should be able to run `ansible all -m ping` and get something back
+like the following:
 
 ```shell
 cldr-ref.unicode.org | SUCCESS => {
@@ -38,9 +40,45 @@ cldr-ref.unicode.org | SUCCESS => {
 
 - Install python3. Make sure `python --version` returns "Python 3…"
 
+- TODO: these shouldn't be needed, but they are. Here's the entire
+install command:
+
+```shell
+sudo apt-get update && sudo apt-get install python3 python-apt python3-pymysql
+```
+
+### Setup: surveytool keypair
+
+Create a RSA keypair with no password for the buildbot:
+
+```shell
+mkdir -p ./local-vars
+ssh-keygen -t rsa -b 4096 -f ./local-vars/surveytool -P '' -C 'surveytool deploy'
+```
+
+The contents of the `local-vars/surveytool.pub` file is used for the
+`key:` parameter below in `local.yml`. The `local-vars/surveytool`
+private key is used in the secret `RSA_KEY_SURVEYTOOL`.
+
+Then setup github secrets as shown:
+
+- `SMOKETEST_HOST` -
+  hostname of smoketest
+- `SMOKETEST_PORT` -
+  port of smoketest
+- `RSA_KEY_SURVEYTOOL` -
+  contents of `local-vars/surveytool` (the secret key)
+- `SMOKETEST_KNOWNHOSTS` -
+  run `ssh-keyscan smoketest.example.com` where _smoketest.example.com_
+  is the name of the smoketest server.  Put the results into this
+  secret. One of these lines should match `~/.ssh/known_hosts` on your
+  own system when you ssh into smoketest.
+  Try `grep -i smoke ~/.ssh/known_hosts`
+
 ### Setup: Config file
 
-- Create a file `local-vars/local.yml` with the following (but with a secure password instead of `hunter42`.)
+- Create a file `local-vars/local.yml` with the following
+(but with a secure password instead of `hunter42`.)
 
 ```yaml
 mysql_users:
@@ -54,6 +92,7 @@ surveytooldeploy:
   testpw: hunter45
   oldversion: 36
   newversion: 37
+  key: ssh-rsa …  ( SSH key goes here)
 ```
 
 ## Configure
@@ -64,7 +103,8 @@ Run the setup playbook.
 ansible-playbook --check setup-playbook.yml
 ```
 
-This is in dry run mode. When it looks good to you, take the `--check` out and run it again.
+This is in dry run mode. When it looks good to you, take the
+`--check` out and run it again.
 
 ## Local Test
 

--- a/tools/scripts/ansible/hosts
+++ b/tools/scripts/ansible/hosts
@@ -1,5 +1,6 @@
 [staging]
-cldr-ref.unicode.org
+#cldr-ref.unicode.org
+cldr-smoke2.unicode.org
 
 [prod]
 
@@ -7,3 +8,7 @@ cldr-ref.unicode.org
 [surveytool:children]
 staging
 prod
+
+# encrypt all of the surveytool hosts
+[letsencrypt:children]
+surveytool

--- a/tools/scripts/ansible/roles.yml
+++ b/tools/scripts/ansible/roles.yml
@@ -1,4 +1,6 @@
 - src: geerlingguy.mysql
   version: 3.3.0
-# - src: geerlingguy.nginx
-#   version: 2.8.0
+- src: geerlingguy.nginx
+  version: 2.8.0
+# - src: geerlingguy.certbot
+#   version: 3.1.0

--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -5,27 +5,26 @@
     - local-vars/local.yml
   roles:
     - { role: geerlingguy.mysql }
-    # - { role: geerlingguy.nginx }
-  # # was only needed for docker
-  # pre_tasks:                                                                                                                                         
-  #   - name: Install policy-rc.d script                                                                                                               
-  #     copy:                                                                                                                                          
-  #       dest: /usr/sbin/policy-rc.d                                                                                                                  
-  #       content: |                                                                                                                                   
-  #         #!/bin/bash                                                                                                                                                                                                              
-  #         exit 0                                                                                                                                                                                                                                                                    
-  #       mode: 0755
+    - { role: geerlingguy.nginx }
   tasks:
     - name: Install server packages
       apt:
         pkg:
           - tomcat8
           - tomcat8-admin # needed for deploy
-          # - libmariadb-java # obviated by CLDR-13913
+          - unzip # needed for deploy
     - name: Setup Server Context
       template:
         src: templates/context.j2
         dest: /etc/tomcat8/context.xml
+        owner: root
+        group: tomcat8
+        mode: '0640'
+      notify: Restart Tomcat
+    - name: Setup tomcat8/server.xml
+      copy:
+        src: templates/server.xml
+        dest: /etc/tomcat8/server.xml
         owner: root
         group: tomcat8
         mode: '0640'
@@ -52,25 +51,69 @@
         force: no
         owner: tomcat8
         group: tomcat8
-        mode: 0644
+        mode: "0644"
       notify: Restart Tomcat
     - name: Checkout CLDR trunk
       git:
         repo: https://github.com/unicode-org/cldr.git
         dest: /var/lib/tomcat8/cldr/cldr-trunk
-        depth: 1 # don't need all history
         force: no
+        update: no
         version: master
+        # this is deep because we will need to keep updating
+        # it with history. It does not include LFS as that
+        # is not needed for the surveytool.
+    - name: Setup index.html
+      copy:
+        src: templates/index.html
+        dest: /var/www/html
+        owner: root
+        group: root
+        mode: '0644'
+    - name: Setup reverse proxy
+      blockinfile:
+        path: /etc/nginx/sites-enabled/default
+        block: |
+          # proxy /cldr-apps/ to tomcat
+          location /cldr-apps/ {
+            allow all;
+            proxy_pass http://localhost:8080/cldr-apps/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+          }
+        marker: '# {mark} ANSIBLE MANAGED BLOCK'
+        insertafter: '^[\s]*server_name' # the LAST uncommented server block
+      notify: 'Restart Nginx'
+    - name: Setup surveytool user for deploy
+      user:
+        name: surveytool
+        shell: /bin/bash
+    - name: Give acess to surveytool user
+      file:
+        path: /var/lib/tomcat8/cldr/cldr-trunk
+        owner: surveytool
+        recurse: yes
+    - name: Setup surveytool auth
+      authorized_key:
+        user: surveytool
+        key: '{{ surveytooldeploy.key }}'
+    - name: Setup deploy-to-tomcat.sh
+      template:
+        src: templates/deploy-sh.j2
+        dest: /usr/local/bin/deploy-to-tomcat.sh
+        owner: root
+        group: root
+        mode: '0755'
   handlers:
     - name: Restart Tomcat
       service:
         name: tomcat8
         state: restarted
+    - name: Restart Nginx
+      service:
+        name: nginx
+        state: restarted
 
-
-
-# these are for convenience of the user, not specific
-# to the surveytool
 - hosts: all
   become: yes
   tasks:
@@ -81,3 +124,17 @@
           - mosh
           - emacs-nox
           - byobu
+- hosts: letsencrypt
+  become: yes
+  vars_files:
+    - vars/main.yml
+    - local-vars/local.yml
+  tasks:
+    - name: Install certbot packages
+      apt:
+        pkg:
+          - python3-certbot-nginx
+    - name: setup certbot
+      command: sudo certbot --nginx  --agree-tos -m {{ certbot_admin_email }} -d {{ inventory_hostname }} --non-interactive --keep
+      args:
+        creates: /etc/letsencrypt/renewal/{{ inventory_hostname }}.conf

--- a/tools/scripts/ansible/templates/deploy-sh.j2
+++ b/tools/scripts/ansible/templates/deploy-sh.j2
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Note: this is managed by Ansible, as deploy-sh.j2
+# Don't modify this file.
+GITHUB_SHA=$1
+export TPASS={{ surveytooldeploy.password }} # from surveytooldeploy.password
+export TUSER=surveytooldeploy # fixed for now
+curl -u ${TUSER}:${TPASS} 'http://localhost:8080/manager/text/undeploy?path=/cldr-apps'
+rm -fv cldr-apps.war .deploystatus
+dd bs=1024000 status=progress of=cldr-apps.war
+echo ; echo -n file count
+(unzip -l cldr-apps.war | wc -l ) || exit 1
+(cd  /var/lib/tomcat8/cldr/cldr-trunk/ && git fetch && git clean -f -d ; git checkout  ${GITHUB_SHA} )
+curl -u ${TUSER}:${TPASS} 'http://localhost:8080/manager/text/deploy?path=/cldr-apps&tag=cldr-apps&update=true' -T ./cldr-apps.war | tee .deploystatus

--- a/tools/scripts/ansible/templates/index.html
+++ b/tools/scripts/ansible/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>Nothing Here</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+</head>
+<body>
+    Nothing to see here.
+</body>
+</html>

--- a/tools/scripts/ansible/templates/server.xml
+++ b/tools/scripts/ansible/templates/server.xml
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server address="127.0.0.1" port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <!--
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  -->
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector address="127.0.0.1" port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               URIEncoding="UTF-8"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               address="127.0.0.1" port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation that requires the JSSE
+         style configuration. When using the APR/native implementation, the
+         OpenSSL style configuration is required as described in the APR/native
+         documentation -->
+    <!--
+    <Connector address="127.0.0.1" port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
+               clientAuth="false" sslProtocol="TLS" />
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector address="127.0.0.1" port="8009" protocol="AJP/1.3" redirectPort="8443" />
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/tools/scripts/ansible/test-local-vars/local.yml
+++ b/tools/scripts/ansible/test-local-vars/local.yml
@@ -10,3 +10,4 @@ surveytooldeploy:
   testpw: hunter45
   oldversion: 36
   newversion: 37
+  key: ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJ5TcIs3HNzv6PIlkJVifUTaWj8CEJmLngvE45F/sL4+oHdOSBHyG/rU04psIuvDjukrQY8a0ZhohGkpcwl1WIY= dummy value just for test

--- a/tools/scripts/ansible/vars/main.yml
+++ b/tools/scripts/ansible/vars/main.yml
@@ -4,3 +4,4 @@ mysql_databases:
     collation: latin1_bin
 mysql_enabled_on_startup: true
 mysql_bind_address: localhost
+ansible_python_interpreter: python3


### PR DESCRIPTION
CLDR-13771

this does the letsencrypt/nginx/proxy setup via ansible

- use cldr-smoke2 but leave cldr-ref out
- the autodeployment on merge is in PR#601 [CLDR-13948]

[CLDR-13948]: https://unicode-org.atlassian.net/browse/CLDR-13948