### PR TITLE
CLDR-12010 Allow for both c and e in the spec

### DIFF
--- a/docs/ldml/tr35-numbers.html
+++ b/docs/ldml/tr35-numbers.html
@@ -2523,7 +2523,7 @@ System Data</a>.</em> ) &gt;<br>
     <p>The xml value for each pluralRule is a <em>condition</em>
     with a boolean result that specifies whether that rule (i.e.
     that plural form) applies to a given numeric value <em>n</em>,
-    where n can be expressed as a decimal fraction<span class='changed'> or with compact decimal formatting, denoted by scientific notation in the syntax, e.g., “1.2e6” for “1.2M”</span>. Clients of CLDR
+    where n can be expressed as a decimal fraction<span class='changed'> or with compact decimal formatting, denoted by a special notation in the syntax, e.g., “1.2c6” for “1.2M”</span>. Clients of CLDR
     may express all the rules for a locale using the following
     syntax:</p>
     <pre>
@@ -2546,13 +2546,13 @@ is_relation     = expr 'is' ('not')? value
 in_relation     = expr (('not')? 'in' | '=' | '!=') range_list
 within_relation = expr ('not')? 'within' range_list
 expr            = operand (('mod' | '%') value)?
-operand         = 'n' | 'i' | 'f' | 't' | 'v' | 'w'<span class="changed"> | 'e'</span>
+operand         = 'n' | 'i' | 'f' | 't' | 'v' | 'w'<span class="changed"> | 'c' | 'e'</span>
 range_list      = (range | value) (',' range_list)*
 range           = value'..'value
 value           = digit+
 sampleList      = sampleRange (',' sampleRange)* (',' ('…'|'...'))?
 sampleRange     = <span class="changed">sample</span>Value ('~' <span class="changed">sample</span>Value)?
-<span class="changed">sample</span>Value     = <span class="changed">value</span> ('.' <span class="changed">digit+</span>)?<span class="changed"> ('e' digitPos digit+)?</span>
+<span class="changed">sample</span>Value     = <span class="changed">value</span> ('.' <span class="changed">digit+</span>)?<span class="changed"> ([ce] digitPos digit+)?</span>
 digit           = <span class="changed">[0-9]</span>
 <span class="changed">digitPos        = [1-9]</span>
                 </pre>
@@ -2621,12 +2621,16 @@ digit           = <span class="changed">[0-9]</span>
           trailing zeros.<span class="changed">*</span></td>
         </tr>
         <tr class='changed'>
-          <td>e</td>
+          <td>c</td>
           <td>compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.</td>
+        </tr>
+        <tr class='changed'>
+          <td>e</td>
+          <td>currently, synonym for ‘c’. however, may be redefined in the future.</td>
         </tr>
       </table>
     </div>
-    <p class='changed'>* If there is a compact decimal exponent value ('e'), then the f, t, v, and w values are computed <em>after</em> shifting the decimal point in the original by the 'e' value. So for 1.2e3, the f, t, v, and w values are the same as those of 1200:  i=1200 and f=0. Similarly, for 1.2005e3 has i=1200 and f=5 (corresponding to 1200.5).</p>
+    <p class='changed'>* If there is a compact decimal exponent value (‘c’), then the f, t, v, and w values are computed <em>after</em> shifting the decimal point in the original by the ‘c’ value. So for 1.2c3, the f, t, v, and w values are the same as those of 1200:  i=1200 and f=0. Similarly, for 1.2005c3 has i=1200 and f=5 (corresponding to 1200.5).</p>
     <div dir="ltr">
       <table class='simple'; style='width:30em'>
         <caption>
@@ -2725,7 +2729,7 @@ digit           = <span class="changed">[0-9]</span>
   <td class='changed' style='text-align:right'>0</td>
 </tr>
 <tr>
-<td class='changed' style='text-align:right'>1.2e6</td>
+<td class='changed' style='text-align:right'>1.2c6</td>
   <td class='changed' style='text-align:right'>1200000</td>
   <td class='changed' style='text-align:right'>1200000</td>
   <td class='changed' style='text-align:right'>0</td>
@@ -2735,7 +2739,7 @@ digit           = <span class="changed">[0-9]</span>
   <td class='changed' style='text-align:right'>6</td>
 </tr>
 <tr>
-<td class='changed' style='text-align:right'>123e6</td>
+<td class='changed' style='text-align:right'>123c6</td>
   <td class='changed' style='text-align:right'>123000000</td>
   <td class='changed' style='text-align:right'>123000000</td>
   <td class='changed' style='text-align:right'>0</td>
@@ -2745,7 +2749,7 @@ digit           = <span class="changed">[0-9]</span>
   <td class='changed' style='text-align:right'>6</td>
 </tr>
 <tr>
-<td class='changed' style='text-align:right'>123e5</td>
+<td class='changed' style='text-align:right'>123c5</td>
   <td class='changed' style='text-align:right'>12300000</td>
   <td class='changed' style='text-align:right'>12300000</td>
   <td class='changed' style='text-align:right'>0</td>
@@ -2755,22 +2759,22 @@ digit           = <span class="changed">[0-9]</span>
   <td class='changed' style='text-align:right'>5</td>
 </tr>
 <tr>
-<td class='changed' style='text-align:right'>1200.5</td>
+<td class='changed' style='text-align:right'>1200.50</td>
   <td class='changed' style='text-align:right'>1200.5</td>
   <td class='changed' style='text-align:right'>1200</td>
+  <td class='changed' style='text-align:right'>2</td>
   <td class='changed' style='text-align:right'>1</td>
-  <td class='changed' style='text-align:right'>1</td>
-  <td class='changed' style='text-align:right'>5</td>
+  <td class='changed' style='text-align:right'>50</td>
   <td class='changed' style='text-align:right'>5</td>
   <td class='changed' style='text-align:right'>0</td>
 </tr>
 <tr>
-<td class='changed' style='text-align:right'>1.2005e3</td>
+<td class='changed' style='text-align:right'>1.20050c3</td>
   <td class='changed' style='text-align:right'>1200.5</td>
   <td class='changed' style='text-align:right'>1200</td>
+  <td class='changed' style='text-align:right'>2</td>
   <td class='changed' style='text-align:right'>1</td>
-  <td class='changed' style='text-align:right'>1</td>
-  <td class='changed' style='text-align:right'>5</td>
+  <td class='changed' style='text-align:right'>50</td>
   <td class='changed' style='text-align:right'>5</td>
   <td class='changed' style='text-align:right'>3</td>
 </tr>
@@ -2953,7 +2957,7 @@ digit           = <span class="changed">[0-9]</span>
     <p>In determining whether a set of samples is infinite, leading
     zero integer digits and trailing zero decimals are not
     significant. Thus "i = 1<span class="changed">000</span> and f = 0" is satisfied by 01<span class="changed">000</span>, 1<span class="changed">000</span>, 1<span class="changed">000</span>.0,
-    1<span class="changed">000</span>.00, 1<span class="changed">000</span>.000, <span class="changed">01e3</span> etc. but is still considered finite.</p>
+    1<span class="changed">000</span>.00, 1<span class="changed">000</span>.000, <span class="changed">01c3</span> etc. but is still considered finite.</p>
     <h4><a name="Using_cardinals" href="#Using_cardinals" id=
     "Using_cardinals">5.1.4 Using Cardinals</a></h4>
     <p>Elements such as &lt;currencyFormats&gt;, &lt;currency&gt;


### PR DESCRIPTION
Allow for both c and e in the spec; update code for DecimalQuantity in the test

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-12010
- [x] Updated PR title and link in previous line to include Issue number

