### PR TITLE
CLDR-14128 fix broken links in spec, pass 1

### DIFF
--- a/docs/ldml/tr35-collation.html
+++ b/docs/ldml/tr35-collation.html
@@ -1169,7 +1169,7 @@ FDD0 0065; [, B1, 09]       # [1644.0020.0004] [0000.0061.0004]     * U+A7A1 LAT
     both.</p>
     <p class="note">Note: CLDR collation tailoring data should
     follow the <a href=
-    "https://unicode.org/cldr/index/cldr-spec/collation-guidelines">CLDR
+    "http://cldr.unicode.org/index/cldr-spec/collation-guidelines">CLDR
     Collation Guidelines</a>.</p>
     <h3>3.1 <a name="Collation_Types" href="#Collation_Types" id=
     "Collation_Types">Collation Types</a></h3>

--- a/docs/ldml/tr35-dates.html
+++ b/docs/ldml/tr35-dates.html
@@ -2122,7 +2122,7 @@ the same as the first <code>allowed</code> value.
     format—then it needs to be done before the dayperiod is
     computed, so that the correct format is shown.</p>
     <p>For examples, see <a href=
-    "https://www.unicode.org/cldr/charts/latest/supplemental/day_periods.html">
+    "https://unicode-org.github.io/cldr-staging/charts/38/supplemental/day_periods.html">
     Day Periods Chart</a>.</p>
     <h2>5 <a name="Time_Zone_Names" href="#Time_Zone_Names" id=
     "Time_Zone_Names">Time Zone Names</a></h2>

