### PR TITLE
CLDR-13197 make it easier to find more details about an error subtype

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -88,6 +88,16 @@
 			<artifactId>json</artifactId>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->
+		<dependency>
+		    <groupId>org.jsoup</groupId>
+		    <artifactId>jsoup</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+		</dependency>
+
 		<!-- codec/util -->
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/HttpStatusCache.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/HttpStatusCache.java
@@ -1,0 +1,106 @@
+package org.unicode.cldr.web;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+/**
+ * This class caches the status (200, 404, etc.) of a set of pages, attempting to
+ * avoid unnecessary server traffic. At present the cache is a singleton.
+ * @author srl
+ *
+ */
+public class HttpStatusCache {
+    /**
+     * Main entrypoint. Check a URL for its status (i.e., is the page found or not?)
+     * @param url
+     * @return
+     */
+    public static final boolean check(final String url) {
+        try {
+            return isGoodStatus(check(new URL(url)));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    public static final Integer check(final URL url) {
+        try {
+            Integer status = urlCache.get(url, () -> internalCheck(url));
+            // For now we just pass the status through.
+            // A future improvement would be to retry on some types of statuses.
+            return status;
+        } catch (ExecutionException e) {
+            System.err.println("HttpStatusCache: Err in check of URL " + url.toString());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Flush the cache of a specific URL or all of them
+     * @param url ('all' if null)
+     */
+    public static final void flush(final URL url) {
+        if(url == null) {
+            System.err.println("HTTP Status Cache: invalidating all " + urlCache.size());
+            urlCache.invalidateAll();
+        } else {
+            urlCache.invalidate(url);
+        }
+    }
+
+    // ----------
+
+    private static Cache<URL, Integer> urlCache = CacheBuilder.newBuilder()
+        .maximumSize(8192)
+        // We would want the expiry time greater if this were used by users, not just TC.
+        .expireAfterWrite(2, TimeUnit.HOURS)
+        .concurrencyLevel(3).build();
+
+
+    /**
+     * Returns the status code.
+     * @param status
+     * @return true if "good" (200-ish)
+     */
+    public static final boolean isGoodStatus(Integer status) {
+        if(status == null) return false;
+        return (status >= 200 && // found-ish
+                status <  400); // redirect-ish
+    }
+
+
+    /**
+     * Perform the actual check.
+     * Does not attempt to limit concurrency.
+     * @param url
+     * @return HTTP status
+     */
+    static final Integer internalCheck(final URL url)  {
+        HttpURLConnection connection = null;
+        try {
+            // We don't need the content, so just do a HEAD check
+            connection = (HttpURLConnection)(url.openConnection());
+            connection.setRequestMethod("HEAD");
+            connection.connect();
+            final int code = connection.getResponseCode();
+            return code;
+        } catch(IOException t) {
+            t.printStackTrace();
+            return 499; // client closed request
+        } finally {
+            // Cleanup.
+            if(connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SubtypeToURLMap.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SubtypeToURLMap.java
@@ -1,0 +1,457 @@
+// © 2020 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+package org.unicode.cldr.web;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRTool;
+
+import com.ibm.icu.text.MessageFormat;
+
+@CLDRTool(alias="subtype-to-url-map", description = "parse each of the params as a path or URL to a subtype map and check.")
+public class SubtypeToURLMap {
+    /**
+     * Little tool for validating input data.
+     * @param args list of files to validate, if empty runs against default data.
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+     public static void main(String args[]) throws FileNotFoundException, IOException {
+        if(args.length == 0) {
+            System.err.println("Usage: SubtypeToURLMap (url or file path). The default map is " + DEFAULT_URL);
+            return;
+        } else {
+            int problems = 0;
+            for(final String fn : args) {
+                System.out.println("data: " + fn);
+                SubtypeToURLMap map = getInstance(new File(fn));
+                problems += map.dump();
+            }
+            if(problems > 0) {
+                throw new IllegalArgumentException(MessageFormat.format("Total problem(s) found: {0} in {1} items(s)", problems, args.length));
+            }
+        }
+    }
+
+    /**
+     * Map from Subtype to URL
+     */
+    private Map<Subtype, String> map;
+
+    /**
+     * The set of URLs is kept as a List so the original order is retained.
+     */
+    private List<String> urlList;
+
+    public static class URLMapReader {
+        final Map<Subtype, String> newMap = new HashMap<>();
+        final List<String> newList = new ArrayList<>();
+        int lineCount = 0;
+        boolean started = false; // Are we in started state?
+        boolean everStarted = false; // did we ever start?
+        boolean hadSubtype = false; // did we have a subtype for this URL?
+        int urlLast = 0; // line number of the last URL
+        int subtypeLast = 0; // line number of the last subtype
+        String url = null; // last URL seen
+        int urlCount = 0; // number of urls
+
+        void read(BufferedReader utf8Data) {
+            try {
+                for(String ln; (ln=utf8Data.readLine())!=null;) {
+                    if(!handleLine(ln)) break;
+                }
+                handleComplete();
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Line " + lineCount + ": Could not read subtypeMapping file", e);
+            }
+        }
+
+        /**
+         *
+         * @param ln
+         * @return true if handled, false if done
+         */
+        private boolean handleLine(String ln) {
+            ++lineCount;
+            ln = ln.trim();
+            if(ln.isEmpty()) return true;
+            if(!started) {
+                if(ln.contains(BEGIN_MARKER)) {
+                    handleBegin();
+                }
+                return true;
+            }
+            if(ln.contains(END_MARKER)) {
+                return handleEnd();
+            } else if(ln.isEmpty() || ln.startsWith(COMMENT)) {
+                return true;
+            } else if(isUrl(ln)) {
+                handleUrl(ln);
+            } else {
+                handleSubtype(ln);
+            }
+            return true;
+        }
+
+        private void handleBegin() {
+            started = everStarted = true;
+        }
+
+        private boolean handleEnd() {
+            started = false;
+            return false; // exit loop, got end
+        }
+
+        private void handleSubtype(String ln) {
+            for(String str : ln.split("[, ]")) {
+                str = str.trim();
+                if(str.isEmpty()) continue;
+                if(url == null) {
+                    throw new IllegalArgumentException("Line " + lineCount + ": No page URL has been found yet for " + str);
+                }
+                try {
+                    Subtype subtype = Subtype.valueOf(str);
+                    newMap.put(subtype, url);
+                    subtypeLast = lineCount;
+                    hadSubtype = true;
+                } catch(IllegalArgumentException iae) {
+                    throw new IllegalArgumentException("Line " + lineCount + ": No subtype named '"+str+"'. See CheckCLDR.Subtype.");
+                }
+            }
+        }
+
+        private boolean isUrl(String ln) {
+            return ln.startsWith("http:") || ln.startsWith("https:");
+        }
+
+        private void handleUrl(String ln) {
+            urlLast = lineCount;
+            url = ln;
+            urlCount++;
+            hadSubtype = false; // reset this
+            try {
+                new java.net.URL(ln);
+            } catch(MalformedURLException mfe) {
+                throw new IllegalArgumentException("Line " + lineCount + ": malformed URL: " + ln);
+            }
+            newList.add(ln);
+        }
+
+        private void handleComplete() {
+            if(started) {
+                throw new IllegalArgumentException("line " + lineCount + " - Error: No END line after line " + urlLast + ".");
+            } else if (!everStarted) {
+                throw new IllegalArgumentException("line " + lineCount + " - Error: No BEGIN line ");
+            }
+            if(urlCount>0 && !hadSubtype) { // had URLs, but did not end with a subtype
+                throw new IllegalArgumentException("Error: Dangling URL " + url.toString() + " from line " + urlLast + " with no subtypes. Comment out that line.");
+            } else if(subtypeLast == 0) {
+                System.err.println("SubtypeToURLMap: Warning: no subtypes specified or no BEGIN line detected.");
+            } else {
+                System.out.println("SubtypeToURLMap: read " + lineCount + " lines, " + urlCount + " urls and " + newMap.size() + " subtypes mapped.");
+            }
+        }
+
+        public Map<Subtype, String> getMap() {
+            return Collections.unmodifiableMap(newMap);
+        }
+
+        public List<String> getList() {
+            return Collections.unmodifiableList(newList);
+        }
+    }
+
+    /**
+     * Internal constructor for
+     * @param utf8Data for cleaned input data (i.e. not HTML)
+     * @throws IllegalArgumentException
+     */
+    protected SubtypeToURLMap(BufferedReader utf8Data) throws IllegalArgumentException{
+        URLMapReader mapReader = new URLMapReader();
+        mapReader.read(utf8Data);
+
+        this.map = mapReader.getMap();
+        this.urlList = mapReader.getList();
+    }
+    public static final String COMMENT = "#";
+    public static final String END_MARKER = "-*- END CheckCLDR.Subtype Mapping -*-";
+    public static final String BEGIN_MARKER = "-*- BEGIN CheckCLDR.Subtype Mapping -*-";
+
+    /**
+     * Dump a subtype map to stderr.
+     * @return unhandled type count, or zero
+     */
+    public int dump() {
+        int count = 0;
+        for(final Subtype s : getHandledTypes()) {
+            System.err.println(s + " => " + get(s));
+        }
+
+        System.err.println("Not Handled:");
+        for(final Subtype s : getUnhandledTypes()) {
+            count++;
+            System.err.println("  " + s.name()+",");
+        }
+        return count;
+    }
+
+    /**
+     * Write the URLMap to a file
+     * @param pw
+     * @throws IOException
+     */
+    public void write(PrintWriter pw) throws IOException {
+        pw.println(COMMENT + " " + "dumped by " + getClass().getSimpleName());
+        pw.println(COMMENT + " " + BEGIN_MARKER);
+        for (final String url : getUrls()) {
+            pw.println(url);
+            for(final Subtype type : getSubtypesForUrl(url)) {
+                pw.println(type.name()+",");
+            }
+            pw.println();
+        }
+        pw.println(COMMENT + " " + END_MARKER);
+    }
+
+    /**
+     * Get a list of the URLs, in original order
+     * @return
+     */
+    public List<String> getUrls() {
+        return urlList;
+    }
+    /**
+     * get the subtypes that match a certain URL
+     */
+    public Set<Subtype> getSubtypesForUrl(final String url) {
+        Set<Subtype> set = new TreeSet<>();
+        map.forEach((Subtype t, String s) -> {
+            if(s.equals(url)) set.add(t);
+        });
+        return set;
+    }
+
+    /**
+     * Get the URL with more information about a subtype.
+     * @param subtype the subtype to fetch
+     * @return url or null
+     */
+    public String get(Subtype subtype) {
+        return map.get(subtype);
+    }
+
+    /**
+     * Get the subtypes that ARE handled by this map.
+     * @return
+     */
+    public Collection<Subtype> getHandledTypes() {
+        return Collections.unmodifiableSet(map.keySet());
+    }
+
+    /**
+     * Get the subtypes that ARE NOT handled by this map.
+     * @return
+     */
+    public Collection<Subtype> getUnhandledTypes() {
+        Set<Subtype> ts = createExpectedSubtypes();
+        ts.removeAll(map.keySet());
+        return Collections.unmodifiableSet(ts);
+    }
+
+    /**
+     * Create a set with the expected subtypes (minus 'none') in name order.
+     * The set is mutable, with the expectation that the caller may use the set
+     * for verification.
+     * @return
+     */
+    static Set<Subtype> createExpectedSubtypes() {
+        return Arrays.stream(Subtype.values())
+        .filter(s -> !(s == Subtype.none)) // do not expect "none"
+        .collect(Collectors.toCollection(
+            () -> new TreeSet<>((Subtype s1, Subtype s2)->s1.name().compareTo(s2.name()))));
+    }
+
+    /**
+     * Get the subtypes that are expected to be handled by this map.
+     * (i.e. minus Subtype.none)
+     * @return
+     */
+    public static Collection<Subtype> getExpectedSubtypes() {
+        return Collections.unmodifiableCollection(createExpectedSubtypes());
+    }
+
+    public static SubtypeToURLMap getInstance(final BufferedReader bufferedReader) {
+        return new SubtypeToURLMap(bufferedReader);
+    }
+
+    public static SubtypeToURLMap getInstance(final File fn) throws IOException, FileNotFoundException {
+        try (InputStream fis = new FileInputStream(fn);
+            InputStreamReader inputStreamReader = new InputStreamReader(fis, Charset.forName("UTF-8"));
+            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+            ) {
+            return SubtypeToURLMap.getInstance(bufferedReader);
+        }
+    }
+
+    /**
+     * Fetch from a URL.
+     *
+     * @param resource
+     * @return
+     * @throws IOException
+     */
+    public static SubtypeToURLMap getInstance(URL resource) throws IOException, URISyntaxException {
+        if(resource.toString().endsWith(".txt")) {
+            // plain text
+            Class<?> classes[] = {InputStream.class};
+            try (InputStream is  = (InputStream)resource.getContent(classes);
+                Reader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+                BufferedReader br = new BufferedReader(isr);
+                ) {
+                return new SubtypeToURLMap(br);
+            }
+        } else if(resource.getProtocol().equals("http") || resource.getProtocol().equals("https")) {
+
+            Document doc = Jsoup.connect(resource.toString()).get();
+            SubtypeToURLMap newMap = getInstance(resource, doc);
+            try(PrintWriter pw = new PrintWriter(new File("/tmp/mymap.txt"), "UTF-8")) { // TODO: in later Java, we can use StandardCharsets.UTF8
+                newMap.write(pw);
+            }
+            return newMap;
+        } else {
+            // assume HTML to parse
+            Class<?> classes[] = {InputStream.class};
+            try (InputStream is  = (InputStream)resource.getContent(classes);
+                ) {
+                Document doc = Jsoup.parse(is, "UTF-8", resource.toString());
+                return getInstance(resource, doc);
+            }
+        }
+    }
+
+    private static SubtypeToURLMap getInstance(URL resource, Document doc) throws IOException {
+        StringBuffer sb = new StringBuffer();
+        doc.select("div code").forEach(n ->
+            n.textNodes()
+                .forEach(tn -> sb.append(tn.text()).append('\n')));
+        System.err.println("Read " + sb.length() + " chars from " + resource.toString());
+        try (Reader sr = new StringReader(sb.toString());
+            BufferedReader br = new BufferedReader(sr);) {
+            return new SubtypeToURLMap(br);
+        }
+    }
+    static final String DEFAULT_URL = /*CLDRConfig.getInstance().getProperty("CLDR_SUBTYPE_URL", */
+        "https://sites.google.com/site/cldr/development/subtypes" /* ) */;
+
+    private static String CACHE_SUBTYPE_FILE = "urlmap-cache.txt";
+
+    private final static class SubtypeToURLMapHelper {
+        static File cacheFile = getCacheFile();
+        private static File getCacheFile() {
+            return new File(CLDRConfig.getInstance().get("CLDRHOME"), CACHE_SUBTYPE_FILE);
+        }
+        static SubtypeToURLMap INSTANCE = make(); // not final, may be reloaded.
+        static SubtypeToURLMap make() {
+            SubtypeToURLMap map = null;
+            if(cacheFile.canRead()) {
+                Instant fileDate = Instant.ofEpochMilli(cacheFile.lastModified());
+                Instant staleAfter = getExpirationDate();
+                // after 1 day, try to reload the file.
+
+                try {
+                    map = getInstance(cacheFile);
+                    System.out.println(" Read " + cacheFile.getAbsolutePath() + " - date " + fileDate);
+                    if(fileDate.isAfter(staleAfter)) {
+                        System.err.println("Cache file stale, will try to reload");
+                    } else {
+                        return map;
+                    }
+                } catch (IOException ioe) {
+                    System.err.println("Could not initialize SubtypeToURLMap from file " + cacheFile.getAbsolutePath());
+                }
+            }
+            try {
+                map = SubtypeToURLMap.getInstance(new URL(getDefaultUrl()));
+                System.out.println("Read new map from " + getDefaultUrl());
+                // now, write out the cache
+                writeToCache(map);
+            } catch (IOException | URISyntaxException e) {
+                System.err.println("Could not initialize SubtypeToURLMap: " + e + " for URL " + getDefaultUrl());
+                e.printStackTrace();
+                // If we loaded the cache file, we will still use it.
+            }
+            return map;
+        }
+        /**
+         * The date before which a cache's contents are invalid.
+         * @return
+         */
+        private static Instant getExpirationDate() {
+            return Instant.now().minus(CLDRConfig.getInstance().getProperty("CLDR_SUBTYPE_EXPIRY_DAYS", 1), ChronoUnit.DAYS);
+        }
+        private static void writeToCache(SubtypeToURLMap map) {
+            try (PrintWriter pw = new PrintWriter(cacheFile, StandardCharsets.UTF_8.name())) {
+                map.write(pw);
+                System.out.println("Updated cachefile " + cacheFile.getAbsolutePath());
+            } catch ( IOException ioe ) {
+                ioe.printStackTrace();
+                System.err.println("Error trying to update cachefile: " + ioe);
+            }
+        }
+    }
+
+    /**
+     * Fetch the URL used for the default map
+     * @return
+     */
+    public static String getDefaultUrl() {
+        return DEFAULT_URL;
+    }
+    /**
+     * Get the default instance.
+     * @return
+     */
+    public static final SubtypeToURLMap getInstance() {
+        return SubtypeToURLMapHelper.INSTANCE;
+    }
+
+    public static String forSubtype(Subtype subType) {
+        if(SubtypeToURLMapHelper.INSTANCE == null) return null;
+        return SubtypeToURLMapHelper.INSTANCE.get(subType);
+    }
+
+    public static SubtypeToURLMap reload() {
+        return (SubtypeToURLMapHelper.INSTANCE = SubtypeToURLMapHelper.make());
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -115,6 +115,12 @@ public class SurveyAjax extends HttpServlet {
             return j.toString();
         }
 
+        /**
+         * Converts this CheckStatus to JSON.
+         * @param status
+         * @return
+         * @throws JSONException
+         */
         public static JSONObject wrap(CheckStatus status) throws JSONException {
             final CheckStatus cs = status;
             return new JSONObject() {
@@ -125,8 +131,10 @@ public class SurveyAjax extends HttpServlet {
                     if (cs.getCause() != null) {
                         put("cause", wrap(cs.getCause()));
                     }
-                    if (cs.getSubtype() != null) {
-                        put("subType", cs.getSubtype().name());
+                    Subtype subType = cs.getSubtype();
+                    if (subType != null) {
+                        put("subType", subType.name());
+                        put("subTypeUrl", SubtypeToURLMap.forSubtype(subType)); // could be null.
                     }
                 }
             };

--- a/tools/cldr-apps/src/main/webapp/js/CldrSurveyVettingLoader.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrSurveyVettingLoader.js
@@ -777,7 +777,12 @@ function showV() {
 							url: surveyUserURL.browse,
 							display: surveyUserPerms.hasDataSource
 						},
-
+						{
+					         title: 'Error Subtypes',
+					         level: 2,
+					         url: './tc-all-errors.jsp',
+					         display: surveyUserPerms.userIsTC
+					 	},
 						{
 							divider: true
 						},

--- a/tools/cldr-apps/src/main/webapp/js/survey.js
+++ b/tools/cldr-apps/src/main/webapp/js/survey.js
@@ -2324,13 +2324,19 @@ function testsToHtml(tests) {
 		} else if (testItem.type == 'Error') {
 			newHtml += ' alert alert-danger fix-popover-help';
 		}
-		newHtml += "' title='" + testItem.type + "'>";
+		newHtml += "' title='" + testItem.type + ': ' + (testItem.cause || {class:'Unknown'}).class + '.'+testItem.subType + "'>";
 		if (testItem.type == 'Warning') {
 			newHtml += warnIcon;
 		} else if (testItem.type == 'Error') {
 			newHtml += stopIcon;
 		}
-		newHtml += tests[i].message;
+		newHtml += testItem.message;
+		// Add a link
+		
+		if(testItem.subTypeUrl) {
+			newHtml += " <a href=\""+testItem.subTypeUrl+"\">(how to fix…)</a>";
+		}
+		
 		newHtml += "</p>";
 	}
 	return newHtml;

--- a/tools/cldr-apps/src/main/webapp/tc-all-errors.jsp
+++ b/tools/cldr-apps/src/main/webapp/tc-all-errors.jsp
@@ -1,0 +1,140 @@
+<%@page import="java.io.PrintWriter"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@page import="org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype"%>
+<%@page import="org.unicode.cldr.web.SubtypeToURLMap"%>
+<%@page import="java.util.TreeSet"%>
+<%@page import="java.net.URL"%>
+<%@page import="org.unicode.cldr.web.HttpStatusCache" %>
+<%@page import="org.unicode.cldr.util.CLDRConfig" %>
+<%@page import="org.unicode.cldr.util.StackTracker" %>
+<%@page import="org.unicode.cldr.util.CLDRURLS" %>
+<%
+final String BASE = request.getContextPath() + request.getServletPath();
+// allow ?flush=true - redirect 
+if(request.getParameter("flush") != null) {
+	final String recheck = request.getParameter("flush");
+	%>
+		<%
+		if(recheck.startsWith("MAP")) {
+			try {
+				%><h1>Reloading URL map... </h1> <%
+				SubtypeToURLMap map = SubtypeToURLMap.reload();
+				if(map == null) {
+					out.println("FAILED. Check for errors.");
+				} else {
+					out.println("SUCCESS!");
+				}
+			} catch(Throwable t) {
+				%> 
+					<a href="<%= BASE %>?flush=MAP">🔄 Try Again</a> | 
+					<a href="<%= BASE %>">Cancel</a> (cache may work)
+					<h1>Reload FAILED with stack:</h1><pre><%
+				t.printStackTrace(new PrintWriter(out));
+				out.println("</pre>");
+				return; // do not auto refresh.
+			}
+		} else if(recheck.startsWith("http")) {
+			%><h1>Flushing <%= recheck %> from cache..</h1> <%
+			HttpStatusCache.flush(new URL(recheck));
+		} else {
+			%><h1>Flushing cache..</h1> <%
+			HttpStatusCache.flush(null);
+		}
+		%>
+	    <meta http-equiv="refresh" content="2;URL='<%= request.getContextPath() %><%= request.getServletPath() %>'" />    
+		<p>(redirect in a couple seconds)</p>
+		<img src="./loader.gif" alt="reloading.." />
+	<%
+	return;
+}
+%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>All Errors</title>
+<link href="./surveytool.css" rel="stylesheet">
+</head>
+<body>
+
+
+<h1>All error subTypes</h1>
+
+<p>
+	
+</p>
+
+<b>CLDR_SUBTYPE_URL</b> <%= CLDRURLS.toHTML(SubtypeToURLMap.getDefaultUrl()) %>
+<br>
+
+<a href="<%= BASE %>?flush=MAP">🔄 Reload Map</a>
+
+<%
+SubtypeToURLMap map = SubtypeToURLMap.getInstance();
+
+if( map==null ) {
+	out.println("<b>Could not load map.</b>");
+	return;
+} else {
+	out.println("Map OK! (may be cached)<br>");
+}
+%>
+
+<P>
+	<i>Instructions</i>:  This shows the status of the subtype to URL mapping data.
+	Each line here shows the CLDR error subtypes.<br />
+			<b>Code</b> - this is the code <br/>
+			<b>url</b> - this is the URL specified in the subtypeMapping.txt file <br/>
+			<b>Status</b> - this shows whether the URL was fetched successfully. (200 indicates success.)
+				Click the 'reload'  🔄 button to re-check the URL.
+</P>
+
+<a href="<%= BASE %>?flush=true">🔄Recheck all URLs </a>
+
+<hr />
+
+<div class="subtypemap">
+<pre><%= SubtypeToURLMap.COMMENT + " " + SubtypeToURLMap.BEGIN_MARKER %></pre>
+
+<%
+for(final String u : map.getUrls()) {
+        Integer checkStatus;
+        checkStatus = HttpStatusCache.check(new URL(u));
+    %>
+<pre>#------------------</pre>
+<pre><a title="HTTP:<%= checkStatus %>" href="<%= u %>"><%= u %></a></pre>
+    <%
+        if(! HttpStatusCache.isGoodStatus(checkStatus)) { %>
+# URL failed to fetch: <%= checkStatus %> <a href="<%= BASE+"?flush="+u %>" title="flush">🔄</a><br/>
+<% } else { %>
+<!-- # URL OK! <%= checkStatus %> <a href="<%= BASE+"?flush="+u %>" title="flush">🔄</a><br/> -->
+<% }
+        for(final Subtype s : map.getSubtypesForUrl(u)) {
+            %>
+<!-- # <%= s.toString() %> -->
+<b><pre title="<%= s.toString() %>"><%= s.name() %>,</pre></b> <%
+        }
+}
+
+if(map.getUnhandledTypes().isEmpty()) {
+%>
+<pre>#------------------</pre>
+<p><b># All types handled!</b></p>
+<% } else { %>
+<p>
+<pre>#------------------</pre>
+<h2># Missing these subtypes:</h2>
+    
+<% for(final Subtype sub : map.getUnhandledTypes()) {    %>
+<pre  title="<%= sub.toString() %>"># <%= sub.name() %>,</pre>
+<%
+    }	
+}
+%>
+
+<pre><%= SubtypeToURLMap.COMMENT + " " + SubtypeToURLMap.END_MARKER %></pre>
+
+
+</body>
+</html>

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestSubtypeToURLMap.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestSubtypeToURLMap.java
@@ -1,0 +1,86 @@
+package org.unicode.cldr.unittest.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.FileReaders;
+import org.unicode.cldr.web.SubtypeToURLMap;
+
+import com.google.common.collect.ImmutableSet;
+
+public class TestSubtypeToURLMap {
+
+    @Test
+    public void TestFlatFile() throws FileNotFoundException, IOException {
+        final String path = "subtypes.txt";
+        SubtypeToURLMap map = getTestDataAsReader(path);
+        assertMapOk(map);
+    }
+    private SubtypeToURLMap getTestDataAsReader(final String path) {
+        SubtypeToURLMap map = SubtypeToURLMap.getInstance(FileReaders.openFile(TestSubtypeToURLMap.class, "data/" + path));
+        return map;
+    }
+    @Test
+    public void TestFlatFileURL() throws FileNotFoundException, IOException, URISyntaxException {
+        final String path = "subtypes.txt";
+        SubtypeToURLMap map = getTestDataAsUrl(path);
+        assertMapOk(map);
+    }
+    private SubtypeToURLMap getTestDataAsUrl(final String path) throws IOException, URISyntaxException {
+        SubtypeToURLMap map = SubtypeToURLMap.getInstance(TestSubtypeToURLMap.class.getResource("data/" + path));
+        return map;
+    }
+    @Test
+    public void TestHTMLURL() throws FileNotFoundException, IOException, URISyntaxException {
+
+        SubtypeToURLMap map = getTestDataAsUrl("subtypes.html");
+        assertMapOk(map);
+    }
+
+    private void assertMapOk(SubtypeToURLMap map) {
+        assertNotNull(map, "SubtypeToURLMap from subtypes.txt");
+        Collection<Subtype> handledTypes = map.getHandledTypes();
+        Collection<Subtype> unHandledTypes = map.getUnhandledTypes();
+        assertTrue(handledTypes.contains(Subtype.numberPatternNotCanonical), "numberPatternNotCanonical is handled");
+        assertFalse(unHandledTypes.contains(Subtype.numberPatternNotCanonical), "numberPatternNotCanonical is handled");
+        assertEquals("http://cldr.unicode.org/translation/numbers-currency/number-symbols",
+            map.get(Subtype.numberPatternNotCanonical), "numberPatternNotCanonical URL");
+        assertFalse(handledTypes.contains(Subtype.auxiliaryExemplarsOverlap), "auxiliaryExemplarsOverlap is NOT handled");
+        assertTrue(unHandledTypes.contains(Subtype.auxiliaryExemplarsOverlap), "auxiliaryExemplarsOverlap is NOT handled");
+    }
+
+
+    @Test
+    public void TestEmpty() throws IOException, URISyntaxException {
+        Assertions.assertEquals(0, getTestDataAsUrl("subtypes_empty.txt").getHandledTypes().size(),
+                "subtypes_empty.txt: empty: should have zero handled types");
+    }
+
+    @Test
+    public void TestFailure() {
+        ImmutableSet<String> failingMaps = ImmutableSet.of(
+            "subtypes_bad_badtype.txt",
+            "subtypes_bad_badurl.txt",
+            "subtypes_bad_dangling.txt",
+            "subtypes_bad_dangling2.txt",
+            "subtypes_bad_noend.txt",
+            "subtypes_bad_nostart.txt",
+            "subtypes_bad_nourl.txt"
+        );
+        Assertions.assertAll("bad maps",
+            failingMaps
+            .stream()
+            .map(path -> ()->Assertions.assertThrows(IllegalArgumentException.class, ()->{getTestDataAsUrl(path);},
+                path+": Should fail to parse")));
+    }
+}

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes.html
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" itemscope="" itemtype="http://schema.org/WebPage">
+<head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="chrome=1" />
+<script type="text/javascript">/* Copyright 2008 Google. */ (function() { /*
+
+Copyright The Closure Library Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+(function(){function e(g){this.t={};this.tick=function(h,k,f){this.t[h]=[void 0!=f?f:(new Date).getTime(),k];if(void 0==f)try{window.console.timeStamp("CSI/"+h)}catch(m){}};this.getStartTickTime=function(){return this.t.start[0]};this.tick("start",null,g)}var a;if(window.performance)var d=(a=window.performance.timing)&&a.responseStart;var l=0<d?new e(d):new e;window.jstiming={Timer:e,load:l};if(a){var b=a.navigationStart;0<b&&d>=b&&(window.jstiming.srt=d-b)}if(a){var c=window.jstiming.load;0<b&&d>=
+b&&(c.tick("_wtsrt",void 0,b),c.tick("wtsrt_","_wtsrt",d),c.tick("tbsd_","wtsrt_"))}try{a=null,window.chrome&&window.chrome.csi&&(a=Math.floor(window.chrome.csi().pageT),c&&0<b&&(c.tick("_tbnd",void 0,window.chrome.csi().startE),c.tick("tbnd_","_tbnd",b))),null==a&&window.gtbExternal&&(a=window.gtbExternal.pageT()),null==a&&window.external&&(a=window.external.pageT,c&&0<b&&(c.tick("_tbnd",void 0,window.external.startE),c.tick("tbnd_","_tbnd",b))),a&&(window.jstiming.pt=a)}catch(g){}})(); })()
+</script>
+<link rel="shortcut icon" type="image/x-icon" href="//www.google.com/images/icons/product/sites-16.ico" />
+<link rel="apple-touch-icon" href="http://www.gstatic.com/sites/p/beb206/system/app/images/apple-touch-icon.png" type="image/png" />
+<script type="text/javascript">/* Copyright 2008 Google. */ (function() { function d(a){return document.getElementById(a)}window.byId=d;function g(a){return a.replace(/^\s+|\s+$/g,"")}window.trim=g;var h=[],k=0;window.JOT_addListener=function(a,b,c){var f=new String(k++);a={eventName:a,handler:b,compId:c,key:f};h.push(a);return f};window.JOT_removeListenerByKey=function(a){for(var b=0;b<h.length;b++)if(h[b].key==a){h.splice(b,1);break}};window.JOT_removeAllListenersForName=function(a){for(var b=0;b<h.length;b++)h[b].eventName==a&&h.splice(b,1)};
+window.JOT_postEvent=function(a,b,c){var f={eventName:a,eventSrc:b||{},payload:c||{}};if(window.JOT_fullyLoaded)for(b=h.length,c=0;c<b&&c<h.length;c++){var e=h[c];e&&e.eventName==a&&(f.listenerCompId=e.compId||"",(e="function"==typeof e.handler?e.handler:window[e.handler])&&e(f))}else window.JOT_delayedEvents.push({eventName:a,eventSrc:b,payload:c})};window.JOT_delayedEvents=[];window.JOT_fullyLoaded=!1;
+window.JOT_formatRelativeToNow=function(a,b){a=((new Date).getTime()-a)/6E4;if(1440<=a||0>a)return null;var c=0;60<=a&&(a/=60,c=2);2<=a&&c++;return b?window.JOT_siteRelTimeStrs[c].replace("__duration__",Math.floor(a)):window.JOT_userRelTimeStrs[c].replace("__duration__",Math.floor(a))}; })()
+</script>
+<script>
+
+  
+
+  var breadcrumbs = [{"path":"/development","deleted":false,"title":"CLDR Development Site","dir":"ltr"},{"path":"/development/subtypes","deleted":false,"title":"CheckCLDR Subtypes","dir":"ltr"}];
+  var JOT_clearDotPath = 'http://www.gstatic.com/sites/p/beb206/system/app/images/cleardot.gif';
+
+  
+  var JOT_userRelTimeStrs = ["a minute ago","__duration__ minutes ago","an hour ago","__duration__ hours ago"];
+
+  
+  
+
+  
+
+  var webspace = {"gvizGstaticVersion":"current","enableAnalytics":true,"pageSharingId":"jotspot_page","codeembeds":{"outerIframeSrc":"https://www.gstatic.com/jotspot/embeds/code/0f08d42392f2000e7e3f3daf5b427a43/outer_iframe.html","innerIframeSrc":"https://1177313512-jotspot-embeds.googleusercontent.com/code/8d87fa64604b2a11fae2ed06104c58d3/inner_iframe.html"},"enableUniversalAnalytics":false,"sharingPolicy":"OPENED","siteTitle":"CLDR - Unicode Common Locale Data Repository","jot2atari":{"eligibility":"ineligible"},"onepickUrl":"https://docs.google.com/picker","adsensePublisherId":null,"features":{"moreMobileStyleImprovements":null,"disableGroups":true,"subscriptionDataMigrationInProgress":null,"plusBadge":false},"isPublic":true,"newSitesBaseUrl":"https://sites.google.com","isConsumer":true,"serverFlags":{"jot2AtariLearnMoreUrl":"https://support.google.com/sites/answer/7035197"},"domainAnalyticsAccountId":"","plusPageId":"","signInUrl":"https://accounts.google.com/AccountChooser?continue\u003dhttp://sites.google.com/site/cldr/development/subtypes\u0026service\u003djotspot","analyticsAccountId":"UA-7672775-1","scottyUrl":"/_/upload","homePath":"/","siteNoticeUrlEnabled":null,"plusPageUrl":"","adsensePromoClickedOrSiteIneligible":true,"csiReportUri":"http://csi.gstatic.com/csi","sharingId":"jotspot","termsUrl":"//www.google.com/intl/en/policies/terms/","gvizVersion":1,"editorResources":{"sitelayout":["http://www.gstatic.com/sites/p/beb206/system/app/css/sitelayouteditor.css"],"text":["http://www.gstatic.com/sites/p/beb206/system/js/codemirror.js","http://www.gstatic.com/sites/p/beb206/system/app/css/codemirror_css.css","http://www.gstatic.com/sites/p/beb206/system/js/trog_edit__en.js","http://www.gstatic.com/sites/p/beb206/system/app/css/trogedit.css","/_/rsrc/1602142236000/system/app/css/editor.css","http://www.gstatic.com/sites/p/beb206/system/app/css/codeeditor.css","/_/rsrc/1602142236000/system/app/css/camelot/editor-jfk.css"]},"sharingUrlPrefix":"/_/sharing","isAdsenseEnabled":true,"domain":"defaultdomain","baseUri":"","name":"cldr","siteTemplateId":false,"siteNoticeRevision":null,"siteNoticeUrlAddress":null,"siteNoticeMessage":null,"page":{"isRtlLocale":false,"canDeleteWebspace":null,"isPageDraft":null,"parentPath":"/development","parentWuid":"wuid:gx:5f29bc741bdf7d81","siteLocale":"en","timeZone":"America/Los_Angeles","type":"text","title":"CheckCLDR Subtypes","locale":"en","wuid":"wuid:gx:2d376253d210b4f6","revision":6,"path":"/development/subtypes","isSiteRtlLocale":false,"pageInheritsPermissions":null,"name":"subtypes","canChangePath":true,"state":"","properties":{},"bidiEnabled":false,"currentTemplate":{"path":"/system/app/pagetemplates/text","title":"Web Page"}},"canPublishScriptToAnyone":true,"user":{"keyboardShortcuts":true,"sessionIndex":"","onePickToken":"","guest_":true,"displayNameOrEmail":"guest","userName":"guest","uid":"","renderMobile":false,"domain":"","namespace":"","hasWriteAccess":false,"namespaceUser":false,"primaryEmail":"guest","hasAdminAccess":false},"gadgets":{"baseUri":"/system/app/pages/gadgets"}};
+  webspace.page.breadcrumbs = breadcrumbs;
+
+  
+  var JOT_siteRelTimeStrs = ["a minute ago","__duration__ minutes ago","an hour ago","__duration__ hours ago"];
+
+</script>
+<script type="text/javascript">
+                window.jstiming.load.tick('scl');
+              </script>
+<link rel="canonical" href="http://cldr.unicode.org/development/subtypes" />
+<meta name="title" content="CheckCLDR Subtypes - CLDR - Unicode Common Locale Data Repository" />
+<meta itemprop="name" content="CheckCLDR Subtypes - CLDR - Unicode Common Locale Data Repository" />
+<meta property="og:title" content="CheckCLDR Subtypes - CLDR - Unicode Common Locale Data Repository" />
+<meta name="description" content="Unicode Locale Data Site" />
+<meta itemprop="description" content="Unicode Locale Data Site" />
+<meta id="meta-tag-description" property="og:description" content="Unicode Locale Data Site" />
+<style type="text/css">
+</style>
+<link rel="stylesheet" type="text/css" href="http://www.gstatic.com/sites/p/beb206/system/app/themes/charcoal/standard-css-charcoal-ltr-ltr.css" />
+<link rel="stylesheet" type="text/css" href="/_/rsrc/1602142236000/system/app/css/overlay.css?cb=charcoal5a100%25%25250goog-ws-leftnonethemedefaultstandard" />
+<link rel="stylesheet" type="text/css" href="/_/rsrc/1602142236000/system/app/css/camelot/allthemes-view.css" />
+<!--[if IE]>
+          <link rel="stylesheet" type="text/css" href="/system/app/css/camelot/allthemes%2die.css" />
+        <![endif]-->
+<title>CheckCLDR Subtypes - CLDR - Unicode Common Locale Data Repository</title>
+<meta itemprop="image" content="/_/rsrc/1570176048971/config/customLogo.gif?revision=2" />
+<meta property="og:image" content="/_/rsrc/1570176048971/config/customLogo.gif?revision=2" />
+<script type="text/javascript">
+                window.jstiming.load.tick('cl');
+              </script>
+</head>
+<body xmlns="http://www.google.com/ns/jotspot" id="body" class=" en            ">
+<div id="sites-page-toolbar" class="sites-header-divider">
+<div xmlns="http://www.w3.org/1999/xhtml" id="sites-status" class="sites-status" style="display:none;"><div id="sites-notice" class="sites-notice" role="status" aria-live="assertive"> </div></div>
+</div>
+<div id="sites-chrome-everything-scrollbar">
+<div id="sites-chrome-everything" class="">
+<div id="sites-chrome-page-wrapper" style="direction: ltr">
+<div id="sites-chrome-page-wrapper-inside">
+<div xmlns="http://www.w3.org/1999/xhtml" id="sites-chrome-header-wrapper" style="height:auto;">
+<table id="sites-chrome-header" class="sites-layout-hbox" cellspacing="0" style="height:auto;">
+<tr class="sites-header-primary-row" id="sites-chrome-userheader">
+<td id="sites-header-title" class="" role="banner"><div class="sites-header-cell-buffer-wrapper"><a href="http://cldr.unicode.org/" id="sites-chrome-userheader-logo"><img id="logo-img-id" src="/_/rsrc/1570176048971/config/customLogo.gif?revision=2" alt="CLDR - Unicode Common Locale Data Repository" class="sites-logo  " /></a><h2><a href="http://cldr.unicode.org/" dir="ltr" id="sites-chrome-userheader-title">CLDR - Unicode Common Locale Data Repository</a></h2></div></td><td class="sites-layout-searchbox  "><div class="sites-header-cell-buffer-wrapper"><form id="sites-searchbox-form" action="/system/app/pages/search" role="search"><input type="hidden" id="sites-searchbox-scope" name="scope" value="search-site" /><input type="text" id="jot-ui-searchInput" name="q" size="20" value="" aria-label="Search this site" /><div id="sites-searchbox-button-set" class="goog-inline-block"><div role="button" id="sites-searchbox-search-button" class="goog-inline-block jfk-button jfk-button-standard" tabindex="0">Search this site</div></div></form></div></td>
+</tr>
+<tr class="sites-header-secondary-row" id="sites-chrome-horizontal-nav">
+<td colspan="2" id="sites-chrome-header-horizontal-nav-container" role="navigation">
+</td>
+</tr>
+</table>
+</div>
+<div id="sites-chrome-main-wrapper">
+<div id="sites-chrome-main-wrapper-inside">
+<table id="sites-chrome-main" class="sites-layout-hbox" cellspacing="0" cellpadding="{scmCellpadding}" border="0">
+<tr>
+<td id="sites-chrome-sidebar-left" class="sites-layout-sidebar-left initial" style="width:250px">
+<div xmlns="http://www.w3.org/1999/xhtml" id="COMP_8290471293936486" class="sites-embed" role="navigation"><h4 class="sites-embed-title">Navigation</h4><div class="sites-embed-content sites-sidebar-nav"><ul role="navigation" jotId="navList"><li class="nav-first "><div dir="ltr" style="padding-left: 5px;"><a href="/index" jotId="wuid:gx:7edc217ccff4d12b" class="sites-navigation-link">Unicode CLDR Project</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/downloads" jotId="wuid:gx:59505df3497f7ac4" class="sites-navigation-link">CLDR Releases/Downloads</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/survey-tool" jotId="wuid:gx:6bb23292d930088" class="sites-navigation-link">CLDR Survey Tool</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/bug-reports" jotId="wuid:gx:5437940dbf4693e0" class="sites-navigation-link">CLDR Change Requests</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/charts" jotId="wuid:gx:3b1b7dee1eed97e7" class="sites-navigation-link">CLDR Charts</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/process" jotId="wuid:gx:10c8fe28b3db0d8f" class="sites-navigation-link">CLDR Process</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/cldr-spec" jotId="wuid:gx:116cb783f6f053ce" class="sites-navigation-link">CLDR Specifications</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/translation" jotId="wuid:gx:3fe05afe3929821c" class="sites-navigation-link">Information Hub for Linguists</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/bcp47-extension" jotId="wuid:gx:2d01d16ab6e81a94" class="sites-navigation-link">Unicode Extensions for BCP 47</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/implementers-faq" jotId="wuid:gx:2cf0e7e6a80783f7" class="sites-navigation-link">Implementer’s FAQ</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="https://github.com/unicode-org/message-format-wg" class="sites-navigation-link">Message Format Subcommittee</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="/index/keyboard-workgroup" jotId="wuid:gx:459485d4bb7d9912" class="sites-navigation-link">Keyboard workgroup</a></div></li><li class=""><div dir="ltr" style="padding-left: 5px;"><a href="https://unicode.org/uli" class="sites-navigation-link">ULI (disbanded)</a></div></li></ul></div></div>
+<div xmlns="http://www.w3.org/1999/xhtml" id="COMP_20659206160749766" class="sites-embed" role="complementary"><h4 class="sites-embed-title">Milestone Schedule</h4><div class="sites-embed-content sites-embed-content-sidebar-textbox"><div dir="ltr">See <a href="https://docs.google.com/spreadsheets/d/1N6inI5R84UoYlRwuCNPBOAP7ri4q2CmJmh8DC5g-S6c/edit#gid=1680747936" style="outline:none;color:rgb(0,0,0)!important" target="_blank">Current CLDR Cycle</a>.</div></div></div>
+<div xmlns="http://www.w3.org/1999/xhtml" id="COMP_2bd" class="sites-embed" role="navigation"><h4 class="sites-embed-title">Internal Development</h4><div class="sites-embed-content sites-sidebar-nav"><ul role="navigation" jotId="navList" class="has-expander"><li class="topLevel nav-first parent " wuid="gx:5f29bc741bdf7d81"><div dir="ltr" style="padding-left: 0px;"><div class="expander"></div><a href="/development" jotId="wuid:gx:5f29bc741bdf7d81" class="sites-navigation-link topLevel">CLDR Development Site</a></div><ul role="navigation" class="has-expander"><li class=""><div dir="ltr" style="padding-left: 38px;"><a href="/development/new-cldr-developers" jotId="wuid:gx:18ab8ea59061ae46" class="sites-navigation-link">New CLDR Developers</a></div></li><li class=""><div dir="ltr" style="padding-left: 38px;"><a href="/development/development-process" jotId="wuid:gx:7d6e9a660c83ae9f" class="sites-navigation-link">Handling Tickets (bugs/enhancements)</a></div></li></ul></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/cldr-big-red-switch" jotId="wuid:gx:57590fd30de419f6" class="sites-navigation-link topLevel">CLDR: Big Red Switch</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/messages" jotId="wuid:gx:4feef20ccf4e2fd2" class="sites-navigation-link topLevel">Messages</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/development-process/design-proposals" jotId="wuid:gx:5af0fb58099bf3f3" class="sites-navigation-link topLevel">Design Proposals</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/guidance-on-direct-modifications-to-cldr-data" jotId="wuid:gx:7841ef5f010f71a6" class="sites-navigation-link topLevel">Direct Modifications to CLDR Data</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/updating-codes" jotId="wuid:gx:147f246c8ecf4b2d" class="sites-navigation-link topLevel">Updating Codes</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/updating-dtds" jotId="wuid:gx:22eddc22506a0ba" class="sites-navigation-link topLevel">Updating DTDs</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/development/editing-cldr-spec" jotId="wuid:gx:190780e91cf61630" class="sites-navigation-link topLevel">Editing the CLDR Spec</a></div></li><li class="topLevel "><div dir="ltr" style="padding-left: 19px;"><a href="/system/app/pages/sitemap/hierarchy" jotId="wuid:gx:64065fcc5305d0e3" class="sites-navigation-link topLevel">Sitemap</a></div></li></ul></div></div>
+<div xmlns="http://www.w3.org/1999/xhtml" id="COMP_8157686524335367" class="sites-embed" role="complementary"><h4 class="sites-embed-title"></h4><div class="sites-embed-content sites-embed-content-sidebar-textbox"><div dir="ltr">
+<a href="http://www.unicode.org/copyright.html" rel="nofollow"> <img alt="Access to Copyright and terms of use" border="0" height="50" src="http://www.unicode.org/img/hb_notice.gif" width="216" /></a></div></div></div>
+</td>
+<td id="sites-canvas-wrapper">
+<div id="sites-canvas" role="main">
+<div id="goog-ws-editor-toolbar-container"> </div>
+<div xmlns="http://www.w3.org/1999/xhtml" id="title-crumbs" style="">
+<A href="/development" dir="ltr">CLDR Development Site</A>‎ &gt; ‎
+  </div>
+<h3 xmlns="http://www.w3.org/1999/xhtml" id="sites-page-title-header" style="" align="left">
+<span id="sites-page-title" dir="ltr" tabindex="-1" style="outline: none">CheckCLDR Subtypes</span>
+</h3>
+<div id="sites-canvas-main" class="sites-canvas-main">
+<div id="sites-canvas-main-content">
+<table xmlns="http://www.w3.org/1999/xhtml" cellspacing="0" class="sites-layout-name-one-column sites-layout-hbox"><tbody><tr><td class="sites-layout-tile sites-tile-name-content-1"><div dir="ltr">This page provides a mapping from CheckCLDR subtypes, to URLs with further information.<div>Do not change the BEGIN and END lines.<br /><div><br /></div></div><div><div></div><div class="sites-codeblock sites-codesnippet-block"><div><code># -*- BEGIN CheckCLDR.Subtype Mapping -*-</code></div><div><code># Format is URL "http..." followed by Subtype values, the latter separated by whitespace (linebreaks or spaces). commas are ignored.</code></div><div><code># Trailing commas are allowed and ignored</code></div><div><code># Each of the Subtypes is covered by documentation at that URL.</code></div><div><code># Comment lines must START with a #, because # is used for HTML fragments.</code></div><div><code> </code></div><div><code>http://cldr.unicode.org/translation/timezones#metazones</code></div><div><code>noMetazoneMapping,</code></div><div><code>noMetazoneMappingAfter1970,</code></div><div><code>noMetazoneMappingBeforeNow,</code></div><div><code>multipleMetazoneMappings,</code></div><div><code>metazoneContainsDigit,</code></div><div><code>extraMetazoneString,</code></div><div><code> </code></div><div><code>http://cldr.unicode.org/translation/numbers-currency/number-symbols</code></div><div><code>numberPatternNotCanonical,</code></div><div><code> </code></div><div><code># -*- END CheckCLDR.Subtype Mapping -*-</code></div></div></div></div></td></tr></tbody></table>
+</div> 
+</div> 
+<div id="sites-canvas-bottom-panel">
+<div xmlns="http://www.w3.org/1999/xhtml" id="COMP_page-subpages"> </div>
+<div id="sites-attachments-container">
+</div>
+<a xmlns="http://www.w3.org/1999/xhtml" name="page-comments"></a>
+<div xmlns="http://www.w3.org/1999/xhtml" id="COMP_page-comments"><div class="sites-comment-docos-wrapper"><div class="sites-comment-docos"><div class="sites-comment-docos-background"></div><div class="sites-comment-docos-header"><div class="sites-comment-docos-header-title">Comments</div></div><div id="sites-comment-docos-pane" class="sites-comment-docos-pane"></div></div></div></div>
+</div>
+</div> 
+</td> 
+</tr>
+</table> 
+</div> 
+</div> 
+<div id="sites-chrome-footer-wrapper">
+<div id="sites-chrome-footer-wrapper-inside">
+<div id="sites-chrome-footer">
+</div>
+</div>
+</div>
+</div> 
+</div> 
+<div id="sites-chrome-adminfooter-container">
+<div xmlns="http://www.w3.org/1999/xhtml" class="sites-adminfooter" role="navigation"><p><a class="sites-system-link" href="https://accounts.google.com/ServiceLogin?continue=http://sites.google.com/site/cldr/development/subtypes&amp;service=jotspot">Sign in</a><span aria-hidden="true">|</span><a class="sites-system-link" href="/system/app/pages/recentChanges">Recent Site Activity</a><span aria-hidden="true">|</span><a class="sites-system-link" href="http://sites.google.com/site/cldr/system/app/pages/reportAbuse" target="_blank">Report Abuse</a><span aria-hidden="true">|</span><a class="sites-system-link" href="javascript:;" onclick="window.open(webspace.printUrl)">Print Page</a><span aria-hidden="true">|</span><span class="sites-system-link">Powered By</span> <b class="powered-by"><a href="http://sites.google.com/site">Google Sites</a></b></p></div>
+</div>
+</div> 
+</div> 
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+    window.jstiming.load.tick('sjl');
+  </script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="http://www.gstatic.com/sites/p/beb206/system/js/jot_min_view__en.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+    window.jstiming.load.tick('jl');
+  </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+                    sites.Searchbox.initialize(
+                        'sites-searchbox-search-button',
+                        {"object":[]}['object'],
+                        'search-site',
+                        {"label":"Configure search options...","url":"/system/app/pages/admin/settings"});
+                  </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+      gsites.HoverPopupMenu.createSiteDropdownMenus('sites-header-nav-dropdown', false);
+    </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript" defer="true">
+            JOT_setupNav("8290471293936486", "Navigation", false);
+            JOT_addListener('titleChange', 'JOT_NAVIGATION_titleChange', 'COMP_8290471293936486');
+          </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript" defer="true">
+            JOT_setupNav("2bd", "Internal Development", false);
+            JOT_addListener('titleChange', 'JOT_NAVIGATION_titleChange', 'COMP_2bd');
+          </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+              new sites.CommentPane('//docs.google.com/comments/d/AAHRpnXu-VcMC14xLqgJFrfQGoZk5NPHWlxgL6zQUPmjSlqHYDVfkkHD6qK9kPOlom7MoBX5NdYQH8IoZu_brpWsdnoJNrU6TispI0lMh6p1nvRqj_8r3o3w/api/js?anon=true',
+                  false, false);
+            </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+  setTimeout(function() {
+    var fingerprint = gsites.date.TimeZone.getFingerprint([1109635200000, 1128902400000, 1130657000000, 1143333000000, 1143806400000, 1145000000000, 1146380000000, 1152489600000, 1159800000000, 1159500000000, 1162095000000, 1162075000000, 1162105500000]);
+    gsites.Xhr.send('http://cldr.unicode.org/_/tz', null, null, 'GET', null, null, { afjstz: fingerprint });
+  }, 500);
+</script>
+<script xmlns="http://www.w3.org/1999/xhtml">
+                    window.onload = function() {
+                      if (false) {
+                        JOT_setMobilePreview();
+                      }
+                      var loadTimer = window.jstiming.load;
+                      loadTimer.tick("ol");
+                      loadTimer["name"] = "load," + webspace.page.type + ",user_page";
+                      window.jstiming.report(loadTimer, {}, 'http://csi.gstatic.com/csi');
+                    }
+                  </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+        JOT_insertAnalyticsCode(false,
+            false);
+      </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+    var maestroRunner = new gsites.pages.view.SitesMaestroRunner(
+        webspace, "en");
+    maestroRunner.initListeners();
+    maestroRunner.installEditRender();
+  </script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript" defer="true">
+  //<![CDATA[
+    // Decorate any fastUI buttons on the page with a class of 'goog-button'.
+    if (webspace.user.hasWriteAccess) {
+      JOT_decorateButtons();
+    }
+
+    // Fires delayed events.
+    (function() {
+      JOT_fullyLoaded = true;
+      var delayedEvents = JOT_delayedEvents;
+      for (var x = 0; x < delayedEvents.length; x++) {
+        var event = delayedEvents[x];
+        JOT_postEvent(event.eventName, event.eventSrc, event.payload);
+      }
+      JOT_delayedEvents = null;
+      JOT_postEvent('pageLoaded');
+    })();
+  //]]>
+</script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="text/javascript">
+    JOT_postEvent('decorateGvizCharts');
+  </script>
+<script type="text/javascript">
+          JOT_setupPostRenderingManager();
+        </script>
+<script type="text/javascript">
+          JOT_postEvent('renderPlus', null, 'sites-chrome-main');
+        </script>
+<script type="text/javascript">
+          sites.codeembed.init();
+        </script>
+<div id="server-timer-div" style="display:none"> </div>
+<script type="text/javascript">
+          window.jstiming.load.tick('render');
+          JOT_postEvent('usercontentrendered', this);
+        </script>
+</body>
+</html>

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes.txt
@@ -1,0 +1,32 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+# Format is URL "http..." followed by Subtype values, the latter separated by commas.
+# Each of the Subtypes is covered by documentation at that URL.
+# Comment lines must START with a #, because # is used for HTML fragments.
+
+
+
+http://cldr.unicode.org/translation/timezones#metazones
+
+noMetazoneMapping,
+
+noMetazoneMappingAfter1970,
+
+noMetazoneMappingBeforeNow,
+
+multipleMetazoneMappings,
+
+metazoneContainsDigit,
+
+# extra comma just to test
+
+,
+ 
+extraMetazoneString,
+
+
+http://cldr.unicode.org/translation/numbers-currency/number-symbols
+
+numberPatternNotCanonical,
+
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_badtype.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_badtype.txt
@@ -1,0 +1,28 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+# Format is URL "http..." followed by Subtype values, the latter separated by commas.
+# Each of the Subtypes is covered by documentation at that URL.
+# Comment lines must START with a #, because # is used for HTML fragments.
+
+
+
+http://cldr.unicode.org/translation/timezones#metazones
+
+noMetazoneMapping,
+
+noMetazoneMappingAfter1970,
+
+noMetazoneMappingBeforeNow,
+
+multipleMetazoneMappings,
+
+metazoneContainsDigit,
+
+extraMetazoneString,
+
+
+http://cldr.unicode.org/translation/numbers-currency/number-symbols
+
+dontMixLinearAAndCyproMinoanDigitsOrThingsMightBreak,
+
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_badurl.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_badurl.txt
@@ -1,0 +1,13 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+# Format is URL "http..." followed by Subtype values, the latter separated by commas.
+# Each of the Subtypes is covered by documentation at that URL.
+# Comment lines must START with a #, because # is used for HTML fragments.
+
+
+
+# FAIL: bad URL
+httpshttpshttps:kittens
+
+sameAsCode,
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_dangling.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_dangling.txt
@@ -1,0 +1,28 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+# Format is URL "http..." followed by Subtype values, the latter separated by commas.
+# Each of the Subtypes is covered by documentation at that URL.
+# Comment lines must START with a #, because # is used for HTML fragments.
+
+
+
+http://cldr.unicode.org/translation/timezones#metazones
+
+noMetazoneMapping,
+
+noMetazoneMappingAfter1970,
+
+noMetazoneMappingBeforeNow,
+
+multipleMetazoneMappings,
+
+metazoneContainsDigit,
+
+extraMetazoneString,
+
+
+http://cldr.unicode.org/translation/numbers-currency/number-symbols
+
+# FAIL: No subtype for the above URL
+
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_dangling2.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_dangling2.txt
@@ -1,0 +1,13 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+# Format is URL "http..." followed by Subtype values, the latter separated by commas.
+# Each of the Subtypes is covered by documentation at that URL.
+# Comment lines must START with a #, because # is used for HTML fragments.
+
+
+
+http://cldr.unicode.org/translation/timezones#metazones
+
+# FAIL: No subtype for the above URL
+
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_noend.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_noend.txt
@@ -1,0 +1,28 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+# Format is URL "http..." followed by Subtype values, the latter separated by commas.
+# Each of the Subtypes is covered by documentation at that URL.
+# Comment lines must START with a #, because # is used for HTML fragments.
+
+
+
+http://cldr.unicode.org/translation/timezones#metazones
+
+noMetazoneMapping,
+
+noMetazoneMappingAfter1970,
+
+noMetazoneMappingBeforeNow,
+
+multipleMetazoneMappings,
+
+metazoneContainsDigit,
+
+extraMetazoneString,
+
+
+http://cldr.unicode.org/translation/numbers-currency/number-symbols
+
+numberPatternNotCanonical,
+
+
+# no end line!

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_nostart.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_nostart.txt
@@ -1,0 +1,3 @@
+# fails, no start line
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_nourl.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_bad_nourl.txt
@@ -1,0 +1,8 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+
+# FAILS: no URL before first mapping
+
+# << should be a URL here
+noMetazoneMapping,
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_empty.txt
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/subtypes_empty.txt
@@ -1,0 +1,6 @@
+# -*- BEGIN CheckCLDR.Subtype Mapping -*-
+
+# FAILS: no content!
+
+
+# -*- END CheckCLDR.Subtype Mapping -*-

--- a/tools/cldr-code/.settings/org.eclipse.wst.validation.prefs
+++ b/tools/cldr-code/.settings/org.eclipse.wst.validation.prefs
@@ -1,0 +1,2 @@
+disabled=06target
+eclipse.preferences.version=1

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -724,6 +724,7 @@ abstract public class CheckCLDR {
 
             @Override
             public String toString() {
+                // converts "thisThisThis" to "this this this"
                 return TO_STRING.matcher(name()).replaceAll(" $1").toLowerCase();
             }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -8,9 +8,20 @@ package org.unicode.cldr.util;
  *
  */
 public abstract class CLDRURLS {
+    /**
+     * Base URL for the CLDR repository
+     */
+    public static final String CLDR_REPO_BASE = "https://github.com/unicode-org/cldr";
+    public static final String DEFAULT_COMMIT_BASE = CLDR_REPO_BASE+"/commit/";
+    /**
+     * Hostname for the Survey Tool
+     */
     public static final String DEFAULT_HOST = "st.unicode.org";
     public static final String DEFAULT_PATH = "/cldr-apps";
-    public static final String DEFAULT_BASE = "http://" + DEFAULT_HOST + DEFAULT_PATH;
+    public static final String DEFAULT_BASE = "https://" + DEFAULT_HOST + DEFAULT_PATH;
+    /**
+     * URL for filing a new ticket
+     */
     public static final String CLDR_NEWTICKET_URL = "http://cldr.unicode.org/index/bug-reports#TOC-Filing-a-Ticket";
     public static final String CLDR_REPO_ROOT = "https://github.com/unicode-org/cldr";
     /**
@@ -252,7 +263,7 @@ public abstract class CLDRURLS {
     public static String gitHashToLink(String hash) {
         if(!isKnownHash(hash)) return "<span class=\"githashLink\">"+hash+"</span>"; // Not linkifiable
         return "<a class=\"githashLink\" href=\"" +
-                CldrUtility.getProperty("CLDR_COMMIT_BASE", "https://github.com/unicode-org/cldr/commit/")
+                CldrUtility.getProperty("CLDR_COMMIT_BASE", DEFAULT_COMMIT_BASE)
                 + hash + "\">" + hash.substring(0, 8) + "</a>";
     }
 
@@ -263,5 +274,24 @@ public abstract class CLDRURLS {
      */
     public static boolean isKnownHash(String hash) {
         return !hash.equals(UNKNOWN_REVISION);
+    }
+
+    /**
+     * Convert a URL into an HTML link to itself
+     * @param url
+     * @param extra extra parts of the <a> tag, such as "class='someClass'"
+     * @return
+     */
+    public static final String toHTML(String url, String extra) {
+        return "<a href=\""+ url + " "+extra+" \">" + url + "</a>";
+    }
+
+    /**
+     * Convert a URL into an HTML link to itself
+     * @param url
+     * @return
+     */
+    public static final String toHTML(String url) {
+        return toHTML(url, "");
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -961,32 +961,32 @@ public class TestUtilities extends TestFmwkPlus {
         final String KOREAN_LANGUAGE = "//ldml/localeDisplayNames/languages/language[@type=\"ko\"]";
         final String KOREAN_LANGUAGE_STRID = "821c2a2fc5c206d";
         final CLDRLocale maltese = CLDRLocale.getInstance("mt");
-        assertEquals("base", "http://st.unicode.org/cldr-apps", CLDRConfig
+        assertEquals("base", "https://st.unicode.org/cldr-apps", CLDRConfig
             .getInstance().urls().base());
         assertEquals(
             "locales list",
-            "http://st.unicode.org/cldr-apps/v#locales///",
+            "https://st.unicode.org/cldr-apps/v#locales///",
             CLDRConfig.getInstance().urls()
                 .forSpecial(CLDRURLS.Special.Locales));
-        assertEquals("maltese", "http://st.unicode.org/cldr-apps/v#/mt//",
+        assertEquals("maltese", "https://st.unicode.org/cldr-apps/v#/mt//",
             CLDRConfig.getInstance().urls().forLocale(maltese));
         assertEquals("korean in maltese",
-            "http://st.unicode.org/cldr-apps/v#/mt//"
+            "https://st.unicode.org/cldr-apps/v#/mt//"
                 + KOREAN_LANGUAGE_STRID,
             CLDRConfig.getInstance()
                 .urls().forXpath(maltese, KOREAN_LANGUAGE));
         assertEquals("korean in maltese via stringid",
-            "http://st.unicode.org/cldr-apps/v#/mt//"
+            "https://st.unicode.org/cldr-apps/v#/mt//"
                 + KOREAN_LANGUAGE_STRID,
             CLDRConfig.getInstance()
                 .urls().forXpathHexId(maltese, KOREAN_LANGUAGE_STRID));
         assertEquals("south east asia in maltese",
-            "http://st.unicode.org/cldr-apps/v#/mt/C_SEAsia/", CLDRConfig
+            "https://st.unicode.org/cldr-apps/v#/mt/C_SEAsia/", CLDRConfig
                 .getInstance().urls().forPage(maltese, PageId.C_SEAsia));
         try {
             String ret = CLDRConfig.getInstance().urls()
                 .forXpathHexId(maltese, KOREAN_LANGUAGE);
-            errln("Error- expected forXpathHexId to choke on  an xpath but got "
+            errln("Error- expected forXpathHexId to choke on an xpath but got "
                 + ret);
         } catch (IllegalArgumentException iae) {
             logln("GOOD: forXpathHexId Caught expected " + iae);
@@ -994,14 +994,14 @@ public class TestUtilities extends TestFmwkPlus {
         try {
             String ret = CLDRConfig.getInstance().urls()
                 .forXpath(maltese, KOREAN_LANGUAGE_STRID);
-            errln("Error- expected forXpath to choke on  a hexid but got "
+            errln("Error- expected forXpath to choke on a hexid but got "
                 + ret);
         } catch (IllegalArgumentException iae) {
             logln("GOOD: forXpath Caught expected " + iae);
         }
 
         assertEquals("korean in maltese - absoluteUrl",
-            "http://st.unicode.org/cldr-apps/v#/mt//"
+            "https://st.unicode.org/cldr-apps/v#/mt//"
                 + KOREAN_LANGUAGE_STRID,
             CLDRConfig.getInstance()
                 .absoluteUrls().forXpath(maltese, KOREAN_LANGUAGE));

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -24,6 +24,7 @@
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>
+                <httpcomponents-version>5.0.3</httpcomponents-version>
 	</properties>
 
 	<modules>
@@ -150,6 +151,18 @@
 				<version>20190722</version>
 			</dependency>
 
+			<!-- HTTP client -->
+			<dependency>
+				<groupId>org.apache.httpcomponents.client5</groupId>
+				<artifactId>httpclient5</artifactId>
+				<version>${httpcomponents-version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jsoup</groupId>
+				<artifactId>jsoup</artifactId>
+				<version>1.13.1</version>
+			</dependency>
+
 			<!-- db connectors -->
 			<dependency>
 				<groupId>org.apache.derby</groupId>
@@ -162,7 +175,6 @@
 				<artifactId>mysql-connector-java</artifactId>
 				<version>8.0.21</version>
 			</dependency>
-			
 			
 			<!-- test -->
 			<dependency>


### PR DESCRIPTION
CLDR-13197
Ready to go.
Note that the URL map only has a couple of entries.
Would like to get this in and make sure it is working, and use CLDR-14277 as a test case, before a subsequent effort to actually populate the subtype map.

- updated utility functions in CLDRURLs et
- added new page "tc-all-errors.jsp" showing all errors
- new data file subtypeMapping.txt mapping subtype to URL
