### PR TITLE
CLDR-14276 Updating ku_arab (ckb) to match official character

### DIFF
--- a/exemplars/main/ku_Arab.xml
+++ b/exemplars/main/ku_Arab.xml
@@ -18,7 +18,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</orientation>
 	</layout>
 	<characters>
-		<exemplarCharacters draft="unconfirmed">[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ك گ ل ڵ م ن ه ە و ۆ ی ێ]</exemplarCharacters>
+		<exemplarCharacters draft="unconfirmed">[ئ ا ب پ ت ج چ ح خ د ر ڕ ز ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ه ە و ۆ ی ێ]</exemplarCharacters>       
 		<exemplarCharacters type="auxiliary" draft="unconfirmed">[ـ\u200C\u200D\u200E\u200F 2 3 ص]</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="unconfirmed">[\- ‐ ‑ , ، ؛ \: ! ؟ . … ‘ ’ ‹ › &quot; “ ” « » ( ) \[ \] \{ \} ﴿ * / • −]</exemplarCharacters>
 	</characters>


### PR DESCRIPTION
CLDR-14276
The one that provided is wrong and not used yet for ku_arab (ckb) central kurdish language, The problem with ە and ك is resolved with government statments which i will mention below.
This code (U+0647) used for ھ And (U+06D5) used for ە, And changing ك to ک which is reperesents by (U+06A9).
http://unicode.ekrg.org/index.html

Best Regards.




- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14276