--- a/docs/ldml/tr35-general.html
+++ b/docs/ldml/tr35-general.html
@@ -3339,7 +3339,7 @@ where a component wouldn’t be a unit_component (eg for “<strong>g</strong>-f
     <p>The rules for transforms are described in Section 10.3
     <a href="#Transform_Rules_Syntax">Transform Rules Syntax</a>.
     For more information on Transliteration, see <a href=
-    "https://unicode.org/cldr/index/cldr-spec/transliteration-guidelines">
+    "http://cldr.unicode.org/index/cldr-spec/transliteration-guidelines">
     Transliteration Guidelines</a>.</p>
     <h3>10.3 <a name="Transform_Rules_Syntax" href=
     "#Transform_Rules_Syntax" id="Transform_Rules_Syntax">Transform
@@ -3629,7 +3629,7 @@ where a component wouldn’t be a unit_component (eg for “<strong>g</strong>-f
     <p>There is an online demo where the rules can be tested,
     at:</p>
     <p><a target="demo" href=
-    "https://unicode.org/cldr/utility/transform.jsp">https://unicode.org/cldr/utility/transform.jsp</a></p>
+    "http://unicode.org/cldr/utility/transform.jsp">http://unicode.org/cldr/utility/transform.jsp</a></p>
     <h4>10.3.5 <a name="Rule_Syntax" href="#Rule_Syntax" id=
     "Rule_Syntax">Rule Syntax</a></h4>
     <p>The following describes the full format of the list of rules

--- a/docs/ldml/tr35-info.html
+++ b/docs/ldml/tr35-info.html
@@ -335,7 +335,7 @@
     </ul>
     <p>For a chart showing the relationships (plus the included
     timezones), see the <a href=
-    "https://www.unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html">
+    "https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_containment_un_m_49.html">
     Territory Containment Chart</a>. The XML structure has the
     following form.</p>
     <pre>&lt;territoryContainment&gt;</pre>
@@ -444,7 +444,7 @@
     language in each territory: that is, the population that is
     able to read and write each language, and is comfortable enough
     to use it with computers. For a chart of this data, see
-    <a href='https://www.unicode.org/cldr/charts/latest/supplemental/territory_language_information.html'>
+    <a href='https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_language_information.html'>
     Territory-Language Information</a>.</p>
     <p><em>Example</em></p>
     <pre style='font-size: 70%'>
@@ -953,7 +953,7 @@ LY MA OM PS QA SA SD SY TN YE"/&gt;
         information about the language and writing system that is
         required before other information can be added using the
         CLDR survey tool. See <a href=
-        "https://unicode.org/cldr/index/cldr-spec/minimaldata">https://unicode.org/cldr/index/cldr-spec/minimaldata</a></td>
+        "http://cldr.unicode.org/index/cldr-spec/minimaldata">http://cldr.unicode.org/index/cldr-spec/minimaldata</a></td>
       </tr>
       <tr>
         <td nowrap>
@@ -1085,7 +1085,7 @@ LY MA OM PS QA SA SD SY TN YE"/&gt;
     <pre>
     &lt;approvalRequirements&gt;<br>   &lt;!--  "high bar" items --&gt;
                 &lt;approvalRequirement votes="20" locales="*" paths="//ldml/numbers/symbols[^/]++/(decimal|group)"/&gt;
-                &lt;!--  established locales - https://unicode.org/cldr/index/process#TOC-Draft-Status-of-Optimal-Field-Value --&gt;
+                &lt;!--  established locales - http://cldr.unicode.org/index/process#TOC-Draft-Status-of-Optimal-Field-Value --&gt;
                 &lt;approvalRequirement votes="8" locales="ar ca cs da de el es fi fr he hi hr hu it ja ko nb nl pl pt pt_PT ro ru sk sl sr sv th tr uk vi zh zh_Hant" paths=""/&gt;
                 &lt;!--  all other items --&gt;
                 &lt;approvalRequirement votes="4" locales="*" paths=""/&gt;<br>&lt;/approvalRequirements&gt;              </pre>
@@ -1095,7 +1095,7 @@ LY MA OM PS QA SA SD SY TN YE"/&gt;
     cs, etc.) requires 8 votes, and that all other locales require
     4 votes only.</p>
     <p>For more information on the CLDR Voting process, See
-    <a href="https://unicode.org/cldr/index/process">https://unicode.org/cldr/index/process</a></p>
+    <a href="http://cldr.unicode.org/index/process">http://cldr.unicode.org/index/process</a></p>
     <h3>8.1 <a name="Coverage_Level_Definitions" href=
     "#Coverage_Level_Definitions" id=
     "Coverage_Level_Definitions">Definitions</a></h3>
@@ -1244,7 +1244,7 @@ LY MA OM PS QA SA SD SY TN YE"/&gt;
         <ul>
           <li>however, in that case the locale must be added to the
           validSubLocale list in <a href=
-          "https://unicode.org/cldr/data/common/collation/root.xml">collation/root.xml</a>.</li>
+          "https://github.com/unicode-org/cldr/blob/master/common/collation/root.xml">collation/root.xml</a>.</li>
         </ul>
       </li>
       <li>for currency symbol, language, territory, script names,
@@ -1492,7 +1492,7 @@ LY MA OM PS QA SA SD SY TN YE"/&gt;
     &gt;<br></p>
     <p>The &lt;cldrVersion&gt; attribute defines the CLDR version
     for this data, as published on <a href=
-    "https://unicode.org/cldr/index/downloads">CLDR
+    "http://cldr.unicode.org/index/downloads">CLDR
     Releases/Downloads</a></p>
     <p>The &lt;unicodeVersion&gt; attribute defines the version of
     the Unicode standard that is used to interpret data.
@@ -2106,7 +2106,7 @@ The intended usage is to take the measure to be formatted, and the desired categ
 
  <li>If there is an exact match for the usage, but not for the region, try region=”001”.</li></ul>
 
-  <li>The specification allows for <a href="https://www.unicode.org/cldr/charts/34/supplemental/territory_containment_un_m_49.html">containment regions</a> , <a href="https://www.unicode.org/cldr/charts/34/supplemental/territory_subdivisions.html">region subdivisions</a>.
+  <li>The specification allows for <a href="https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_containment_un_m_49.html">containment regions</a> , <a href="https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_subdivisions.html">region subdivisions</a>.
   <li>While in version 37 only 001 is used, in the future the data may contain others.
   <li>The fallback is: subdivision2 ⇒ subdivision1 ⇒ region/country ⇒ subcontinent ⇒ continent ⇒ world
   <li>Example: 

--- a/docs/ldml/tr35-numbers.html
+++ b/docs/ldml/tr35-numbers.html
@@ -2353,7 +2353,7 @@ System Data</a>.</em> ) &gt;<br>
       <strong>them</strong>?</li>
     </ol>
     <p>For more information, see <a href=
