### PR TITLE
CLDR-10883 improving JSON RBNF

### DIFF
--- a/tools/java/src/main/java/org/unicode/cldr/json/CldrNode.java
+++ b/tools/java/src/main/java/org/unicode/cldr/json/CldrNode.java
@@ -166,6 +166,20 @@ public class CldrNode {
                 attributesAsValues.put(key, nondistinguishingAttributes.get(key));
             }
         }
+
+        // ADJUST RADIX BASED ON ICU RULE
+        final String radixValue = attributesAsValues.get("radix");
+        if(radixValue != null) {
+            attributesAsValues.remove("radix");
+            for (Map.Entry<String, String> attributes : attributesAsValues.entrySet()) {
+                String oldKey = attributes.getKey();
+                String newValue = attributes.getValue();
+                String newKey = oldKey + "/" + radixValue;
+                attributesAsValues.remove(oldKey);
+                attributesAsValues.put(newKey, newValue);
+
+            }
+        }
         return attributesAsValues;
     }
 


### PR DESCRIPTION
- simplify so there are fewer rbnf special cases
- change to simpler tuple form:
 "%spellout-cardinal": [ ["-x","მინუს →→;"],["x.x","←← მძიმე →→;"],
 to preserve ordering

Might need resolution with #830 