### PR TITLE
CLDR-10338 add u locale extension -dx, disable dictionary break for listed scripts

### DIFF
--- a/common/bcp47/segmentation.xml
+++ b/common/bcp47/segmentation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldmlBCP47 SYSTEM "../../common/dtd/ldmlBCP47.dtd">
 <!--
-Copyright © 1991-2015 Unicode, Inc.
+Copyright © 1991-2020 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -9,6 +9,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 <ldmlBCP47>
     <version number="$Revision$"/>
     <keyword>
+        <key name="dx" description="Scripts to exclude from dictionary break" valueType="multiple" since="38">
+            <type name="SCRIPT_CODE" description="ISO 15924 script code"/>
+        </key>
+
         <key name="lb" description="Line break type key" since="27">
             <type name="strict" description="CSS level 3 line-break=strict, e.g. treat CJ as NS"/>
             <type name="normal" description="CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh"/>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1248,6 +1248,7 @@ annotations.
 			<key type="colStrength">Sorting Strength</key>
 			<key type="currency">Currency</key>
 			<key type="d0">Transform Destination</key>
+			<key type="dx">Dictionary Break Exclusions</key>
 			<key type="em">Emoji Presentation Style</key>
 			<key type="fw">First day of week</key>
 			<key type="h0">Mixed-in</key>

--- a/docs/ldml/tr35-general.html
+++ b/docs/ldml/tr35-general.html
@@ -433,6 +433,7 @@
 		  <li>Format special values. As usual, if  lacking  data, use the subtag(s).
 		    <ol>
 		      <li>key=&quot;kr&quot;: (REORDER_CODE) assume the value is a script code, and get its display name.</li>
+		      <li class="changed">key=&quot;dx&quot;: (SCRIPT_CODE) assume the value is a script code, and get its display name.</li>
 		      <li>key=&quot;vt&quot;: (CODEPOINTS, deprecated) the value is a list of code points. Set the value display name to it, after replacing [-_] by space.</li>
 		      <li>key=&quot;x0&quot;: (PRIVATE_USE) the value is a list of subtags. No formatting available, so use the subtag(s).</li>
 		      <li>key=&quot;sd&quot;: (SUBDIVISION_CODE) use the subdivision data to find the display name.</li>

--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -102,7 +102,7 @@
       </tr>
       <tr>
         <td>Date</td>
-        <td class="changed">2020-05-13</td>
+        <td class="changed">2020-09-03</td>
       </tr>
       <tr>
         <!-- This link must be made live when posting the final version but is disabled during proposed update stage. -->
@@ -2369,6 +2369,30 @@ zh-Hant-HK</pre>
           <em>Unknown or Invalid Currency</em>.</p>
         </td>
       </tr>
+      <tr class="changed">
+        <td colspan="4"><strong>A <a href=
+        "#UnicodeDictionaryBreakExclusionIdentifier" name=
+        "UnicodeDictionaryBreakExclusionIdentifier" id=
+        "UnicodeDictionaryBreakExclusionIdentifier">Unicode Dictionary Break Exclusion Identifier</a>
+        specifies scripts to be excluded from dictionary-based text break (for words and lines).
+        The valid values are of one or more items of type SCRIPT_CODE as specified in the
+        <em>name</em> attribute value in the <em>type</em>
+        element of key name="dx" in bcp47/<a target="_blank" href=
+        "https://github.com/unicode-org/cldr/tree/latest/common/bcp47/segmentation.xml">segmentation.xml</a>.</strong></td>
+      </tr>
+      <tr class="changed">
+        <td>"dx"</td>
+        <td>Dictionary break script exclusions</td>
+        <td>
+          <i><code><a href="#unicode_script_subtag">unicode_script_subtag</a></code> values</i>
+        </td>
+        <td>
+          <p>One or more items of type SCRIPT_CODE, which are valid
+          <code><a href="#unicode_script_subtag">unicode_script_subtag</a></code> values.</p>
+          <p>The code Zyyy (Common) can be specified to exclude all scripts, in which case
+          it should be the only SCRIPT_CODE value specified.</p>
+        </td>
+      </tr>
       <tr>
         <td colspan="4"><strong>A <a href=
         "#UnicodeEmojiPresentationStyleIdentifier" name=
