### PR TITLE
CLDR-11585 maven: single jar assembly, mysql, cleanup

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,11 +27,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build with Maven
-        run: mvn -s .github/workflows/mvn-settings.xml -B package --file tools/pom.xml -DskipTests=true
+        run: >
+          mvn -s .github/workflows/mvn-settings.xml -B package --file tools/pom.xml
+          -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup MySQL
+        run: |
+          sudo systemctl start mysql.service
+          sleep 3
+          mysql --user=root --password=root < tools/cldr-apps/test-setup.sql
       - name: Test with maven
-        run: mvn -s .github/workflows/mvn-settings.xml -B test --file tools/pom.xml
+        run: >
+          mvn -s .github/workflows/mvn-settings.xml -B test --file tools/pom.xml
+          '-Dorg.unicode.cldr.unittest.web.jdbcurl=jdbc:mysql://cldrtest:VbrB3LFCr6A!@localhost/cldrtest?useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC'
+          '-Dorg.unicode.cldr.unittest.web.KeepDb=true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -162,16 +162,9 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.1.0</version>
-				</plugin>
-				<!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging -->
-				<plugin>
-					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.2</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.0</version>
 					<configuration>
 						<includes>
 							<include>org/**/*.java</include>
@@ -180,7 +173,6 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.2.2</version>
 					<configuration>
 						<webResources>
 							<resource>
@@ -200,20 +192,10 @@
 							</manifestEntries>
 						</archive>
 					</configuration>
-
-				</plugin>
-				<plugin>
-					<artifactId>maven-install-plugin</artifactId>
-					<version>2.5.2</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>buildnumber-maven-plugin</artifactId>
-					<version>1.4</version>
 					<executions>
 						<execution>
 							<phase>validate</phase>

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestShim.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestShim.java
@@ -23,8 +23,9 @@ class TestShim {
 
     @Test
     public void TestTestShimUtilTest() {
-        // Note: checks the system property corresponding to java.lang,
-        // we expect this to be unset!
+        // Note: checks the system property corresponding to java.lang
+        // We expect the system property "java.lang.testArgs" will not be set,
+        // and so the default "-a -b -c" will be used.
         String args[] = TestShimUtils.getArgs(java.lang.String.class, "-a -b -c");
         String expectArgs[] = { "-a", "-b", "-c" };
         assertArrayEquals(args, expectArgs, "Expected arg parse");

--- a/tools/java/pom.xml
+++ b/tools/java/pom.xml
@@ -11,6 +11,10 @@
 
 	<url>https://unicode.org/cldr</url>
 
+	<properties>
+		<mainClass>org.unicode.cldr.tool.Main</mainClass>
+	</properties>
+
 	<scm>
 		<connection>scm:git:https://github.com/unicode-org/cldr.git</connection>
 	</scm>
@@ -124,7 +128,7 @@
 				<configuration>
 					<archive>
 						<manifest>
-							<mainClass>org.unicode.cldr.tool.Main</mainClass>
+							<mainClass>${mainClass}</mainClass>
 						</manifest>
 						<manifestEntries>
 							<Built-By>${user.name}</Built-By>
@@ -135,7 +139,19 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>${mainClass}</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
 		</plugins>
-
 	</build>
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -15,7 +15,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<!-- TODO: fix when https://github.com/unicode-org/icu/pull/1270 lands -->
 		<icu4j.version>68.1-SNAPSHOT-cldr-2020-09-22</icu4j.version>
 		<junit.version>4.11</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
@@ -238,12 +237,20 @@
 					<version>3.0.2</version>
 				</plugin>
 				<plugin>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>3.2.2</version>
+				</plugin>
+				<plugin>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>2.5.2</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>2.8.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>3.3.0</version>
 				</plugin>
 				<!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
 				<plugin>


### PR DESCRIPTION
CLDR-11585

- create an uber-jar for cldr.jar with:

    mvn -pl java package assembly:single -DskipTests=true

- fix a comment in TestShim.java (missed in #741)

- run Maven test against MySQL
(this is an update to CLDR-8383 CI against mysql (#705) and
corrects 6adc82b6b6116bb67e046ec129adb66f4aa6aac4 which introduced
Maven CI against Derby)

- Move more pluginDependencies up from cldr-apps/pom.xml to tools/pom.xml

No plugin versions are specified in sub-poms now.

-----

Note: This unblocks CLDR-8383 from a code perspective.  The only thing holding us to Derby is
user docs / dev environment setup!