### PR TITLE
CLDR-13870 Instruction content update

### DIFF
--- a/tools/cldr-apps/WebContent/AdminPanel.jsp
+++ b/tools/cldr-apps/WebContent/AdminPanel.jsp
@@ -125,7 +125,7 @@ String sql = request.getContextPath()+"/survey?sql="+vap+"";
 <a href="<%= request.getContextPath() + request.getServletPath()  + "?vap="+vap+"#!admin_ops" %>">Return to Admin Panel</a>
 <% } else { %>
 <div class='fnotebox'>
-    For instructions, see <a href='http://cldr.unicode.org/index/survey-tool/admin'>Admin Docs</a>. <br>
+    For instructions, see <a href='<%= SurveyMain.ADMIN_HELP_URL %>'>Admin Docs</a>. <br>
     Tabs do not (currently) auto update. Click a tab again to update. <br>
     Be careful!
 </div>

--- a/tools/cldr-apps/WebContent/js/redesign.js
+++ b/tools/cldr-apps/WebContent/js/redesign.js
@@ -492,17 +492,6 @@ function popupAlert(type, content, head, aj, dur) {
 }
 
 /**
- * Set the content for the instruction menu
- *
- * @param content
- *
- * Called only by showInPop2 in survey.js
- */
-function setHelpContent(content) {
-	$('#help-content').html(content);
-}
-
-/**
  * Create/update the pull-down menu popover
  *
  * @param event

--- a/tools/cldr-apps/WebContent/js/survey.js
+++ b/tools/cldr-apps/WebContent/js/survey.js
@@ -2243,13 +2243,12 @@ require(["dojo/ready"], function(ready) {
 					pucontent.appendChild(td);
 				}
 			} else {
-				var clone = td.cloneNode(true);
-				setHelpContent(td);
 				if (!isDashboard()) {
+					// show, for example, dataPageInitialGuidance in Info Panel
+					var clone = td.cloneNode(true);
 					removeAllChildNodes(pucontent);
 					pucontent.appendChild(clone);
 				}
-
 			}
 			td = null;
 

--- a/tools/cldr-apps/WebContent/v.jsp
+++ b/tools/cldr-apps/WebContent/v.jsp
@@ -290,14 +290,9 @@ surveyUser =  <%=ctx.session.user.toJSONString()%>;
                       </ul>
            </li>
             
-            <li id="help-menu" class="pull-menu">
-		          <a href="#"><%= SurveyMain.GENERAL_HELP_NAME %> <b class="caret"></b></a>
-		          <ul class="nav nav-pills nav-stacked" style="display:none">
-		            <li><a href="<%= SurveyMain.GENERAL_HELP_URL %>" target="_blank"><%= SurveyMain.GENERAL_HELP_NAME %> <span class="glyphicon glyphicon-share"></span></a></li>
-		            <li class="nav-divider"></li>
-		            <li id="help-content">Welcome</li>
-		          </ul>
-		   </li>
+            <li>
+		        <a href="<%= SurveyMain.GENERAL_HELP_URL %>" target="_blank"><%= SurveyMain.GENERAL_HELP_NAME %></a>
+            </li>
           </ul>
           <p class="navbar-text navbar-right">
               <span id="flag-info"></span>

--- a/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/SurveyMain.java
@@ -281,11 +281,14 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * TODO: CLDR no longer uses trac; change BUG_URL_BASE to link to github instead
      */
     public static final String BUG_URL_BASE = URL_CLDR + "trac";
-    public static final String GENERAL_HELP_URL = URL_CLDR + "survey_tool.html";
+
+    public static final String GENERAL_HELP_URL = "https://sites.google.com/site/cldr/translation";
     public static final String GENERAL_HELP_NAME = "Instructions";
 
+    public static final String ADMIN_HELP_URL = "http://cldr.unicode.org/index/survey-tool/admin";
+
     // ===== url prefix for help
-    public static final String CLDR_HELP_LINK = GENERAL_HELP_URL + "#";
+    public static final String CLDR_HELP_LINK = URL_CLDR + "survey_tool.html" + "#";
 
     // ===== Hash keys and field values
     public static final String PROPOSED_DRAFT = "proposed-draft";
@@ -935,7 +938,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         ctx.println("<script>timerSpeed = 6000;</script>");
         String q = ctx.field("q");
         boolean tblsel = false;
-        printAdminMenu(ctx, "/AdminSql");
+        printAdminMenu(ctx);
         ctx.println("<h1>SQL Console (" + DBUtils.getDBKind() + ")</h1>");
 
         ctx.println("<i style='font-size: small; color: silver;'>" + DBUtils.getInstance().getDBInfo() + "</i><br/>");
@@ -1171,9 +1174,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * Admin panel
      *
      * @param ctx
-     * @param helpLink
      */
-    private void printAdminMenu(WebContext ctx, String helpLink) {
+    private void printAdminMenu(WebContext ctx) {
 
         boolean isDump = ctx.hasField("dump");
         boolean isSql = ctx.hasField("sql");
@@ -1186,7 +1188,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         ctx.print(" | ");
         ctx.print("<a class='" + (isSql ? "" : "not") + "selected' href='" + ctx.base() + "?sql=" + vap + "'>SQL</a>");
         ctx.print("<br>");
-        ctx.printHelpLink(helpLink, "Admin Help", true);
+        ctx.print("<a href=\"" + SurveyMain.ADMIN_HELP_URL + "\">Admin Help</a>");
         ctx.println("</div>");
     }
 

--- a/tools/cldr-apps/src/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/web/WebContext.java
@@ -1212,7 +1212,7 @@ public class WebContext implements Cloneable, Appendable {
      * @param parens
      */
     @Deprecated
-    public void printHelpLink(String what, String title, boolean doEdit, boolean parens) {
+    private void printHelpLink(String what, String title, boolean doEdit, boolean parens) {
         if (parens) {
             print("(");
         }


### PR DESCRIPTION
-Simplify link in v.jsp; Instructions is no longer a menu

-Remove setHelpContent

-Change GENERAL_HELP_URL to https://sites.google.com/site/cldr/translation

-Fix already-broken AdminSql link; use new SurveyMain.ADMIN_HELP_URL; also in AdminPanel.jsp

-Make 4-arg deprecated WebContext.printHelpLink private

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13870
- [x] Updated PR title and link in previous line to include Issue number