-    "https://unicode.org/cldr/index/cldr-spec/plural-rules#TOC-Determining-Plural-Categories">
+    "http://cldr.unicode.org/index/cldr-spec/plural-rules#TOC-Determining-Plural-Categories">
     Determining-Plural-Categories</a>.</p>
     <p>English does not have a separate plural category for “zero”,
     because it does not require a different message for “0”. For
@@ -2580,7 +2580,7 @@ digit           = <span class="changed">[0-9]</span>
                 </pre>
     <ul>
       <li>Whitespace (defined as Unicode <a href=
-      "https://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7BPattern_White_Space%7D">
+      "http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7BPattern_White_Space%7D">
       Pattern_White_Space</a>) can occur between or around any of
       the above tokens, with the exception of the tokens in value,
       digit, and decimalValue.</li>

--- a/docs/ldml/tr35.html
+++ b/docs/ldml/tr35.html
@@ -125,7 +125,7 @@
       <tr>
         <td>Corrigenda</td>
         <td><a href=
-        "https://unicode.org/cldr/corrigenda.html">https://unicode.org/cldr/corrigenda.html</a></td>
+        "http://unicode.org/cldr/corrigenda.html">http://unicode.org/cldr/corrigenda.html</a></td>
       </tr>
       <tr>
         <td>Latest Proposed Update</td>
@@ -139,8 +139,8 @@
       </tr>
       <tr>
         <td>DTDs</td>
-        <td class="changed"><a href="https://unicode.org/cldr/dtd/38/">
-		https://unicode.org/cldr/dtd/38/</a></td>
+        <td class="changed"><a href="http://unicode.org/cldr/dtd/38/"> <!-- this link may not work until release -->
+		http://unicode.org/cldr/dtd/38/</a></td>
       </tr>
       <tr>
         <td>Revision</td>
