### PR TITLE
CLDR-14128 he, revert currency format changes, back to CLDR 37 version

### DIFF
--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -6072,10 +6072,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern>‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14128
- [x] Updated PR title and link in previous line to include Issue number

To avoid regressions, revert Hebrew currency formats to CLDR 37 versions. Will use https://unicode-org.atlassian.net/browse/CLDR-14077 to investigate the proposed changes for a future version.