### PR TITLE
CLDR-14226 reduce use of term grandfathered in code

### DIFF
--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/LocaleMatcherTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/LocaleMatcherTest.java
@@ -313,7 +313,7 @@ public class LocaleMatcherTest extends TestFmwk {
             matchEnHantTw < matchZh);
     }
 
-    public void testMatchGrandfatheredCode() {
+    public void testMatchLegacyCode() {
         if (logKnownIssue("CLDR-14166", "Skip until CLDR updated for new ICU4J LocaleMatcher")) {
             return;
         }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -84,7 +84,7 @@ public class TestAttributeValues extends TestFmwk {
         String dtdTypeArg = params.props == null ? null : (String) params.props.get("dtdtype");
 
         // short- circuits for testing. null means do all
-        Set<DtdType> checkTypes = dtdTypeArg == null ? DtdType.STANDARD_SET 
+        Set<DtdType> checkTypes = dtdTypeArg == null ? DtdType.STANDARD_SET
             : Collections.singleton(DtdType.valueOf(dtdTypeArg)) ;
         ImmutableSet<ValueStatus> showStatuses = null ; // ImmutableSet.of(ValueStatus.invalid, ValueStatus.unknown);
 
@@ -94,14 +94,14 @@ public class TestAttributeValues extends TestFmwk {
                 Set<String> files = new TreeSet<>();
                 for (String stringDir : dtdType.directories) {
                     addXMLFiles(dtdType, mainDirs + stringDir, files);
-                    if (isVerbose()) 
+                    if (isVerbose())
                         synchronized (pathChecker.testLog) {
                         warnln(mainDirs + stringDir);
                     }
                 }
                 Stream<String> stream = SERIAL ? files.stream() : files.parallelStream();
                 stream.forEach(file -> checkFile(pathChecker, file));
-                
+
 //                for (String file : files) {
 //                    checkFile(pathChecker, file);
 //                }
@@ -134,7 +134,7 @@ public class TestAttributeValues extends TestFmwk {
             return;
         }
         if (!dirFile.isDirectory()) {
-            if (getInclusion() <= 5 
+            if (getInclusion() <= 5
                 && dtdType == DtdType.ldml) {
                 if (path.contains("/annotationsDerived/")) {
                     return;
@@ -215,7 +215,7 @@ public class TestAttributeValues extends TestFmwk {
     }
 
     static class PathChecker {
-        private final ChainedMap.M5<ValueStatus, String, String, String, Boolean> valueStatusInfo 
+        private final ChainedMap.M5<ValueStatus, String, String, String, Boolean> valueStatusInfo
         = ChainedMap.of(new TreeMap(), new TreeMap(), new TreeMap(), new TreeMap(), Boolean.class);
         private final Set<String> seen = new HashSet<>();
         private final Map<String,Map<String,Map<String,Boolean>>> seenEAV = new ConcurrentHashMap<>();
@@ -302,7 +302,7 @@ public class TestAttributeValues extends TestFmwk {
             boolean haveProblems = false;
 //          if (testLog.logKnownIssue("cldrbug 10120", "Don't enable error until complete")) {
 //              testLog.warnln("Counts: " + counter.toString());
-//          } else 
+//          } else
             for (ValueStatus valueStatus : ValueStatus.values()) {
                 if (valueStatus == ValueStatus.valid) {
                     continue;
@@ -324,7 +324,7 @@ public class TestAttributeValues extends TestFmwk {
             out.append("attribute\tCount:\t" + dtdData.dtdType + "\t" + attributeCount + "\n");
 
             out.append("\nStatus\tDtdType\tElement\tAttribute\tMatch expression\t#Failures\tFailing values\n");
-            
+
             for (Entry<ValueStatus, Map<String, Map<String, Map<String, Boolean>>>> entry : valueStatusInfo) {
                 ValueStatus valueStatus = entry.getKey();
                 if (retain != null && !retain.contains(valueStatus)) {
@@ -340,17 +340,17 @@ public class TestAttributeValues extends TestFmwk {
                         Set<String> validFound = entry3.getValue().keySet();
                         String matchValue = matchValues.get(elementName + "\t" + attributeName);
                         out.append(
-                            valueStatus 
-                            + "\t" + dtdData.dtdType 
-                            + "\t" + elementName 
-                            + "\t" + attributeName 
+                            valueStatus
+                            + "\t" + dtdData.dtdType
+                            + "\t" + elementName
+                            + "\t" + attributeName
                             + "\t" + (matchValue == null ? "" : matchValue)
                             + "\t" + validFound.size()
                             + "\t" + Joiner.on(", ").join(validFound)
                             + "\n"
                             );
                         if (valueStatus == ValueStatus.valid) try {
-                            LstrType lstr = LstrType.valueOf(elementName);
+                            LstrType lstr = LstrType.fromString(elementName);
                             Map<String, Validity.Status> codeToStatus = VALIDITY.getCodeToStatus(lstr);
                             Set<String> missing = new TreeSet<>(codeToStatus.keySet());
                             if (lstr == LstrType.variant) {
@@ -366,19 +366,19 @@ public class TestAttributeValues extends TestFmwk {
                             }
                             if (!missing.isEmpty()) {
                                 out.append(
-                                    "unused" 
-                                        + "\t" + dtdData.dtdType 
-                                        + "\t" + elementName 
-                                        + "\t" + attributeName 
-                                        + "\t" + "" 
-                                        + "\t" + "" 
+                                    "unused"
+                                        + "\t" + dtdData.dtdType
+                                        + "\t" + elementName
+                                        + "\t" + attributeName
+                                        + "\t" + ""
+                                        + "\t" + ""
                                         + "\t" + Joiner.on(", ").join(missing)
                                         + "\n"
                                     );
                             }
                         } catch (Exception e) {}
                     }
-                } 
+                }
             }
             synchronized (testLog) {
                 testLog.errln(out.toString());

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -205,7 +205,7 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                         shouldHave.add("<" + typeCompat + "Alias"
                             + " type=\"" + subtagCompat + "\""
                             + (possibleReplacement == null || possibleReplacement.isEmpty() ? "" : " replacement=\"" + possibleReplacement + "\"")
-                            + " reason=\"" + (type == LstrType.grandfathered || type == LstrType.redundant ? type.toString() : "deprecated") + "\""
+                            + " reason=\"" + (type == LstrType.legacy || type == LstrType.redundant ? type.toString() : "deprecated") + "\""
                             + "/>  <!-- " + subtagInfo.get(LstrField.Description) + " -->");
                     } else {
                         shouldSkip.add(subtag);

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestUnits.java
@@ -796,7 +796,7 @@ public class TestUnits extends TestFmwk {
     }
 
     static final UnicodeSet ALLOWED_IN_COMPONENT = new UnicodeSet("[a-z0-9]").freeze();
-    static final Set<String> GRANDFATHERED_SIMPLES = ImmutableSet.of("em", "g-force", "therm-us");
+    static final Set<String> STILL_RECOGNIZED_SIMPLES = ImmutableSet.of("em", "g-force", "therm-us");
 
     public void TestOrder() {
         if (SHOW_DATA) System.out.println();
@@ -807,7 +807,7 @@ public class TestUnits extends TestFmwk {
             }
         }
         for (String unit : CORE_TO_TYPE.keySet()) {
-            if (!GRANDFATHERED_SIMPLES.contains(unit)) {
+            if (!STILL_RECOGNIZED_SIMPLES.contains(unit)) {
                 for (String part : unit.split("-")) {
                     assertTrue(unit + " has no parts < 2 in length", part.length() > 2);
                     assertTrue(unit + " has only allowed characters", ALLOWED_IN_COMPONENT.containsAll(part));

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestValidity.java
@@ -411,7 +411,7 @@ public class TestValidity extends TestFmwkPlus {
         }
 
 
-        ImmutableSet<LstrType> LstrTypesToSkip = ImmutableSet.of(LstrType.extlang, LstrType.grandfathered, LstrType.redundant);
+        ImmutableSet<LstrType> LstrTypesToSkip = ImmutableSet.of(LstrType.extlang, LstrType.legacy, LstrType.redundant);
         Set<LstrType> lstrTypesToTest = EnumSet.allOf(LstrType.class);
         lstrTypesToTest.removeAll(LstrTypesToSkip);
         Set<String> missingAliases = new LinkedHashSet<>();

--- a/tools/java/org/unicode/cldr/test/CheckAttributeValues.java
+++ b/tools/java/org/unicode/cldr/test/CheckAttributeValues.java
@@ -532,7 +532,7 @@ public class CheckAttributeValues extends FactoryCheckCLDR {
     }
 
     public static class LocaleMatcher implements Predicate<String> {
-        Predicate<String> grandfathered = variables.get("$grandfathered").matcher;
+        Predicate<String> legacy = variables.get("$grandfathered").matcher;
         Predicate<String> language = variables.get("$language").matcher;
         Predicate<String> script = variables.get("$script").matcher;
         Predicate<String> territory = variables.get("$territory").matcher;
@@ -555,7 +555,7 @@ public class CheckAttributeValues extends FactoryCheckCLDR {
 
         @Override
         public boolean test(String value) {
-            if (grandfathered.test(value)) return true;
+            if (legacy.test(value)) return true;
             lip.set((String) value);
             String field = lip.getLanguage();
             if (!language.test(field)) return false;

--- a/tools/java/org/unicode/cldr/tool/CheckLangTagBNF.java
+++ b/tools/java/org/unicode/cldr/tool/CheckLangTagBNF.java
@@ -46,7 +46,7 @@ class CheckLangTagBNF {
 
     private static final String[] groupNames = { "whole", "lang", "script", "region", "variants", "extensions",
         "privateuse",
-        "grandfathered", "privateuse", "localeExtensions"
+        "legacy", "privateuse", "localeExtensions"
     };
 
     /**
@@ -215,15 +215,6 @@ class CheckLangTagBNF {
 
         System.out.println(contents);
 
-        // System.out.println(langTagPattern);
-        // System.out.println(cleanedLangTagPattern);
-//        StandardCodes sc = StandardCodes.make();
-//        Set<String> grandfathered = sc.getAvailableCodes("grandfathered");
-        // for (Iterator it = grandfathered.iterator(); it.hasNext();) {
-        // System.out.print(it.next() + " | ");
-        // }
-        // System.out.println();
-
         LanguageTagParser ltp = new LanguageTagParser();
         SimpleLocaleParser simpleLocaleParser = new SimpleLocaleParser();
         boolean expected = true;
@@ -294,7 +285,7 @@ class CheckLangTagBNF {
 
             if (ltp.getLanguage().length() != 0)
                 System.out.println("\tlang:    \t" + ltp.getLanguage()
-                    + (ltp.isGrandfathered() ? " (grandfathered)" : ""));
+                    + (ltp.isLegacy() ? " (legacy)" : ""));
             if (ltp.getScript().length() != 0) System.out.println("\tscript:\t" + ltp.getScript());
             if (ltp.getRegion().length() != 0) System.out.println("\tregion:\t" + ltp.getRegion());
             if (ltp.getVariants().size() != 0) System.out.println("\tvariants:\t" + ltp.getVariants());

--- a/tools/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/java/org/unicode/cldr/tool/CountItems.java
@@ -817,9 +817,9 @@ public class CountItems {
     public static Map<String, String> getVariables(VariableType variableType) {
         String sep = CldrUtility.LINE_SEPARATOR + "\t\t\t\t";
         Map<String, String> variableSubstitutions = new LinkedHashMap<>();
-        for (String type : new String[] { "grandfathered", "territory", "script", "variant" }) {
+        for (String type : new String[] { "legacy", "territory", "script", "variant" }) {
             Set<String> i;
-            i = (variableType == VariableType.full || type.equals("grandfathered")) ? sc.getAvailableCodes(type) : sc.getGoodAvailableCodes(type);
+            i = (variableType == VariableType.full || type.equals("legacy")) ? sc.getAvailableCodes(type) : sc.getGoodAvailableCodes(type);
             addVariable(variableSubstitutions, type, i, sep);
         }
 

--- a/tools/java/org/unicode/cldr/tool/FallbackIterator.java
+++ b/tools/java/org/unicode/cldr/tool/FallbackIterator.java
@@ -77,18 +77,18 @@ public class FallbackIterator implements Iterator<String> {
 
             "canonicalize", // mechanically generated
 
-            // grandfathered
+            // Language tags marked as “Type: grandfathered” in BCP 47.
             "art-lojban;jbo",
-            "cel-gaulish;xcg", // Grandfathered code with special replacement: cel-gaulish
-            "en-GB-oed;en-GB-x-oed", // Grandfathered code with special replacement: en-GB-oed
+            "cel-gaulish;xcg", // Special replacement: cel-gaulish
+            "en-GB-oed;en-GB-x-oed", // Special replacement: en-GB-oed
             "i-ami;ami",
             "i-bnn;bnn",
-            "i-default;und", // Grandfathered code with special replacement: i-default
-            "i-enochian;x-enochian", // Grandfathered code with special replacement: i-enochian
+            "i-default;und", // Special replacement: i-default
+            "i-enochian;x-enochian", // Special replacement: i-enochian
             "i-hak;zh-hakka",
             "i-klingon;tlh",
             "i-lux;lb",
-            "i-mingo;see", // Grandfathered code with special replacement: i-mingo
+            "i-mingo;see", // Special replacement: i-mingo
             "i-navajo;nv",
             "i-pwn;pwn",
             "i-tao;tao",
@@ -105,7 +105,7 @@ public class FallbackIterator implements Iterator<String> {
             "zh-gan;gan",
             "zh-guoyu;zh-cmn",
             "zh-hakka;hak",
-            "zh-min;nan", // Grandfathered code with special replacement: zh-min
+            "zh-min;nan", // Special replacement: zh-min
             "zh-min-nan;nan",
             "zh-wuu;wuu",
             "zh-xiang;hsn",

--- a/tools/java/org/unicode/cldr/tool/FallbackIteratorDataGenerator.java
+++ b/tools/java/org/unicode/cldr/tool/FallbackIteratorDataGenerator.java
@@ -21,9 +21,9 @@ public class FallbackIteratorDataGenerator {
 
         for (String type : sc.getAvailableTypes()) {
             final boolean isLanguage = type.equals("language");
-            final boolean isGrandfathered = type.equals("grandfathered");
+            final boolean isLegacy = type.equals("legacy");
             final boolean isRegion = type.equals("territory");
-            final String canonicalizationFormat = isGrandfathered ? "\t\t\"%s;%s\","
+            final String canonicalizationFormat = isLegacy ? "\t\t\"%s;%s\","
                 : isLanguage ? "\t\t\"%s(-.*)?;%s$1\","
                     : isRegion ? "\t\t\"(.*-)%s(-.*)?;$1%s$2\","
                         : null;
@@ -42,8 +42,8 @@ public class FallbackIteratorDataGenerator {
 
                 if (canonicalValue == null || canonicalValue.length() == 0) {
                     // System.out.println("\t\t\\\\ skipping " + code);
-                    if (isGrandfathered) {
-                        System.out.println("\t\t// Grandfathered code with no replacement " + code);
+                    if (isLegacy) {
+                        System.out.println("\t\t// Legacy code with no replacement " + code);
                         continue;
                     } else {
                         continue;
@@ -55,10 +55,10 @@ public class FallbackIteratorDataGenerator {
                 }
                 System.out.format(canonicalizationFormat, code, canonicalValue);
                 if (special != null) {
-                    System.out.print("\t\t// Grandfathered code with special replacement: " + code);
+                    System.out.print("\t\t// Legacy code with special replacement: " + code);
                 }
                 System.out.println();
-                if (!isGrandfathered) {
+                if (!isLegacy) {
                     decanonicalizeList.add(String.format(canonicalizationFormat, canonicalValue, code));
                 }
             }

--- a/tools/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -224,11 +224,11 @@ public class GenerateG2xG2 {
         } else {
             boolean USE_3066bis = choice == 2;
             // produce random list of RFC3066 language tags
-            Set<String> grandfathered = sc.getAvailableCodes("grandfathered");
+            Set<String> legacy = sc.getAvailableCodes("legacy");
             List<String> language_subtags = new ArrayList<>(sc.getGoodAvailableCodes("language"));
             List<String> script_subtags = new ArrayList<>(sc.getGoodAvailableCodes("script"));
             List<String> region_subtags = new ArrayList<>(sc.getGoodAvailableCodes("territory"));
-            for (String possibility : grandfathered) {
+            for (String possibility : legacy) {
                 System.out.println(possibility);
                 if (new ULocale(possibility).getScript().length() != 0) {
                     System.out.println("\tAdding");

--- a/tools/java/org/unicode/cldr/tool/LocaleReplacements.java
+++ b/tools/java/org/unicode/cldr/tool/LocaleReplacements.java
@@ -169,7 +169,7 @@ public class LocaleReplacements {
         if (key == null) {
             return;
         }
-        if (type.equals("grandfathered") || type.equals("redundant")) {
+        if (type.equals("legacy") || type.equals("redundant")) {
             type = "language";
         }
 

--- a/tools/java/org/unicode/cldr/tool/SimpleLocaleParser.java
+++ b/tools/java/org/unicode/cldr/tool/SimpleLocaleParser.java
@@ -40,7 +40,7 @@ class SimpleLocaleParser {
             " | ( x (?: [-_] [a-z 0-9]{1,8} )+ )"
             + // private use
             " | ( en [-_] GB [-_] oed"
-            + // grandfathered gorp
+            + // legacy gorp
             "   | i [-_] (?: ami | bnn | default | enochian | hak | klingon | lux | mingo | navajo | pwn | tao | tay | tsu )"
             +
             "   | no [-_] (?: bok | nyn )" +
@@ -89,7 +89,7 @@ class SimpleLocaleParser {
         }
         language = root.group(1);
         if (language == null) {
-            language = root.group(8); // grandfathered
+            language = root.group(8); // marked as “Type: grandfathered” in BCP 47
             if (language == null) {
                 language = "und"; // placeholder for completely private use
             }

--- a/tools/java/org/unicode/cldr/util/AttributeValueValidity.java
+++ b/tools/java/org/unicode/cldr/util/AttributeValueValidity.java
@@ -696,7 +696,6 @@ public class AttributeValueValidity {
     }
 
     public static class LocaleMatcher extends MatcherPattern {
-        //final ObjectMatcherReason grandfathered = getNonNullVariable("$grandfathered").matcher;
         final MatcherPattern language;
         final MatcherPattern script = getNonNullVariable("$_script");
         final MatcherPattern territory = getNonNullVariable("$_region");
@@ -712,9 +711,6 @@ public class AttributeValueValidity {
 
         @Override
         public boolean matches(String value, Output<String> reason) {
-//            if (grandfathered.matches(value, reason)) {
-//                return true;
-//            }
             lip.set(value);
             String field = lip.getLanguage();
             if (!language.matches(field, reason)) {

--- a/tools/java/org/unicode/cldr/util/LanguageTagParser.java
+++ b/tools/java/org/unicode/cldr/util/LanguageTagParser.java
@@ -91,10 +91,10 @@ public class LanguageTagParser {
     }
 
     /**
-     * @return Returns the grandfathered flag
+     * @return True if the language tag is marked as “Type: grandfathered” in BCP 47.
      */
-    public boolean isGrandfathered() {
-        return grandfathered;
+    public boolean isLegacy() {
+        return legacy;
     }
 
     /**
@@ -168,7 +168,7 @@ public class LanguageTagParser {
     // private fields
 
     private String original;
-    private boolean grandfathered = false;
+    private boolean legacy = false;
     private String language;
     private String script;
     private String region;
@@ -183,7 +183,7 @@ public class LanguageTagParser {
     private static final UnicodeSet X = new UnicodeSet("[xX]").freeze();
     private static final UnicodeSet ALPHA_MINUS_X = new UnicodeSet(ALPHA).removeAll(X).freeze();
     private static StandardCodes standardCodes = StandardCodes.make();
-    private static final Set<String> grandfatheredCodes = standardCodes.getAvailableCodes("grandfathered");
+    private static final Set<String> legacyCodes = standardCodes.getAvailableCodes("legacy");
     private static final String separator = "-_"; // '-' alone for 3066bis language tags
     private static final UnicodeSet SEPARATORS = new UnicodeSet().addAll(separator).freeze();
     private static final Splitter SPLIT_BAR = Splitter.on(CharMatcher.anyOf(separator));
@@ -215,7 +215,7 @@ public class LanguageTagParser {
 
         // clear everything out
         language = region = script = "";
-        grandfathered = false;
+        legacy = false;
         variants.clear();
         extensions.clear();
         localeExtensions.clear();
@@ -246,10 +246,9 @@ public class LanguageTagParser {
             languageTag = languageTag.substring(0, atPosition);
         }
 
-        // first test for grandfathered
-        if (grandfatheredCodes.contains(languageTag)) {
+        if (legacyCodes.contains(languageTag)) {
             language = languageTag;
-            grandfathered = true;
+            legacy = true;
             return this;
         }
 
@@ -327,7 +326,7 @@ public class LanguageTagParser {
      * @return true iff the language tag validates
      */
     public boolean isValid() {
-        if (grandfathered) return true; // don't need further checking, since we already did so when parsing
+        if (legacy) return true; // don't need further checking, since we already did so when parsing
         if (!validates(language, "language")) return false;
         if (!validates(script, "script")) return false;
         if (!validates(region, "territory")) return false;

--- a/tools/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/java/org/unicode/cldr/util/MatchValue.java
@@ -264,7 +264,7 @@ public abstract class MatchValue implements Predicate<String> {
             if (shortId) {
                 typeName = typeName.substring(6);
             }
-            LstrType type = LstrType.valueOf(typeName);
+            LstrType type = LstrType.fromString(typeName);
             return new ValidityMatchValue(type, statuses, shortId);
         }
 

--- a/tools/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/java/org/unicode/cldr/util/StandardCodes.java
@@ -48,7 +48,7 @@ import com.ibm.icu.util.Output;
 public class StandardCodes {
 
     public enum CodeType {
-        language, script, territory, extlang, grandfathered, redundant, variant, currency, tzid;
+        language, script, territory, extlang, legacy, redundant, variant, currency, tzid;
         public static CodeType from(String name) {
             if ("region".equals(name)) {
                 return territory;
@@ -193,7 +193,7 @@ public class StandardCodes {
      */
     @Deprecated
     public List<String> getCodes(String type, String data) {
-        return getCodes(CodeType.valueOf(type), data);
+        return getCodes(CodeType.from(type), data);
     }
 
     /**
@@ -212,7 +212,7 @@ public class StandardCodes {
      */
     @Deprecated
     public String getPreferred(String type, String code) {
-        return getPreferred(CodeType.valueOf(type), code);
+        return getPreferred(CodeType.from(type), code);
     }
 
     /**
@@ -1031,7 +1031,7 @@ public class StandardCodes {
         region("ZZ"),
         variant(),
         extlang(true, false),
-        grandfathered(true, false),
+        legacy(true, false),
         redundant(true, false),
         /** specialized codes for validity; TODO: rename LstrType **/
         currency(false, true, "XXX"),
@@ -1078,7 +1078,7 @@ public class StandardCodes {
         public String toCompatString() {
             switch (this) {
             case region: return "territory";
-            case grandfathered: return "language";
+            case legacy: return "language";
             case redundant: return "language";
             default: return toString();
             }
@@ -1206,9 +1206,11 @@ public class StandardCodes {
                 LstrField label = LstrField.from(line.substring(0, pos2));
                 String rest = line.substring(pos2 + 1).trim();
                 if (label == LstrField.Type) {
-                    subtagData = CldrUtility.get(result2, lastType = LstrType.valueOf(rest));
+                    lastType = rest.equals("grandfathered") ?
+                        LstrType.legacy : LstrType.fromString(rest);
+                    subtagData = CldrUtility.get(result2, lastType);
                     if (subtagData == null) {
-                        result2.put(LstrType.valueOf(rest), subtagData = new TreeMap<>());
+                        result2.put(lastType, subtagData = new TreeMap<>());
                     }
                 } else if (label == LstrField.Subtag
                     || label == LstrField.Tag) {
@@ -1286,9 +1288,9 @@ public class StandardCodes {
 
         // add extras
         for (int i = 0; i < extras.length; ++i) {
-            Map<String, Map<LstrField, String>> subtagData = CldrUtility.get(result2, LstrType.valueOf(extras[i][0]));
+            Map<String, Map<LstrField, String>> subtagData = CldrUtility.get(result2, LstrType.fromString(extras[i][0]));
             if (subtagData == null) {
-                result2.put(LstrType.valueOf(extras[i][0]), subtagData = new TreeMap<>());
+                result2.put(LstrType.fromString(extras[i][0]), subtagData = new TreeMap<>());
             }
             Map<LstrField, String> labelData = new TreeMap<>();
             for (int j = 2; j < extras[i].length; j += 2) {

--- a/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -1806,7 +1806,6 @@ public class SupplementalDataInfo {
             }
             if (level2.equals("alias")) {
                 // <alias>
-                // <!-- grandfathered 3066 codes -->
                 // <languageAlias type="art-lojban" replacement="jbo"/> <!-- Lojban -->
                 String level3 = parts.getElement(3);
                 if (!level3.endsWith("Alias")) {

--- a/tools/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/java/org/unicode/cldr/util/TestUtilities.java
@@ -568,7 +568,7 @@ public class TestUtilities {
             Map<String, Map<String, String>> subtagData = m.get(type);
             String oldType = type.equals("region") ? "territory" : type;
 
-            String aliasType = oldType.equals("grandfathered") ? "language" : oldType;
+            String aliasType =oldType.equals("legacy") ? "language" : oldType;
             Set<String> allCodes = new TreeSet<>();
             Set<String> deprecatedCodes = new TreeSet<>();
 

--- a/tools/java/org/unicode/cldr/util/Validity.java
+++ b/tools/java/org/unicode/cldr/util/Validity.java
@@ -57,7 +57,7 @@ public class Validity {
             }
             LstrType type = null;
             try {
-                type = LstrType.valueOf(file.substring(0, file.length() - 4));
+                type = LstrType.fromString(file.substring(0, file.length() - 4));
             } catch (Exception e) {
                 continue;
             }
@@ -77,7 +77,7 @@ public class Validity {
                 if (!"id".equals(parts.getElement(-1))) {
                     continue;
                 }
-                LstrType typeAttr = LstrType.valueOf(parts.getAttributeValue(-1, "type"));
+                LstrType typeAttr = LstrType.fromString(parts.getAttributeValue(-1, "type"));
                 if (typeAttr != type) {
                     throw new IllegalArgumentException("Corrupt value for " + type);
                 }


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/CLDR-14226

For affected enums, I replaced several calls to Enum.valueOf(String) with .from(String) or .fromString(String) and temporarily still handled the old name. Set a breakpoint, ran the unit tests, updated call sites, removed the alias.

For other string comparisons I also set temporary breakpoints to make sure the unit tests don't show use of the old name.

I did not change what looked like data file syntax.