### PR TITLE
CLDR-14130 zh, short dates in japanese/roc calendars should use single y

### DIFF
--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -4805,7 +4805,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>Gyy-MM-dd</pattern>
+							<pattern>Gy-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -5095,7 +5095,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>Gyy/M/d</pattern>
+							<pattern>Gy/M/d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14130
- [x] Updated PR title and link in previous line to include Issue number

in zh, short dates in japanese/roc calendars should use single y instead of yy. All other short dates in zh, zh_Hant (ncluding roc), ja (including japanese) and yue already use single y.