### PR TITLE
CLDR-14212 Update GitHub actions to @vx vs @vx.y.z

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: clone CLDR
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.end-ref }}
           lfs: false # not needed here
           path: cldr
           fetch-depth: 0 # expensive, but needed for checker
       - name: clone ICU for tools
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v2
         with:
           repository: ${{ github.event.inputs.tool-repository }}
           ref: ${{ github.event.inputs.tool-ref }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,15 +12,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v2
         with:
           lfs: true
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1.4.2
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - name: Cache local Maven repository
-        uses: actions/cache@v2.1.1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('tools/**/pom.xml') }}


### PR DESCRIPTION
CLDR-14212

- Background: https://github.community/t/version-numbering-for-actions/16307/4
- Specific issue: https://github.com/actions/setup-java/pull/104#issuecomment-715489633
actions/setup-java@v1.4.2 was creating warning messages about set-env,
needed to switch to v1.4.3.  Instead, all actions now use @v1 or @v2, which points to a
branch.
