### PR TITLE
CLDR-14084 zh time fmt, revert full to match v37, make others consistent

### DIFF
--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -1568,17 +1568,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m" draft="contributed">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 							<greatestDifference id="m" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">vah时至ah时</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah时至h时</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah时至ah时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
@@ -2105,20 +2105,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">HH:mm至HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">HH:mm至HH:mm v</greatestDifference>
-							<greatestDifference id="m" draft="contributed">HH:mm至HH:mm v</greatestDifference>
+							<greatestDifference id="H" draft="contributed">v HH:mm至HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">v HH:mm至HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">vah至ah时</greatestDifference>
-							<greatestDifference id="h">vah至h时</greatestDifference>
+							<greatestDifference id="a">v ah至ah时</greatestDifference>
+							<greatestDifference id="h">v ah至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">HH–HH v</greatestDifference>
+							<greatestDifference id="H">v HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M">L至L</greatestDifference>
@@ -2905,17 +2905,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H">v HH:mm – HH:mm</greatestDifference>
 							<greatestDifference id="m">v HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">vah时至ah时</greatestDifference>
-							<greatestDifference id="h">vah时至h时</greatestDifference>
+							<greatestDifference id="a">v ah时至ah时</greatestDifference>
+							<greatestDifference id="h">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
@@ -3308,7 +3308,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<timeFormats>
 					<timeFormatLength type="full">
 						<timeFormat>
-							<pattern>zzzza h:mm:ss</pattern>
+							<pattern>zzzz ah:mm:ss</pattern>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="long">
@@ -3470,17 +3470,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H">v HH:mm–HH:mm</greatestDifference>
 							<greatestDifference id="m">v HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">vah时至ah时</greatestDifference>
-							<greatestDifference id="h">vah时至h时</greatestDifference>
+							<greatestDifference id="a">v ah时至ah时</greatestDifference>
+							<greatestDifference id="h">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H">v HH–HH</greatestDifference>
@@ -3714,17 +3714,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m" draft="contributed">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 							<greatestDifference id="m" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">vah时至ah时</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah时至h时</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah时至ah时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M月</greatestDifference>
@@ -3931,17 +3931,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m" draft="contributed">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 							<greatestDifference id="m" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">vah时至ah时</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah时至h时</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah时至ah时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M月</greatestDifference>
@@ -5150,17 +5150,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">vah:mm至ah:mm</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah:mm至h:mm</greatestDifference>
-							<greatestDifference id="m" draft="contributed">vah:mm至h:mm</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah:mm至ah:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">v ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 							<greatestDifference id="m" draft="contributed">v HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">vah时至ah时</greatestDifference>
-							<greatestDifference id="h" draft="contributed">vah时至h时</greatestDifference>
+							<greatestDifference id="a" draft="contributed">v ah时至ah时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M月</greatestDifference>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14084
- [x] Updated PR title and link in previous line to include Issue number

In zh:
- revert standard full time format from "zzzza h:mm:ss" to "zzzz ah:mm:ss" as in v37
- standard long already had "z ah:mm:ss", matching the reverted format (no change needed)
- availableFormats already matched this style (no change needed):
    - &lt;dateFormatItem id="hmsv"&gt;v ah:mm:ss&lt;/dateFormatItem&gt;
    - &lt;dateFormatItem id="Hmsv"&gt;v HH:mm:ss&lt;/dateFormatItem&gt;
    - &lt;dateFormatItem id="hmv"&gt;v ah:mm&lt;/dateFormatItem&gt;
    - &lt;dateFormatItem id="Hmv"&gt;v HH:mm&lt;/dateFormatItem&gt;
- some intervalFormats needed updating to be consistent with this style
