### PR TITLE
CLDR-14066 Fix display of constraints in Delta DTD charts

### DIFF
--- a/tools/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/java/org/unicode/cldr/util/DtdData.java
@@ -102,6 +102,12 @@ public class DtdData extends XMLFileReader.SimpleHandler {
     static final Set<String> DRAFT_ON_NON_LEAF_ALLOWED = ImmutableSet.of("collation", "transform", "unitPreferenceData", "rulesetGrouping");
 
     public static class Attribute implements Named {
+        private static final Joiner JOINER_COMMA_SPACE = Joiner.on(", ");
+        public static final String AUG_TRAIL = "⟫";
+        public static final String AUG_LEAD = "⟪";
+        public static final String ENUM_TRAIL = "⟩";
+        public static final String ENUM_LEAD = "⟨";
+        public static final Pattern LEAD_TRAIL = Pattern.compile("(.*[" + AUG_LEAD + ENUM_LEAD + "])(.*)([" + AUG_TRAIL + ENUM_TRAIL + "].*)");
         public final String name;
         public final Element element;
         public final Mode mode;
@@ -309,9 +315,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         }
 
         public String getMatchString() {
-            return type == AttributeType.ENUMERATED_TYPE ? "⟨" + Joiner.on(", ")
-                .join(values.keySet()) + "⟩"
-                : matchValue != null ? "⟪" + matchValue.toString() + "⟫"
+            return type == AttributeType.ENUMERATED_TYPE ? ENUM_LEAD + JOINER_COMMA_SPACE.join(values.keySet()) + ENUM_TRAIL
+                : matchValue != null ? AUG_LEAD + matchValue.toString() + AUG_TRAIL
                     : "";
         }
 


### PR DESCRIPTION
Remove + on attribute if only constraints changed. Suppress identical constraint words for a more concise format. 
Results are in https://unicode-org.github.io/cldr-staging/charts/38/supplemental/dtd_deltas.html

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14066
- [x] Updated PR title and link in previous line to include Issue number

