### PR TITLE
CLDR-13139 Upgrade Tomcat using Ansible

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Install Vagrant and Ansible
       run: brew install ansible
     - name: Try the provision
-      run: cd tools/scripts/ansible && ansible-galaxy install -r roles.yml && ln -sv test-local-vars local-vars && vagrant up
+      run: cd tools/scripts/ansible && ansible-galaxy install -r requirements.yml && ln -sv test-local-vars local-vars && vagrant up

--- a/tools/scripts/ansible/README.md
+++ b/tools/scripts/ansible/README.md
@@ -17,7 +17,7 @@ This is your local system, where you control the others from.
 - Install some prereqs:
 
 ```shell
-ansible-galaxy install -r roles.yml
+ansible-galaxy install -r requirements.yml
 ```
 
 - Make sure you can `ssh` into all of the needed systems. For example,
@@ -139,8 +139,8 @@ vagrant up
 - to deploy ST to this, use the following:
 
 ```shell
-(cd ../../cldr-apps ; ant war) # to build ST if not already built
-vagrant ssh -- sudo -u surveytool /usr/local/bin/deploy-to-tomcat.sh $(git rev-parse HEAD) < ../../cldr-apps/cldr-apps.war
+(cd ../.. ; mvn package) # go to the tools folder and build ST (cldr-apps.war, etc.) if not already built
+vagrant ssh -- sudo -u surveytool /usr/local/bin/deploy-to-tomcat.sh $(git rev-parse HEAD) < ../../cldr-apps/target/cldr-apps.war
 ```
 
 - Now you should be able to login at <http://127.0.0.1:8880/cldr-apps/>

--- a/tools/scripts/ansible/Vagrantfile
+++ b/tools/scripts/ansible/Vagrantfile
@@ -2,6 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
   # increase the boot timeout
   config.vm.boot_timeout = 600
   config.vm.box = "ubuntu/bionic64"
@@ -15,8 +18,6 @@ Vagrant.configure("2") do |config|
     apt-get install -y python3 sudo
   SHELL
   config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "setup-playbook.yml"
+    ansible.playbook = "vagrant-playbook.yml"
   end
 end
-
-

--- a/tools/scripts/ansible/cldr-apps-playbook.yml
+++ b/tools/scripts/ansible/cldr-apps-playbook.yml
@@ -47,6 +47,13 @@
         # this is deep because we will need to keep updating
         # it with history. It does not include LFS as that
         # is not needed for the surveytool.
+    - name: Change ownership of CLDR trunk to surveytool
+      file:
+        path: "{{ cldr_trunk_path }}"
+        owner: surveytool
+        group: root
+        state: directory
+        recurse: yes
   handlers:
     - name: Restart Tomcat
       service:

--- a/tools/scripts/ansible/mysql-playbook.yml
+++ b/tools/scripts/ansible/mysql-playbook.yml
@@ -2,6 +2,7 @@
   become: yes
   vars_files:
     - vars/main.yml
+    - vars/mysql.yml
     - local-vars/local.yml
   roles:
     - { role: geerlingguy.mysql }

--- a/tools/scripts/ansible/requirements.yml
+++ b/tools/scripts/ansible/requirements.yml
@@ -1,3 +1,17 @@
-sprylab.tomcat-ubuntu
-geerlingguy.mysql
-derjd.journald
+- src: geerlingguy.mysql
+  version: 3.3.0
+- src: geerlingguy.nginx
+  version: 2.8.0
+- src: derjd.journald
+  version: 0.0.1
+- src: robertdebock.tomcat
+  version: 4.6.2
+# The following are also required for robertdebock.tomcat
+- src: robertdebock.bootstrap
+  version: 4.3.4
+- src: robertdebock.core_dependencies
+  version: 1.5.2
+- src: robertdebock.java
+  version: 3.0.0
+- src: robertdebock.service
+  version: 2.8.2

--- a/tools/scripts/ansible/roles.yml
+++ b/tools/scripts/ansible/roles.yml
@@ -1,8 +1,0 @@
-- src: geerlingguy.mysql
-  version: 3.3.0
-- src: geerlingguy.nginx
-  version: 2.8.0
-- src: derjd.journald
-  version: 0.0.1
-# - src: geerlingguy.certbot
-#   version: 3.1.0

--- a/tools/scripts/ansible/templates/context.j2
+++ b/tools/scripts/ansible/templates/context.j2
@@ -5,10 +5,11 @@
 <Resource name="jdbc/SurveyTool"
   auth="Container" type="javax.sql.DataSource"
   username="surveytool"
-  driverClassName="com.mysql.jdbc.Driver"
+  driverClassName="com.mysql.cj.jdbc.Driver"
   password="{{ mysql_users[0].password }}"
   url="jdbc:mysql://localhost:3306/cldrdb?ConnectionRetryCount=5&amp;ConnectionRetryDelay=20&amp;useJDBCCompliantTimezoneShift=true&amp;useLegacyDatetimeCode=false&amp;serverTimezone=UTC"
   maxActive="8" maxIdle="4" removeAbandoned="true" removeAbandonedTimeout="60" logAbandoned="true" defaultAutoCommit="false"
   poolPreparedStatements="true" maxOpenPreparedStatements="150"
 />
