### PR TITLE
CLDR-11585 maven package/install

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: >
-          mvn -s .github/workflows/mvn-settings.xml -B package --file tools/pom.xml
+          mvn -s .github/workflows/mvn-settings.xml -B compile install package --file tools/pom.xml
           -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -38,13 +38,11 @@
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j-for-cldr</artifactId>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>utilities-for-cldr</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<!-- cldr -->
 		<dependency>


### PR DESCRIPTION
CLDR-11585

- ICU/CLDR need to be default scope in pom
- "mvn install" needed for successful packaging (update to workflow)

I might not have been testing cldr-apps.war properly before.
