### PR TITLE
CLDR-11585 update icu4j to 68.1-SNAPSHOT-cldr-2020-09-22

### DIFF
--- a/.github/workflows/mvn-settings.xml
+++ b/.github/workflows/mvn-settings.xml
@@ -25,9 +25,9 @@ TODO: Remove this when ICU-21251 is completed.
           <snapshots><enabled>true</enabled></snapshots>
         </repository>
         <repository>
-          <id>githubsrl295</id>
-          <name>GitHub srl295/icu Apache Maven Packages</name>
-          <url>https://maven.pkg.github.com/srl295/icu</url>
+          <id>githubicu</id>
+          <name>GitHub unicode-org/icu Apache Maven Packages</name>
+          <url>https://maven.pkg.github.com/unicode-org/icu</url>
         </repository>
         <repository>
           <id>github</id>
@@ -45,7 +45,7 @@ TODO: Remove this when ICU-21251 is completed.
       <password>${GITHUB_TOKEN}</password>
     </server>
     <server>
-      <id>githubsrl295</id>
+      <id>githubicu</id>
       <username>${GITHUB_ACTOR}</username>
       <password>${GITHUB_TOKEN}</password>
     </server>

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -37,13 +37,13 @@
 		<!-- icu -->
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
-			<artifactId>icu4j</artifactId>
+			<artifactId>icu4j-for-cldr</artifactId>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
-			<artifactId>utilities</artifactId>
+			<artifactId>utilities-for-cldr</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<!-- cldr -->

--- a/tools/java/pom.xml
+++ b/tools/java/pom.xml
@@ -25,12 +25,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
-			<artifactId>icu4j</artifactId>
+			<artifactId>icu4j-for-cldr</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
-			<artifactId>utilities</artifactId>
+			<artifactId>utilities-for-cldr</artifactId>
 		</dependency>
 
 		<dependency>
@@ -138,10 +138,9 @@
 
 	<repositories>
 		<repository>
-			<!-- TODO: fix when https://github.com/unicode-org/icu/pull/1270 lands -->
-			<id>githubsrl295</id>
-			<name>HACK: GitHub srl295 Apache Maven Packages</name>
-			<url>https://maven.pkg.github.com/srl295/icu</url>
+			<id>githubicu</id>
+          	<name>GitHub unicode-org/icu Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/unicode-org/icu</url>
 		</repository>
 	</repositories>
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- TODO: fix when https://github.com/unicode-org/icu/pull/1270 lands -->
-		<icu4j.version>0.0.0-cldr-38-d00</icu4j.version>
+		<icu4j.version>68.1-SNAPSHOT-cldr-2020-09-22</icu4j.version>
 		<junit.version>4.11</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
@@ -40,12 +40,12 @@
 			<!-- ICU -->
 			<dependency>
 				<groupId>com.ibm.icu</groupId>
-				<artifactId>icu4j</artifactId>
+				<artifactId>icu4j-for-cldr</artifactId>
 				<version>${icu4j.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.ibm.icu</groupId>
-				<artifactId>utilities</artifactId>
+				<artifactId>utilities-for-cldr</artifactId>
 				<version>${icu4j.version}</version>
 			</dependency>
 


### PR DESCRIPTION
CLDR-11585
updates to the tag `cldr/2020-09-22` from ICU
- switch settings from srl295 to unicode-org
- parallel to b3254d3f3ca4fbc32e8c6e1fe14406edf793b5e3 / #731
- will update developer docs to explain how to configure maven