### PR TITLE
CLDR-14176 change plural rule regeneration to have exponent samples

### DIFF
--- a/common/supplemental/ordinals.xml
+++ b/common/supplemental/ordinals.xml
@@ -61,7 +61,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="other"> @integer 0~7, 9, 10, 12~17, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
         <pluralRules locales="lij">
-            <pluralRule count="many">n = 11,8,80..89,800..899 @integer 8, 11, 80~89, 800~899</pluralRule>
+            <pluralRule count="many">n = 11,8,80..89,800..899 @integer 8, 11, 80~89, 800~803</pluralRule>
             <pluralRule count="other"> @integer 0~7, 9, 10, 12~17, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -26,11 +26,6 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="fr">
-            <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
-            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0 .. 5 @integer 1000000</pluralRule>
-            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
-        </pluralRules>
         <pluralRules locales="pt">
             <pluralRule count="one">i = 0..1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
@@ -116,6 +111,14 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="other"> @integer 0, 5~19, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 0.5~1.0, 1.5~2.0, 2.5~2.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
 
+        <!-- 3: one,many,other -->
+
+        <pluralRules locales="fr">
+            <pluralRule count="one">i = 0,1 @integer 0, 1, 1e5 @decimal 0.0~1.5, 1.1e5</pluralRule>
+            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 2e6, 3e6, 4e6, 5e6, 6e6, 7e6, … @decimal 2.1e6, 3.1e6, 4.1e6, 5.1e6, 6.1e6, 7.1e6, …</pluralRule>
+            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 2e5, 3e5, 4e5, 5e5, 6e5, 7e5, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 2.1e5, 3.1e5, 4.1e5, 5.1e5, 6.1e5, 7.1e5, …</pluralRule>
+        </pluralRules>
+
         <!-- 4: one,two,few,other -->
 
         <pluralRules locales="gd">
@@ -191,7 +194,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">n % 10 = 1 and n % 100 != 11,71,91 @integer 1, 21, 31, 41, 51, 61, 81, 101, 1001, … @decimal 1.0, 21.0, 31.0, 41.0, 51.0, 61.0, 81.0, 101.0, 1001.0, …</pluralRule>
             <pluralRule count="two">n % 10 = 2 and n % 100 != 12,72,92 @integer 2, 22, 32, 42, 52, 62, 82, 102, 1002, … @decimal 2.0, 22.0, 32.0, 42.0, 52.0, 62.0, 82.0, 102.0, 1002.0, …</pluralRule>
             <pluralRule count="few">n % 10 = 3..4,9 and n % 100 != 10..19,70..79,90..99 @integer 3, 4, 9, 23, 24, 29, 33, 34, 39, 43, 44, 49, 103, 1003, … @decimal 3.0, 4.0, 9.0, 23.0, 24.0, 29.0, 33.0, 34.0, 103.0, 1003.0, …</pluralRule>
-            <pluralRule count="many">n != 0 and n % 1000000 = 0 @integer 1000000, … @decimal 1000000.0, 1000000.00, 1000000.000, …</pluralRule>
+            <pluralRule count="many">n != 0 and n % 1000000 = 0 @integer 1000000, … @decimal 1000000.0, 1000000.00, 1000000.000, 1000000.0000, …</pluralRule>
             <pluralRule count="other"> @integer 0, 5~8, 10~20, 100, 1000, 10000, 100000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, …</pluralRule>
         </pluralRules>
         <pluralRules locales="ga">

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
@@ -1,9 +1,12 @@
 package org.unicode.cldr.unittest;
 
