### PR TITLE
CLDR-14212 publish to maven on release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,41 @@
+name: cldr-mvn-deploy
+
+on:
+  release:
+    types: [created]
+jobs:
+  mvn-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: false
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('tools/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build with Maven
+        run: >
+          mvn -s .github/workflows/mvn-settings.xml -B compile install package --file tools/pom.xml
+          -DskipTests=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: set version to generic number
+        run: |
+          mvn -s .github/workflows/mvn-settings.xml --file tools/pom.xml versions:set -DnewVersion=0.0.0-SNAPSHOT-$(echo ${GITHUB_SHA} | cut -c1-10)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to GitHub maven
+        # only for head fork
+        if: github.repository == 'unicode-org/cldr'
+        run: |
+          mvn -s .github/workflows/mvn-settings.xml  --file tools/pom.xml deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mvn-settings.xml
+++ b/.github/workflows/mvn-settings.xml
@@ -39,5 +39,10 @@ TODO: Remove this when ICU-21251 is completed.
       <username>${GITHUB_ACTOR}</username>
       <password>${GITHUB_TOKEN}</password>
     </server>
+    <server>
+      <id>githubcldr</id>
+      <username>${GITHUB_ACTOR}</username>
+      <password>${GITHUB_TOKEN}</password>
+    </server>
   </servers>
 </settings>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -284,4 +284,11 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	<distributionManagement>
+		<repository>
+			<id>githubcldr</id>
+			<name>Maven@unicode-org/cldr</name>
+			<url>https://maven.pkg.github.com/unicode-org/cldr</url>
+		</repository>
+	</distributionManagement>
 </project>


### PR DESCRIPTION
CLDR-14212

publish ( using version `0.0.0-SNAPSHOT-`_hash_ where _hash_ is the git hash ) all released versions to maven