### PR TITLE
CLDR-13728 Fix test case in unitsTest.txt: s/lux/lumen/

### DIFF
--- a/common/testData/units/unitsTest.txt
+++ b/common/testData/units/unitsTest.txt
@@ -104,7 +104,7 @@ length  ;   solar-radius    ;   meter   ;   695,700,000 * x ;   6.957E11
 length  ;   astronomical-unit   ;   meter   ;   149,597,900,000 * x ;   1.495979E14
 length  ;   light-year  ;   meter   ;   9,460,730,000,000,000 * x   ;   9.46073E18
 length  ;   parsec  ;   meter   ;   30,856,780,000,000,000 * x  ;   3.085678E19
-luminous-flux   ;   lux ;   candela-square-meter-per-square-meter   ;   1 * x   ;   1000.0
+luminous-flux   ;   lumen   ;   candela-square-meter-per-square-meter   ;   1 * x   ;   1000.0
 luminous-intensity  ;   candela ;   candela ;   1 * x   ;   1,000.00
 mass    ;   microgram   ;   kilogram    ;   0.000000001 * x ;   1.0E-6
 mass    ;   milligram   ;   kilogram    ;   0.000001 * x    ;   0.001


### PR DESCRIPTION
This PR is a test case fix needed in conjunction with https://github.com/unicode-org/cldr/pull/466 - lumen and lux were fixed. Lumen is the luminous-flux unit, not lux. Lux is a unit of luminance.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13728
- [X] Updated PR title and link in previous line to include Issue number

