### PR TITLE
CLDR-14236 zh_Hant, revert to CLDR 37 value for <metazone type="Indochina">

### DIFF
--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -9656,7 +9656,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Indochina">
 				<long>
-					<standard>印度中國時間</standard>
+					<standard>印度支那時間</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Central">


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14236
- [x] Updated PR title and link in previous line to include Issue number

Per TC discussion: Just as https://github.com/unicode-org/cldr/pull/800 did for zh, this PR reverts zh_Hant to the CLDR 37 value for `<metazone type="Indochina">`, i.e. with the region portion of the name being "印度支那" (Indochina) instead of "印度中國" (India-China)
