### PR TITLE
CLDR-13328 remove last bits of svn mention, cleanup urls

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -70,10 +70,6 @@
 		</dependency>
 
 		<!-- mail / rss -->
-		<dependency>
-			<groupId>rome</groupId>
-			<artifactId>rome</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>javax.mail</groupId>
@@ -90,12 +86,6 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-		</dependency>
-
-		<!-- scm -->
-		<dependency>
-			<groupId>org.tmatesoft.svnkit</groupId>
-			<artifactId>svnkit</artifactId>
 		</dependency>
 
 		<!-- codec/util -->
@@ -131,11 +121,6 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.myanmartools</groupId>
-			<artifactId>myanmar-tools</artifactId>
 		</dependency>
 
 		<dependency>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -117,7 +117,6 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     public static final String CLDR_NEWVERSION = "CLDR_NEWVERSION";
     public static final String CLDR_LASTVOTEVERSION = "CLDR_LASTVOTEVERSION";
     public static final String CLDR_DIR = "CLDR_DIR";
-    private static final String CLDR_DIR_REPOS = "http://unicode.org/repos/cldr";
 
     private static final String NEWVERSION_EPOCH = "1970-01-01 00:00:00";
 
@@ -3195,7 +3194,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             final File list[] = getFileBases();
             CLDRConfig config = CLDRConfig.getInstance();
             // may fail at server startup time- should do this through setup mode
-            ensureOrCheckout(null, "CLDR_DIR", config.getCldrBaseDirectory(), CLDR_DIR_REPOS);
+            ensureOrCheckout(null, "CLDR_DIR", config.getCldrBaseDirectory(), CLDRURLS.CLDR_REPO_ROOT);
             // verify readable
             File root = new File(config.getCldrBaseDirectory(), "common/main");
             if (!root.isDirectory()) {

--- a/tools/cldr-apps/src/main/webapp/cldr-setup.jsp
+++ b/tools/cldr-apps/src/main/webapp/cldr-setup.jsp
@@ -2,8 +2,6 @@
 <%@page import="java.sql.SQLException"%>
 <%@page import="org.unicode.cldr.util.VoteResolver.VoterInfo"%>
 <%@page import="com.ibm.icu.util.VersionInfo"%>
-<%@page
-	import="org.tmatesoft.sqljet.core.internal.lang.SqlParser.commit_stmt_return"%>
 <%@page import="java.util.Properties"%>
 <%@page import="java.io.InputStream"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.unicode.cldr.tool.FormattedFileWriter.Anchors;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 import com.ibm.icu.text.ListFormatter;
@@ -27,7 +28,7 @@ public abstract class Chart {
     public static final String PREV_CHART_VERSION_DIRECTORY = ToolConstants.getBaseDirectory(ToolConstants.PREV_CHART_VERSION);
     public static final String CHART_VERSION_DIRECTORY = ToolConstants.getBaseDirectory(ToolConstants.CHART_VERSION);
 
-    private static final String GITHUB_ROOT = "https://github.com/unicode-org/cldr/blob/master/";
+    private static final String GITHUB_ROOT = CLDRURLS.CLDR_REPO_ROOT + "/blob/master/";
     private static final String LDML_SPEC = "https://unicode.org/reports/tr35/";
 
     public static String dataScrapeMessage(String specPart, String testFile, String... dataFiles) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -12,6 +12,7 @@ public abstract class CLDRURLS {
     public static final String DEFAULT_PATH = "/cldr-apps";
     public static final String DEFAULT_BASE = "http://" + DEFAULT_HOST + DEFAULT_PATH;
     public static final String CLDR_NEWTICKET_URL = "http://cldr.unicode.org/index/bug-reports#TOC-Filing-a-Ticket";
+    public static final String CLDR_REPO_ROOT = "https://github.com/unicode-org/cldr";
     /**
      * Override this property if you want to change the absolute URL to the SurveyTool base from DEFAULT_BASE
      */

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -130,18 +130,12 @@
 			</dependency>
 
 			<!-- mail / rss -->
-			<dependency>
-				<groupId>rome</groupId>
-				<artifactId>rome</artifactId>
-				<version>1.0</version>
-			</dependency>
 
 			<dependency>
 				<groupId>javax.mail</groupId>
 				<artifactId>mail</artifactId>
 				<version>1.5.0-b01</version>
 			</dependency>
-
 
 			<dependency>
 				<groupId>com.sun.activation</groupId>
@@ -154,13 +148,6 @@
 				<groupId>org.json</groupId>
 				<artifactId>json</artifactId>
 				<version>20190722</version>
-			</dependency>
-
-			<!-- scm -->
-			<dependency>
-				<groupId>org.tmatesoft.svnkit</groupId>
-				<artifactId>svnkit</artifactId>
-				<version>1.7.4-v1</version>
 			</dependency>
 
 			<!-- db connectors -->


### PR DESCRIPTION
CLDR-13328
- common constant for repo root
- remove unneeded libs for Subversion
- also remove 'rome' which is an RSS library, not used.
