### PR TITLE
CLDR-14149 ar, remove leading NBSP in some compact currency formats

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -6189,48 +6189,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="zero"> 0 ألف ¤</pattern>
-					<pattern type="1000" count="one"> 0 ألف ¤</pattern>
-					<pattern type="1000" count="two"> 0 ألف ¤</pattern>
-					<pattern type="1000" count="few"> 0 ألف ¤</pattern>
-					<pattern type="1000" count="many"> 0 ألف ¤</pattern>
-					<pattern type="1000" count="other"> 0 ألف ¤</pattern>
-					<pattern type="10000" count="zero"> 00 ألف ¤</pattern>
-					<pattern type="10000" count="one"> 00 ألف ¤</pattern>
-					<pattern type="10000" count="two"> 00 ألف ¤</pattern>
-					<pattern type="10000" count="few"> 00 ألف ¤</pattern>
-					<pattern type="10000" count="many"> 00 ألف ¤</pattern>
-					<pattern type="10000" count="other"> 00 ألف ¤</pattern>
+					<pattern type="1000" count="zero">0 ألف ¤</pattern>
+					<pattern type="1000" count="one">0 ألف ¤</pattern>
+					<pattern type="1000" count="two">0 ألف ¤</pattern>
+					<pattern type="1000" count="few">0 ألف ¤</pattern>
+					<pattern type="1000" count="many">0 ألف ¤</pattern>
+					<pattern type="1000" count="other">0 ألف ¤</pattern>
+					<pattern type="10000" count="zero">00 ألف ¤</pattern>
+					<pattern type="10000" count="one">00 ألف ¤</pattern>
+					<pattern type="10000" count="two">00 ألف ¤</pattern>
+					<pattern type="10000" count="few">00 ألف ¤</pattern>
+					<pattern type="10000" count="many">00 ألف ¤</pattern>
+					<pattern type="10000" count="other">00 ألف ¤</pattern>
 					<pattern type="100000" count="zero">↑↑↑</pattern>
-					<pattern type="100000" count="one"> 000 ألف ¤</pattern>
-					<pattern type="100000" count="two"> 000 ألف ¤</pattern>
-					<pattern type="100000" count="few"> 000 ألف ¤</pattern>
-					<pattern type="100000" count="many"> 000 ألف ¤</pattern>
-					<pattern type="100000" count="other"> 000 ألف ¤</pattern>
-					<pattern type="1000000" count="zero"> 0 مليون ¤</pattern>
-					<pattern type="1000000" count="one"> 0 مليون ¤</pattern>
-					<pattern type="1000000" count="two"> 0 مليون ¤</pattern>
-					<pattern type="1000000" count="few"> 0 مليون ¤</pattern>
-					<pattern type="1000000" count="many"> 0 مليون ¤</pattern>
-					<pattern type="1000000" count="other"> 0 مليون ¤</pattern>
-					<pattern type="10000000" count="zero"> 00 مليون ¤</pattern>
-					<pattern type="10000000" count="one"> 00 مليون ¤</pattern>
-					<pattern type="10000000" count="two"> 00 مليون ¤</pattern>
-					<pattern type="10000000" count="few"> 00 مليون ¤</pattern>
-					<pattern type="10000000" count="many"> 00 مليون ¤</pattern>
-					<pattern type="10000000" count="other"> 00 مليون ¤</pattern>
-					<pattern type="100000000" count="zero"> 000 مليون ¤</pattern>
-					<pattern type="100000000" count="one"> 000 مليون ¤</pattern>
-					<pattern type="100000000" count="two"> 000 مليون ¤</pattern>
-					<pattern type="100000000" count="few"> 000 مليون ¤</pattern>
-					<pattern type="100000000" count="many"> 000 مليون ¤</pattern>
-					<pattern type="100000000" count="other"> 000 مليون ¤</pattern>
-					<pattern type="1000000000" count="zero"> 0 مليار ¤</pattern>
-					<pattern type="1000000000" count="one"> 0 مليار ¤</pattern>
-					<pattern type="1000000000" count="two"> 0 مليار ¤</pattern>
-					<pattern type="1000000000" count="few"> 0 مليار ¤</pattern>
-					<pattern type="1000000000" count="many"> 0 مليار ¤</pattern>
-					<pattern type="1000000000" count="other"> 0 مليار ¤</pattern>
+					<pattern type="100000" count="one">000 ألف ¤</pattern>
+					<pattern type="100000" count="two">000 ألف ¤</pattern>
+					<pattern type="100000" count="few">000 ألف ¤</pattern>
+					<pattern type="100000" count="many">000 ألف ¤</pattern>
+					<pattern type="100000" count="other">000 ألف ¤</pattern>
+					<pattern type="1000000" count="zero">0 مليون ¤</pattern>
+					<pattern type="1000000" count="one">0 مليون ¤</pattern>
+					<pattern type="1000000" count="two">0 مليون ¤</pattern>
+					<pattern type="1000000" count="few">0 مليون ¤</pattern>
+					<pattern type="1000000" count="many">0 مليون ¤</pattern>
+					<pattern type="1000000" count="other">0 مليون ¤</pattern>
+					<pattern type="10000000" count="zero">00 مليون ¤</pattern>
+					<pattern type="10000000" count="one">00 مليون ¤</pattern>
+					<pattern type="10000000" count="two">00 مليون ¤</pattern>
+					<pattern type="10000000" count="few">00 مليون ¤</pattern>
+					<pattern type="10000000" count="many">00 مليون ¤</pattern>
+					<pattern type="10000000" count="other">00 مليون ¤</pattern>
+					<pattern type="100000000" count="zero">000 مليون ¤</pattern>
+					<pattern type="100000000" count="one">000 مليون ¤</pattern>
+					<pattern type="100000000" count="two">000 مليون ¤</pattern>
+					<pattern type="100000000" count="few">000 مليون ¤</pattern>
+					<pattern type="100000000" count="many">000 مليون ¤</pattern>
+					<pattern type="100000000" count="other">000 مليون ¤</pattern>
+					<pattern type="1000000000" count="zero">0 مليار ¤</pattern>
+					<pattern type="1000000000" count="one">0 مليار ¤</pattern>
+					<pattern type="1000000000" count="two">0 مليار ¤</pattern>
+					<pattern type="1000000000" count="few">0 مليار ¤</pattern>
+					<pattern type="1000000000" count="many">0 مليار ¤</pattern>
+					<pattern type="1000000000" count="other">0 مليار ¤</pattern>
 					<pattern type="10000000000" count="zero">00 مليار ¤</pattern>
 					<pattern type="10000000000" count="one">00 مليار ¤</pattern>
 					<pattern type="10000000000" count="two">00 مليار ¤</pattern>

