### PR TITLE
CLDR-14222 uk, data for "energy-foodcalorie" should be the same as for "energy-kilocalorie"

### DIFF
--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -8567,11 +8567,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} калорії</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>Калорії</displayName>
-				<unitPattern count="one">{0} Калорія</unitPattern>
-				<unitPattern count="few">{0} Калорії</unitPattern>
-				<unitPattern count="many">{0} Калорій</unitPattern>
-				<unitPattern count="other">{0} Калорії</unitPattern>
+				<displayName>кілокалорії</displayName>
+				<unitPattern count="one">{0} кілокалорія</unitPattern>
+				<unitPattern count="few">{0} кілокалорії</unitPattern>
+				<unitPattern count="many">{0} кілокалорій</unitPattern>
+				<unitPattern count="other">{0} кілокалорії</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>кілоджоулі</displayName>
@@ -9952,11 +9952,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>Ккал</displayName>
-				<unitPattern count="one">{0} Ккал</unitPattern>
-				<unitPattern count="few">{0} Ккал</unitPattern>
-				<unitPattern count="many">{0} Ккал</unitPattern>
-				<unitPattern count="other">{0} Ккал</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="few">{0} ккал</unitPattern>
+				<unitPattern count="many">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>кал</displayName>
@@ -9966,11 +9966,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>Кал</displayName>
-				<unitPattern count="one">{0} Кал</unitPattern>
-				<unitPattern count="few">{0} Кал</unitPattern>
-				<unitPattern count="many">{0} Кал</unitPattern>
-				<unitPattern count="other">{0} Кал</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="few">{0} ккал</unitPattern>
+				<unitPattern count="many">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>кілоджоуль</displayName>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14222
- [x] Updated PR title and link in previous line to include Issue number

In uk Ukrainian, per TC discussion, copy the data for "energy-kilocalorie" to "energy-foodcalorie" (replacing the bogus data currently in "energy-foodcalorie"). Only have this for long and short forms, no data for narrow. Then for both "energy-kilocalorie" and "energy-foodcalorie", "Ккал" should be lowercased.
