### PR TITLE
CLDR-14128 Update pom.xml for maven for ICU4J libs to Oct 21

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -15,7 +15,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<icu4j.version>68.1-SNAPSHOT-cldr-2020-09-22</icu4j.version>
+                <!--
+                    Note: see https://github.com/unicode-org/icu/packages/411079/versions for the
+                    icu4j.version tag to use
+                -->
+		<icu4j.version>68.1-cldr-2020-10-21</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>


### PR DESCRIPTION
 (ICU tag `cldr/2020-10-21`)

followon to #806

- also, update documentation in tools/pom.xml
