### PR TITLE
CLDR-11585 Maven: Add tests, simplify pom setup

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,3 +24,8 @@ jobs:
         run: mvn -s .github/workflows/mvn-settings.xml -B package --file tools/pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test with maven
+        run: mvn -s .github/workflows/mvn-settings.xml -B test --file tools/pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/mvn-settings.xml
+++ b/.github/workflows/mvn-settings.xml
@@ -25,11 +25,6 @@ TODO: Remove this when ICU-21251 is completed.
           <snapshots><enabled>true</enabled></snapshots>
         </repository>
         <repository>
-          <id>githubicu</id>
-          <name>GitHub unicode-org/icu Apache Maven Packages</name>
-          <url>https://maven.pkg.github.com/unicode-org/icu</url>
-        </repository>
-        <repository>
           <id>github</id>
           <name>GitHub unicode-org/cldr Apache Maven Packages</name>
           <url>https://maven.pkg.github.com/unicode-org/cldr</url>

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -148,6 +148,15 @@
 	<build>
 		<finalName>cldr-apps</finalName>
 		<sourceDirectory>src</sourceDirectory> <!-- TODO: HACK! until we can pivot src dirs -->
+		<testResources>
+			<testResource>
+				<directory>src</directory>
+				<includes>
+					<include>org/unicode/cldr/unittest/web/data/**/*</include>
+				</includes>
+			</testResource>
+		</testResources>
+
 		<pluginManagement><!-- lock down plugins versions to avoid using Maven 
 				defaults (may be moved to parent pom) -->
 			<plugins>

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestAll.java
@@ -7,6 +7,7 @@ package org.unicode.cldr.unittest.web;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.PrintWriter;
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
@@ -86,9 +87,20 @@ public class TestAll extends TestGroup {
     public static final String DERBY_PREFIX = "jdbc:derby:";
 
     public static void main(String[] args) {
+        main(args, null);
+        /* NOTREACHED */
+    }
+
+    public static void main(String[] args, PrintWriter logs) {
         CheckCLDR.setDisplayInformation(CLDRConfig.getInstance().getEnglish());
         args = TestAll.doResetDb(args);
-        new TestAll().run(args);
+        TestAll test = new TestAll();
+        if(logs != null) {
+            test.run(args, logs);
+        } else {
+            test.run(args);
+            /* NOTREACHED */
+        }
     }
 
     public static String[] doResetDb(String[] args) {

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestShim.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestShim.java
@@ -1,0 +1,18 @@
+package org.unicode.cldr.unittest.web;
+
+import java.io.PrintWriter;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * a JUnit test that calls TestAll.
+ */
+class TestShim {
+    @Test
+    public void TestAll() {
+        String args[] = { "-q" };
+        // regular main() will System.exit() which is not too friendly.
+        // call this instead.
+        TestAll.main(args, new PrintWriter(System.out)); // TODO: parameterize
+    }
+}

--- a/tools/cldr-unittest/build.xml
+++ b/tools/cldr-unittest/build.xml
@@ -95,6 +95,7 @@
 		<mkdir dir="${log.dir}" />
 		<javac srcdir="${src.dir}"
 			includes="org/unicode/cldr/**/*.java"
+			excludes="**/TestShim.java"
 			destdir="${build.dir}" classpathref="project.class.path" source="1.8"
 			target="1.8" debug="on" deprecation="off" includeantruntime="false"
 			encoding="UTF-8" />

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAll.java
@@ -158,6 +158,16 @@ public class TestAll extends TestGroup {
     }
 
     public static void main(String[] args) {
+        int errCount = runTests(args);
+        if (errCount != 0) {
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Run all tests, but do not System.exit at the end.
+     */
+    public static int runTests(String[] args) {
         final boolean doTimeStamps = false;
         TimeStampingPrintWriter tspw = new TimeStampingPrintWriter(System.out);
         if (!doTimeStamps) {
@@ -172,9 +182,7 @@ public class TestAll extends TestGroup {
         sb.append("Tests took ");
         sb.append(dispBean.toString());
         System.out.println(sb.toString());
-        if (errCount != 0) {
-            System.exit(1);
-        }
+        return errCount;
     }
 
     public TestAll() {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestShim.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestShim.java
@@ -1,0 +1,20 @@
+package org.unicode.cldr.unittest;
+
+import java.io.PrintWriter;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * a JUnit test that calls TestAll.
+ */
+class TestShim {
+    @Test
+    public void TestAll() {
+        String args[] = { "-n", "-q" }; // TODO: parameterize
+        // regular main() will System.exit() which is not too friendly.
+        // call this instead.
+        int errCount = TestAll.runTests(args);
+        assertEquals(errCount, 0, "Test had errors");
+    }
+}

--- a/tools/java/pom.xml
+++ b/tools/java/pom.xml
@@ -33,9 +33,15 @@
 			<artifactId>utilities-for-cldr</artifactId>
 		</dependency>
 
+		<!-- test -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -71,6 +77,7 @@
 	</dependencies>
 
 	<build>
+		<testSourceDirectory>${project.basedir}/../cldr-unittest/src</testSourceDirectory>
 		<sourceDirectory>.</sourceDirectory> <!-- TODO: fix by refactoring source dirs, CLDR-11585 -->
 		<resources>
 			<resource>
@@ -87,6 +94,15 @@
 				</includes>
 			</resource>
 		</resources>
+		<testResources>
+			<testResource>
+				<directory>${project.basedir}/../cldr-unittest/src</directory>
+				<includes>
+					<include>org/unicode/cldr/unittest/*.txt</include>
+					<include>org/unicode/cldr/unittest/data/**/*</include>
+				</includes>
+			</testResource>
+		</testResources>
 
 		<plugins>
 			<plugin>
@@ -135,12 +151,4 @@
 		</plugins>
 
 	</build>
-
-	<repositories>
-		<repository>
-			<id>githubicu</id>
-          	<name>GitHub unicode-org/icu Apache Maven Packages</name>
-			<url>https://maven.pkg.github.com/unicode-org/icu</url>
-		</repository>
-	</repositories>
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -196,6 +196,14 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<repositories>
+		<repository>
+			<id>githubicu</id>
+			<name>GitHub unicode-org/icu Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/unicode-org/icu</url>
+		</repository>
+	</repositories>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -216,6 +224,9 @@
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire-plugin-version}</version>
+					<configuration>
+						<argLine>-DCLDR_ENVIRONMENT=UNITTEST -Djava.awt.headless=true  -DCLDR_DIR=../../ -Xmx6g -enableassertions</argLine>
+					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
CLDR-11585


after this, then https://sites.google.com/site/cldr/development/maven instructions should work to use maven (from the command line, at least).

-----

Rescoping this one to also include adding (via a shim) all tests (but not consolecheck).