### PR TITLE
CLDR-14220 Azure migration: fix db backup rsync to corp

### DIFF
--- a/tools/scripts/ansible/backup-db-playbook.yml
+++ b/tools/scripts/ansible/backup-db-playbook.yml
@@ -34,7 +34,7 @@
     - name: set up /home/cldrbackup/.ssh/config
       template:
         src: templates/cldrbackup/config.j2
-        dest: /home/cldrbackup/.ssh/config.j2
+        dest: /home/cldrbackup/.ssh/config
         owner: cldrbackup
         group: cldrbackup
         mode: '0640'


### PR DESCRIPTION
-Fix the name of .ssh/config, should not have .j2 extension

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14220
- [x] Updated PR title and link in previous line to include Issue number

