### PR TITLE
CLDR-11585 mavenize (2020 parallel version)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,25 @@
+name: cldr-mvn
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -s .github/workflows/mvn-settings.xml -B package --file tools/pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mvn-settings.xml
+++ b/.github/workflows/mvn-settings.xml
@@ -1,0 +1,53 @@
+<!--
+Copyright © 1991 and later Unicode, Inc.
+All rights reserved.
+License and terms of use: http://www.unicode.org/copyright.html
+
+This file is used during builds to be able to access a temporary copy
+of icu4j.jar and utilities.jar. See CLDR-11585.
+TODO: Remove this when ICU-21251 is completed.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+        <repository>
+          <id>githubsrl295</id>
+          <name>GitHub srl295/icu Apache Maven Packages</name>
+          <url>https://maven.pkg.github.com/srl295/icu</url>
+        </repository>
+        <repository>
+          <id>github</id>
+          <name>GitHub unicode-org/cldr Apache Maven Packages</name>
+          <url>https://maven.pkg.github.com/unicode-org/cldr</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${GITHUB_ACTOR}</username>
+      <password>${GITHUB_TOKEN}</password>
+    </server>
+    <server>
+      <id>githubsrl295</id>
+      <username>${GITHUB_ACTOR}</username>
+      <password>${GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Everywhere
 .DS_Store
 
+# Maven output directories
+/tools/target
+/tools/*/target
+
 # /
 /.project
 /.classpath

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Latest Release: [v37.0](http://cldr.unicode.org/index/downloads/cldr-37#TOC-V37)
 
 GitHub: 
 [![cldr-ant](https://github.com/unicode-org/cldr/workflows/cldr-ant/badge.svg)](https://github.com/unicode-org/cldr/actions?query=branch%3Amaster+workflow%3A%22cldr-ant%22)
+[![cldr-mvn](https://github.com/unicode-org/cldr/workflows/cldr-mvn/badge.svg)](https://github.com/unicode-org/cldr/actions?query=branch%3Amaster+workflow%3A%22cldr-mvn%22)
 [![Ansible Lint](https://github.com/unicode-org/cldr/workflows/Ansible%20Lint/badge.svg)](https://github.com/unicode-org/cldr/actions?query=branch%3Amaster+workflow%3A%22Ansible+Lint%22)
 
 Jenkins: [![Build Status](https://cldr-build.unicode.org/jenkins/buildStatus/icon?job=cldr%2Fcldr-master)](https://cldr-build.unicode.org/jenkins/job/cldr/job/cldr-master/) :lock: 

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>cldr-apps</artifactId>
+	<packaging>war</packaging>
+	<name>CLDR Survey Tool</name>
+
+	<url>https://unicode.org/cldr</url>
+
+	<scm>
+		<connection>scm:git:https://github.com/unicode-org/cldr.git</connection>
+	</scm>
+
+	<parent>
+		<groupId>org.unicode.cldr</groupId>
+		<artifactId>cldr-all</artifactId>
+		<version>38.0-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<!-- test -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- icu -->
+		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>icu4j</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>utilities</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<!-- cldr -->
+		<dependency>
+			<groupId>org.unicode.cldr</groupId>
+			<artifactId>cldr</artifactId>
+		</dependency>
+
+		<!-- API -->
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.servlet.jsp</groupId>
+			<artifactId>javax.servlet.jsp-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- mail / rss -->
+		<dependency>
+			<groupId>rome</groupId>
+			<artifactId>rome</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>mail</artifactId>
+		</dependency>
+
+
+		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>javax.activation</artifactId>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.json/json -->
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+		</dependency>
+
+		<!-- scm -->
+		<dependency>
+			<groupId>org.tmatesoft.svnkit</groupId>
+			<artifactId>svnkit</artifactId>
+		</dependency>
+
+		<!-- codec/util -->
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<!-- db -->
+		<dependency>
+			<groupId>org.apache.derby</groupId>
+			<artifactId>derby</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.myanmartools</groupId>
+			<artifactId>myanmar-tools</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+		</dependency>
+	</dependencies>
+	<build>
+		<finalName>cldr-apps</finalName>
+		<sourceDirectory>src</sourceDirectory> <!-- TODO: HACK! until we can pivot src dirs -->
+		<pluginManagement><!-- lock down plugins versions to avoid using Maven 
+				defaults (may be moved to parent pom) -->
+			<plugins>
+				<plugin>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+				<!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging -->
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+					<configuration>
+						<includes>
+							<include>org/**/*.java</include>
+						</includes>
+					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin-version}</version>
+					<configuration>
+						<systemPropertyVariables>
+							<CLDR_DIR>${project.basedir}/../../</CLDR_DIR>
+							<CLDR_ENVIRONMENT>UNITTEST</CLDR_ENVIRONMENT>
+							<java.awt.headless>true</java.awt.headless>
+							<!-- <rununittest.arg>-n -q</rununittest.arg> -->
+						</systemPropertyVariables>
+					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>3.2.2</version>
+					<configuration>
+						<webResources>
+							<resource>
+								<!-- this is relative to the pom.xml directory -->
+								<directory>WebContent</directory>
+								<excludes>
+									<exclude>WEB-INF/lib/*</exclude>
+								</excludes>
+							</resource>
+						</webResources>
+						<archive>
+							<manifestEntries>
+								<Built-By>${user.name}</Built-By>
+								<Build-Time>${maven.build.timestamp}</Build-Time>
+								<CLDR-Apps-Git-Commit>${buildNumber}</CLDR-Apps-Git-Commit>
+								<CLDR-Apps-Git-Branch>${scmBranch}</CLDR-Apps-Git-Branch>
+							</manifestEntries>
+						</archive>
+					</configuration>
+
+				</plugin>
+				<plugin>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>2.5.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.8.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>buildnumber-maven-plugin</artifactId>
+					<version>1.4</version>
+					<executions>
+						<execution>
+							<phase>validate</phase>
+							<goals>
+								<goal>create</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+						<attach>true</attach>
+						<addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>buildnumber-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tools/java/pom.xml
+++ b/tools/java/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>cldr</artifactId>
+
+	<name>CLDR Java Tools</name>
+
+	<url>https://unicode.org/cldr</url>
+
+	<scm>
+		<connection>scm:git:https://github.com/unicode-org/cldr.git</connection>
+	</scm>
+
+	<parent>
+		<groupId>org.unicode.cldr</groupId>
+		<artifactId>cldr-all</artifactId>
+		<version>38.0-SNAPSHOT</version>
+	</parent>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>icu4j</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>utilities</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.ant</groupId>
+			<artifactId>ant</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.myanmartools</groupId>
+			<artifactId>myanmar-tools</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>.</sourceDirectory> <!-- TODO: fix by refactoring source dirs, CLDR-11585 -->
+		<resources>
+			<resource>
+				<directory>.</directory>
+				<includes>
+					<include>org/unicode/cldr/icu/*.html</include>
+					<include>org/unicode/cldr/icu/*.txt</include>
+					<include>org/unicode/cldr/json/*.txt</include>
+					<include>org/unicode/cldr/tool/*.css</include>
+					<include>org/unicode/cldr/tool/*.html</include>
+					<include>org/unicode/cldr/tool/*.txt</include>
+					<include>org/unicode/cldr/tool/*.xml</include>
+					<include>org/unicode/cldr/util/data/**/*</include>
+				</includes>
+			</resource>
+		</resources>
+
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<!-- TODO: fix by refactoring source dirs, CLDR-11585 -->
+					<includes>
+						<include>com/**/*.java</include>
+						<include>org/**/*.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<CLDR_DIR>${project.basedir}/../../</CLDR_DIR>
+						<CLDR_ENVIRONMENT>UNITTEST</CLDR_ENVIRONMENT>
+						<java.awt.headless>true</java.awt.headless>
+						<datacheck.arg>-S common,seed -e -z FINAL_TESTING</datacheck.arg>
+						<rununittest.arg>-n -q</rununittest.arg>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>buildnumber-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>org.unicode.cldr.tool.Main</mainClass>
+						</manifest>
+						<manifestEntries>
+							<Built-By>${user.name}</Built-By>
+							<Build-Time>${maven.build.timestamp}</Build-Time>
+							<CLDR-Tools-Git-Commit>${buildNumber}</CLDR-Tools-Git-Commit>
+							<CLDR-Tools-Git-Branch>${scmBranch}</CLDR-Tools-Git-Branch>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+
+	</build>
+
+	<repositories>
+		<repository>
+			<!-- TODO: fix when https://github.com/unicode-org/icu/pull/1270 lands -->
+			<id>githubsrl295</id>
+			<name>HACK: GitHub srl295 Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/srl295/icu</url>
+		</repository>
+	</repositories>
+</project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.unicode.cldr</groupId>
+	<artifactId>cldr-all</artifactId>
+	<version>38.0-SNAPSHOT</version>
+	<name>CLDR Parent</name>
+	<packaging>pom</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<!-- TODO: fix when https://github.com/unicode-org/icu/pull/1270 lands -->
+		<icu4j.version>0.0.0-cldr-38-d00</icu4j.version>
+		<junit.version>4.11</junit.version>
+		<junit.jupiter.version>5.5.1</junit.jupiter.version>
+		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
+		<assertj-version>3.11.1</assertj-version>
+	</properties>
+
+	<modules>
+		<module>java</module>
+		<module>cldr-apps</module>
+	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- CLDR -->
+			<dependency>
+				<groupId>org.unicode.cldr</groupId>
+				<artifactId>cldr</artifactId>
+				<version>${project.version}</version> <!-- this seems to work -->
+			</dependency>
+
+			<!-- ICU -->
+			<dependency>
+				<groupId>com.ibm.icu</groupId>
+				<artifactId>icu4j</artifactId>
+				<version>${icu4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.ibm.icu</groupId>
+				<artifactId>utilities</artifactId>
+				<version>${icu4j.version}</version>
+			</dependency>
+
+			<!-- Misc Libs -->
+			<dependency>
+				<groupId>com.google.code.gson</groupId>
+				<artifactId>gson</artifactId>
+				<version>2.8.6</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>29.0-jre</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.ant</groupId>
+				<artifactId>ant</artifactId>
+				<version>1.10.6</version>
+			</dependency>
+
+			<dependency>
+				<groupId>xerces</groupId>
+				<artifactId>xercesImpl</artifactId>
+				<version>2.12.0</version>
+			</dependency>
+			<dependency>
+				<groupId>xml-apis</groupId>
+				<artifactId>xml-apis</artifactId>
+				<version>1.4.01</version>
+				<scope>compile</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.myanmartools</groupId>
+				<artifactId>myanmar-tools</artifactId>
+				<version>1.1.1</version>
+			</dependency>
+			<!-- codec/util -->
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-fileupload</groupId>
+				<artifactId>commons-fileupload</artifactId>
+				<version>1.3.1</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.4</version>
+			</dependency>
+
+
+			<!-- API -->
+			<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>javax.servlet-api</artifactId>
+				<version>3.1.0</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>javax.servlet.jsp</groupId>
+				<artifactId>javax.servlet.jsp-api</artifactId>
+				<version>2.3.1</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>2.3.1</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<!-- mail / rss -->
+			<dependency>
+				<groupId>rome</groupId>
+				<artifactId>rome</artifactId>
+				<version>1.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>javax.mail</groupId>
+				<artifactId>mail</artifactId>
+				<version>1.5.0-b01</version>
+			</dependency>
+
+
+			<dependency>
+				<groupId>com.sun.activation</groupId>
+				<artifactId>javax.activation</artifactId>
+				<version>1.2.0</version>
+			</dependency>
+
+			<!-- https://mvnrepository.com/artifact/org.json/json -->
+			<dependency>
+				<groupId>org.json</groupId>
+				<artifactId>json</artifactId>
+				<version>20190722</version>
+			</dependency>
+
+			<!-- scm -->
+			<dependency>
+				<groupId>org.tmatesoft.svnkit</groupId>
+				<artifactId>svnkit</artifactId>
+				<version>1.7.4-v1</version>
+			</dependency>
+
+
+
+			<!-- db connectors -->
+			<dependency>
+				<groupId>org.apache.derby</groupId>
+				<artifactId>derby</artifactId>
+				<version>10.10.1.1</version>
+			</dependency>
+
+			<dependency>
+				<groupId>mysql</groupId>
+				<artifactId>mysql-connector-java</artifactId>
+				<version>8.0.21</version>
+			</dependency>
+			<!-- test -->
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-api</artifactId>
+				<version>${junit.jupiter.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>${junit.jupiter.version}</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+				<plugin>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+				<!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin-version}</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>2.5.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.8.2</version>
+				</plugin>
+				<!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+				<plugin>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.7.1</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-project-info-reports-plugin</artifactId>
+					<version>3.0.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>buildnumber-maven-plugin</artifactId>
+					<version>1.4</version>
+					<executions>
+						<execution>
+							<phase>validate</phase>
+							<goals>
+								<goal>create</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+						<attach>true</attach>
+						<addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>


### PR DESCRIPTION
CLDR-11585

So, it turns out this can be done a little bit in parallel after all.

- add pom.xml and use the _current_ directory structure. Once this is working, then switch over.
- no tests yet (this needs code refactoring)
- cldr-apps builds and runs OK
- it's possible some of the libs are slightly out of date, but that's easily fixable.
- using a temporary repo for ICU4J/utilities until https://github.com/unicode-org/icu/pull/1270 gets merged.