### PR TITLE
CLDR-14205 commit checker: update

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -8,9 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       end-ref:
-        description: CLDR Commit to check
+        description: CLDR Commit (e.g. master or maint/maint-38)
         required: true
-        default: 'master'
       fix-version:
         description: Fix Version (e.g. 38)
         required: true
@@ -54,13 +53,14 @@ jobs:
           command -v pipenv >/dev/null 2>/dev/null || sudo pip3 install pipenv
           pipenv install
           pipenv run python3 check.py \
+          --nocopyright \
           --jira-query "project=CLDR AND fixVersion=${FV}" \
           --repo-root ${GITHUB_WORKSPACE}/cldr \
           --github-url https://github.com/unicode-org/cldr \
           --rev-range "release-${LV}..${END_REF}" > ${GITHUB_WORKSPACE}/${REPORT}.md
           cd ${GITHUB_WORKSPACE}
           wc -l ${REPORT}.md
-          npx markdown-to-html --flavor gfm --title ${REPORT} ${REPORT}.md -c unicode-org/cldr README.md --stylesheet github-markdown.css > ${REPORT}.html
+          npx -p markdown-to-html markdown --flavor gfm --title ${REPORT} ${REPORT}.md -c unicode-org/cldr README.md --stylesheet github-markdown.css > ${REPORT}.html
           echo "${RSA_KEY_CCC}" > ${HOME}/.key && chmod go= ${HOME}/.key
           echo "${CCC_KNOWNHOSTS}" > ${HOME}/.knownhosts && chmod go= ${HOME}/.knownhosts
           ln ${REPORT}.md CLDR_REPORT.md # use a fixed name for the publish step


### PR DESCRIPTION
CLDR-14205
- improve markdown processing

This is an update to the calling button only. It will solve the "links from the TOC do not work".
The markdown processing wasn't specified properly previously.