+import java.text.ParseException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.unicode.cldr.tool.EFixedDecimal;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
@@ -11,6 +14,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.SampleType;
+import com.ibm.icu.util.ICUException;
 
 public class TestPluralRuleGeneration extends TestFmwkPlus {
     public static void main(String[] args) {
@@ -88,5 +92,53 @@ public class TestPluralRuleGeneration extends TestFmwkPlus {
             System.out.println(item);
         }
 
+    }
+
+    public void TestEFixedDecimal() {
+        PluralRules test;
+        try {
+            test = PluralRules.parseDescription("many: e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0 .. 5 @integer 1000000");
+        } catch (ParseException e) {
+            throw new ICUException(e);
+        }
+        Object[][] checkItems = {
+            {"1234567.8", 1234567.8, 1, 0, "other"},
+            {"123456.78e1", 123456.78, 2, 1, "other"},
+            {"12.345678e5", 12.345678, 6, 5, "other"},
+            {"1.2345678e6", 1.2345678, 7, 6, "many"}
+        };
+        EFixedDecimal lastFromString = null;
+        for (Object[] row : checkItems) {
+            String rowString = Arrays.asList(row).toString();
+            final String arg0 = (String)row[0];
+            final double f = (double)row[1];
+            final int v = (int)row[2];
+            final int e = (int)row[3];
+            final String expected = (String)row[4];
+
+            EFixedDecimal fromString = EFixedDecimal.fromString(arg0);
+            EFixedDecimal fromDoubleAndExponent = EFixedDecimal.fromDoubleVisibleAndExponent(f, v, e);
+            double expectedDouble = f*Math.pow(10,e);
+
+            assertEquals(rowString + " double vs fromString", expectedDouble, fromString.doubleValue());
+            assertEquals(rowString + " double vs fromDoubleAndExponent", expectedDouble, fromDoubleAndExponent.doubleValue());
+
+            assertEquals(rowString + " fromString vs fromDoubleAndExponent", fromString, fromDoubleAndExponent);
+            assertEquals(rowString + " exponent, fromString vs fromDoubleAndExponent", fromString.getExponent(), fromDoubleAndExponent.getExponent());
+            assertEquals(rowString + " exponent vs getPluralOperand(e)", (double)fromString.getExponent(), fromString.getPluralOperand(PluralRules.Operand.e));
+
+            assertEquals(rowString + " fromString vs fromDoubleAndExponent", 0, fromString.compareTo(fromDoubleAndExponent));
+            assertEquals(rowString + " fromString.toString", (row[0]), fromString.toString());
+
+            String actual = test.select(fromString);
+            assertEquals(rowString + " plural category", expected, actual);
+
+            if (lastFromString != null) {
+                assertEquals(lastFromString + " vs " + fromString, 1, lastFromString.compareTo(fromString));
+                assertEquals("double " + lastFromString + " vs " + fromString, lastFromString.doubleValue(), lastFromString.doubleValue());
+            }
+
+            lastFromString = fromString;
+        }
     }
 }

