### PR TITLE
CLDR-14212 update .classpath to include JUnit

### DIFF
--- a/tools/cldr-apps/.classpath
+++ b/tools/cldr-apps/.classpath
@@ -89,5 +89,6 @@
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tools/cldr-unittest/.classpath
+++ b/tools/cldr-unittest/.classpath
@@ -12,5 +12,6 @@
 	<classpathentry kind="lib" path="/cldr-tools/libs/guava.jar"/>
 	<classpathentry kind="lib" path="/cldr-tools/libs/failureaccess.jar"/>
 	<classpathentry kind="lib" path="/cldr-tools/libs/myanmar-tools-1.1.1.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>


### PR DESCRIPTION
CLDR-14212
- a temporary fix until the final Maven switchover, where we will delete the .classpath and other setting files