@@ -2987,6 +3011,14 @@ zh-Hant-HK</pre>
         "rg" key; this is a subdivision
         code with idStatus='unknown' or 'regular' from the
         idValidity data in common/validity/subdivision.xml.</p>
+        <h5 class="changed"><a name="SCRIPT_CODE" href="#SCRIPT_CODE" id=
+        "SCRIPT_CODE">SCRIPT_CODE</a></h5>
+        <p class="changed">The type name <strong>"SCRIPT_CODE"</strong> is
+        reserved for <code><a href="#unicode_script_subtag">unicode_script_subtag</a></code>
+        values (e.g. "thai", "laoo").
+        The type "SCRIPT_CODE" is used for locale extension key "dx".
+        The value of type for "dx" is represented by one or more SCRIPT_CODEs,
+        such as "thai-laoo".</p>
         <h5><a name="SUBDIVISION_CODE" href="#SUBDIVISION_CODE" id=
         "SUBDIVISION_CODE">SUBDIVISION_CODE</a></h5>
         <p>The type name <strong>"SUBDIVISION_CODE"</strong> is
@@ -9025,8 +9057,18 @@ decimal?, group?, special*)) &gt;</pre>
     "Modifications">Modifications</a></h2>
 
     <p class="changed"><b>Revision 60</b></p>
-	<ul>
-	  <li class="changed" ><b>Proposed Update</b> for CLDR 38.</li>
+	<ul class="changed">
+	  <li><b>Proposed Update</b> for CLDR 38.</li>
+
+	  <li><strong>Part 1: <a href="tr35.html#Contents">Core</a> (languages, locales, basic structure)</strong>		  
+        <ul>
+          <li><strong>Section 3.6.1 <a href="#Key_And_Type_Definitions_" >Key And Type Definitions</a></strong>:
+          added new key “dx”, for <a href="#UnicodeDictionaryBreakExclusionIdentifier" >Unicode Dictionary Break Exclusion Identifier</a>.</li>
+          <li><strong>Section 3.6.4 <a href="#Unicode_Locale_Extension_Data_Files" >U Extension Data Files</a></strong>:
+          added description of <a href="#SCRIPT_CODE" >SCRIPT_CODE</a> value for key “dx”.</li>
+        </ul>
+	  </li>
+
 	</ul>
 
     <p><b>Revision 59</b></p>

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBCP47.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBCP47.java
@@ -129,7 +129,7 @@ public class TestBCP47 extends TestFmwk {
         }
     }
 
-    static final ImmutableSet<String> SKIP_TYPES = ImmutableSet.of("REORDER_CODE", "RG_KEY_VALUE", "SUBDIVISION_CODE", "CODEPOINTS", "PRIVATE_USE");
+    static final ImmutableSet<String> SKIP_TYPES = ImmutableSet.of("REORDER_CODE", "RG_KEY_VALUE", "SCRIPT_CODE", "SUBDIVISION_CODE", "CODEPOINTS", "PRIVATE_USE");
 
     private void checkKeyType(
         String bcp47Key,

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
@@ -542,6 +542,9 @@ public class TestLocale extends TestFmwkPlus {
             case "tz": 
                 showName(cldrFile, seen, localeBase, "uslax", "gblon", "chzrh");
                 continue keyLoop;
+            case "dx": 
+                // skip for now, probably need to fix something in CLDRFile
+                continue keyLoop;
             }
             for (String value : keyValues.getValue()) {
                 if ("true".equals(deprecatedMap.get(Row.of(key, value)))) {
@@ -705,6 +708,9 @@ public class TestLocale extends TestFmwkPlus {
             break;
         case "REORDER_CODE":    // [u, kr, REORDER_CODE] 
             valuesSet = ImmutableSet.of("arab", "digit-deva-latn");
+            break;
+        case "SCRIPT_CODE":    // [u, dx, SCRIPT_CODE] 
+            valuesSet = ImmutableSet.of("thai", "thai-laoo");
             break;
         case "RG_KEY_VALUE":    // [u, rg, RG_KEY_VALUE]
             valuesSet = ImmutableSet.of("ustx", "gbeng");


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10338
- [x] Updated PR title and link in previous line to include Issue number

Add u locale extension key -dx to disable dictionary breaks for one or more script codes listed as arguments.
- Add BCP47 info
- Add key name in English
- Update LDML spec
- Update tests; this is a bit incomplete for now.