### PR TITLE
CLDR-13730 json: support unit preferences

### DIFF
--- a/tools/java/org/unicode/cldr/json/CldrItem.java
+++ b/tools/java/org/unicode/cldr/json/CldrItem.java
@@ -89,6 +89,15 @@ public class CldrItem implements Comparable<CldrItem> {
      */
     private String untransformedPath;
 
+    protected String getUntransformedPath() {
+        return untransformedPath;
+    }
+
+    @Override
+    public String toString() {
+        return "[CldrItem " + getUntransformedPath()+"]";
+    }
+
     /**
      * The value of this CLDR item.
      */
@@ -222,7 +231,7 @@ public class CldrItem implements Comparable<CldrItem> {
      * <calendarPreference territories="CN" ordering="gregorian chinese"/>
      * <calendarPreference territories="CX" ordering="gregorian chinese"/>
      *
-     * @return Array of CldrItem if it can be split, otherwise null.
+     * @return Array of CldrItem if it can be split, otherwise null if nothing to split.
      */
     public CldrItem[] split() {
         XPathParts xpp = XPathParts.getFrozenInstance(path);
@@ -237,6 +246,8 @@ public class CldrItem implements Comparable<CldrItem> {
                 String[] words = null;
                 words = wordString.trim().split("\\s+");
                 for (String word : words) {
+                    // TODO: Ideally, there would be a separate post-split path transform.
+
                     XPathParts newxpp = xpp.cloneAsThawed();
                     XPathParts newfullxpp = fullxpp.cloneAsThawed();
                     XPathParts untransformednewxpp = untransformedxpp.cloneAsThawed();
@@ -265,7 +276,7 @@ public class CldrItem implements Comparable<CldrItem> {
                 return list.toArray(new CldrItem[list.size()]);
             }
         }
-        return null;
+        return null; // nothing to split
     }
 
     /**

--- a/tools/java/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/java/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -18,6 +18,9 @@ section=languageMatching ; path=//cldr/supplemental/languageMatching/.* ; packag
 section=territoryInfo ; path=//cldr/supplemental/territoryInfo/.* ; package=core
 section=calendarData ; path=//cldr/supplemental/calendarData/.* ; package=core
 section=calendarPreferenceData ; path=//cldr/supplemental/calendarPreferenceData/.* ; package=core
+section=unitPreferenceData ; path=//cldr/supplemental/unitPreferenceData/.* ; package=core
+# TODO: Blocked by [CLDR-14272] - need more documentation
+#section=grammaticalFeatures ; path=//cldr/supplemental/grammaticalData/.* ; package=core
 section=weekData ; path=//cldr/supplemental/weekData/.* ; package=core
 section=timeData ; path=//cldr/supplemental/timeData/.* ; package=core
 section=measurementData ; path=//cldr/supplemental/measurementData/.* ; package=core

--- a/tools/java/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/java/org/unicode/cldr/json/pathTransforms.txt
@@ -1,0 +1,143 @@
+# Path Transformations
+
+# see LdmlConvertRule.java
+
+#     * Some special transformation, like add an additional layer, can be easily
+#     * done by transforming the path. Following rules covers these kind of
+#     * transformation.
+#     * Note: It is important to keep the order for these rules. Whenever a
+#     * rule matches, further rules won't be applied.
+#
+# Syntax:
+#
+# # line comment
+# < match pattern
+# > replacement pattern
+#
+
+# separate them to two layers.
+< (.*ldml/exemplarCharacters)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# Add "standard" as type attribute to exemplarCharacter element if there is none
+< (.*ldml/exemplarCharacters)(.*)$
+> $1/standard$2
+
+## (Note: CLDR version is added in code)
+
+# Transform underscore to hyphen-minus in language keys
+< (.*/language\[@type="[a-z]{2,3})_([^"]*"\](\[@alt="short"])?)
+> $1-$2
+
+# Separate "ellipsis" from its type as another layer.
+< (.*/ellipsis)\[@type="([^"]*)"\](.*)$
+> $1/$2$3
+
+# Remove unnecessary dateFormat/pattern
+< (.*/calendars)/calendar\[@type="([^"]*)"\](.*)Length\[@type="([^"]*)"\]/(date|time|dateTime)Format\[@type="([^"]*)"\]/pattern\[@type="([^"]*)"\](.*)
+> $1/$2/$5Formats/$4$8
+
+# Separate calendar type
+< (.*/calendars)/calendar\[@type="([^"]*)"\](.*)$
+> $1/$2$3
+
+# Separate "metazone" from its type as another layer
+< (.*/metazone)\[@type="([^"]*)"\]/(.*)$
+> $1/$2/$3
+
+# Split out types into its various fields
+< (.*)/types/type\[@key="([^"]*)"\]\[@type="([^"]*)"\](.*)$
+> $1/types/$2/$3$4
+
+# Typographic
+< (.*)/(typographicNames)/(axisName|featureName)\[@type="([^"]*)"\](.*)$
+> $1/$2/$3s/$4$5
+
+# Typographic
+< (.*)/(typographicNames)/(styleName)(.*)$
+> $1/$2/$3s/$3$4
+
+# put CharacterLabelPatterns under CharacterLabelPatterns
+< (.*)/(characterLabels)/(characterLabelPattern)(.*)$
+> $1/characterLabelPatterns/$3$4
+
+# add type=standard
+< (.*/numbers/(decimal|scientific|percent|currency)Formats\[@numberSystem="([^"]*)"\])/(decimal|scientific|percent|currency)FormatLength/(decimal|scientific|percent|currency)Format\[@type="standard"]/pattern.*$
+> $1/standard
+
+# 
+< (.*/numbers/currencyFormats\[@numberSystem="([^"]*)"\])/currencyFormatLength/currencyFormat\[@type="accounting"]/pattern.*$
+> $1/accounting
+
+# Add "type" attribute with value "standard" if there is no "type" in "decimalFormatLength".
+< (.*/numbers/(decimal|scientific|percent)Formats\[@numberSystem="([^"]*)"\]/(decimal|scientific|percent)FormatLength)/(.*)$
+> $1[@type="standard"]/$5
+
+# 
+< (.*/listPattern)/(.*)$
+> $1[@type="standard"]/$2
+
+# 
+< (.*/languagePopulation)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/languageAlias)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/scriptAlias)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/territoryAlias)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/subdivisionAlias)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/variantAlias)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/zoneAlias)\[@type="([^"]*)"\](.*)
+> $1/$2$3
+
+# 
+< (.*/alias)(.*)
+> $1/alias$2
+
+# 
+< (.*currencyData/region)(.*)
+> $1/region$2
+
+# Skip exemplar city in /etc/GMT or UTC timezones, since they don't have them
+< (.*(GMT|UTC).*/exemplarCity)(.*)
+> 
+
+# 
+< (.*/transforms/transform[^/]*)/(.*)
+> $1/tRules/$2
+
+# 
+< (.*)\[@territories="([^"]*)"\](.*)\[@alt="variant"\](.*)
+> $1\[@territories="$2-alt-variant"\]
+
+# 
+< (.*)/weekData/(.*)\[@alt="variant"\](.*)
+> $1/weekData/$2$3
+
+# unit preferences
+#< (.*)/unitPreferenceData/unitPreferences\[@category="([^"]*)"\]\[@usage="([^"]*)"\]([^/]*)/unitPreference\[@_q="[0-9]*"\]\[@regions="([^"]*)"\](.*)
+#> $1/unitPreferenceData/unitPreferences/$2/$3$4/$5/unitPreference$6
+
+# Annotations: If there is a type, move that into a sibling value
+< (.*)/(annotations)/(annotation)\[@cp="([^"]*)"\]\[@type="([^"]*)"\](.*)$
+> $1/$2/$4/$5$6
+
+# Annotations: If there is a type, move that into a sibling value
+< (.*)/(annotations)/(annotation)\[@cp="([^"]*)"\](.*)$
+> $1/$2/$4/default$5
+