+<Resources cacheMaxSize="100000" cachingAllowed="true"/>
 </Context>

--- a/tools/scripts/ansible/templates/deploy-sh.j2
+++ b/tools/scripts/ansible/templates/deploy-sh.j2
@@ -11,8 +11,8 @@ dogit() {
     rm -f ${WORKDIR}/git-list.txt
     if [[ ${GITHUB_SHA} = "master" ]];
     then
-	echo "changing 'master' to 'origin/master' to get the latest"
-	GITHUB_SHA=origin/master
+        echo "changing 'master' to 'origin/master' to get the latest"
+        GITHUB_SHA=origin/master
     fi
     git fetch -p || exit 1
     git clean -f -d || echo 'warning: err on cleanup'
@@ -23,29 +23,29 @@ dogit() {
     git rev-parse --short "${GITHUB_SHA}" || exit 1 # fail on err
     if [[ $(git rev-parse --short HEAD) = $(git rev-parse --short "${GITHUB_SHA}") ]];
     then
-	echo "No checkout needed. Continuing with redeploy."
+        echo "No checkout needed. Continuing with redeploy."
     else
-	echo "Deploy will include these new items:"
-	echo "---"
-	(git log --oneline HEAD..${GITHUB_SHA} | tee ${WORKDIR}/git-list.txt) || exit 1
-	echo "---"
-	if [[ ! -s ${WORKDIR}/git-list.txt ]]; # if empty..
-	then
-	    echo "Note, ${GITHUB_SHA} is not ahead of HEAD"  $(git rev-parse --short HEAD)
-	    echo "Checking for items that would be REVERTED if we proceed:"
-	    echo "---"
-	    git log --oneline ${GITHUB_SHA}..HEAD
-	    echo "---"
-	    if [[ "${UNLOCK}" = "--override" ]];
-	    then
-		echo ".. continuing anyway! due to " "${UNLOCK}"
-	    else
-		echo "STOP. Check the override box if you really want to do this"
-		exit 1
-	    fi
-	fi
-	git checkout -f ${GITHUB_SHA}
-	echo "HEAD is now at" $(git rev-parse --short HEAD) "!"
+        echo "Deploy will include these new items:"
+        echo "---"
+        (git log --oneline HEAD..${GITHUB_SHA} | tee ${WORKDIR}/git-list.txt) || exit 1
+        echo "---"
+        if [[ ! -s ${WORKDIR}/git-list.txt ]]; # if empty..
+        then
+            echo "Note, ${GITHUB_SHA} is not ahead of HEAD"  $(git rev-parse --short HEAD)
+            echo "Checking for items that would be REVERTED if we proceed:"
+            echo "---"
+            git log --oneline ${GITHUB_SHA}..HEAD
+            echo "---"
+            if [[ "${UNLOCK}" = "--override" ]];
+            then
+                echo ".. continuing anyway! due to " "${UNLOCK}"
+            else
+                echo "STOP. Check the override box if you really want to do this"
+                exit 1
+            fi
+        fi
+        git checkout -f ${GITHUB_SHA}
+        echo "HEAD is now at" $(git rev-parse --short HEAD) "!"
      fi
 }
 

--- a/tools/scripts/ansible/templates/server.xml
+++ b/tools/scripts/ansible/templates/server.xml
@@ -84,15 +84,6 @@
          style configuration. When using the APR/native implementation, the
          OpenSSL style configuration is required as described in the APR/native
          documentation -->
-    <!--
-    <Connector address="127.0.0.1" port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
-               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
-               clientAuth="false" sslProtocol="TLS" />
-    -->
-
-    <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector address="127.0.0.1" port="8009" protocol="AJP/1.3" redirectPort="8443" />
-
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone

--- a/tools/scripts/ansible/tomcat-playbook.yml
+++ b/tools/scripts/ansible/tomcat-playbook.yml
@@ -1,18 +1,22 @@
 - hosts: surveytool
   become: yes
+  gather_facts: yes
   vars_files:
     - vars/main.yml
+    - vars/tomcat.yml
     - local-vars/local.yml
+  vars:
+    tomcat_address: 127.0.0.1
+    tomcat_instances:
+      - name: "tomcat"
+  roles:
+    - role: robertdebock.java
+    - role: robertdebock.tomcat
   tasks:
-    - name: Install server packages
-      apt:
-        pkg:
-          - tomcat8
-          - tomcat8-admin # needed for deploy
     - name: Setup Server Context
       template:
         src: templates/context.j2
-        dest: "/etc/{{ cldr_tomcat_folder }}/context.xml"
+        dest: "{{ cldr_tomcat_conf_path }}/context.xml"
         owner: root
         group: "{{ cldr_tomcat_group }}"
         mode: '0640'
@@ -20,7 +24,7 @@
     - name: Setup Tomcat server.xml
       copy:
         src: templates/server.xml
-        dest: "/etc/{{ cldr_tomcat_folder }}/server.xml"
+        dest: "{{ cldr_tomcat_conf_path }}/server.xml"
         owner: root
         group: "{{ cldr_tomcat_group }}"
         mode: '0640'
@@ -28,7 +32,7 @@
     - name: Setup Server Users
       template:
         src: templates/users.j2
-        dest: "/etc/{{ cldr_tomcat_folder }}/tomcat-users.xml"
+        dest: "{{ cldr_tomcat_conf_path }}/tomcat-users.xml"
         owner: root
         group: "{{ cldr_tomcat_group }}"
         mode: '0640'

--- a/tools/scripts/ansible/vagrant-playbook.yml
+++ b/tools/scripts/ansible/vagrant-playbook.yml
@@ -1,0 +1,2 @@
+- import_playbook: setup-playbook.yml
+# Note: any additional setup specifically for vagrant could be done here, such as adding a self-signed ssl cert

--- a/tools/scripts/ansible/vars/main.yml
+++ b/tools/scripts/ansible/vars/main.yml
@@ -1,17 +1,15 @@
+ansible_python_interpreter: python3
+
 cldr_database_name: cldrdb
 cldr_db_backup_host: corp.unicode.org
 cldr_db_backup_user: cldrbackup
 cldr_db_backup_destination: "{{ cldr_db_backup_host }}:/home/users/{{ cldr_db_backup_user }}"
-mysql_databases:
-  - name: "{{ cldr_database_name }}"
-    encoding: latin1
-    collation: latin1_bin
-mysql_enabled_on_startup: true
-mysql_bind_address: localhost
-ansible_python_interpreter: python3
-cldr_tomcat_service: tomcat8
+
+cldr_tomcat_service: tomcat
+cldr_tomcat_parent: etc
 cldr_tomcat_folder: "{{ cldr_tomcat_service }}"
+cldr_tomcat_conf_path: "/{{ cldr_tomcat_parent }}/{{ cldr_tomcat_folder }}/conf"
 cldr_tomcat_user: "{{ cldr_tomcat_service }}"
 cldr_tomcat_group: "{{ cldr_tomcat_user }}"
-cldr_path: "/var/lib/{{ cldr_tomcat_folder }}/cldr"
+cldr_path: "/{{ cldr_tomcat_parent }}/{{ cldr_tomcat_folder }}/cldr"
 cldr_trunk_path: "{{ cldr_path }}/cldr-trunk"

--- a/tools/scripts/ansible/vars/mysql.yml
+++ b/tools/scripts/ansible/vars/mysql.yml
@@ -1,0 +1,6 @@
+mysql_databases:
+  - name: "{{ cldr_database_name }}"
+    encoding: latin1
+    collation: latin1_bin
+mysql_enabled_on_startup: true
+mysql_bind_address: localhost

--- a/tools/scripts/ansible/vars/tomcat.yml
+++ b/tools/scripts/ansible/vars/tomcat.yml
@@ -1,0 +1,15 @@
+# This file contains variables used by robertdebock.tomcat for Survey Tool
+# Reference: https://galaxy.ansible.com/robertdebock/tomcat
+tomcat_version9: 9.0.36
+tomcat_version: 9
+tomcat_mirror: "https://archive.apache.org" # where to download Apache Tomcat
+tomcat_name: "{{ cldr_tomcat_service }}"
+tomcat_directory: "/{{ cldr_tomcat_parent }}" # /etc or /opt; as in /etc/tomcat
+tomcat_user: "{{ cldr_tomcat_user }}"
+tomcat_group: "{{ cldr_tomcat_group }}"
+
+tomcat_instances:
+  - name: "{{ tomcat_name }}"
+    version: "{{ tomcat_version }}"
+    user: "{{ tomcat_user }}"
+    group: "{{ tomcat_group }}"


### PR DESCRIPTION
-Revise tomcat-playbook.yml to use robertdebock.tomcat

-Move parts of vars/main.yml to new mysql.yml, tomcat.yml

-Make cldr_tomcat_conf_path end in /conf

-Use only /etc/tomcat, never /var/lib/tomcat (which no longer exists)

-Remove roles.yml; use requirements.yml instead in ansible-lint.yml

-Update README.md: requirements.yml not roles.yml; mvn not ant

-Revise context.j2: com.mysql.cj.jdbc.Driver not com.mysql.jdbc.Driver; cachingAllowed; cacheMaxSize

-For vagrant only, new vagrant-playbook.yml; just calls setup-playbook.yml but adds flexibility

-Remove problematic AJP section from server.xml

-In deploy-sh.j2 use only spaces for indentation, rather than mix tabs and spaces

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13139
- [x] Updated PR title and link in previous line to include Issue number

