### PR TITLE
CLDR-14285 cause TestFmwk.sourceLocation() to handle lambdas

### DIFF
--- a/tools/java/src/main/java/com/ibm/icu/dev/test/TestFmwk.java
+++ b/tools/java/src/main/java/com/ibm/icu/dev/test/TestFmwk.java
@@ -116,7 +116,7 @@ public class TestFmwk extends AbstractTestLog {
                 errln(ex.toString() + '\n' + msg);
             }
         } else {
-            errln(ex.toString() + '\n' + msg);
+            errln(sourceLocation(ex) + ex.toString() + '\n' + msg);
         }
     }
     // use this instead of new random so we get a consistent seed
@@ -1989,20 +1989,34 @@ public class TestFmwk extends AbstractTestLog {
         return obj.getClass().getName() + "<" + obj + ">";
     }
 
-    // Return the source code location of the caller located callDepth frames up the stack.
+    // Return the source code location of the calling test
+    // or "" if not found
     public static String sourceLocation() {
+        return sourceLocation(new Throwable());
+    }
+
+    // Return the source code location of the specified throwable's calling test
+    // returns "" if not found
+    public static String sourceLocation(Throwable forThrowable) {
         // Walk up the stack to the first call site outside this file
         for (StackTraceElement st : new Throwable().getStackTrace()) {
             String source = st.getFileName();
-            if (source != null && !source.equals("TestFmwk.java") && !source.equals("AbstractTestLog.java")) {
+            if(source.equals("TestShim.java")) {
+                return ""; // hit the end of helpful stack traces
+            }
+            if (source != null && !source.equals("TestFmwk.java") 
+                && !source.equals("AbstractTestLog.java")) {
                 String methodName = st.getMethodName();
+                if(methodName != null && methodName.startsWith("lambda$")) { // unpack inner lambda
+                    methodName = methodName.substring("lambda$".length()); // lambda$TestValid$0 -> TestValid$0
+                }
                 if (methodName != null &&
                        (methodName.startsWith("Test") || methodName.startsWith("test") || methodName.equals("main"))) {
-                    return "(" + source + ":" + st.getLineNumber() + ") ";
+                   return "(" + source + ":" + st.getLineNumber() + ") ";
                 }
             }
         }
-        throw new InternalError();
+        return ""; // not found
     }
 
 

--- a/tools/java/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/java/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -163,16 +163,19 @@ public class TestAttributeValues extends TestFmwk {
 
         int _elementCount = 0;
         int _attributeCount = 0;
+        String lastElement = null;
 
         try {
+            XMLStreamReader r = null;
             try (InputStream fis = new FileInputStream(fullFile)) {
-                XMLStreamReader r = f.createXMLStreamReader(fullFile, fis);
+                r = f.createXMLStreamReader(fullFile, fis);
                 String element = null;
                 while(r.hasNext()) {
                     try {
                         switch(r.next()){
                         case XMLStreamConstants.START_ELEMENT:
                             element = r.getLocalName();
+                            lastElement = element;
                             ++_elementCount;
                             int attributeSize = r.getAttributeCount();
                             for (int i = 0; i < attributeSize; ++i) {
@@ -197,8 +200,12 @@ public class TestAttributeValues extends TestFmwk {
                 } else {
                     throw (IllegalArgumentException) new IllegalArgumentException("Can't read " + fullFile).initCause(e);
                 }
+            } catch (Throwable e) {
+                if(r == null) throw e;
+                throw (IllegalArgumentException) new IllegalArgumentException(" at " + r.getLocation()).initCause(e);
             }
         } catch (Exception e) {
+            System.err.println("Exception occured in " + fullFile + " after parsing " + lastElement);
             throw new ICUException(fullFile, e);
         }
         pathChecker.elementCount.addAndGet(_elementCount);


### PR DESCRIPTION
CLDR-14285

The search code for the relevant test source file was wrong.
This fixes it to skip 'lambda$' if present, otherwise the
error source is obscured.