### PR TITLE
CLDR-14180 cleanup SupplementalDataInfo  / CLDRConfig.getStandardCodes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -4751,6 +4751,10 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     }
 
     private static long shortN = 0;
+    /**
+     * Only used by about.jsp to know whether it's safe to call DBUtils.getInstance()
+     */
+    public static boolean isDbSetup = false;
     private static final int MAX_CHARS = 100;
     private static final String SHORT_A = "(Click to show entire message.)";
     private static final String SHORT_B = "(hide.)";
@@ -4832,6 +4836,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         try {
             progress.update("begin.."); // restore
             dbUtils.startupDB(this, progress);
+            SurveyMain.isDbSetup  = true;
             // now other tables..
             progress.update("Setup databases "); // restore
             try {

--- a/tools/cldr-apps/src/main/webapp/about.jsp
+++ b/tools/cldr-apps/src/main/webapp/about.jsp
@@ -76,18 +76,21 @@
             <th>SurveyMain.TRANS_HINT_LANGUAGE_NAME</th>
             <td> <%=org.unicode.cldr.web.SurveyMain.TRANS_HINT_LANGUAGE_NAME%>  </td>
         </tr>
-        <% for(String k : org.unicode.cldr.util.CLDRConfigImpl.ALL_GIT_HASHES) { %>
-	        <tr class="row<%= ((i++)%2) %>">
-	            <th><%= k %></th>
-	            <td> <%= CLDRURLS.gitHashToLink(CLDRConfigImpl.getInstance().getProperty(k)) %>  </td>
-	        </tr>
-        <% } %>
+        <% 
+        	if(SurveyMain.isConfigSetup) {
+	        	for(String k : org.unicode.cldr.util.CLDRConfigImpl.ALL_GIT_HASHES) { %>
+		        <tr class="row<%= ((i++)%2) %>">
+		            <th><%= k %></th>
+		            <td> <%= CLDRURLS.gitHashToLink(CLDRConfigImpl.getInstance().getProperty(k)) %>  </td>
+		        </tr>
+        <% 		}
+	        }%>
     </table>    
     <%
         }
     %>
 
-<% { org.unicode.cldr.web.DBUtils d = org.unicode.cldr.web.DBUtils.peekInstance();  if (d!=null) { %>
+<% if(SurveyMain.isDbSetup) { org.unicode.cldr.web.DBUtils d = org.unicode.cldr.web.DBUtils.getInstance();  if (d!=null) { %>
 
         <h4 class="selected">Database information</h4>
     <% 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/LanguageTest.java
@@ -31,14 +31,14 @@ public class LanguageTest extends TestFmwk {
         .getSupplementalDataInfo();
     final Map<String, String> likelyMap = supplementalDataInfo
         .getLikelySubtags();
-    final HashMap<String, String> language2likely = new HashMap<String, String>();
-    final HashMap<String, String> script2likely = new HashMap<String, String>();
+    final HashMap<String, String> language2likely = new HashMap<>();
+    final HashMap<String, String> script2likely = new HashMap<>();
     {
-        final HashMap<String, Map<Type, String>> language2script = new HashMap<String, Map<Type, String>>();
-        final HashMap<String, Map<Type, String>> language2territory = new HashMap<String, Map<Type, String>>();
-        final HashMap<String, Map<Type, String>> script2language = new HashMap<String, Map<Type, String>>();
-        final HashMap<String, Map<Type, String>> script2territory = new HashMap<String, Map<Type, String>>();
-        final HashSet<String> scriptSet = new HashSet<String>();
+        final HashMap<String, Map<Type, String>> language2script = new HashMap<>();
+        final HashMap<String, Map<Type, String>> language2territory = new HashMap<>();
+        final HashMap<String, Map<Type, String>> script2language = new HashMap<>();
+        final HashMap<String, Map<Type, String>> script2territory = new HashMap<>();
+        final HashSet<String> scriptSet = new HashSet<>();
         for (String language : supplementalDataInfo
             .getBasicLanguageDataLanguages()) {
             for (BasicLanguageData basic : supplementalDataInfo
@@ -89,7 +89,7 @@ public class LanguageTest extends TestFmwk {
         String language, final String script, Type type) {
         Map<Type, String> old = hashMap.get(language);
         if (old == null) {
-            hashMap.put(language, old = new EnumMap<Type, String>(Type.class));
+            hashMap.put(language, old = new EnumMap<>(Type.class));
         }
         if (!old.containsKey(type)) {
             old.put(type, script);
@@ -101,9 +101,9 @@ public class LanguageTest extends TestFmwk {
     }
 
     public void TestThatLanguagesHaveScript() {
-        Set<String> needTransfer = new LinkedHashSet<String>();
+        Set<String> needTransfer = new LinkedHashSet<>();
         LanguageTagParser parser = new LanguageTagParser();
-        Map<String, Counter2<String>> scriptToLanguageCounter = new TreeMap<String, Counter2<String>>();
+        Map<String, Counter2<String>> scriptToLanguageCounter = new TreeMap<>();
         for (String language : supplementalDataInfo
             .getLanguagesForTerritoriesPopulationData()) {
             String script = parser.set(language).getScript();
@@ -125,7 +125,7 @@ public class LanguageTest extends TestFmwk {
             }
             Counter2<String> c = scriptToLanguageCounter.get(script);
             if (c == null) {
-                scriptToLanguageCounter.put(script, c = new Counter2<String>());
+                scriptToLanguageCounter.put(script, c = new Counter2<>());
             }
             for (String territory : supplementalDataInfo
                 .getTerritoriesForPopulationData(language)) {
@@ -153,7 +153,7 @@ public class LanguageTest extends TestFmwk {
         if (false)
             throw new IllegalArgumentException(
                 "    Remove Kana => Ainu, Bopo, Latn => Afar");
-        Set<String> needTransfer = new LinkedHashSet<String>();
+        Set<String> needTransfer = new LinkedHashSet<>();
         Set<String> unicodeScripts = getUnicodeScripts();
         for (String script : unicodeScripts) {
             String likely = likelyMap.get("und_" + script);
@@ -211,7 +211,7 @@ public class LanguageTest extends TestFmwk {
     }
 
     Set<String> getUnicodeScripts() {
-        Set<String> scripts = new TreeSet<String>();
+        Set<String> scripts = new TreeSet<>();
         int min = UCharacter.getIntPropertyMinValue(UProperty.SCRIPT);
         int max = UCharacter.getIntPropertyMaxValue(UProperty.SCRIPT);
         UnicodeSet temp = new UnicodeSet();
@@ -237,7 +237,7 @@ public class LanguageTest extends TestFmwk {
 
     public String getDescription(String type, String token) {
         try {
-            testInfo.getStandardCodes();
+            StandardCodes.make();
             String name = StandardCodes.getLStreg().get(type).get(token)
                 .get("Description");
             int pos = name.indexOf('▪');

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestBasic.java
@@ -51,6 +51,7 @@ import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathUtilities;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
@@ -372,7 +373,7 @@ public class TestBasic extends TestFmwkPlus {
 
     public void TestCurrencyFallback() {
         Factory cldrFactory = testInfo.getCldrFactory();
-        Set<String> currencies = testInfo.getStandardCodes().getAvailableCodes(
+        Set<String> currencies = StandardCodes.make().getAvailableCodes(
             "currency");
 
         final UnicodeSet CHARACTERS_THAT_SHOULD_HAVE_FALLBACKS = new UnicodeSet(

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -62,7 +62,7 @@ import com.ibm.icu.util.ULocale;
 public class TestCoverageLevel extends TestFmwkPlus {
 
     private static CLDRConfig testInfo = CLDRConfig.getInstance();
-    private static final StandardCodes STANDARD_CODES = testInfo.getStandardCodes();
+    private static final StandardCodes STANDARD_CODES = StandardCodes.make();
     private static final CLDRFile ENGLISH = testInfo.getEnglish();
     private static final SupplementalDataInfo SDI = testInfo.getSupplementalDataInfo();
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestInheritance.java
@@ -78,7 +78,7 @@ public class TestInheritance extends TestFmwk {
         Relation<String, String> languageLocalesSeen = Relation.of(
             new TreeMap<String, Set<String>>(), TreeSet.class);
 
-        Set<String> testOrg = testInfo.getStandardCodes()
+        Set<String> testOrg = StandardCodes.make()
             .getLocaleCoverageLocales("google");
         ChainedMap.M4<String, OfficialStatus, String, Boolean> languageToOfficialChildren = ChainedMap
             .of(new TreeMap<String, Object>(),
@@ -845,7 +845,7 @@ public class TestInheritance extends TestFmwk {
 
     // TODO move this into central utilities
 
-    private static final StandardCodes STANDARD_CODES = testInfo.getStandardCodes();
+    private static final StandardCodes STANDARD_CODES = StandardCodes.make();
     private static final Map<String, Map<String, R2<List<String>, String>>> DEPRECATED_INFO = dataInfo
         .getLocaleAliasInfo();
 

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestLocale.java
@@ -31,6 +31,7 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LanguageTagParser.Format;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.SimpleXMLSource;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.CodeType;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo;
@@ -63,9 +64,9 @@ public class TestLocale extends TestFmwkPlus {
         Type.Living, Type.Constructed, Type.Historical, Type.Extinct, Type.Special);
     static Set<Scope> ALLOWED_LANGUAGE_SCOPES = EnumSet.of(Scope.Individual,
         Scope.Macrolanguage, Scope.Special); // , Special, Collection, PrivateUse, Unknown
-    static Set<String> ALLOWED_SCRIPTS = testInfo.getStandardCodes()
+    static Set<String> ALLOWED_SCRIPTS = StandardCodes.make()
         .getGoodAvailableCodes(CodeType.script);
-    static Set<String> ALLOWED_REGIONS = testInfo.getStandardCodes()
+    static Set<String> ALLOWED_REGIONS = StandardCodes.make()
         .getGoodAvailableCodes(CodeType.territory);
 
     /**
@@ -74,9 +75,9 @@ public class TestLocale extends TestFmwkPlus {
     static String XPATH_ALIAS_STRING = "//alias";
 
     public void TestLanguageRegions() {
-        Set<String> missingLanguageRegion = new LinkedHashSet<String>();
+        Set<String> missingLanguageRegion = new LinkedHashSet<>();
         // TODO This should be derived from metadata: https://unicode.org/cldr/trac/ticket/11224
-        Set<String> knownMultiScriptLanguages = new HashSet<String>(Arrays.asList("az", "ff", "bs", "hi", "ks", "mni", "ms", "pa", "sat", "sd", "shi", "sr", "su", "vai", "uz", "yue", "zh"));
+        Set<String> knownMultiScriptLanguages = new HashSet<>(Arrays.asList("az", "ff", "bs", "hi", "ks", "mni", "ms", "pa", "sat", "sd", "shi", "sr", "su", "vai", "uz", "yue", "zh"));
         Set<String> available = testInfo.getCldrFactory().getAvailable();
         LanguageTagParser ltp = new LanguageTagParser();
         Set<String> defaultContents = SUPPLEMENTAL_DATA_INFO
@@ -440,7 +441,7 @@ public class TestLocale extends TestFmwkPlus {
         assertEquals("Locale name", "中国語 (アラビア文字\u3001アメリカ合衆国)",
             japanese.getName("zh-Arab-US"));
     }
-    
+
     public void TestLocaleDisplay() {
         System.out.println("\nUse -v to get samples for tests");
         String fileName = CLDRPaths.TEST_DATA + "localeIdentifiers/localeDisplayName.txt";
@@ -455,7 +456,7 @@ public class TestLocale extends TestFmwkPlus {
         };
         Factory factory = SimpleFactory.make(paths, ".*");
         Set<String> seen = new HashSet<>();
-        
+
         try {
             for (String line : Files.readLines(new File(fileName), UTF_8)) {
                 line = line.trim();
@@ -463,10 +464,10 @@ public class TestLocale extends TestFmwkPlus {
                 if (line.startsWith("@")) {
                     String[] parts = line.split("=");
                     switch(parts[0]) {
-                    case "@locale": 
+                    case "@locale":
                         cldrFile = factory.make(parts[1], true);
                         break;
-                    case "@compound": 
+                    case "@compound":
                         switch(parts[1]) {
                         case "true": compound=true; break;
                         case "false": compound=false; break;
@@ -490,10 +491,10 @@ public class TestLocale extends TestFmwkPlus {
 //                String uLocaleAsBcp47 = forComparison.toLanguageTag();
 //                assertEquals("ICU roundtrips", localeId, uLocaleAsBcp47);
 
-                
+
 //                String bcp47 = ltp.toString(OutputOption.BCP47);
 //                String icuFormat = ltp.toString(OutputOption.ICU);
-                
+
 //                // check that the icuFormat is ok except for order
 //                Set<String> icuComponents = new TreeSet<>(AT_AND_SEMI.splitToList(forComparison.toString().toLowerCase(Locale.ROOT)));
 //                Set<String> icuFormatComponents = new TreeSet<>(AT_AND_SEMI.splitToList(icuFormat.toLowerCase(Locale.ROOT)));
@@ -503,12 +504,12 @@ public class TestLocale extends TestFmwkPlus {
 //                LanguageTagParser ltp2 = new LanguageTagParser()
 //                    .set(icuFormat);
 //                String roundTripId = ltp2.toString(OutputOption.BCP47);
-                
-                
+
+
 //                // check that the format roundtrips
 //                assertEquals("LTP(BCP47)=>ICU=>BCP47", bcp47, roundTripId);
 
-                canonicalizer.transform(ltp);                
+                canonicalizer.transform(ltp);
                 String name = cldrFile.getName(ltp, true, null);
                 if (assertEquals(cldrFile.getLocaleID() + "; " + localeId, expected, name)) {
                     formattedExamplesForSpec.append("<tr><td>")
@@ -536,13 +537,13 @@ public class TestLocale extends TestFmwkPlus {
             String localeBase = "en-" + (LanguageTagParser.isTKey(key) ? "t-" : "u-") + key + "-";
             // abbreviate some values
             switch(key) {
-            case "cu": 
+            case "cu":
                 showName(cldrFile, seen, localeBase, "eur", "jpy", "usd", "chf");
                 continue keyLoop;
-            case "tz": 
+            case "tz":
                 showName(cldrFile, seen, localeBase, "uslax", "gblon", "chzrh");
                 continue keyLoop;
-            case "dx": 
+            case "dx":
                 // skip for now, probably need to fix something in CLDRFile
                 continue keyLoop;
             }
@@ -564,7 +565,7 @@ public class TestLocale extends TestFmwkPlus {
             showName(cldrFile, skipLocales, localeBase, sample);
         }
     }
-    
+
     private void showName(CLDRFile cldrFile, Set<String> skipLocales, String localeBase, String... samples) {
         for (String sample : samples) {
             showName(cldrFile, skipLocales, localeBase, sample);
@@ -572,7 +573,7 @@ public class TestLocale extends TestFmwkPlus {
     }
 
     static final UnicodeSet LOCALIZED = new UnicodeSet("[A-Z€$¥${foobar2}]");
-    
+
     private void showName(CLDRFile cldrFile, Set<String> skipLocales, String localeBase, String value) {
         String locale = localeBase + value;
         if (skipLocales.contains(locale)) {
@@ -674,7 +675,7 @@ public class TestLocale extends TestFmwkPlus {
 
 
                     String gorp = key.equals(lastKey) ? "" :
-                        (key.equals("t") ? "-u-ca-persian" : "-t-hi") 
+                        (key.equals("t") ? "-u-ca-persian" : "-t-hi")
                         + "-a-AA-v-VV-y-YY-x-foobar";
 
                     lastKey = key;
@@ -706,10 +707,10 @@ public class TestLocale extends TestFmwkPlus {
         case "PRIVATE_USE": // [t, x0, PRIVATE_USE]
             valuesSet = ImmutableSet.of("foobar2");
             break;
-        case "REORDER_CODE":    // [u, kr, REORDER_CODE] 
+        case "REORDER_CODE":    // [u, kr, REORDER_CODE]
             valuesSet = ImmutableSet.of("arab", "digit-deva-latn");
             break;
-        case "SCRIPT_CODE":    // [u, dx, SCRIPT_CODE] 
+        case "SCRIPT_CODE":    // [u, dx, SCRIPT_CODE]
             valuesSet = ImmutableSet.of("thai", "thai-laoo");
             break;
         case "RG_KEY_VALUE":    // [u, rg, RG_KEY_VALUE]
@@ -718,7 +719,7 @@ public class TestLocale extends TestFmwkPlus {
         case "SUBDIVISION_CODE":    // [u, sd, SUBDIVISION_CODE]
             valuesSet = ImmutableSet.of("usca", "gbsct", "frnor");
             break;
-        default: 
+        default:
             throw new IllegalArgumentException();
         }
         return valuesSet;
@@ -734,7 +735,7 @@ public class TestLocale extends TestFmwkPlus {
             + "-" + key + "-" + String.join("-", values) + gorp;
         ltp.set(locale);
 
-        logln(ltp.toString(Format.bcp47) 
+        logln(ltp.toString(Format.bcp47)
             + " == " + ltp.toString(Format.icu)
             + "\n\t\tstructure:\t" + ltp.toString(Format.structure));
         try {

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestPathHeader.java
@@ -820,8 +820,7 @@ public class TestPathHeader extends TestFmwkPlus {
     }
 
     public void TestTerritoryOrder() {
-        final Set<String> goodAvailableCodes = CLDRConfig.getInstance()
-            .getStandardCodes().getGoodAvailableCodes("territory");
+        final Set<String> goodAvailableCodes = StandardCodes.make().getGoodAvailableCodes("territory");
         Set<String> results = showContained("001", 0, new HashSet<>(
             goodAvailableCodes));
         results.remove("ZZ");

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -49,7 +49,7 @@ public class TestScriptMetadata extends TestFmwkPlus {
 
     public void TestScriptOfSample() {
         BitSet bitset = new BitSet();
-        for (String script : new TreeSet<String>(ScriptMetadata.getScripts())) {
+        for (String script : new TreeSet<>(ScriptMetadata.getScripts())) {
             Info info0 = ScriptMetadata.getInfo(script);
             int codePointCount = UTF16.countCodePoint(info0.sampleChar);
             assertEquals("Sample must be single character", 1, codePointCount);
@@ -99,7 +99,7 @@ public class TestScriptMetadata extends TestFmwkPlus {
     @SuppressWarnings("deprecation")
     public void TestScripts() {
         UnicodeSet temp = new UnicodeSet();
-        Set<String> missingScripts = new TreeSet<String>();
+        Set<String> missingScripts = new TreeSet<>();
         Relation<IdUsage, String> map = Relation.of(
             new EnumMap<IdUsage, Set<String>>(IdUsage.class),
             LinkedHashSet.class);
@@ -133,7 +133,7 @@ public class TestScriptMetadata extends TestFmwkPlus {
 
     // lifted from ShowLanguages
     private static Set<String> getEnglishTypes(String type, int code, StandardCodes sc, CLDRFile english) {
-        Set<String> result = new HashSet<String>(sc.getSurveyToolDisplayCodes(type));
+        Set<String> result = new HashSet<>(sc.getSurveyToolDisplayCodes(type));
         for (Iterator<String> it = english.getAvailableIterator(code); it.hasNext();) {
             XPathParts parts = XPathParts.getFrozenInstance(it.next());
             String newType = parts.getAttributeValue(-1, "type");
@@ -152,9 +152,9 @@ public class TestScriptMetadata extends TestFmwkPlus {
 
     public void TestShowLanguages() {
         // lifted from ShowLanguages - this is what ShowLanguages tried to do.
-        StandardCodes sc = testInfo.getStandardCodes();
+        StandardCodes sc = StandardCodes.make();
         CLDRFile english = testInfo.getEnglish();
-        Set<String> bads = new TreeSet<String>();
+        Set<String> bads = new TreeSet<>();
         UnicodeSet temp = new UnicodeSet();
         for (String s : getScriptsToShow(sc, english)) {
             if (ScriptMetadata.getInfo(s) == null) {
@@ -175,7 +175,7 @@ public class TestScriptMetadata extends TestFmwkPlus {
 
     public void TestGeographicGrouping() {
         CLDRFile english = testInfo.getEnglish();
-        Set<Row.R3<IdUsage, String, String>> lines = new TreeSet<Row.R3<IdUsage, String, String>>();
+        Set<Row.R3<IdUsage, String, String>> lines = new TreeSet<>();
         Set<String> extras = ScriptMetadata.getExtras();
         for (Entry<String, Info> sc : ScriptMetadata.iterable()) {
             String scriptCode = sc.getKey();
@@ -205,7 +205,7 @@ public class TestScriptMetadata extends TestFmwkPlus {
     public void TestScriptCategories() {
 
         // test completeness
-        Set<String> scripts = new TreeSet<String>(ScriptMetadata.getScripts());
+        Set<String> scripts = new TreeSet<>(ScriptMetadata.getScripts());
         scripts.removeAll(Arrays.asList("Zinh", "Zyyy", "Zzzz"));
         logln("All: " + scripts);
         for (ScriptMetadata.Groupings x : ScriptMetadata.Groupings.values()) {
@@ -249,9 +249,9 @@ public class TestScriptMetadata extends TestFmwkPlus {
         TreeSet<String> b = With.in(bRaw).toCollection(
             ScriptMetadata.TO_SHORT_SCRIPT, new TreeSet<String>());
 
-        Set<String> a_b = new TreeSet<String>(a);
+        Set<String> a_b = new TreeSet<>(a);
         a_b.removeAll(b);
-        Set<String> b_a = new TreeSet<String>(b);
+        Set<String> b_a = new TreeSet<>(b);
         b_a.removeAll(a);
         assertEquals(title + " New vs Old, ", a_b.toString(), b_a.toString());
     }

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -97,8 +97,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     static CLDRConfig testInfo = CLDRConfig.getInstance();
 
-    private static final StandardCodes STANDARD_CODES = testInfo
-        .getStandardCodes();
+    private static final StandardCodes STANDARD_CODES = StandardCodes.make();
 
     private static final SupplementalDataInfo SUPPLEMENTAL = testInfo
         .getSupplementalDataInfo();
@@ -182,7 +181,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             }
             localesToTest.add(locale);
         }
-        Set<String> modernLocales = testInfo.getStandardCodes()
+        Set<String> modernLocales = StandardCodes.make()
             .getLocaleCoverageLocales(Organization.cldr,
                 EnumSet.of(Level.MODERN));
 
@@ -975,7 +974,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     }
 
     public void TestAliases() {
-        testInfo.getStandardCodes();
+        StandardCodes.make();
         Map<String, Map<String, Map<String, String>>> bcp47Data = StandardCodes
             .getLStreg();
         Map<String, Map<String, R2<List<String>, String>>> aliases = SUPPLEMENTAL

--- a/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-unittest/src/org/unicode/cldr/unittest/TestUnits.java
@@ -59,6 +59,7 @@ import org.unicode.cldr.util.Rational.ContinuedFraction;
 import org.unicode.cldr.util.Rational.FormatStyle;
 import org.unicode.cldr.util.Rational.RationalParser;
 import org.unicode.cldr.util.SimpleXMLSource;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
@@ -1919,7 +1920,7 @@ public class TestUnits extends TestFmwk {
 
         // first gather all the  examples
         Set<String> skippedUnits = new LinkedHashSet<>();
-        Set<String> testSet = CLDR_CONFIG.getStandardCodes().getLocaleCoverageLocales(Organization.cldr);
+        Set<String> testSet = StandardCodes.make().getLocaleCoverageLocales(Organization.cldr);
         Counter<String> localeToErrorCount = new Counter<>();
         for (String localeId : testSet) {
             if (localeId.contains("_")) {

--- a/tools/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -26,7 +26,6 @@ public class CompareSuppress {
 
     public static void main(String[] args) {
         CLDRConfig config = CLDRConfig.getInstance();
-        config.getStandardCodes();
         Map<LstrType, Map<String, Map<LstrField, String>>> lstr = StandardCodes.getEnumLstreg();
         Map<String, Map<LstrField, String>> langData = lstr.get(LstrType.language);
         LanguageTagParser ltp = new LanguageTagParser();

--- a/tools/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/java/org/unicode/cldr/tool/CountItems.java
@@ -430,7 +430,7 @@ public class CountItems {
     public static void writeMetazonePrettyPath() {
         CLDRConfig testInfo = ToolConfig.getToolInstance();
         Map<String, Map<String, String>> map = testInfo.getSupplementalDataInfo().getMetazoneToRegionToZone();
-        Map zoneToCountry = testInfo.getStandardCodes().getZoneToCounty();
+        Map zoneToCountry = StandardCodes.make().getZoneToCounty();
         Set<Pair<String, String>> results = new TreeSet<>();
         Map<String, String> countryToContinent = getCountryToContinent(testInfo.getSupplementalDataInfo(),
             testInfo.getEnglish());

--- a/tools/java/org/unicode/cldr/tool/FallbackIteratorDataGenerator.java
+++ b/tools/java/org/unicode/cldr/tool/FallbackIteratorDataGenerator.java
@@ -13,7 +13,7 @@ public class FallbackIteratorDataGenerator {
     static CLDRConfig testInfo = ToolConfig.getToolInstance();
 
     public static void main(String[] args) {
-        final StandardCodes sc = testInfo.getStandardCodes();
+        final StandardCodes sc = StandardCodes.make();
         List<String> decanonicalizeList = new ArrayList<>();
         System.out.println();
         System.out.println("\t\t\"canonicalize\",\t\t// mechanically generated");

--- a/tools/java/org/unicode/cldr/tool/FindWidths.java
+++ b/tools/java/org/unicode/cldr/tool/FindWidths.java
@@ -13,6 +13,7 @@ import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
+import org.unicode.cldr.util.StandardCodes;
 
 import com.ibm.icu.text.NumberFormat;
 
@@ -47,7 +48,7 @@ public class FindWidths {
         Factory phf = PathHeader.getFactory(english);
         Map<PathHeader, Integer> englishWidths = new HashMap<>();
         Map<PathHeader, Data> maxWidths = new TreeMap<>();
-        Set<String> sampleLocales = testInfo.getStandardCodes().getLocaleCoverageLocales("google");
+        Set<String> sampleLocales = StandardCodes.make().getLocaleCoverageLocales("google");
 
         for (String path : english) {
             PathHeader ph = phf.fromPath(path);

--- a/tools/java/org/unicode/cldr/tool/FixTransformNames.java
+++ b/tools/java/org/unicode/cldr/tool/FixTransformNames.java
@@ -18,6 +18,7 @@ import org.unicode.cldr.util.CLDRTransforms.Direction;
 import org.unicode.cldr.util.CLDRTransforms.ParsedTransformID;
 import org.unicode.cldr.util.CLDRTransforms.Visibility;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.CodeType;
 import org.unicode.cldr.util.With;
 
@@ -41,7 +42,7 @@ public class FixTransformNames {
 
     private void run(String[] args) {
         CLDRFile file = testInfo.getEnglish();
-        for (String lang : testInfo.getStandardCodes().getAvailableCodes(CodeType.language)) {
+        for (String lang : StandardCodes.make().getAvailableCodes(CodeType.language)) {
             String name = file.getName(lang);
             if (!name.equals(lang)) {
                 fieldToCode.put(name, lang);

--- a/tools/java/org/unicode/cldr/tool/GenerateCasingChart.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateCasingChart.java
@@ -19,6 +19,7 @@ import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Splitter;
@@ -97,7 +98,7 @@ public class GenerateCasingChart {
                 new LinkedHashMap<ContextTransformType, Object>(),
                 ContextTransformValue.class);
 
-            Level level = CLDRConfig.getInstance().getStandardCodes().getLocaleCoverageLevel("cldr", locale);
+            Level level = StandardCodes.make().getLocaleCoverageLevel("cldr", locale);
             boolean hasCasedLetters = changesUpper.containsSome(exemplars);
             Set<String> items = new LinkedHashSet<>();
             cldrFile.iterator("//ldml/contextTransforms").forEachRemaining(items::add);

--- a/tools/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -25,6 +25,7 @@ import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XMLSource;
 
@@ -51,7 +52,7 @@ public class GenerateChangeChart {
 
         CLDRFile currentRoot = current.make("root", true);
         CLDRFile oldRoot = old.make("root", true);
-        Set<String> locales = CONFIG.getStandardCodes().getLocaleCoverageLocales(Organization.cldr, EnumSet.of(Level.MODERN));
+        Set<String> locales = StandardCodes.make().getLocaleCoverageLocales(Organization.cldr, EnumSet.of(Level.MODERN));
         String dir = CLDRPaths.CHART_DIRECTORY + "changes/";
         CoverageInfo coverage = CONFIG.getCoverageInfo();
         EnumSet<SectionId> sections = EnumSet.noneOf(SectionId.class);

--- a/tools/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
@@ -24,7 +24,7 @@ import com.ibm.icu.util.ULocale;
 public class GenerateDayPeriodChart {
     static final SupplementalDataInfo SUP = CLDRConfig.getInstance().getSupplementalDataInfo();
     static final CLDRFile ENGLISH = CLDRConfig.getInstance().getEnglish();
-    static final StandardCodes SC = CLDRConfig.getInstance().getStandardCodes();
+    static final StandardCodes SC = StandardCodes.make();
     static final int MINUTE = 60 * 1000;
     static final int HOUR = 60 * MINUTE;
 

--- a/tools/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -24,6 +24,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.SimpleXMLSource;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 
 import com.google.common.base.Joiner;
@@ -144,7 +145,7 @@ public class GenerateDerivedAnnotations {
             }
             failures.freeze();
             if (!failures.isEmpty()) {
-                Level level = CLDR_CONFIG.getStandardCodes().getLocaleCoverageLevel(Organization.cldr, locale);
+                Level level = StandardCodes.make().getLocaleCoverageLevel(Organization.cldr, locale);
                 System.out.println("Failures\t" + locale
                     + "\t" + level
                     + "\t" + english.getName(locale)

--- a/tools/java/org/unicode/cldr/tool/GeneratePluralConfirmation.java
+++ b/tools/java/org/unicode/cldr/tool/GeneratePluralConfirmation.java
@@ -30,7 +30,7 @@ public class GeneratePluralConfirmation {
 
     private static final CLDRConfig testInfo = ToolConfig.getToolInstance();
 
-    private static final StandardCodes STANDARD_CODES = testInfo.getStandardCodes();
+    private static final StandardCodes STANDARD_CODES = StandardCodes.make();
 
     private static final SupplementalDataInfo SUPPLEMENTAL = testInfo.getSupplementalDataInfo();
 

--- a/tools/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/java/org/unicode/cldr/tool/GetChanges.java
@@ -21,6 +21,7 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.XMLSource;
 
 import com.google.common.collect.ImmutableSet;
@@ -229,7 +230,7 @@ public class GetChanges {
 
         Multimap<String,PathHeader> missing = TreeMultimap.create();
 
-        Set<String> locales = testInfo.getStandardCodes().getLocaleCoverageLocales(Organization.cldr, Collections.singleton(Level.MODERN));
+        Set<String> locales = StandardCodes.make().getLocaleCoverageLocales(Organization.cldr, Collections.singleton(Level.MODERN));
 
         LanguageTagParser ltp = new LanguageTagParser();
         for (String locale : locales) {

--- a/tools/java/org/unicode/cldr/tool/ListCoverageLevels.java
+++ b/tools/java/org/unicode/cldr/tool/ListCoverageLevels.java
@@ -42,7 +42,7 @@ import com.google.common.collect.TreeMultimap;
 public class ListCoverageLevels {
     public static void main(String[] args) {
         CLDRConfig config = CLDRConfig.getInstance();
-        StandardCodes sc = config.getStandardCodes();
+        StandardCodes sc = StandardCodes.make();
         SupplementalDataInfo sdi = config.getSupplementalDataInfo();
         LanguageTagParser ltp = new LanguageTagParser();
         Set<String> defaultContents = sdi.getDefaultContentLocales();

--- a/tools/java/org/unicode/cldr/tool/ListRedundantUnicodeSets.java
+++ b/tools/java/org/unicode/cldr/tool/ListRedundantUnicodeSets.java
@@ -47,7 +47,7 @@ public class ListRedundantUnicodeSets {
 
         Factory cldrFactory = CLDRConfig.getInstance().getCldrFactory();
         SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
-        StandardCodes sdc = CLDRConfig.getInstance().getStandardCodes();
+        StandardCodes sdc = StandardCodes.make();
 
         for (String localeID : cldrFactory.getAvailable()) {
             Level localeCoverageLevel = sdc.getLocaleCoverageLevel(Organization.cldr, localeID);

--- a/tools/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -138,7 +138,7 @@ public class ShowLocaleCoverage {
     private static final String LATEST = ToolConstants.CHART_VERSION;
     private static final double CORE_SIZE = CoreItems.values().length - CoreItems.ONLY_RECOMMENDED.size();
     public static CLDRConfig testInfo = ToolConfig.getToolInstance();
-    private static final StandardCodes SC = testInfo.getStandardCodes();
+    private static final StandardCodes SC = StandardCodes.make();
     private static final SupplementalDataInfo SUPPLEMENTAL_DATA_INFO = testInfo.getSupplementalDataInfo();
     private static final StandardCodes STANDARD_CODES = SC;
 

--- a/tools/java/org/unicode/cldr/tool/ShowRegionalVariants.java
+++ b/tools/java/org/unicode/cldr/tool/ShowRegionalVariants.java
@@ -27,6 +27,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.SectionId;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 import com.google.common.base.Objects;
@@ -50,6 +51,7 @@ public class ShowRegionalVariants {
 
     enum MyOptions {
         targetDir(".*", CLDRPaths.GEN_DIRECTORY + "/regional/", "target output file."),;
+
         // boilderplate
         final Option option;
 
@@ -63,7 +65,7 @@ public class ShowRegionalVariants {
 
         MY_DIR = MyOptions.targetDir.option.getValue();
 
-        Set<String> coverageLocales = CONFIG.getStandardCodes().getLocaleCoverageLocales("cldr");
+        Set<String> coverageLocales = StandardCodes.make().getLocaleCoverageLocales("cldr");
         Set<String> dc = new HashSet<>(SUPPLEMENTAL_DATA_INFO.getDefaultContentLocales());
         Set<String> skipLocales = new HashSet<>(Arrays.asList("root", "en_US_POSIX", "sr_Latn"));
 

--- a/tools/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/java/org/unicode/cldr/util/CLDRConfig.java
@@ -175,16 +175,6 @@ public class CLDRConfig extends Properties {
         return SupplementalDataInfoHelper.SINGLETON;
     }
 
-    /**
-     * StandardCodes.make() already returns a singleton
-     * @deprecated use {@link StandardCodes#make()}
-     * @return
-     */
-    @Deprecated
-    public final StandardCodes getStandardCodes() {
-        return StandardCodes.make();
-    }
-
     private static final class CoverageInfoHelper {
         static final CoverageInfo SINGLETON = new CoverageInfo(getInstance().getSupplementalDataInfo());
     }

--- a/tools/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -32,7 +32,7 @@ public class DayPeriodsCheck {
             localesToCheck.clear();
             switch (arg) {
             case "groups":
-                StandardCodes sc = CLDRConfig.getInstance().getStandardCodes();
+                StandardCodes sc = StandardCodes.make();
                 CLDRFile english = CLDRConfig.getInstance().getEnglish();
                 english.getName(LanguageGroup.uralic.iso);
 

--- a/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -981,7 +981,6 @@ public class SupplementalDataInfo {
         return getInstance(getNormalizedPathString(supplementalDirectory));
     }
 
-    static private SupplementalDataInfo defaultInstance = null;
     /**
      * Which directory did we come from?
      */
@@ -995,18 +994,19 @@ public class SupplementalDataInfo {
      * @return
      */
     public static SupplementalDataInfo getInstance() {
-        if (defaultInstance != null) {
-            return defaultInstance;
-        }
-        return CLDRConfig.getInstance().getSupplementalDataInfo();
-        // return getInstance(CldrUtility.SUPPLEMENTAL_DIRECTORY);
+        return SupplementalDataInfoHelper.SINGLETON;
     }
 
     /**
      * Mark this as the default instance to be returned by getInstance()
      */
     public void setAsDefaultInstance() {
-        defaultInstance = this;
+        SupplementalDataInfoHelper.SINGLETON = this;
+    }
+
+    public static final class SupplementalDataInfoHelper {
+        // Note: not final, because setAsDefaultInstance can modify it.
+        static SupplementalDataInfo SINGLETON = CLDRConfig.getInstance().getSupplementalDataInfo();
     }
 
     public static SupplementalDataInfo getInstance(String supplementalDirectory) {

--- a/tools/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -223,7 +223,7 @@ public class WikipediaOfficialLanguages {
         CLDRConfig testInfo = ToolConfig.getToolInstance();
         CLDRFile english = testInfo.getEnglish();
         SupplementalDataInfo supplementalDataInfo = testInfo.getSupplementalDataInfo();
-        StandardCodes sc = testInfo.getStandardCodes();
+        StandardCodes sc = StandardCodes.make();
         Set<String> locales = sc.getLocaleCoverageLocales("google"); // for now, restrict this
 
         System.out.println("Cc\tCountry\tLc\tLanguage Name\tWiki status (heuristic)\tCLDR status\t\tWiki notes");


### PR DESCRIPTION
CLDR-14180

- change SupplementalDataInfo to a mutable Bill Pugh singleton
SupplementalDataInfo needs to be able to change its default instance

- remove CLDRConfig.getStandardCodes() - use StandardCodes.make() instead.
