### PR TITLE
CLDR-14220 Azure migration: log rotation

### DIFF
--- a/tools/scripts/ansible/setup-playbook.yml
+++ b/tools/scripts/ansible/setup-playbook.yml
@@ -47,6 +47,23 @@
         owner: tomcat8
         group: tomcat8
         mode: 0775
+    - name: Rotate CLDR logs
+      blockinfile:
+        path: "/etc/logrotate.d/surveytool-logs"
+        owner: root
+        mode: "0644"
+        block: |
+          /var/lib/tomcat8/cldr/cldrmail.log /var/lib/tomcat8/cldr/exception.log {
+            daily
+            rotate 7
+            compress
+            copytruncate
+            missingok
+            notifempty
+            dateext
+            create 0640 surveytool cldr
+          }
+        create: true
     - name: Create cldr.properties
       template:
         dest: /var/lib/tomcat8/cldr/cldr.properties


### PR DESCRIPTION
-Add Ansible setup for /etc/logrotate.d/surveytool-logs

-Rotate /var/lib/tomcat8/cldr/exception.log same as on old server

-Also similarly rotate /var/lib/tomcat8/cldr/cldrmail.log

-Note: catalina.out already uses system default /etc/logrotate.d/tomcat8

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14220
- [x] Updated PR title and link in previous line to include Issue number

