### PR TITLE
CLDR-14301 Add Windows mapping for Yukon Standard Time zone

### DIFF
--- a/common/supplemental/windowsZones.xml
+++ b/common/supplemental/windowsZones.xml
@@ -9,7 +9,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 <supplementalData>
 	<version number="$Revision$"/>
 	<windowsZones>
-		<mapTimezones otherVersion="7e11500" typeVersion="2020a">
+		<mapTimezones otherVersion="7e11800" typeVersion="2020d">
 
 			<!-- (UTC-12:00) International Date Line West -->
 			<mapZone other="Dateline Standard Time" territory="001" type="Etc/GMT+12"/>
@@ -64,7 +64,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 			<!-- (UTC-07:00) Arizona -->
 			<mapZone other="US Mountain Standard Time" territory="001" type="America/Phoenix"/>
-			<mapZone other="US Mountain Standard Time" territory="CA" type="America/Whitehorse America/Creston America/Dawson America/Dawson_Creek America/Fort_Nelson"/>
 			<mapZone other="US Mountain Standard Time" territory="MX" type="America/Hermosillo"/>
 			<mapZone other="US Mountain Standard Time" territory="US" type="America/Phoenix"/>
 			<mapZone other="US Mountain Standard Time" territory="ZZ" type="Etc/GMT+7"/>
@@ -79,6 +78,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="Mountain Standard Time" territory="MX" type="America/Ojinaga"/>
 			<mapZone other="Mountain Standard Time" territory="US" type="America/Denver America/Boise"/>
 			<mapZone other="Mountain Standard Time" territory="ZZ" type="MST7MDT"/>
+
+			<!-- (UTC-07:00) Yukon -->
+			<mapZone other="Yukon Standard Time" territory="001" type="America/Whitehorse"/>
+			<mapZone other="Yukon Standard Time" territory="CA" type="America/Whitehorse America/Creston America/Dawson America/Dawson_Creek America/Fort_Nelson"/>
 
 			<!-- (UTC-06:00) Central America -->
 			<mapZone other="Central America Standard Time" territory="001" type="America/Guatemala"/>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14301
- [x] Updated PR title and link in previous line to include Issue number


This PR adds the new `Yukon Standard Time` time zone added here:
https://techcommunity.microsoft.com/t5/daylight-saving-time-time-zone/2020-time-zone-updates-for-yukon-now-available/ba-p/1598976

It also updates the version numbers to their current values.

