### PR TITLE
CLDR-13771 ansible: fix proxy so users don't all appear as 127.0.0.1

### DIFF
--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -83,6 +83,7 @@
             proxy_pass http://localhost:8080/cldr-apps/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
           }
         marker: '# {mark} ANSIBLE MANAGED BLOCK'
         insertafter: '^[\s]*server_name' # the LAST uncommented server block
@@ -91,7 +92,7 @@
       user:
         name: surveytool
         shell: /bin/bash
-    - name: Give acess to surveytool user
+    - name: Give access to surveytool user
       file:
         path: /var/lib/tomcat8/cldr/cldr-trunk
         owner: surveytool


### PR DESCRIPTION
CLDR-13771 ansible: fix proxy so users don't all appear as 127.0.0.1

A proxy header was set incorrectly, but it's been resolved now.  Yoshito might recognize this issue

thanks for reporting this @btangmu 