### PR TITLE
CLDR-14220 Azure migration: set st.unicode.org hostname

### DIFF
--- a/tools/scripts/ansible/hostname-playbook.yml
+++ b/tools/scripts/ansible/hostname-playbook.yml
@@ -2,5 +2,6 @@
   become: yes
   tasks:
     - name: Set the hostname
+      # for sending email from st.unicode.org through corp.unicode.org
       hostname:
-         name: st.unicode.org
+         name: "{{ inventory_hostname }}"


### PR DESCRIPTION
-Use inventory_hostname instead of hard-coded st.unicode.org

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14220
- [x] Updated PR title and link in previous line to include Issue number

