### PR TITLE
CLDR-10365 Logic for Losing in sublocales is faulty, Part One

### DIFF
--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/TestSTFactory.java
@@ -16,6 +16,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.SpecialLocales;
 import org.unicode.cldr.util.StackTracker;
 import org.unicode.cldr.util.VoteResolver;
@@ -372,6 +373,9 @@ public class TestSTFactory extends TestFmwk {
         runDataDrivenTest("TestUserRegistry");
     }
 
+    /*
+     * TODO: shorten this function, over 300 lines; use subroutines
+     */
     private void runDataDrivenTest(final String fileBasename) throws SQLException, IOException {
         final STFactory fac = getFactory();
         final File targDir = TestAll.getEmptyDir(TestSTFactory.class.getName() + "_output");
@@ -605,7 +609,7 @@ public class TestSTFactory extends TestFmwk {
                         errln(pathCount + "g Expected from XML: Status=" + expStatus + " got " + xpathStatusBack + " " + locale + ":"
                             + fullXpathBack + " Resolver=" + box.getResolver(xpath));
                     }
-
+                    verifyOrgStatus(r, attrs);
                 }
                     break;
                 case "verifyUser": {
@@ -658,6 +662,25 @@ public class TestSTFactory extends TestFmwk {
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown test element type " + elem);
+                }
+            }
+
+            /**
+             * If a "verify" element includes "orgStatus" and "statusOrg" attributes, then report an
+             * error unless getStatusForOrganization returns the specified status for the specified org
+             *
+             * @param r the VoteResolver
+             * @param attrs the attributes
+             */
+            private void verifyOrgStatus(VoteResolver<String> r, Map<String, String> attrs) {
+                final String expOrgStatus = attrs.get("orgStatus"); // e.g., "ok"
+                final String expStatusOrg = attrs.get("statusOrg"); // e.g., "apple"
+                if (expOrgStatus != null && expStatusOrg != null) {
+                    final Organization org = Organization.fromString(expStatusOrg);
+                    final String actualOrgStatus = r.getStatusForOrganization(org).toString();
+                    if (!expOrgStatus.equals(actualOrgStatus)) {
+                        errln("Error: expected + " + expOrgStatus + " got " + actualOrgStatus + " for " + expStatusOrg);
+                    }
                 }
             }
 

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/data/TestSTFactory.dtd
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/data/TestSTFactory.dtd
@@ -32,6 +32,8 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST verify locale CDATA #REQUIRED>
 <!ATTLIST verify xpath CDATA #REQUIRED>
 <!ATTLIST verify status NMTOKEN #REQUIRED>
+<!ATTLIST verify orgStatus CDATA #IMPLIED>
+<!ATTLIST verify statusOrg CDATA #IMPLIED>
 
 <!ELEMENT setvar EMPTY >
 <!ATTLIST setvar locale CDATA #REQUIRED>

--- a/tools/cldr-apps/src/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
+++ b/tools/cldr-apps/src/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
@@ -183,5 +183,17 @@
 	<!-- G1 Aprel should be eliminated. G2 ↑↑↑ should combine with F1 aprel to beat M1 Aprel.
 		Winner should be ↑↑↑, and ↑↑↑ resolves to the Bailey value aprel. -->
 	<verify status="approved" locale="az" xpath="//ldml/dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='wide']/month[@type='4']" >aprel</verify>
-	
+
+	<!-- Make sure Bailey and inheritance are combined for the purpose of getStatusForOrganization.
+	     This scenario is based on one for which a bug was encountered previously.
+	     Two vetters for 'hard' Bailey should defeat one vetter for 'soft' inheritance, but the latter's vote
+	     should not cause inclusion in the 'losing' or 'disputed' sections of the Dashboard
+	     Reference: https://unicode-org.atlassian.net/browse/CLDR-10365 -->
+	<user name="OrgStatA1" org="apple" level="vetter" locales="*"/>
+	<user name="OrgStatG1" org="google" level="vetter" locales="*"/>
+	<user name="OrgStatM1" org="microsoft" level="vetter" locales="*"/>
+	<vote name="OrgStatA1" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">pistolet à eau</vote>
+	<vote name="OrgStatM1" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">pistolet à eau</vote>
+	<vote name="OrgStatG1" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">↑↑↑</vote>
+	<verify status="approved" orgStatus="ok" statusOrg="google" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">pistolet à eau</verify>
 </TestSTFactory>


### PR DESCRIPTION
-Revise equalsOrgVote to prevent Dashboard Losing

-New itemsWithVotes = countDistinctValuesWithVotes to prevent Dashboard Disputed

-New bothInheritanceAndBaileyHadVotes, refactor combineInheritanceWithBaileyForVoting

-Remove condition voteCount != null in reallyCombineInheritanceWithBailey (never null)

-New unit test in TestSTFactory.xml, using new method TestSTFactory.verifyOrgStatus

-Add attributes statusOrg, orgStatus in TestSTFactory.dtd for verifyOrgStatus

-Make getStatusForOrganization slightly more efficient; methods were called even when not needed

-Change some methods from public to private

-Delete some dead/deprecated code

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10365
- [x] Updated PR title and link in previous line to include Issue number