@@ -180,7 +180,7 @@
     </blockquote>
     <p><i>Please submit corrigenda and other comments with the CLDR
     bug reporting form [<a href=
-    "https://unicode.org/cldr/index/bug-reports">Bugs</a>]. Related
+    "http://cldr.unicode.org/index/bug-reports">Bugs</a>]. Related
     information that is useful in understanding this document is
     found in the <a href="#References">References</a>. For the
     latest version of the Unicode Standard see [<a href=
@@ -813,7 +813,7 @@
         <td><code><a href=
         '#unicode_language_subtag_validity'>validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/validity/language.xml'>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/language.xml'>
         latest-data</a></code></td>
       </tr>
       <tr>
@@ -824,7 +824,7 @@
         <td><code><a href=
         '#unicode_script_subtag_validity'>validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/validity/script.xml'>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/script.xml'>
         latest-data</a></code></td>
       </tr>
       <tr>
@@ -835,7 +835,7 @@
         <td><code><a href=
         '#unicode_language_subtag_validity'>validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/validity/region.xml'>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/region.xml'>
         latest-data</a></code></td>
       </tr>
       <tr>
@@ -847,7 +847,7 @@
         <td><code><a href=
         '#unicode_language_subtag_validity'>validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/validity/variant.xml'>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/variant.xml'>
         latest-data</a></code></td>
       </tr>
       <tr>
@@ -981,7 +981,7 @@
           (Note that this is narrower than in [<a href="https://www.ietf.org/rfc/rfc6067.txt" title="https://www.ietf.org/rfc/rfc6067.txt">RFC6067</a>], so that it is disjoint with tkey.)</td>
         <td><code><a href="#Key_Type_Definitions">validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/bcp47'>latest-data</a></code></td>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47'>latest-data</a></code></td>
       </tr>
       <tr>
         <td><code>type</code><br>
@@ -990,7 +990,7 @@
         &nbsp; (sep alphanum{3,8})* ;</code></td>
         <td><code><a href="#Key_Type_Definitions">validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/bcp47'>latest-data</a></code></td>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47'>latest-data</a></code></td>
       </tr>
       <tr>
         <td><code>attribute</code></td>
@@ -1010,7 +1010,7 @@
         <td><code><a href=
         '#unicode_subdivision_subtag_validity'>validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/validity/subdivision.xml'>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/subdivision.xml'>
         latest-data</a></code></td>
       </tr>
       <tr>
@@ -1025,7 +1025,7 @@
         &nbsp; (sep alphanum{3,8})* ;</code></td>
         <td><code><a href='#Validity_Data'>validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/validity/unit.xml'>latest-data</a></code></td>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/unit.xml'>latest-data</a></code></td>
       </tr>
       <tr>
         <td><code>tlang</code></td>
@@ -1039,7 +1039,7 @@
         <td><code>= tkey tvalue;</code></td>
         <td><code><a href="#BCP47_T_Extension">validity</a><br>
         <a href=
-        'https://unicode.org/cldr/latest/common/bcp47'>latest-data</a></code></td>
+        'https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47'>latest-data</a></code></td>
       </tr>
       <tr>
         <td><code>tkey</code></td>
@@ -1583,7 +1583,7 @@
           codes, including mapping overlong codes like "eng-840" or
           "eng-USA" to the correct code "en-US"; see the
           <strong><a href=
-          "https://www.unicode.org/cldr/charts/latest/supplemental/aliases.html">
+          "https://unicode-org.github.io/cldr-staging/charts/38/supplemental/aliases.html">
           Aliases</a></strong> Chart.</p>
           <p>The following are special language subtags:</p>
           <table class="simple" border="1" cellspacing="0"
@@ -1773,7 +1773,7 @@
               <td>Outlying Oceania</td>
               <td>countries in Oceania [009] that do not have a
               <a href=
-              "https://www.unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html">
+              "https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_containment_un_m_49.html">
               subcontinent</a>.</td>
               <td>private use</td>
             </tr>
@@ -2102,7 +2102,7 @@ zh-Hant-HK</pre>
     "#Unicode_locale_identifier">Section 3.2 Unicode locale
 		identifier</a>. The canonical syntax is defined as in <a href="#Canonical_Unicode_Locale_Identifiers">3.2.1 Canonical Unicode Locale Identifiers</a>.    </p>
     <p><em>See also <a href=
-    "https://unicode.org/cldr/index/bcp47-extension">Unicode
+    "http://cldr.unicode.org/index/bcp47-extension">Unicode
     Extensions for BCP 47</a> on the CLDR site.</em></p>
     <h4><a href="#Key_And_Type_Definitions_" name=
     "Key_And_Type_Definitions_" id=
@@ -4665,7 +4665,7 @@ root</pre>
     resolved [<a href="#XPath">XPath</a>] leading from the root to
     an element, with attributes on each element in alphabetical
     order. So in, say, <a href=
-    "https://unicode.org/cldr/data/common/main/el.xml">https://unicode.org/cldr/data/common/main/el.xml</a>
+    "https://github.com/unicode-org/cldr/blob/master/common/main/el.xml">https://github.com/unicode-org/cldr/blob/master/common/main/el.xml</a>
     we may have:</p>
     <pre>&lt;ldml&gt;
   &lt;identity&gt;
@@ -4797,7 +4797,7 @@ root</pre>
     <p>The attribute <i>draft="x"</i> in LDML means that the data
     has not been approved by the subcommittee. (For more
     information, see <a href=
-    "https://unicode.org/cldr/index/process">Process</a>). However,
+    "http://cldr.unicode.org/index/process">Process</a>). However,
     some data that is not explicitly marked as <i>draft</i> may be
     implicitly <i>draft</i>, either because it inherits it from a
     parent, or from an enclosing element.</p>
@@ -5869,7 +5869,7 @@ root</pre>
     listed in serialElements in the supplemental metadata. See also
     <i><a href="#Inheritance_and_Validity">Section 4.2 Inheritance
     and Validity</a></i>. For more technical details, see <a href=
