### PR TITLE
CLDR-13948 only deploy to smoketest in head fork

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -13,7 +13,7 @@ name: cldr-ant
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches: '*'
 
@@ -124,6 +124,7 @@ jobs:
     - name: CLDR Data Check
       run: ant -noinput datacheck -f tools/cldr-unittest/build.xml -DCLDR_DIR=$(pwd)
   deploy:
+    if: github.repository == 'unicode-org/cldr' && github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs:
       - build
       - surveytest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,9 +3,10 @@ name: cldr-mvn
 on:
   push:
     branches:
-      - master
+    - '*'
   pull_request:
-    branches: '*'
+    branches:
+    - '*'
 
 jobs:
   build:


### PR DESCRIPTION
CLDR-13948

- otherwise, any fork with a master branch will attempt (and fail) to deploy.

-----
Specifically locks the smoketest deployment to https://github.com/unicode-org/cldr.git
I don't think there's a reason to lock down "push to production" because it's manually triggered. 

- example where the repo doesn't match (i.e. fork): https://github.com/srl295/cldr/actions/runs/262743821
- example where the repo matches (simulating 'head fork'): https://github.com/srl295/cldr/actions/runs/262751278 (i've changed the workflow to check for `srl295/cldr`)


This brings up a question, though. The maven (and ant) builds currently run on:
 - branch 'master' (any fork)
 - pull request from any branch (any fork)

We may want to change this to actually `push: branches: '*'` so that builds happen on any branch, any fork, and only restrict the automatic deployment step to be branch master, and the head fork.