### PR TITLE
CLDR-14220 Azure migration: fix db backup and log rotation

### DIFF
--- a/tools/scripts/ansible/server-playbook.yml
+++ b/tools/scripts/ansible/server-playbook.yml
@@ -61,7 +61,7 @@
             missingok
             notifempty
             dateext
-            create 0640 surveytool cldr
+            create 0640 tomcat8 tomcat8
           }
         create: true
     - name: Create cldr.properties

--- a/tools/scripts/ansible/templates/mycnf.j2
+++ b/tools/scripts/ansible/templates/mycnf.j2
@@ -1,5 +1,7 @@
 # managed by ansible setup-playboook.yml
 [client]
 user=cldradmin
-database={{ cldr_database_name }}
 password={{ cldradmin_pw }}
+
+[mysql]
+database={{ cldr_database_name }}


### PR DESCRIPTION
-Move database in .my.cnf (mycnf.j2) under [mysql] to prevent mysqldump failure

-Fix logrotate: on new servers, log files are owned by tomcat8 tomcat8

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14220
- [x] Updated PR title and link in previous line to include Issue number

