### PR TITLE
CLDR-14283 Fix MySQLIntegrityConstraintViolationException for cldr_review_hide

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
@@ -32,24 +32,9 @@ public class ReviewHide {
                 s.execute(sql = "CREATE TABLE " + DBUtils.Table.REVIEW_HIDE + " (id int not null " + DBUtils.DB_SQL_IDENTITY
                     + ", path int not null, choice varchar(20) not null, user_id int not null, locale varchar(20) not null)");
                 s.execute(sql = "CREATE UNIQUE INDEX " + DBUtils.Table.REVIEW_HIDE + "_id ON " + DBUtils.Table.REVIEW_HIDE + " (id) ");
-
-                try {
-                    s.execute(sql = "ALTER TABLE " + DBUtils.Table.REVIEW_HIDE + " ADD CONSTRAINT review_hide_fk FOREIGN KEY (user_id) REFERENCES "
-                        + UserRegistry.CLDR_USERS + "(id) ON DELETE CASCADE");
-                } catch (SQLException se) {
-                    // This seems to require InnoDB.
-                    System.err.println("Warning: could not add Foreign Key constraint to " + DBUtils.Table.REVIEW_HIDE + " - skipping.  SQL was " + sql
-                        + ", err was " + DBUtils.unchainSqlException(se));
-                    SurveyLog
-                        .logException(se, "Warning: could not add Foreign Key constraint to " + DBUtils.Table.REVIEW_HIDE + " - skipping.  SQL was " + sql);
-                }
-                sql = null;
-
                 s.close();
                 s = null;
-
                 conn.commit();
-
                 sql = null;
             } finally {
                 DBUtils.close(s);

--- a/tools/cldr-apps/src/main/webapp/js/review.js
+++ b/tools/cldr-apps/src/main/webapp/js/review.js
@@ -752,6 +752,9 @@ function designFixPanel() {
  */
 function fixPopoverVotePos() {
 	var button = $('.fix-parent #popover-vote').closest('.fix-parent').find('.fix');
+	if (!button || !button.position()) {
+		return;
+	}
 	var popover = button.parent().find('.popover');
 	var decal = 75;
 	popover.css('top', button.position().top - decal);


### PR DESCRIPTION
-Remove the constraint in ReviewHide.java, not needed

-Also fix a bug in review.js: do not crash in fixPopoverVotePos if no button.position(), as while loading

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14283
- [x] Updated PR title and link in previous line to include Issue number

