### PR TITLE
CLDR-14128 fix name/symbol collisions only reported in cldr-staging tests

### DIFF
--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -7361,11 +7361,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
-			<unit type="volume-quart">
-				<displayName>quarts</displayName>
-				<unitPattern count="one">{0} quart</unitPattern>
-				<unitPattern count="other">{0} quarts</unitPattern>
-			</unit>
 			<unit type="volume-pint">
 				<displayName>pints</displayName>
 				<unitPattern count="one">{0} pint</unitPattern>
@@ -7404,7 +7399,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">{0} dessert spoons</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
@@ -8395,11 +8390,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} gal.</unitPattern>
 				<unitPattern count="other">{0} gal.</unitPattern>
 				<perUnitPattern>{0}/gal.</perUnitPattern>
-			</unit>
-			<unit type="volume-quart">
-				<displayName>qts</displayName>
-				<unitPattern count="one">{0} qt</unitPattern>
-				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pints</displayName>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -210,7 +210,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="gan">↑↑↑</language>
 			<language type="gay">↑↑↑</language>
 			<language type="gba">↑↑↑</language>
-			<language type="gbz" draft="contributed">dari</language>
 			<language type="gd">↑↑↑</language>
 			<language type="gez">↑↑↑</language>
 			<language type="gil">gilbertin</language>

--- a/common/main/pt_CV.xml
+++ b/common/main/pt_CV.xml
@@ -50,7 +50,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<decimal>$</decimal>
 			</currency>
 			<currency type="PTE">
-				<symbol>↑↑↑</symbol>
+				<symbol>PTE</symbol>
+				<decimal>,</decimal>
+				<group> </group>
 			</currency>
 		</currencies>
 	</numbers>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14128
- [x] Updated PR title and link in previous line to include Issue number

Fix name/symbol collisions only reported in running ConsoleCheckCLDR on cldr-staging/production data (not on regular cldr data). Nte that I have filed https://unicode-org.atlassian.net/browse/CLDR-14172 to improve the tests to detect these in regular CLDR data.

1. en_AU, use inherited names for "volume-quart" and "volume-dessert-spoon" instead of specifying names that conflict with the inherited names (from en_001) for the imperial versions of those units.
1. fr_CA, delete the entry for gbz with name "dari" that collides with the name "dari" inherited from fr for fa_AF
3. pt_CV, for currency PTE stop inheriting the symbol also specified by pt_CV for CVE. Instead, for PTE, use symbol "PTE" and the normal decimal and group separators for pt_CV.