--- a/tools/java/org/unicode/cldr/tool/EFixedDecimal.java
+++ b/tools/java/org/unicode/cldr/tool/EFixedDecimal.java
@@ -1,0 +1,82 @@
+package org.unicode.cldr.tool;
+
+import com.ibm.icu.text.PluralRules.FixedDecimal;
+import com.ibm.icu.text.PluralRules.IFixedDecimal;
+import com.ibm.icu.text.PluralRules.Operand;
+import com.ibm.icu.text.UnicodeSet;
+
+@SuppressWarnings("deprecation")
+public final class EFixedDecimal extends FixedDecimal {
+    private static final long serialVersionUID = 1L;
+    private int e;
+
+    private EFixedDecimal(String n, int e) {
+        this(Double.parseDouble(n), getVisibleFractionCount(n), e);
+    }
+
+    private EFixedDecimal(double fd, int v, int e) {
+        super(fd, v);
+        this.e = e;
+        if (super.getIntegerValue() < 0) {
+            throw new IllegalArgumentException("unexpected negative value" + super.getIntegerValue());
+        }
+    }
+
+    static final UnicodeSet exp = new UnicodeSet("[eE]").freeze();
+
+    public static EFixedDecimal fromString(String expFormat) {
+        int posE = exp.findIn(expFormat, 0, false); // returns length if not found
+        final int exponent = posE == expFormat.length() ? 0 :
+            Integer.parseInt(expFormat.substring(posE+1));
+        return new EFixedDecimal(expFormat.substring(0,posE), exponent);
+    }
+
+    public static EFixedDecimal fromDoubleVisibleAndExponent(double fd, int v, int exp) {
+        return new EFixedDecimal(fd, v, exp);
+    }
+
+    public static EFixedDecimal fromDoubleAndVisibleDigits(double fd, int visibleDigits) {
+        return new EFixedDecimal(fd, visibleDigits, 0);
+    }
+
+    public int getExponent() {
+        return e;
+    }
+
+    private static int getVisibleFractionCount(String value) { // is in FixedDecimal, but we don't have access
+        value = value.trim();
+        int decimalPos = value.indexOf('.') + 1;
+        if (decimalPos == 0) {
+            return 0;
+        } else {
+            return value.length() - decimalPos;
+        }
+    }
+
+    @Override
+    public double getPluralOperand(Operand operand) {
+        switch(operand) {
+        case e: return e;
+        default: return super.getPluralOperand(operand);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return e == 0 ? super.toString() : super.toString() + "e" + e;
+    }
+    @Override
+    public boolean equals(Object arg0) {
+        return super.equals(arg0) && ((IFixedDecimal)arg0).getPluralOperand(Operand.e) == e;
+    }
+
+    public int compareTo(EFixedDecimal arg0) {
+        int result = super.compareTo(arg0);
+        return result != 0 ? result : Integer.compare(e, arg0.e);
+    }
+
+    @Override
+    public double doubleValue() {
+        return super.doubleValue()*Math.pow(10, e);
+    }
+}

--- a/tools/java/org/unicode/cldr/tool/GeneratedPluralSamples.java
+++ b/tools/java/org/unicode/cldr/tool/GeneratedPluralSamples.java
@@ -28,7 +28,6 @@ import org.unicode.cldr.util.TempPrintWriter;
 import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.PluralRules;
-import com.ibm.icu.text.PluralRules.FixedDecimal;
 
 /**
  * Regenerate the plural files. Related classes are:
@@ -59,7 +58,7 @@ public class GeneratedPluralSamples {
         /**
          * Must only be called if visibleFractionDigitCount are the same.
          */
-        public Range(FixedDecimal start, FixedDecimal end) {
+        public Range(EFixedDecimal start, EFixedDecimal end) {
             int temp = 1;
             for (long i = start.getVisibleDecimalDigitCount(); i > 0; --i) {
                 temp *= 10;
@@ -97,7 +96,7 @@ public class GeneratedPluralSamples {
         /**
          * Must only be called if visibleFractionDigitCount are the same.
          */
-        Status getStatus(FixedDecimal ni) {
+        Status getStatus(EFixedDecimal ni) {
             long newValue = ni.getIntegerValue() * offset + ni.getDecimalDigits();
             if (newValue < 0) {
                 throw new IllegalArgumentException("Must not be negative");
@@ -133,6 +132,7 @@ public class GeneratedPluralSamples {
         }
     }
 
+
     private static void append(StringBuilder b, long startValue2, long visibleFractionDigitCount2) {
         int len = b.length();
         for (int i = 0; i < visibleFractionDigitCount2; ++i) {
@@ -143,7 +143,7 @@ public class GeneratedPluralSamples {
         b.insert(len, startValue2);
     }
 
-    public static long getFlatValue(FixedDecimal start) {
+    public static long getFlatValue(EFixedDecimal start) {
         int temp = 1;
         for (long i = start.getVisibleDecimalDigitCount(); i != 0; i /= 10) {
             temp *= 10;
@@ -156,7 +156,7 @@ public class GeneratedPluralSamples {
      */
     static class Ranges {
         @SuppressWarnings("unchecked")
-        Set<Range>[] data = new Set[5];
+        Set<Range>[] data = new Set[10];
         int size = 0;
         {
             for (int i = 0; i < data.length; ++i) {
@@ -176,7 +176,7 @@ public class GeneratedPluralSamples {
             // TODO Auto-generated constructor stub
         }
 
-        void add(FixedDecimal ni) {
+        void add(EFixedDecimal ni) {
             Set<Range> set = data[ni.getVisibleDecimalDigitCount()];
             for (Range item : set) {
                 switch (item.getStatus(ni)) {
@@ -257,8 +257,9 @@ public class GeneratedPluralSamples {
         int countNoTrailing = -1;
         final Set<Double> noTrailing = new TreeSet<>();
         final Ranges samples = new Ranges();
-        final FixedDecimal[] digitToSample = new FixedDecimal[10];
+        final EFixedDecimal[] digitToSample = new EFixedDecimal[20];
         final PluralRules.SampleType sampleType;
+        final Set<EFixedDecimal> exponentSamples = new TreeSet<>();
         private boolean isBounded;
 
         public DataSample(PluralRules.SampleType sampleType) {
@@ -268,15 +269,34 @@ public class GeneratedPluralSamples {
         @Override
         public String toString() {
             Ranges samples2 = new Ranges(samples);
-            for (FixedDecimal ni : digitToSample) {
+            for (EFixedDecimal ni : digitToSample) {
                 if (ni != null) {
                     samples2.add(ni);
                 }
             }
-            return samples2 + (isBounded ? "" : ", …");
+            return format(samples2) + (isBounded ? "" : ", …");
         }
 
-        private void add(FixedDecimal ni) {
+        private String format(Ranges samples2) {
+            StringBuilder builder = new StringBuilder().append(samples2);
+            int max = 5;
+            for (EFixedDecimal exponentSample : exponentSamples) {
+                if (builder.length() != 0) {
+                    builder.append(", ");
+                }
+                builder.append(exponentSample);
+                if (--max < 0) {
+                    break;
+                }
+            }
+            return builder.toString();
+        }
+
+        private void add(EFixedDecimal ni) {
+            if (ni.getExponent() != 0) {
+                exponentSamples.add(ni);
+                return;
+            }
             ++count;
             if (samples.size() < SAMPLE_LIMIT * 2) {
                 samples.add(ni);
@@ -295,17 +315,19 @@ public class GeneratedPluralSamples {
             DataSample other = (DataSample) obj;
             return count == other.count
                 && samples.equals(other.samples)
-                && digitToSample.equals(other.digitToSample);
+                && digitToSample.equals(other.digitToSample)
+                && exponentSamples.equals(other.exponentSamples)
+                ;
         }
 
         @Override
         public int hashCode() {
             // TODO Auto-generated method stub
-            return count ^ samples.hashCode() ^ Arrays.asList(digitToSample).hashCode();
+            return count ^ samples.hashCode() ^ Arrays.asList(digitToSample).hashCode() ^ exponentSamples.hashCode();
         }
 
         public void freeze(String keyword, PluralRules rule) {
-            countNoTrailing = noTrailing.size();
+            countNoTrailing = noTrailing.size() + exponentSamples.size();
             //System.out.println(sampleType + ", " + keyword + ", " + countNoTrailing + ", " + rule);
             isBounded = computeBoundedWithSize(keyword, rule);
             if (countNoTrailing > 0) {
@@ -361,7 +383,7 @@ public class GeneratedPluralSamples {
             this.rules = rules;
         }
 
-        private void add(FixedDecimal ni) {
+        private void add(EFixedDecimal ni) {
             if (boundsComputed) {
                 throw new IllegalArgumentException("Can't call 'add' after 'toString'");
             }
@@ -433,7 +455,7 @@ public class GeneratedPluralSamples {
     //        return true;
     //    }
 
-    static private int getDigit(FixedDecimal ni) {
+    static private int getDigit(EFixedDecimal ni) {
         int result = 0;
         long value = ni.getIntegerValue();
         do {
@@ -446,30 +468,42 @@ public class GeneratedPluralSamples {
     private final TreeMap<String, DataSamples> keywordToData = new TreeMap<>();
     private final PluralType type;
 
-    GeneratedPluralSamples(PluralInfo pluralInfo, PluralType type) {
+    GeneratedPluralSamples(PluralInfo pluralInfo, PluralType type, Set<String> equivalentLocales) {
         this.type = type;
-        PluralInfo pluralRule = pluralInfo;
+
         // 9999, powers; no decimals
-        collect(pluralRule, 10000, 0);
-        collect10s(pluralRule, 10000, 1000000, 0);
+        collect(pluralInfo, 0, 10_000, 0);
+        collect10s(pluralInfo, 10_000, 1_000_000, 0);
 
         if (type == PluralType.cardinal) {
-
             // 9999.9, powers .0
-            collect(pluralRule, 10000, 1);
-            collect10s(pluralRule, 10000, 1000000, 1);
+            collect(pluralInfo, 0, 10_000, 1);
+            collect10s(pluralInfo, 10_000, 1_000_000, 1);
 
             // 999.99, powers .00
-            collect(pluralRule, 1000, 2);
-            collect10s(pluralRule, 1000, 1000000, 2);
+            collect(pluralInfo, 0, 1000, 2);
+            collect10s(pluralInfo, 1000, 1_000_000, 2);
 
             // 99.999, powers .000
-            collect(pluralRule, 100, 3);
-            collect10s(pluralRule, 100, 1000000, 3);
+            collect(pluralInfo, 0, 100, 3);
+            collect10s(pluralInfo, 100, 1_000_000, 3);
 
             // 9.9999, powers .0000
-            collect(pluralRule, 10, 4);
-            collect10s(pluralRule, 10, 1000000, 4);
+            collect(pluralInfo, 0, 10, 4);
+            collect10s(pluralInfo, 10, 1_000_000, 4);
+
+            // add some exponent samples for French
+            // TODO check for any rule with exponent operand and do the same.
+            if (equivalentLocales.contains("fr")) {
+                for (int i = 1; i < 30; ++i) {
+                    add(pluralInfo.getPluralRules(), EFixedDecimal.fromDoubleVisibleAndExponent(i, 0, 5));
+                    add(pluralInfo.getPluralRules(), EFixedDecimal.fromDoubleVisibleAndExponent(i, 0, 6));
+                    add(pluralInfo.getPluralRules(), EFixedDecimal.fromDoubleVisibleAndExponent(i, 0, 7));
+                    add(pluralInfo.getPluralRules(), EFixedDecimal.fromDoubleVisibleAndExponent(i+0.1, 1, 5));
+                    add(pluralInfo.getPluralRules(), EFixedDecimal.fromDoubleVisibleAndExponent(i+0.1, 1, 6));
+                    add(pluralInfo.getPluralRules(), EFixedDecimal.fromDoubleVisibleAndExponent(i+0.1, 1, 7));
+                }
+            }
         }
 
         for (Entry<String, DataSamples> entry : keywordToData.entrySet()) {
@@ -477,22 +511,22 @@ public class GeneratedPluralSamples {
         }
     }
 
-    private void collect10s(PluralInfo pluralInfo, int start, int end, int decimals) {
+    private void collect10s(PluralInfo pluralInfo, long start, long end, int decimals) {
         double power = Math.pow(10, decimals);
         for (long i = start * (int) power; i <= end * (int) power; i *= 10) {
             add(pluralInfo, i / power, decimals);
         }
     }
 
-    private void collect(PluralInfo pluralInfo, int limit, int decimals) {
+    private void collect(PluralInfo pluralInfo, long start, long limit, int decimals) {
         double power = Math.pow(10, decimals);
-        for (int i = 0; i <= limit * (int) power; ++i) {
+        for (long i = start; i <= limit * (int) power; ++i) {
             add(pluralInfo, i / power, decimals);
         }
     }
 
     private void add(PluralInfo pluralInfo, double d, int visibleDecimals) {
-        FixedDecimal ni = new FixedDecimal(d, visibleDecimals);
+        EFixedDecimal ni = EFixedDecimal.fromDoubleAndVisibleDigits(d, visibleDecimals);
         PluralRules pluralRules = pluralInfo.getPluralRules();
         if (CHECK_VALUE && d == VALUE_TO_CHECK) {
             int debug = 0; // debugging
@@ -500,6 +534,16 @@ public class GeneratedPluralSamples {
         String keyword = pluralRules.select(ni);
 
         INFO.add(Info.Type.Warning, checkForDuplicates(pluralRules, ni));
+        add(pluralRules, keyword, ni);
+    }
+
+    public void add(PluralRules pluralRules, EFixedDecimal ni) {
+        String keyword = pluralRules.select(ni);
+        System.out.println(ni + " => " + keyword + ", " + (ni.getVisibleDecimalDigitCount() == 0 ? "integer" : "decimal"));
+        add(pluralRules, keyword, ni);
+    }
+
+    public void add(PluralRules pluralRules, String keyword, EFixedDecimal ni) {
         DataSamples data = keywordToData.get(keyword);
         if (data == null) {
             keywordToData.put(keyword, data = new DataSamples(keyword, pluralRules));
@@ -507,7 +551,7 @@ public class GeneratedPluralSamples {
         data.add(ni);
     }
 
-    public static String checkForDuplicates(PluralRules pluralRules, FixedDecimal ni) {
+    public static String checkForDuplicates(PluralRules pluralRules, EFixedDecimal ni) {
         // add test that there are no duplicates
         Set<String> keywords = new LinkedHashSet<>();
         for (String keywordCheck : pluralRules.getKeywords()) {
@@ -554,10 +598,8 @@ public class GeneratedPluralSamples {
         }
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         myOptions.parse(MyOptions.filter, args, true);
-        PluralRules test = PluralRules.parseDescription("one: n in 3,4 or f mod 5 in 3..4;");
-        System.out.println("Check: " + test);
 
         Matcher localeMatcher = !MyOptions.filter.option.doesOccur() ? null : PatternCache.get(MyOptions.filter.option.getValue()).matcher("");
         boolean fileFormat = true; //MyOptions.xml.option.doesOccur();
@@ -568,7 +610,7 @@ public class GeneratedPluralSamples {
         int failureCount = 0;
 
         PluralRules pluralRules2 = PluralRules.createRules("one: n is 3..9; two: n is 7..12");
-        System.out.println("Check: " + checkForDuplicates(pluralRules2, new FixedDecimal(8)));
+        System.out.println("Check: " + checkForDuplicates(pluralRules2, EFixedDecimal.fromString("8e1")));
 
         for (PluralType type : PluralType.values()) {
             try (TempPrintWriter out = TempPrintWriter.openUTF8Writer(MyOptions.output.option.getValue(), type == PluralType.cardinal ? "plurals.xml" : "ordinals.xml")) {
@@ -613,13 +655,19 @@ public class GeneratedPluralSamples {
                     if (fileFormat) {
                         if (!keywords.equals(oldKeywords)) {
                             out.println("\n        <!-- " + keywords.size() + ": " + Joiner.on(",")
-                                .join(keywords) + " -->\n");
+                            .join(keywords) + " -->\n");
                             oldKeywords = keywords;
                         }
                         out.println(WritePluralRules.formatPluralRuleHeader(equivalentLocales));
                         System.out.println(type + "\t" + equivalentLocales);
                     }
-                    GeneratedPluralSamples samples = new GeneratedPluralSamples(pluralInfo, type);
+                    GeneratedPluralSamples samples;
+                    try {
+                        samples = new GeneratedPluralSamples(pluralInfo, type, equivalentLocales);
+                    } catch (Exception e) {
+                        out.dontReplaceFile();
+                        throw e;
+                    }
                     samplesToPlurals.put(samples, pluralInfo);
                     for (String keyword : keywords) {
                         Count count = Count.valueOf(keyword);
@@ -667,7 +715,7 @@ public class GeneratedPluralSamples {
                         String first = remainder.iterator().next();
                         remainder.remove(first);
                         System.err.println(type + "\tEQUIV:\t\t" + first + "\t≣\t" + Joiner.on(", ")
-                            .join(remainder));
+                        .join(remainder));
                     }
                     System.out.println();
                 }

--- a/tools/java/org/unicode/cldr/util/TempPrintWriter.java
+++ b/tools/java/org/unicode/cldr/util/TempPrintWriter.java
@@ -22,6 +22,7 @@ public class TempPrintWriter extends Writer {
     final PrintWriter tempPrintWriter;
     final String tempName;
     final String filename;
+    boolean noReplace = false;
 
 
     public static TempPrintWriter openUTF8Writer(String filename) {
@@ -53,11 +54,19 @@ public class TempPrintWriter extends Writer {
         }
     }
 
+    public void dontReplaceFile() {
+        noReplace = true;
+    }
+
     @Override
     public void close() {
         tempPrintWriter.close();
         try {
-            replaceDifferentOrDelete(filename, tempName, false);
+            if (noReplace) {
+                new File(tempName).delete();
+            } else {
+                replaceDifferentOrDelete(filename, tempName, false);
+            }
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }


### PR DESCRIPTION
A test failure in ICU exposed that the samples were being generated incorrectly for the new French 'many' plural rule. This should fix that problem, although ICU may now need some changes to recognize syntax like "1.2e6", and as being different than 1200000.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14176
- [ ] Updated PR title and link in previous line to include Issue number

