### PR TITLE
CLDR-11585 Remove unused CLDR_VET_WEB

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -315,7 +315,6 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      */
     @Deprecated
     private String defaultBase = CLDRURLS.DEFAULT_BASE + "/survey"; /* base URL */
-    private static String vetweb = System.getProperty("CLDR_VET_WEB"); // dir for web data
     public static String fileBase = null; // not static - may change later.
     // Common dir
     public static String fileBaseSeed = null; // not static - may change later.
@@ -4167,10 +4166,6 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             } else {
                 survprops.getEnvironment();
             }
-            vetweb = survprops.getProperty("CLDR_VET_WEB", cldrHome + "/vetdata"); // dir
-            // for
-            // web
-            // data
 
             getFileBase();
             getFileBaseSeed();
@@ -4194,10 +4189,6 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             }
             if (!new File(fileBaseSeed).isDirectory()) {
                 busted("CLDR_SEED isn't a directory: " + fileBaseSeed);
-                return;
-            }
-            if (!new File(vetweb).isDirectory()) {
-                busted("CLDR_VET_WEB isn't a directory: " + vetweb);
                 return;
             }
             progress.update("Setup supplemental..");


### PR DESCRIPTION
-Also remove unused vetweb

-This is to stop spurious warnings after Maven switch

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11585
- [x] Updated PR title and link in previous line to include Issue number

