### PR TITLE
CLDR-14238 Include pluralRanges in ldml2json output

### DIFF
--- a/tools/java/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/java/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -8,6 +8,7 @@ section=primaryZones ; path=//cldr/supplemental/primaryZones/.* ; package=core
 section=numberingSystems ; path=//cldr/supplemental/numberingSystems/.* ; package=core
 section=ordinals ; path=//cldr/supplemental/plurals\[@type="ordinal"\]/.* ; package=core
 section=plurals ; path=//cldr/supplemental/plurals\[@type="cardinal"\]/.* ; package=core
+section=pluralRanges ; path=//cldr/supplemental/plurals/.* ; package=core
 section=postalCodeData ; path=//cldr/supplemental/postalCodeData/.* ; package=core
 section=currencyData ; path=//cldr/supplemental/currencyData/.* ; package=core
 section=territoryContainment ; path=//cldr/supplemental/territoryContainment/.* ; package=core

--- a/tools/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -13,7 +13,7 @@ import com.google.common.collect.ImmutableSet;
 class LdmlConvertRules {
 
     /** File sets that will not be processed in JSON transformation. */
-    public static final ImmutableSet<String> IGNORE_FILE_SET = ImmutableSet.of("attributeValueValidity", "coverageLevels", "grammaticalFeatures", "postalCodeData", "pluralRanges",
+    public static final ImmutableSet<String> IGNORE_FILE_SET = ImmutableSet.of("attributeValueValidity", "coverageLevels", "grammaticalFeatures", "postalCodeData",
         "subdivisions", "units");
 
     /**
@@ -57,6 +57,8 @@ class LdmlConvertRules {
         "unitPreferenceDataData:unitPreferences:category",
         "measurementData:measurementSystem:category",
         "supplemental:plurals:type",
+        "pluralRanges:pluralRange:start",
+        "pluralRanges:pluralRange:end",
         "pluralRules:pluralRule:count",
         "languageMatches:languageMatch:desired");
 
@@ -175,6 +177,9 @@ class LdmlConvertRules {
         // common/collation
         "collations:default:choice",
 
+        // common/supplemental/pluralRanges.xml
+        "pluralRanges:pluralRange:result",
+
         // identity elements
         "identity:language:type",
         "identity:script:type",
@@ -259,6 +264,7 @@ class LdmlConvertRules {
      */
     public static final SplittableAttributeSpec[] SPLITTABLE_ATTRS = {
         new SplittableAttributeSpec("calendarPreference", "territories", null),
+        new SplittableAttributeSpec("pluralRanges", "locales", null),
         new SplittableAttributeSpec("pluralRules", "locales", null),
         new SplittableAttributeSpec("minDays", "territories", "count"),
         new SplittableAttributeSpec("firstDay", "territories", "day"),
@@ -297,7 +303,7 @@ class LdmlConvertRules {
      * multiple items, and items for each locale should be grouped together.
      */
     public static final String[] ELEMENT_NEED_SORT = {
-        "zone", "timezone", "zoneItem", "typeMap", "dayPeriodRule",
+        "zone", "timezone", "zoneItem", "typeMap", "dayPeriodRule", "pluralRanges",
         "pluralRules", "personList", "calendarPreferenceData", "character-fallback", "types", "timeData", "minDays",
         "firstDay", "weekendStart", "weekendEnd", "measurementData", "measurementSystem"
     };

--- a/tools/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/java/org/unicode/cldr/util/CLDRFile.java
@@ -126,8 +126,8 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     public static final String GEN_VERSION = "38";
     public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "grammaticalFeatures",
         "languageInfo",
-        "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "plurals", "postalCodeData", "rgScope", "supplementalData",
-        "supplementalMetadata", "telephoneCodeData", "units", "windowsZones");
+        "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "pluralRanges", "plurals", "postalCodeData", "rgScope",
+        "supplementalData", "supplementalMetadata", "telephoneCodeData", "units", "windowsZones");
 
     private Set<String> extraPaths = null;
 


### PR DESCRIPTION
[CLDR-14238](https://unicode-org.atlassian.net/browse/CLDR-14238)

This adds pluralRanges to the data handled by ldml2json, which will allow it to be included in the `cldr-core` npm package.

As a sidenote, I needed to locally replace the master branch contents of `tools/java/lib/` with those of the release 37 tools.zip in order to get `ant jar` to succeed, but did not investigate the cause for this.