### PR TITLE
CLDR-13582 Make sure browser uses most recent JavaScript files for ST

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestMisc.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestMisc.java
@@ -7,6 +7,7 @@ package org.unicode.cldr.unittest.web;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfigImpl;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.web.STFactory;
 import org.unicode.cldr.web.WebContext;
@@ -82,9 +83,23 @@ public class TestMisc extends TestFmwk {
     }
 
     public void TestGitHash() {
-        String appsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Apps");
+        final String appsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Apps");
+        System.out.println("TestGitHash: appsVersion = " + appsVersion);
         assertNotNull("getting CLDR-Apps version", appsVersion);
-        String toolsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Tools");
+        if (CLDRURLS.UNKNOWN_REVISION.equals(appsVersion)) {
+            errln("❌ appsVersion = UNKNOWN_REVISION: " + appsVersion);
+        }
+
+        final String toolsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Tools");
         assertNotNull("getting CLDR-Tools version", toolsVersion);
+        if (CLDRURLS.UNKNOWN_REVISION.equals(toolsVersion)) {
+            errln("❌ toolsVersion = UNKNOWN_REVISION: " + toolsVersion);
+        }
+
+        final String hash = CLDRConfig.getInstance().getProperty("CLDR_DATA_HASH");
+        assertNotNull("getting CLDR_DATA_HASH", hash);
+        if (hash != null && !hash.matches("[0-9a-f]+")) {
+            errln("❌ CLDR_DATA_HASH is not hex: " + hash);
+        }
     }
 }

--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -79,6 +79,7 @@
         block: |
           # proxy /cldr-apps/ to tomcat
           location /cldr-apps/ {
+            rewrite ^/(.+)\._[\da-f]+_\.(js|css)$ /$1.$2 break;
             allow all;
             proxy_pass http://localhost:8080/cldr-apps/;
             proxy_set_header Host $host;


### PR DESCRIPTION
-Change filename like `CldrStAjax._b7a33e9fe_.js` instead of query string

-Change filename only if using reverse proxy, detected by X-Real-IP in request.getHeader

-Use Ansible to set up nginx.conf rewrite rule

-Revise unit test TestGitHash for cldr-apps TestAll; TODO: currently it fails

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13582
- [x] Updated PR title and link in previous line to include Issue number

