### PR TITLE
CLDR-14212 rename java to cldr-code: fix cldr-apps

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -47,7 +47,7 @@
 		<!-- cldr -->
 		<dependency>
 			<groupId>org.unicode.cldr</groupId>
-			<artifactId>cldr</artifactId>
+			<artifactId>cldr-code</artifactId>
 		</dependency>
 
 		<!-- API -->

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -36,7 +36,7 @@
 			<!-- CLDR -->
 			<dependency>
 				<groupId>org.unicode.cldr</groupId>
-				<artifactId>cldr</artifactId>
+				<artifactId>cldr-code</artifactId>
 				<version>${project.version}</version> <!-- this seems to work -->
 			</dependency>
 


### PR DESCRIPTION
CLDR-14212
- cldr-apps was still depending on the old artifact!
- fixup to d6ead5d07db76e934d4cfe3220f28ac1114f3032

I was seeing strange errors, and realized that cldr-apps did not get updated to use `cldr-code` and not `cldr` as the artifact.
