### PR TITLE
CLDR-14215 Make js unit test work in all time zones

### DIFF
--- a/tools/cldr-apps/js-unittest/TestCldrStForum.js
+++ b/tools/cldr-apps/js-unittest/TestCldrStForum.js
@@ -20,6 +20,8 @@
 			const posts = json.ret;
 			assert(posts != null, "posts is not null");
 
+			cldrStForum.test.setDisplayUtc(true); // so test can pass regardless of time zone
+
 			const content = cldrStForum.parseContent(posts, 'info');
 			assert(content != null, "content is not null");
 
@@ -27,34 +29,34 @@
 
 			assert(content.firstChild != null, "first child is not null");
 			assert.equal(content.firstChild.id, "fthr_fr_CA|45347");
-			const s1 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:26ClosedClosetest"
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:28Closetest reply blah!";
+			const s1 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:26 UTCClosedClosetest"
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:28 UTCClosetest reply blah!";
 			assert.equal(normalizeWhitespace(content.firstChild.textContent), normalizeWhitespace(s1));
 
 			const firstSibling = content.firstChild.nextSibling;
 			assert(firstSibling != null, "first sibling is not null");
 			assert.equal(firstSibling.id, "fthr_fr_CA|45346");
-			const s2 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:20ClosedCloseFUrthermore";
+			const s2 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:20 UTCClosedCloseFUrthermore";
 			assert.equal(normalizeWhitespace(firstSibling.textContent), normalizeWhitespace(s2));
 
 			const secondSibling = firstSibling.nextSibling;
 			assert(secondSibling != null, "second sibling is not null");
 			assert.equal(secondSibling.id, "fthr_fr_CA|45343");
-			const s3 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:17ClosedClosetest"
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:18CloseOK, replying to test in Dashboard"
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:19CloseAnd replying to reply";
+			const s3 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:17 UTCClosedClosetest"
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:18 UTCCloseOK, replying to test in Dashboard"
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:19 UTCCloseAnd replying to reply";
 			assert.equal(normalizeWhitespace(secondSibling.textContent), normalizeWhitespace(s3));
 
 			const thirdSibling = secondSibling.nextSibling;
 			assert(thirdSibling != null, "third sibling is not null");
 			assert.equal(thirdSibling.id, "fthr_fr_CA|45341");
-			const s4 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:12ClosedCloseAnd another post from Dashboard."
-				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 12:14CloseAnd another reply, this time from Dashboard Fix pop-up!!!";
+			const s4 = "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:12 UTCClosedCloseAnd another post from Dashboard."
+				+ "n (Gaeilge) userlevel_tc[v38] 2020-02-06 17:14 UTCCloseAnd another reply, this time from Dashboard Fix pop-up!!!";
 			assert.equal(normalizeWhitespace(thirdSibling.textContent), normalizeWhitespace(s4));
 
 			assert(content.lastChild != null, "last child is not null");
 			assert.equal(content.lastChild.id, "fthr_fr|363");
-			const sLast = "n (Microsoft) userlevel_vetter[v28] 2015-05-19 11:58ClosedClose...";
+			const sLast = "n (Microsoft) userlevel_vetter[v28] 2015-05-19 15:58 UTCClosedClose...";
 			assert.equal(normalizeWhitespace(content.lastChild.textContent), normalizeWhitespace(sLast));
 		});
 	});

--- a/tools/cldr-apps/src/main/webapp/js/CldrStForum.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrStForum.js
@@ -60,6 +60,12 @@ const cldrStForum = (function() {
 	let userCanPost = false;
 
 	/**
+	 * Whether to use UTC for displaying date/time
+	 * Helpful for unit tests
+	 */
+	let displayUtc = false;
+
+	/**
 	 * Fetch the Forum data from the server, and "load" it
 	 *
 	 * @param locale the locale string, like "fr_CA" (surveyCurrentLocale)
@@ -1085,6 +1091,10 @@ const cldrStForum = (function() {
 		function pad(n) {
 			return (n < 10) ? '0' + n : n;
 		}
+		if (displayUtc) {
+			return d.getUTCFullYear() + '-' + pad(d.getUTCMonth() + 1) + '-' + pad(d.getUTCDate()) +
+			' ' + pad(d.getUTCHours()) + ':' + pad(d.getUTCMinutes() + ' UTC');
+		}
 		return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
 			' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
 	}
@@ -1232,6 +1242,13 @@ const cldrStForum = (function() {
 		return threadHash;
 	}
 
+	/**
+	 * Set whether to use UTC for displaying date/time
+	 */
+	function setDisplayUtc(utc) {
+		displayUtc = utc ? true : false;
+	}
+
 	/*
 	 * Make only these functions accessible from other files:
 	 */
@@ -1247,6 +1264,7 @@ const cldrStForum = (function() {
 		 */
 		test: {
 			getThreadHash: getThreadHash,
+			setDisplayUtc: setDisplayUtc,
 		}
 	};
 })();


### PR DESCRIPTION
-New function cldrStForum.setDisplayUtc to use UTC for unit test only

-Update unit test to request and expect UTC

-No change to Survey Tool interface, which still displays local time zone

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14215
- [x] Updated PR title and link in previous line to include Issue number

