### PR TITLE
CLDR-13582 Make sure browser uses most recent JavaScript files for ST

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestMisc.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestMisc.java
@@ -82,9 +82,27 @@ public class TestMisc extends TestFmwk {
     }
 
     public void TestGitHash() {
-        String appsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Apps");
+        final String appsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Apps");
         assertNotNull("getting CLDR-Apps version", appsVersion);
-        String toolsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Tools");
+        /*
+         * TODO: fail if CLDRURLS.UNKNOWN_REVISION.equals(appsVersion))
+         * and likewise for toolsVersion
+         */
+        // if (CLDRURLS.UNKNOWN_REVISION.equals(appsVersion)) {
+        //    errln("❌ appsVersion = UNKNOWN_REVISION: " + appsVersion);
+        // }
+
+        final String toolsVersion = CLDRConfigImpl.getGitHashForSlug("CLDR-Tools");
         assertNotNull("getting CLDR-Tools version", toolsVersion);
+
+        /*
+         * TODO: add a regression test here for CLDR_DATA_HASH
+         * Reference: https://unicode-org.atlassian.net/browse/CLDR-13582
+         */
+        // final String hash = CLDRConfig.getInstance().getProperty("CLDR_DATA_HASH");
+        // assertNotNull("getting CLDR_DATA_HASH", hash);
+        // if (hash != null && !hash.matches("[0-9a-f]+")) {
+        //    errln("❌ CLDR_DATA_HASH is not hex: " + hash);
+        // }
     }
 }

--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -79,6 +79,7 @@
         block: |
           # proxy /cldr-apps/ to tomcat
           location /cldr-apps/ {
+            rewrite ^/(.+)\._[\da-f]+_\.(js|css)$ /$1.$2 break;
             allow all;
             proxy_pass http://localhost:8080/cldr-apps/;
             proxy_set_header Host $host;


### PR DESCRIPTION
-Change filename like `CldrStAjax._b7a33e9fe_.js` instead of query string

-Change filename only if using reverse proxy, detected by X-Real-IP in request.getHeader

-Use Ansible to set up nginx.conf rewrite rule

-Comments in unit test TestGitHash about what it currently fails to test

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13582
- [x] Updated PR title and link in previous line to include Issue number