--- a/seed/main/la.xml
+++ b/seed/main/la.xml
@@ -611,19 +611,19 @@ For terms of use, see http://www.unicode.org/copyright.html
 							<pattern draft="provisional">EEEE, 'die' d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
-					<dateFormatLength type="long" draft="provisional">
+					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>'die' d MMMM y G</pattern>
+							<pattern draft="provisional">'die' d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
-					<dateFormatLength type="medium" draft="provisional">
+					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>'die' d MMM y G</pattern>
+							<pattern draft="provisional">'die' d MMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
-					<dateFormatLength type="short" draft="provisional">
+					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>d M y G</pattern>
+							<pattern draft="provisional">d M y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -633,19 +633,19 @@ For terms of use, see http://www.unicode.org/copyright.html
 							<pattern draft="provisional">HH:mm:ss zzzz</pattern>
 						</timeFormat>
 					</timeFormatLength>
-					<timeFormatLength type="long" draft="provisional">
+					<timeFormatLength type="long">
 						<timeFormat>
-							<pattern>HH:mm:ss z</pattern>
+							<pattern draft="provisional">HH:mm:ss z</pattern>
 						</timeFormat>
 					</timeFormatLength>
-					<timeFormatLength type="medium" draft="provisional">
+					<timeFormatLength type="medium">
 						<timeFormat>
-							<pattern>HH:mm:ss</pattern>
+							<pattern draft="provisional">HH:mm:ss</pattern>
 						</timeFormat>
 					</timeFormatLength>
-					<timeFormatLength type="short" draft="provisional">
+					<timeFormatLength type="short">
 						<timeFormat>
-							<pattern>HH:mm</pattern>
+							<pattern draft="provisional">HH:mm</pattern>
 						</timeFormat>
 					</timeFormatLength>
 				</timeFormats>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14149
- [x] Updated PR title and link in previous line to include Issue number

Remove leading NBSP ins eom Arabic compact currency formats.

Also, for standard date/time formats in seed/main/la.xml, move draft attribute to correct element. This fixes a bug introduced in https://github.com/unicode-org/cldr/pull/578 that was preventing my pre-submit tests from passing.
