### PR TITLE
CLDR-14212 add generated .gitignore from eclipse

### DIFF
--- a/tools/cldr-apps/.gitignore
+++ b/tools/cldr-apps/.gitignore
@@ -1,0 +1,2 @@
+/.apt_generated/
+/.apt_generated_tests/


### PR DESCRIPTION
CLDR-14212

hopefully we won't have too many of these.