### PR TITLE
CLDR-14126 Updated tz version numbers in windowsZones.xml

### DIFF
--- a/common/supplemental/windowsZones.xml
+++ b/common/supplemental/windowsZones.xml
@@ -9,7 +9,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 <supplementalData>
 	<version number="$Revision$"/>
 	<windowsZones>
-		<mapTimezones otherVersion="7e11200" typeVersion="2019b">
+		<mapTimezones otherVersion="7e11500" typeVersion="2020a">
 
 			<!-- (UTC-12:00) International Date Line West -->
 			<mapZone other="Dateline Standard Time" territory="001" type="Etc/GMT+12"/>
@@ -64,7 +64,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 			<!-- (UTC-07:00) Arizona -->
 			<mapZone other="US Mountain Standard Time" territory="001" type="America/Phoenix"/>
-			<mapZone other="US Mountain Standard Time" territory="CA" type="America/Whitehorse America/Creston  America/Dawson  America/Dawson_Creek America/Fort_Nelson"/>
+			<mapZone other="US Mountain Standard Time" territory="CA" type="America/Whitehorse America/Creston America/Dawson America/Dawson_Creek America/Fort_Nelson"/>
 			<mapZone other="US Mountain Standard Time" territory="MX" type="America/Hermosillo"/>
 			<mapZone other="US Mountain Standard Time" territory="US" type="America/Phoenix"/>
 			<mapZone other="US Mountain Standard Time" territory="ZZ" type="Etc/GMT+7"/>


### PR DESCRIPTION
I used data generation tool and the US Mountain Standard Time mapping data line for Canada was update becuase it contained extra spaces. There are no real changes except IANA tz database and Windows TimeZone versions.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14126
- [x] Updated PR title and link in previous line to include Issue number

