### PR TITLE
CLDR-11585 improve maven tests 

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -179,18 +179,6 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>${maven-surefire-plugin-version}</version>
-					<configuration>
-						<systemPropertyVariables>
-							<CLDR_DIR>${project.basedir}/../../</CLDR_DIR>
-							<CLDR_ENVIRONMENT>UNITTEST</CLDR_ENVIRONMENT>
-							<java.awt.headless>true</java.awt.headless>
-							<!-- <rununittest.arg>-n -q</rununittest.arg> -->
-						</systemPropertyVariables>
-					</configuration>
-				</plugin>
-				<plugin>
 					<artifactId>maven-war-plugin</artifactId>
 					<version>3.2.2</version>
 					<configuration>

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestShim.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestShim.java
@@ -4,13 +4,15 @@ import java.io.PrintWriter;
 
 import org.junit.jupiter.api.Test;
 
+import org.unicode.cldr.util.TestShimUtils;
+
 /**
  * a JUnit test that calls TestAll.
  */
 class TestShim {
     @Test
     public void TestAll() {
-        String args[] = { "-q" };
+        String args[] = TestShimUtils.getArgs(TestShim.class, "-n -q");
         // regular main() will System.exit() which is not too friendly.
         // call this instead.
         TestAll.main(args, new PrintWriter(System.out)); // TODO: parameterize

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestShim.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestShim.java
@@ -2,8 +2,11 @@ package org.unicode.cldr.unittest;
 
 import java.io.PrintWriter;
 
+import org.unicode.cldr.util.TestShimUtils;
+
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * a JUnit test that calls TestAll.
@@ -11,10 +14,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TestShim {
     @Test
     public void TestAll() {
-        String args[] = { "-n", "-q" }; // TODO: parameterize
+        String args[] = TestShimUtils.getArgs(TestShim.class, "-n -q");
         // regular main() will System.exit() which is not too friendly.
         // call this instead.
         int errCount = TestAll.runTests(args);
         assertEquals(errCount, 0, "Test had errors");
+    }
+
+    @Test
+    public void TestTestShimUtilTest() {
+        // Note: checks the system property corresponding to java.lang,
+        // we expect this to be unset!
+        String args[] = TestShimUtils.getArgs(java.lang.String.class, "-a -b -c");
+        String expectArgs[] = { "-a", "-b", "-c" };
+        assertArrayEquals(args, expectArgs, "Expected arg parse");
     }
 }

--- a/tools/java/org/unicode/cldr/util/TestShimUtils.java
+++ b/tools/java/org/unicode/cldr/util/TestShimUtils.java
@@ -1,0 +1,17 @@
+package org.unicode.cldr.util;
+
+/**
+ * Utilities for the TestShims
+ * should go away when we move to all junit tests.
+ * These are here so they can be shared between tools/java and tools/cldr-apps
+ */
+public class TestShimUtils {
+    public static String[] getArgs(Class<?> clazz, String defaultArgs) {
+        final String packageName = clazz.getPackage().getName();
+        final String propKey = packageName+".testArgs";
+        final String toSplit = System.getProperty(propKey, defaultArgs);
+        System.err.println(propKey+"="+toSplit);
+        final String s[] = toSplit.split(" "); // TODO: quoted strings, etc.
+        return s;
+    }
+}

--- a/tools/java/pom.xml
+++ b/tools/java/pom.xml
@@ -116,19 +116,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<systemPropertyVariables>
-						<CLDR_DIR>${project.basedir}/../../</CLDR_DIR>
-						<CLDR_ENVIRONMENT>UNITTEST</CLDR_ENVIRONMENT>
-						<java.awt.headless>true</java.awt.headless>
-						<datacheck.arg>-S common,seed -e -z FINAL_TESTING</datacheck.arg>
-						<rununittest.arg>-n -q</rununittest.arg>
-					</systemPropertyVariables>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>buildnumber-maven-plugin</artifactId>
 			</plugin>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -225,7 +225,12 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire-plugin-version}</version>
 					<configuration>
-						<argLine>-DCLDR_ENVIRONMENT=UNITTEST -Djava.awt.headless=true  -DCLDR_DIR=../../ -Xmx6g -enableassertions</argLine>
+						<systemPropertyVariables>
+							<CLDR_DIR>${project.basedir}/../../</CLDR_DIR> <!-- this is valid for tools/java and tools/cldr-apps-->
+							<CLDR_ENVIRONMENT>UNITTEST</CLDR_ENVIRONMENT>
+							<java.awt.headless>true</java.awt.headless>
+						</systemPropertyVariables>
+						<argLine>-Xmx6g -enableassertions</argLine>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
you can now run specific subtests with:

```
mvn test '-Dorg.unicode.cldr.unittest.web.testArgs=-f:TestMisc -n -q' '-Dorg.unicode.cldr.unittest.testArgs=-f:TestUntimedCounter -n -q' 
```

I was unable to get code coverage to work here, but it's just a config file change away.