### PR TITLE
CLDR-11131 record full git hash, shorten to 8 in UI

### DIFF
--- a/tools/cldr-apps/build.xml
+++ b/tools/cldr-apps/build.xml
@@ -237,7 +237,6 @@
     <target name="init-githash" depends="init" description="calculate build.githash">
       <exec executable="git" outputproperty="build.githash" failifexecutionfails="false">
         <arg value="rev-parse" />
-        <arg value="--short" />
         <arg value="HEAD" />
       </exec>
       <condition property="build.githash" value="(unknown)">

--- a/tools/cldr-apps/src/org/unicode/cldr/util/CLDRConfigImpl.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/util/CLDRConfigImpl.java
@@ -195,7 +195,7 @@ public class CLDRConfigImpl extends CLDRConfig implements JSONString {
      * @return
      */
     public final static String getGitHashForDir(String dir) {
-        final String GIT_HASH_COMMANDS[] = { "git",  "rev-parse", "--short", "HEAD" };
+        final String GIT_HASH_COMMANDS[] = { "git",  "rev-parse", "HEAD" };
         try {
             if(dir == null) return CLDRURLS.UNKNOWN_REVISION; // no dir
             File f = new File(dir);

--- a/tools/java/build.xml
+++ b/tools/java/build.xml
@@ -151,7 +151,6 @@
         <target name="init-githash" depends="init" description="calculate build.githash">
           <exec executable="git" outputproperty="build.githash" failifexecutionfails="false">
             <arg value="rev-parse" />
-            <arg value="--short" />
             <arg value="HEAD" />
           </exec>
           <condition property="build.githash" value="(unknown)">

--- a/tools/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/java/org/unicode/cldr/util/CLDRURLS.java
@@ -252,7 +252,7 @@ public abstract class CLDRURLS {
         if(!isKnownHash(hash)) return "<span class=\"githashLink\">"+hash+"</span>"; // Not linkifiable
         return "<a class=\"githashLink\" href=\"" +
                 CldrUtility.getProperty("CLDR_COMMIT_BASE", "https://github.com/unicode-org/cldr/commit/")
-                + hash + "\">" + hash + "</a>";
+                + hash + "\">" + hash.substring(0, 8) + "</a>";
     }
 
     /**


### PR DESCRIPTION
CLDR-11131

- store full git hash in war/jar and live fetch from CLDR_DIR
- show as 8 chars in UI
- this prevents false mismatches from 7, 8-char and 10-char hashes mismatching


so before this fix, cldr-smoke2  shows at the bottom:
> Version: utilities=8fb7d4c data=8fb7d4ca29 surveytool=8fb7d4c

There are three because they are ≠, otherwise it would show "the version". However, you can tell they are 7 and 10 character substrings of the _same hash_. This PR fixes this problem by keeping the whole hash around, and truncating at the UI side.
