### PR TITLE
CLDR-14163 Add missing character to parseLenients

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -68,11 +68,11 @@ for derived annotations.
 		</parseLenients>
 		<parseLenients scope="number" level="lenient">
 			<parseLenient sample="-">[\-‐‒–⁻₋−➖﹣－]</parseLenient>
-			<parseLenient sample=",">[,،٫、︐︑﹐﹑，､]</parseLenient>
+			<parseLenient sample=",">[,،٫⹁、︐︑﹐﹑，､]</parseLenient>
 			<parseLenient sample="+">[+⁺₊➕﬩﹢＋]</parseLenient>
 		</parseLenients>
 		<parseLenients scope="number" level="stricter">
-			<parseLenient sample=",">[,٫︐﹐，]</parseLenient>
+			<parseLenient sample=",">[,٫⹁︐﹐，]</parseLenient>
 			<parseLenient sample=".">[.․﹒．｡]</parseLenient>
 		</parseLenients>
 	</characters>

--- a/common/main/sat.xml
+++ b/common/main/sat.xml
@@ -660,11 +660,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<native draft="contributed">↑↑↑</native>
 		</otherNumberingSystems>
 		<symbols numberSystem="latn">
-			<decimal>ᱹ</decimal>
+			<decimal>.</decimal>
 			<group>,</group>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
-			<minusSign>ᱼ</minusSign>
+			<minusSign>-</minusSign>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>


### PR DESCRIPTION
This should fix the failing ICU exhaustive test.

I only updated these sets in the root.  I did not touch any that might exist in child locales.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14163
- [x] Updated PR title and link in previous line to include Issue number