--- a/tools/java/org/unicode/cldr/util/FileProcessor.java
+++ b/tools/java/org/unicode/cldr/util/FileProcessor.java
@@ -39,7 +39,7 @@ public class FileProcessor {
 
     public FileProcessor process(Class<?> classLocation, String fileName) {
         try {
-            System.err.println("# Reading config file " + fileName);
+            System.err.println("# Reading config file " + classLocation.getPackage().getName() + "/"+ fileName);
             BufferedReader in = FileReaders.openFile(classLocation, fileName);
             return process(in, fileName);
         } catch (Exception e) {


### PR DESCRIPTION
CLDR-13730

- Also, move path transforms out to a separate file
- Other JSON code improvements

Example files:

### `unitPreferenceData.json`

```json
{
  "supplemental": {
    "version": {
      "_unicodeVersion": "13.0.0",
      "_cldrVersion": "38"
    },
    "unitPreferenceData": {
      "area": {
        "default": {
          "001": [
            {
              "unit": "square-kilometer"
            },
            {
              "unit": "hectare"
            },
            {
              "unit": "square-meter"
            },
            {
              "unit": "square-centimeter"
            }
          ],
…
        "person-height": {
          "001": [
            {
              "unit": "centimeter"
            }
          ],
…
          "CA": [
            {
              "unit": "foot-and-inch",
              "geq": 3.0
            },
            {
              "unit": "inch"
            }
          ],
}
```

- [ ] OK, grammatical features are still missing, will recheck