### PR TITLE
CLDR-13899 Fix casing of drw and tnf to fa_AF

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -74,7 +74,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="coy" replacement="pij" reason="deprecated"/> <!-- Coyaima -->
 			<languageAlias type="cqu" replacement="quh" reason="deprecated"/> <!-- Chilean Quechua -->
 			<languageAlias type="drh" replacement="mn" reason="deprecated"/> <!-- Darkhat -->
-			<languageAlias type="drw" replacement="fa_af" reason="deprecated"/> <!-- Darwazi -->
+			<languageAlias type="drw" replacement="fa_AF" reason="deprecated"/> <!-- Darwazi -->
 			<languageAlias type="gav" replacement="dev" reason="deprecated"/> <!-- Gabutamon -->
 			<languageAlias type="gfx" replacement="vaj" reason="deprecated"/> <!-- Mangetti Dune ǃXung -->
 			<languageAlias type="ggn" replacement="gvr" reason="deprecated"/> <!-- Eastern Gurung -->
@@ -122,7 +122,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="tlw" replacement="weo" reason="deprecated"/> <!-- South Wemale -->
 			<languageAlias type="tmp" replacement="tyj" reason="deprecated"/> <!-- Tai Mène -->
 			<languageAlias type="tne" replacement="kak" reason="deprecated"/> <!-- Tinoc Kallahan -->
-			<languageAlias type="tnf" replacement="fa_af" reason="deprecated"/> <!-- Tangshewi -->
+			<languageAlias type="tnf" replacement="fa_AF" reason="deprecated"/> <!-- Tangshewi -->
 			<languageAlias type="tsf" replacement="taj" reason="deprecated"/> <!-- Southwestern Tamang -->
 			<languageAlias type="uok" replacement="ema" reason="deprecated"/> <!-- Uokha -->
 			<languageAlias type="xba" replacement="cax" reason="deprecated"/> <!-- Kamba [Brazil] -->


### PR DESCRIPTION
Fix casing in replacement of drw and tnf
type="drw" replacement="fa_af" =>  replacement="fa_AF"
type="tnf" replacement="fa_af" =>  replacement="fa_AF"

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13899
- [X] Updated PR title and link in previous line to include Issue number