-    "https://unicode.org/cldr/development/updating-dtds">Updating-DTDs</a>.</p>
+    "http://cldr.unicode.org/development/updating-dtds">Updating-DTDs</a>.</p>
     <p>Note that the data in examples given below is purely
     illustrative, and does not match any particular language. For a
     more detailed example of this format, see [<a href=
@@ -6241,7 +6241,7 @@ root</pre>
     <p>For more information on precisely how these values are
     computed for any given release, see 
 	<a href=
-    "https://unicode.org/cldr/index/process#TOC-Data--Submission-and-Vetting">
+    "http://cldr.unicode.org/index/process#TOC-Data--Submission-and-Vetting">
     Data Submission and Vetting Process</a> on the CLDR
     website.</p>
     <p>The draft attribute should only occur on "leaf" elements,
@@ -6416,7 +6416,7 @@ root</pre>
     <em>Wildcards in Property Values</em>. That feature can be
     supported in clients such as ICU by implementing a “hook” as is
     done in the <a href=
-    "https://unicode.org/cldr/utility/list-unicodeset.jsp?a=/p{name=/APPLE/}">
+    "http://unicode.org/cldr/utility/list-unicodeset.jsp?a=/p{name=/APPLE/}">
     online UnicodeSet utilities</a>.</p>
     <p>A UnicodeSet may be cited in specifications outside of the
     domain of LDML. In such a case, the specification may specify a
@@ -8934,7 +8934,7 @@ decimal?, group?, special*)) &gt;</pre>
         <td class="noborder" width="730">CLDR Bug Reporting
         form<br>
         <a href=
-        "https://unicode.org/cldr/index/bug-reports">https://unicode.org/cldr/index/bug-reports</a></td>
+        "http://cldr.unicode.org/index/bug-reports">http://cldr.unicode.org/index/bug-reports</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="Charts" href=
@@ -9118,7 +9118,7 @@ decimal?, group?, special*)) &gt;</pre>
         "#ISO15924" id="ISO15924">ISO15924</a>]</td>
         <td class="noborder" width="730">ISO Script Codes<br>
         <a href=
-        "https://www.unicode.org/iso15924/standard/index.html">https://www.unicode.org/iso15924/standard/index.html</a><br>
+        "https://www.unicode.org/iso15924/index.html">https://www.unicode.org/iso15924/index.html</a><br>
 
         Actual List<br>
         <a href=
@@ -9200,7 +9200,7 @@ decimal?, group?, special*)) &gt;</pre>
         <td class="noborder" width="730">Comparisons between locale
         data from different sources<br>
         <a href=
-        "https://unicode.org/cldr/data/diff/">https://unicode.org/cldr/data/diff/</a></td>
+        "http://unicode.org/cldr/data/diff/">http://unicode.org/cldr/data/diff/</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="CurrencyInfo"
@@ -9216,7 +9216,7 @@ decimal?, group?, special*)) &gt;</pre>
         <td class="noborder" width="730">CLDR Translation
         Guidelines<br>
         <a href=
-        "https://unicode.org/cldr/translation">https://unicode.org/cldr/translation</a></td>
+        "http://cldr.unicode.org/translation">http://cldr.unicode.org/translation</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="LDML" href=
@@ -9232,8 +9232,8 @@ decimal?, group?, special*)) &gt;</pre>
         "ICUCollation">ICUCollation</a>]</td>
         <td class="noborder" width="730">ICU rule syntax<br>
         <a href=
-        "http://userguide.icu-project.org/Collate_Customization">
-        http://userguide.icu-project.org/Collate_Customization</a></td>
+        "https://unicode-org.github.io/icu/userguide/collation/customization/">
+        https://unicode-org.github.io/icu/userguide/collation/customization/</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="ICUTransforms"
@@ -9241,8 +9241,8 @@ decimal?, group?, special*)) &gt;</pre>
         "ICUTransforms">ICUTransforms</a>]</td>
         <td class="noborder" width="730">Transforms<br>
         <a href=
