### PR TITLE
CLDR-14175 update JSON converter to handle compoundUnitPattern1

### DIFF
--- a/tools/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -39,6 +39,10 @@ class LdmlConvertRules {
         "decimalFormat:pattern:count",
         "currencyFormat:pattern:count",
         "unit:unitPattern:count",
+        // compound units
+        "compoundUnit:compoundUnitPattern1:count",
+        "compoundUnit:compoundUnitPattern1:gender",
+        "compoundUnit:compoundUnitPattern1:case",
         "field:relative:type",
         "field:relativeTime:type",
         "relativeTime:relativeTimePattern:count",


### PR DESCRIPTION
CLDR-14175

this was broken for, say, Amharic also.  My first fix is this.
From:

 ```json
          "power2": {
            "compoundUnitPattern1": "{0}²",
            "compoundUnitPattern1": "{0}²",
            "compoundUnitPattern1": "{0}²"
          },
```

 ```json
          "power2": {
            "compoundUnitPattern1": "{0}²",
            "compoundUnitPattern1-count-one": "{0}²",
            "compoundUnitPattern1-count-other": "{0}²"
          },
```

Now, for German a similar issue ensued. My fix outputs this:

```json
          "power2": {
            "compoundUnitPattern1": "Quadrat{0}",
            "compoundUnitPattern1-count-one": "Quadrat{0}",
            "compoundUnitPattern1-count-one-case-accusative": "Quadrat{0}",
            "compoundUnitPattern1-count-one-case-dative": "Quadrat{0}",
            "compoundUnitPattern1-count-one-case-genitive": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-one": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-one-case-accusative": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-one-case-dative": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-one-case-genitive": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-one": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-one-case-accusative": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-one-case-dative": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-one-case-genitive": "Quadrat{0}",
            "compoundUnitPattern1-count-other": "Quadrat{0}",
            "compoundUnitPattern1-count-other-case-accusative": "Quadrat{0}",
            "compoundUnitPattern1-count-other-case-dative": "Quadrat{0}",
            "compoundUnitPattern1-count-other-case-genitive": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-other": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-other-case-accusative": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-other-case-dative": "Quadrat{0}",
            "compoundUnitPattern1-gender-feminine-count-other-case-genitive": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-other": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-other-case-accusative": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-other-case-dative": "Quadrat{0}",
            "compoundUnitPattern1-gender-masculine-count-other-case-genitive": "Quadrat{0}"
          },
```