### PR TITLE
CLDR-14236 zh, revert to CLDR 37 value for <metazone type="Indochina">

### DIFF
--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -7563,7 +7563,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Indochina">
 				<long>
-					<standard>印度中国时间</standard>
+					<standard>印度支那时间</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Central">


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14236
- [x] Updated PR title and link in previous line to include Issue number

Per TC discussion: In zh, revert to CLDR 37 value for &lt;metazone type="Indochina"&gt;, i.e. with the region portion of the name being "印度支那" (Indochina) instead of "印度中国" (India-China)
