### PR TITLE
CLDR-13948 Push to Production Improvements

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -146,4 +146,4 @@ jobs:
       run: |
         echo "${RSA_KEY_SURVEYTOOL}" > .key && chmod go= .key
         echo "${SMOKETEST_KNOWNHOSTS}" > .knownhosts && chmod go= .knownhosts
-        ssh -C -o UserKnownHostsFile=.knownhosts -i .key -p ${SMOKETEST_PORT} surveytool@${SMOKETEST_HOST} sh /usr/local/bin/deploy-to-tomcat.sh < cldr-apps.war ${GITHUB_SHA}
+        ssh -C -o UserKnownHostsFile=.knownhosts -i .key -p ${SMOKETEST_PORT} surveytool@${SMOKETEST_HOST} bash /usr/local/bin/deploy-to-tomcat.sh < cldr-apps.war ${GITHUB_SHA} --override

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,9 +10,13 @@ on:
       git-ref:
         description: Git Ref to Deploy (master, hash, tag)
         required: true
+      option:
+        description: use --override to allow any ref
+        required: false
+        default: ''
 jobs:
   build:
-    name: Deploy To Production
+    name: Build for Production
     runs-on: ubuntu-latest
     steps:
       # - name: Clone Repository (Latest)
@@ -57,6 +61,7 @@ jobs:
           name: cldr-apps
           path: tools/cldr-apps/cldr-apps.war
   deploy:
+    name: Deploy to Production
     needs:
       - build
     runs-on: ubuntu-latest
@@ -80,7 +85,8 @@ jobs:
         # the ~/.ssh/known_hosts line mentioning SMOKETEST_HOST
         SURVEYTOOL_KNOWNHOSTS: ${{ secrets.SURVEYTOOL_KNOWNHOSTS }}
         DEPLOY_SHA: ${{ github.event.inputs.git-ref }}
+        OVERRIDE: ${{ github.event.inputs.override }}
       run: |
         echo "${RSA_KEY_SURVEYTOOL}" > .key && chmod go= .key
         echo "${SURVEYTOOL_KNOWNHOSTS}" > .knownhosts && chmod go= .knownhosts
-        ssh -C -o UserKnownHostsFile=.knownhosts -i .key -p ${SURVEYTOOL_PORT} surveytool@${SURVEYTOOL_HOST} sh /usr/local/bin/deploy-to-tomcat.sh < cldr-apps.war ${DEPLOY_SHA}
+        ssh -C -o UserKnownHostsFile=.knownhosts -i .key -p ${SURVEYTOOL_PORT} surveytool@${SURVEYTOOL_HOST} bash /usr/local/bin/deploy-to-tomcat.sh < cldr-apps.war ${DEPLOY_SHA} ${OVERRIDE}

--- a/tools/scripts/ansible/templates/deploy-sh.j2
+++ b/tools/scripts/ansible/templates/deploy-sh.j2
@@ -1,13 +1,63 @@
-#!/bin/sh
+#!/bin/bash
 # Note: this is managed by Ansible, as deploy-sh.j2
 # Don't modify this file.
 GITHUB_SHA=$1
+UNLOCK=$2
 export TPASS={{ surveytooldeploy.password }} # from surveytooldeploy.password
 export TUSER=surveytooldeploy # fixed for now
+
+dogit() {
+    rm -f ~/git-list.txt
+    if [[ ${GITHUB_SHA} = "master" ]];
+    then
+	echo "changing 'master' to 'origin/master' to get the latest"
+	GITHUB_SHA=origin/master
+    fi
+    git fetch -p || exit 1
+    git clean -f -d || echo 'warning: err on cleanup'
+    # what are we deploying?
+
+    echo    "cldr-trunk was at  :" $(git rev-parse --short HEAD)
+    echo -n "you want to move to:"
+    git rev-parse --short "${GITHUB_SHA}" || exit 1 # fail on err
+    if [[ $(git rev-parse --short HEAD) = $(git rev-parse --short "${GITHUB_SHA}") ]];
+    then
+	echo "No checkout needed. Continuing with redeploy."
+    else
+	echo "Deploy will include these new items:"
+	echo "---"
+	(git log --oneline HEAD..${GITHUB_SHA} | tee ~/git-list.txt) || exit 1
+	echo "---"
+	if [[ ! -s ~/git-list.txt ]]; # if empty..
+	then
+	    echo "Note, ${GITHUB_SHA} is not ahead of HEAD"  $(git rev-parse --short HEAD)
+	    echo "Checking for items that would be REVERTED if we proceed:"
+	    echo "---"
+	    git log --oneline ${GITHUB_SHA}..HEAD
+	    echo "---"
+	    if [[ "${UNLOCK}" = "--override" ]];
+	    then
+		echo ".. continuing anyway! due to " "${UNLOCK}"
+	    else
+		echo "STOP. Check the override box if you really want to do this"
+		exit 1
+	    fi
+	fi
+	git checkout -f ${GITHUB_SHA}
+	echo "HEAD is now at" $(git rev-parse --short HEAD) "!"
+     fi
+}
+
+# Check git first, before undeploying. Want to exit early
+(cd  /var/lib/tomcat8/cldr/cldr-trunk/ && dogit ) || exit 1
+# undeploy old ST
 curl -u ${TUSER}:${TPASS} 'http://localhost:8080/manager/text/undeploy?path=/cldr-apps'
+# reset last deploy status
 rm -fv cldr-apps.war .deploystatus
+# copy cldr-apps.war from action runner to server
 dd bs=1024000 status=progress of=cldr-apps.war
-echo ; echo -n file count
+# this counts the # of files to make sure it's not too short, but also verifies that unzip is OK
+echo ; echo -n 'Unzip check, # of files in cldr-apps.war: '
 (unzip -l cldr-apps.war | wc -l ) || exit 1
-(cd  /var/lib/tomcat8/cldr/cldr-trunk/ && git fetch && git clean -f -d ; git checkout  ${GITHUB_SHA} )
-curl -u ${TUSER}:${TPASS} 'http://localhost:8080/manager/text/deploy?path=/cldr-apps&tag=cldr-apps&update=true' -T ./cldr-apps.war | tee .deploystatus
+# Now, do the deployment!
+curl -q -u ${TUSER}:${TPASS} 'http://localhost:8080/manager/text/deploy?path=/cldr-apps&tag=cldr-apps&update=true' -T ./cldr-apps.war | tee .deploystatus


### PR DESCRIPTION
CLDR-13948

Note: I put the branch on the 'head fork', so that it can be tried out (see below)

- “we only go forward”:  for all deployments (smoketest and production), display a list of what changes are about to be incorporated.  Allow a `--override` option if we really want to roll backward. If we roll backward, show what we are reverting!

- updates the deploy script deployed by ansible.  This is where the core implementation is done.

- Add a UI for the above.

-----
## How to try it out
1. go to [⏯️ Actions](https://github.com/unicode-org/cldr/actions?query=workflow%3Aproduction), to the "production" workflow
2.  find the Run Workflow button
3. change the branch to **srl-deploy-13948** (Note: once this is merged, use `master` !) 
4. Should appear as below. Enter in a SHA (hash), or a tag, or `master`.  
5. If you need to roll back (i.e. go to a commit PRIOR to the current deployment) add `--override` in the 2nd box.
6. click **Run Workflow**
7. Watch the build status, and then check out https://st2.unicode.org/cldr-apps/ for the result.

![image](https://user-images.githubusercontent.com/855219/92151526-e779c680-ede6-11ea-920f-5a0d00de4c49.png)
