### PR TITLE
CLDR-11283 Make regular automated backups of Survey Tool database

### DIFF
--- a/tools/scripts/ansible/README.md
+++ b/tools/scripts/ansible/README.md
@@ -75,6 +75,13 @@ Then setup github secrets as shown:
   own system when you ssh into smoketest.
   Try `grep -i smoke ~/.ssh/known_hosts`
 
+Create a folder "cldrbackup" inside local-vars
+```shell
+mkdir -p ./local-vars/cldrbackup
+```
+
+Add three files inside local-vars/cldrbackup-vars: id_rsa, id_rsa.pub, and known_hosts. These must correspond to the public key for cldrbackup on corp.unicode.org. Copy existing versions if you have them. Otherwise, create new ones with `ssh-keygen -t rsa` and copy the public key to corp.unicode.org with `ssh-copy-id -i ~/.ssh/id_rsa cldrbackup@corp.unicode.org`
+
 ### Setup: Config file
 
 - Create a file `local-vars/local.yml` matching the example values in [test-local-vars/local.yml](test-local-vars/local.yml) (but with a secure password instead of `hunter42`!.)

--- a/tools/scripts/ansible/backup-db-playbook.yml
+++ b/tools/scripts/ansible/backup-db-playbook.yml
@@ -1,0 +1,75 @@
+- hosts: backupdb
+  become: yes
+  vars_files:
+    - vars/main.yml
+    - local-vars/local.yml
+  tasks:
+    - name: ensure cldrbackup group is there
+      group:
+        name: cldrbackup
+        state: present
+    - name: ensure cldrbackup user is there
+      user:
+        name: cldrbackup
+        groups:
+          - cldrbackup
+        append: yes # add to the groups, do not remove
+        state: present
+        create_home: true
+    - name: set up /home/cldrbackup/.my.cnf
+      no_log: true
+      template:
+        src: templates/mycnf.j2
+        dest: /home/cldrbackup/.my.cnf
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0640'
+    - name: set up /home/cldrbackup/.ssh/
+      file:
+        path: /home/cldrbackup/.ssh/
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0700'
+        state: directory
+    - name: set up /home/cldrbackup/.ssh/config
+      template:
+        src: templates/cldrbackup/config.j2
+        dest: /home/cldrbackup/.ssh/config.j2
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0640'
+    - name: set up /home/cldrbackup/.ssh/id_rsa
+      no_log: true
+      copy:
+        src: local-vars/cldrbackup/id_rsa
+        dest: /home/cldrbackup/.ssh/id_rsa
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0640'
+    - name: set up /home/cldrbackup/.ssh/id_rsa.pub
+      copy:
+        src: local-vars/cldrbackup/id_rsa.pub
+        dest: /home/cldrbackup/.ssh/id_rsa.pub
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0640'
+    - name: set up /home/cldrbackup/.ssh/known_hosts
+      copy:
+        src: local-vars/cldrbackup/known_hosts
+        dest: /home/cldrbackup/.ssh/known_hosts
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0640'
+    - name: set up /home/cldrbackup/backup.sh
+      template:
+        src: templates/cldrbackup/backup_sh.j2
+        dest: /home/cldrbackup/.ssh/backup.sh
+        owner: cldrbackup
+        group: cldrbackup
+        mode: '0640'
+    - name: set up daily db backup cron job
+      cron:
+        name: "backup db"
+        minute: "37"
+        hour: "7"
+        job: "sh /home/cldrbackup/backup.sh >/dev/null 2>&1"

--- a/tools/scripts/ansible/hosts
+++ b/tools/scripts/ansible/hosts
@@ -13,3 +13,7 @@ prod
 # encrypt all of the surveytool hosts
 [letsencrypt:children]
 surveytool
+
+# auto-backup cldr db only for production
+[backupdb:children]
+prod

--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -196,3 +196,5 @@
         --keep --redirect --uir --hsts --staple-ocsp --must-staple
       args:
         creates: /etc/letsencrypt/renewal/{{ inventory_hostname }}.conf
+
+- import_playbook: backup-db-playbook.yml

--- a/tools/scripts/ansible/templates/cldrbackup/backup_sh.j2
+++ b/tools/scripts/ansible/templates/cldrbackup/backup_sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# A cron job may call this with a line such as:
+#     37 7 * * * sh /home/cldrbackup/backup.sh >/dev/null 2>&1
+
+DATABASE_NAME={{ cldr_database_name }}
+FNAME={{ cldr_database_name }}-DUMP-`date +%Y-%m-%d`
+RSYNC_DEST={{ cldr_db_backup_destination }}
+
+cd /home/cldrbackup
+mysqldump ${DATABASE_NAME} --add-drop-table --create-options --default-character-set=utf8mb4 > ${FNAME}.sql
+xz ${FNAME}.sql
+rsync -q ${FNAME}.sql.xz ${RSYNC_DEST}

--- a/tools/scripts/ansible/templates/cldrbackup/config.j2
+++ b/tools/scripts/ansible/templates/cldrbackup/config.j2
@@ -1,0 +1,3 @@
+Host {{ cldr_db_backup_host }}
+ User {{ cldr_db_backup_user }}
+ IdentityFile ~/.ssh/id_rsa

--- a/tools/scripts/ansible/templates/mycnf.j2
+++ b/tools/scripts/ansible/templates/mycnf.j2
@@ -1,5 +1,5 @@
 # managed by ansible setup-playboook.yml
 [client]
 user=cldradmin
-database=cldrdb
+database={{ cldr_database_name }}
 password={{ cldradmin_pw }}

--- a/tools/scripts/ansible/vars/main.yml
+++ b/tools/scripts/ansible/vars/main.yml
@@ -1,5 +1,9 @@
+cldr_database_name: cldrdb
+cldr_db_backup_host: corp.unicode.org
+cldr_db_backup_user: cldrbackup
+cldr_db_backup_destination: "{{ cldr_db_backup_host }}:/home/users/{{ cldr_db_backup_user }}"
 mysql_databases:
-  - name: cldrdb
+  - name: "{{ cldr_database_name }}"
     encoding: latin1
     collation: latin1_bin
 mysql_enabled_on_startup: true


### PR DESCRIPTION
-Use Ansible to automate not only the backups but the setup of the backups

-Variables cldr_database_name, cldr_db_backup_host, cldr_db_backup_user, cldr_db_backup_destination

-Name backups like cldrdb-DUMP... instead of cldr-DUMP..., distinguish st2 from st during overlap

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11283
- [x] Updated PR title and link in previous line to include Issue number

