### PR TITLE
CLDR-14241 Forum Participation is breaking

### DIFF
--- a/tools/scripts/ansible/server-playbook.yml
+++ b/tools/scripts/ansible/server-playbook.yml
@@ -94,7 +94,10 @@
       blockinfile:
         path: /etc/nginx/sites-enabled/default
         block: |
-          # proxy /cldr-apps/ to tomcat
+          # proxy /cldr-apps/ to tomcat, with generous timeouts
+          proxy_connect_timeout 60s;
+          proxy_send_timeout 500s;
+          proxy_read_timeout 500s;
           location /cldr-apps/ {
             rewrite ^/(.+)\._[\da-f]+_\.(js|css)$ /$1.$2 break;
             allow all;


### PR DESCRIPTION
-Configure nginx with same generous timeouts as it had on the old server

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14241 
- [x] Updated PR title and link in previous line to include Issue number

