### PR TITLE
CLDR-14226 change more uses of "grandfathered", and of "blacklist", "crazy"

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -30,7 +30,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <attributes element="weekendStart" attribute="time" attributeValue="00:00"/>
         </suppress>
         <alias>
-            <!-- grandfathered BCP47 codes -->
+            <!-- legacy language tags (marked as “Type: grandfathered” in BCP 47) -->
             <languageAlias type="art_lojban" replacement="jbo" reason="deprecated"/> <!-- Lojban -->
             <languageAlias type="i_ami" replacement="ami" reason="deprecated"/> <!-- Amis -->
             <languageAlias type="i_bnn" replacement="bnn" reason="deprecated"/> <!-- Bunun -->

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -501,7 +501,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
 
     public static String defaultServletPath = null;
     /**
-     * IP blacklist
+     * IP exclusion list
      */
     static Hashtable<String, Object> BAD_IPS = new Hashtable<>();
     public static String fileBaseA;

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/data/localeMatcherTest.txt
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/data/localeMatcherTest.txt
@@ -147,7 +147,7 @@ en-Hant-TW, und-TW ; 	zh-Hant ; 	und-TW	# zh-Hant should be closer to und-TW tha
 en-Hant-TW, und-TW ; 	zh ; 	und-TW	# zh should be closer to und-TW than to en-Hant-TW
 
 ##################################################
-# testMatchGrandfatheredCode
+# testMatchLegacyCode
 
 fr, i-klingon, en-Latn-US ; 	en-GB-oed ; 	en-Latn-US
 

--- a/tools/java/org/unicode/cldr/util/Rational.java
+++ b/tools/java/org/unicode/cldr/util/Rational.java
@@ -313,7 +313,7 @@ public final class Rational implements Comparable<Rational> {
 
         switch (style) {
         case repeating:
-            String result = toRepeating(30); // limit of 30 on the repeating length, so we don't get crazy
+            String result = toRepeating(30); // limit of 30 on the repeating length, so we don't get unreasonable
             if (result != null) {
                 return result;
             }

--- a/tools/java/org/unicode/cldr/util/data/langtagRegex.txt
+++ b/tools/java/org/unicode/cldr/util/data/langtagRegex.txt
@@ -35,7 +35,7 @@ $extension  = $singleton (?: $s $alphanum{2,8} )+ ; # singleton 1*("-" (2*8alpha
 
 $privateUse = $x (?: $s $alphanum{1,8} )+ ; # "x" 1*("-" (1*8alphanum))
 
-# Define certain grandfathered codes, since otherwise the regex is pretty useless.
+# Define certain legacy codes (marked as “Type: grandfathered” in BCP 47), since otherwise the regex is pretty useless.
 # Since these are limited, this is safe even later changes to the registry --
 # the only oddity is that it might change the type of the tag, and thus
 # the results from the capturing groups.

--- a/tools/java/org/unicode/cldr/util/data/langtagTest.txt
+++ b/tools/java/org/unicode/cldr/util/data/langtagTest.txt
@@ -50,21 +50,22 @@ fr-Latn-CA
 fr-Latn-FR
 fr-shadok 	 # Variant
 fr-y-myext-myext2
-i-default      	 # grandfathered
-i-default 	 # grandfathered
-i-enochian 	 # Grand fathered
-i-klingon 	 # grandfathered
-i-klingon 	 # grandfathered with singleton
+i-default      	 # legacy (marked as “Type: grandfathered” in BCP 47)
+i-default 	 # legacy
+i-enochian 	 # legacy
+i-klingon 	 # legacy
+i-klingon 	 # legacy with singleton
 mn-Cyrl-MN
 mN-cYrL-Mn
-no-bok 	 # grandfathered without singleton
+no-bok 	 # legacy without singleton
 sl-IT-nedis
 sl-nedis
 sr-Latn-CS
 x-12345678-a
 x-fr-CH
 
-#all of the grandfathered codes; first the really goofy ones. Cased oddly for an extra test.
+#all of the legacy codes (marked as “Type: grandfathered” in BCP 47); first the really goofy ones.
+#Cased oddly for an extra test.
 En-Gb-Oed
 I-Ami
 I-Bnn
@@ -264,7 +265,7 @@ fr-Latn-F
 overlongone
 tlh-a-b-foo
 
-i-notexist          	 # grandfathered but not registered: invalid, even if we only test well-formedness
+i-notexist          	 # legacy but not registered: invalid, even if we only test well-formedness
 
 en-enx                    # Extended tag
 en-enx-eny-enz-latn-us    # Extended tag


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14226
- [x] Updated PR title and link in previous line to include Issue number

This changes more "uses" of "grandfathered" to "legacy", and also replaces uses of "blacklist" and "crazy".

There are remaining uses of "grandfathered" specifically in reference to BCP47, and remaining uses of "master" specifically referring to a github branch (and URLs for it), but there is not much we can do about those for the time being. I think this PR represents the final chnages in this area for CLDR v38. We can investigate more for v39 (with a new ticket).

Note that some sensitive terms are present just as (1) terms for which we have IPA transcription data, and (2) localized name of language "den".