### PR TITLE
CLDR-14113 uppercase value of type in <variantAlias> and remove dup 

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1575,9 +1575,10 @@ For terms of use, see http://www.unicode.org/copyright.html
             <variantAlias type="AALAND" replacement="AX" reason="deprecated"/>
             <variantAlias type="POLYTONI" replacement="POLYTON" reason="deprecated"/>
             <variantAlias type="HEPLOC" replacement="ALALC97" reason="deprecated"/>
-			<variantAlias type="arevela" replacement="hy" reason="deprecated"/> <!-- arevela -->
-			<variantAlias type="arevmda" replacement="hyw" reason="deprecated"/> <!-- arevmda -->
-			<variantAlias type="heploc" replacement="alalc97" reason="deprecated"/> <!-- heploc -->
+	    <variantAlias type="AREVELA" replacement="hy" reason="deprecated"/> <!-- arevela -->
+	    <variantAlias type="AREVMDA" replacement="hyw" reason="deprecated"/> <!-- arevmda -->
+		
+            <!-- zones -->		
             <zoneAlias type="Africa/Timbuktu" replacement="Africa/Bamako" reason="deprecated"/>          
             <zoneAlias type="Pacific/Yap" replacement="Pacific/Truk" reason="deprecated"/>          
             <zoneAlias type="Europe/Belfast" replacement="Europe/London" reason="deprecated"/>


### PR DESCRIPTION
Uppercase value of type in <variantAlias> and removed duplicate  type="heploc"

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14113
- [X] Updated PR title and link in previous line to include Issue number

