### PR TITLE
CLDR-13771 update ansible scripts in production

### DIFF
--- a/tools/scripts/ansible/README.md
+++ b/tools/scripts/ansible/README.md
@@ -77,8 +77,7 @@ Then setup github secrets as shown:
 
 ### Setup: Config file
 
-- Create a file `local-vars/local.yml` with the following
-(but with a secure password instead of `hunter42`.)
+- Create a file `local-vars/local.yml` matching the example values in [test-local-vars/local.yml](test-local-vars/local.yml) (but with a secure password instead of `hunter42`!.)
 
 ```yaml
 mysql_users:
@@ -105,6 +104,9 @@ ansible-playbook --check setup-playbook.yml
 
 This is in dry run mode. When it looks good to you, take the
 `--check` out and run it again.
+
+You can also use the `-l cldr-smoke.unicode.org` option to limit
+the operation to a single host.
 
 ## Local Test
 

--- a/tools/scripts/ansible/requirements.yml
+++ b/tools/scripts/ansible/requirements.yml
@@ -1,2 +1,3 @@
 sprylab.tomcat-ubuntu
 geerlingguy.mysql
+derjd.journald

--- a/tools/scripts/ansible/roles.yml
+++ b/tools/scripts/ansible/roles.yml
@@ -2,5 +2,7 @@
   version: 3.3.0
 - src: geerlingguy.nginx
   version: 2.8.0
+- src: derjd.journald
+  version: 0.0.1
 # - src: geerlingguy.certbot
 #   version: 3.1.0

--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -108,6 +108,49 @@
         owner: root
         group: root
         mode: '0755'
+    - name: ensure cldradmin group is there
+      group:
+        name: cldradmin
+        state: present
+    - name: ensure cldradmin user is there
+      user:
+        name: cldradmin
+        comment: CLDR Admin
+        groups:
+          - cldradmin
+        append: yes # add to the groups, do not remove
+        state: present
+        create_home: true
+    - name: Setup /home/cldradmin/.my.cnf
+      template:
+        src: templates/mycnf.j2
+        dest: /home/cldradmin/.my.cnf
+        owner: cldradmin
+        group: cldradmin
+        mode: '0640'
+    - name: make sure /home/cldradmin/.ssh/ exists
+      file:
+        path: /home/cldradmin/.ssh/
+        owner: cldradmin
+        group: cldradmin
+        mode: '0700'
+        state: directory
+    - name: make sure /home/cldradmin/.ssh/authorized_keys exists
+      file:
+        dest: /home/cldradmin/.ssh/authorized_keys
+        owner: cldradmin
+        group: cldradmin
+        mode: '0600'
+        state: touch #https://github.com/ansible/ansible/issues/7490#issuecomment-497373505
+        modification_time: preserve
+        access_time: preserve
+    - name: add cldradmin to sudoers
+      template:
+        dest: /etc/sudoers.d/55-cldradmin-users
+        owner: root
+        group: root
+        mode: '440'
+        src: templates/55-cldradmin.conf
   handlers:
     - name: Restart Tomcat
       service:
@@ -120,6 +163,11 @@
 
 - hosts: all
   become: yes
+  roles:
+     - role: derJD.journald
+       vars:
+          journald_options:
+            SystemMaxUse: 512M  #reduce logfile use
   tasks:
     - name: Install some packages
       apt:
@@ -130,6 +178,7 @@
           - byobu
           # these are for monitoring
           - prometheus-node-exporter
+
 - hosts: letsencrypt
   become: yes
   vars_files:
@@ -141,6 +190,9 @@
         pkg:
           - python3-certbot-nginx
     - name: setup certbot
-      command: sudo certbot --nginx  --agree-tos -m {{ certbot_admin_email }} -d {{ inventory_hostname }} --non-interactive --keep
+      command: >
+        sudo certbot --nginx --agree-tos -m {{ certbot_admin_email }}
+        -d {{ inventory_hostname }} --non-interactive
+        --keep --redirect --uir --hsts --staple-ocsp --must-staple
       args:
         creates: /etc/letsencrypt/renewal/{{ inventory_hostname }}.conf

--- a/tools/scripts/ansible/templates/55-cldradmin.conf
+++ b/tools/scripts/ansible/templates/55-cldradmin.conf
@@ -1,0 +1,2 @@
+# managed by ansible setup-playbook.yml
+cldradmin ALL=(ALL) NOPASSWD:ALL

--- a/tools/scripts/ansible/templates/mycnf.j2
+++ b/tools/scripts/ansible/templates/mycnf.j2
@@ -1,0 +1,5 @@
+# managed by ansible setup-playboook.yml
+[client]
+user=cldradmin
+database=cldrdb
+password={{ cldradmin_pw }}

--- a/tools/scripts/ansible/test-local-vars/local.yml
+++ b/tools/scripts/ansible/test-local-vars/local.yml
@@ -1,9 +1,20 @@
 # these are used for CI testing
+# and, they also serve as an example of how to
+# configure local-vars/local.yml
+
+cldradmin_pw: hunter46 # needs to match cldradmin pw below
 mysql_users:
+  # this is the account used by the survey tool itself
   - name: surveytool
     host: localhost
     password: hunter42
     priv: 'cldrdb.*:ALL'
+  # this is the account used for administrative tasks
+  - name: cldradmin
+    password: hunter46
+    priv: 'cldrdb.*:ALL/*.*:PROCESS'
+    append_privs: yes
+# this is the account used for deployment
 surveytooldeploy:
   password: hunter43
   vap: hunter44


### PR DESCRIPTION
CLDR-13771

- regularize users/mysql users
- update the docs: "test-local-vars/local.yml" is now the documentation
for the variables.
- add enable-redirect capability into the certbot command line