-        "http://userguide.icu-project.org/Transformations">
-        http://userguide.icu-project.org/Transformations</a><br>
+        "https://unicode-org.github.io/icu/userguide/transforms/">
+        https://unicode-org.github.io/icu/userguide/transforms/</a><br>
 
         Transforms Demo<br>
         <a href=
@@ -9254,11 +9254,11 @@ decimal?, group?, special*)) &gt;</pre>
         "ICUUnicodeSet">ICUUnicodeSet</a>]</td>
         <td class="noborder" width="730">ICU UnicodeSet<br>
         <a href=
-        "http://userguide.icu-project.org/strings/unicodeset">http://userguide.icu-project.org/strings/unicodeset<br>
+        "https://unicode-org.github.io/icu/userguide/strings/unicodeset.html">https://unicode-org.github.io/icu/userguide/strings/unicodeset.html<br>
         </a> API<br>
         <a href=
-        "http://www.icu-project.org/apiref/icu4j/com/ibm/icu/text/UnicodeSet.html">
-        http://www.icu-project.org/apiref/icu4j/com/ibm/icu/text/UnicodeSet.html</a></td>
+        "https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/text/UnicodeSet.html">
+        https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/text/UnicodeSet.html</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="ITUE164" href=
@@ -9302,8 +9302,8 @@ decimal?, group?, special*)) &gt;</pre>
         <td class="noborder" width="730">Rule-Based Number
         Format<br>
         <a href=
-        "http://www.icu-project.org/apiref/icu4c/classRuleBasedNumberFormat.html">
-        http://www.icu-project.org/apiref/icu4c/classRuleBasedNumberFormat.html#_details</a></td>
+        "https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1RuleBasedNumberFormat.html">
+        https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1RuleBasedNumberFormat.html</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="RBBI" href=
@@ -9311,8 +9311,8 @@ decimal?, group?, special*)) &gt;</pre>
         <td class="noborder" width="730">Rule-Based Break
         Iterator<br>
         <a href=
-        "http://userguide.icu-project.org/boundaryanalysis">
-        http://userguide.icu-project.org/boundaryanalysis</a></td>
+        "https://unicode-org.github.io/icu/userguide/boundaryanalysis">
+        https://unicode-org.github.io/icu/userguide/boundaryanalysis</a></td>
       </tr>
       <tr>
         <td class="noborder" width="148">[<a name="UCAChart" href=


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14128
- [x] Updated PR title and link in previous line to include Issue number

Made a first pass at fixing broken links in the spec, following the general approach of Mark's e-mail "Re: TR35 - critical header link issues / tr35.html" of 2020-Oct-21 6:06 PM PDT, with changes and additions as follows:

1. So at a minimum we have to change https://unicode.org/cldr/X back to http://unicode.org/cldr/X
- except for https://unicode.org/cldr/dtd/ which needs to stay that way
- also have to change http[s]://unicode.org/cldr/index/ -> http://cldr.unicode.org/index/

2. The second issue is that if we have links to XML files, those need to go to github. Handle that as follows:
- http://unicode.org/cldr/data/ -> https://github.com/unicode-org/cldr/blob/master/
- http://unicode.org/cldr/latest/ -> https://github.com/unicode-org/cldr/blob/maint/maint-38/ (which is permanently valid for this version of the spec)

3. And where we have links to charts, those need to go to URLs like ... (these were all for supplemental, some for latest and some for v34 which was the latest version at the time those were added, so:
- https://www.unicode.org/cldr/charts/latest/ -> https://unicode-org.github.io/cldr-staging/charts/38/
- https://www.unicode.org/cldr/charts/24/ -> https://unicode-org.github.io/cldr-staging/charts/38/

4. Misc updates (not in Mark's list), in the References section
- Update links to the ICU User Guide to use the new markdown version in github
- References to links on the CLDR home page side par need to use http://cldr.unicode.org/
- Misc other updates

5. Open issues
- One still-nonworking link in the references section is for http://unicode.org/cldr/data/diff/ (“Comparisons between locale data from different sources”), not sure what that should be updated to.


