### PR TITLE
CLDR-14057 Survey Tool CLDR_PHASE=FINAL_TESTING should not allow vetters to vote

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -4591,6 +4591,10 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         return phase() == Phase.BETA;
     }
 
+    public static boolean isPhaseFinalTesting() {
+        return phase() == Phase.FINAL_TESTING;
+    }
+
     public static final Phase phase() {
         return currentPhase;
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -1760,10 +1760,15 @@ public class UserRegistry {
     }
 
     public enum ModifyDenial {
-        DENY_NULL_USER("No user specified"), DENY_LOCALE_READONLY("Locale is read-only"), DENY_PHASE_READONLY(
-            "SurveyTool is in read-only mode"), DENY_ALIASLOCALE("Locale is an alias"), DENY_DEFAULTCONTENT(
-                "Locale is the Default Content for another locale"), DENY_PHASE_CLOSED("SurveyTool is in 'closed' phase"), DENY_NO_RIGHTS(
-                    "User does not have any voting rights"), DENY_LOCALE_LIST("User does not have rights to vote for this locale");
+        DENY_NULL_USER("No user specified"),
+        DENY_LOCALE_READONLY("Locale is read-only"),
+        DENY_PHASE_READONLY("SurveyTool is in read-only mode"),
+        DENY_ALIASLOCALE("Locale is an alias"),
+        DENY_DEFAULTCONTENT("Locale is the Default Content for another locale"),
+        DENY_PHASE_CLOSED("SurveyTool is in 'closed' phase"),
+        DENY_NO_RIGHTS("User does not have any voting rights"),
+        DENY_LOCALE_LIST("User does not have rights to vote for this locale"),
+        DENY_PHASE_FINAL_TESTING("SurveyTool is in the 'final testing' phase");
 
         ModifyDenial(String reason) {
             this.reason = reason;
@@ -1891,6 +1896,9 @@ public class UserRegistry {
         if (SurveyMain.isPhaseReadonly())
             return ModifyDenial.DENY_PHASE_READONLY;
 
+        if (SurveyMain.isPhaseFinalTesting()) {
+            return ModifyDenial.DENY_PHASE_FINAL_TESTING;
+        }
         return null;
     }
 
@@ -2453,6 +2461,7 @@ public class UserRegistry {
                 rs = ps.executeQuery();
                 if (rs == null) {
                     out.println("\t<!-- No results -->");
+                    out.close();
                     return 0;
                 }
                 Organization lastOrg = null;

--- a/tools/cldr-apps/src/main/webapp/WEB-INF/tmpl/manage.jsp
+++ b/tools/cldr-apps/src/main/webapp/WEB-INF/tmpl/manage.jsp
@@ -21,9 +21,6 @@ String helpName = subCtx.getString("helpName");
            
            <%
            boolean haveCookies = (subCtx.getCookie(SurveyMain.QUERY_EMAIL)!=null&&subCtx.getCookie(SurveyMain.QUERY_PASSWORD)!=null);
-            if(false && !haveCookies && !subCtx.hasField(SurveyMain.QUERY_SAVE_COOKIE)) {
-                subCtx.println(" <a class='notselected' href='"+subCtx.url()+subCtx.urlConnector()+SurveyMain.QUERY_SAVE_COOKIE+"=iva'>Log me in automatically next time</a>");
-            }
             %>
             <a href='?do=listu'>My Account Settings</a>
               <a href='<%= request.getContextPath()   %>/lock.jsp?email=<%= subCtx.session.user.email %>'>Permanently disable my account! (account lock)</a>
@@ -42,7 +39,7 @@ String helpName = subCtx.getString("helpName");
                 SurveyMain.printMenu(subCtx, doWhat, "list", "Manage&nbsp;Users", SurveyMain.QUERY_DO);
             } else {
                 if(UserRegistry.userIsVetter(subCtx.session.user)) {
-                    SurveyMain.printMenu(subCtx, doWhat, "list", "List " + subCtx.session.user.org + " Users", subCtx.sm.QUERY_DO);
+                    SurveyMain.printMenu(subCtx, doWhat, "list", "List " + subCtx.session.user.org + " Users", SurveyMain.QUERY_DO);
                 } else if(UserRegistry.userIsLocked(subCtx.session.user)) {
                     subCtx.println("<b>LOCKED: Note: your account is currently locked. Please contact " + subCtx.session.user.org + "'s CLDR Technical Committee member.</b> ");
                 }
@@ -55,9 +52,11 @@ String helpName = subCtx.getString("helpName");
                 subCtx.println("<br> (Note: in the Vetting phase, you may not submit new data.) ");
             } else if(SurveyMain.isPhaseClosed() && !UserRegistry.userIsTC(subCtx.session.user)) {
                 subCtx.println("<br>(SurveyTool is closed to vetting and data submissions.)");
+            } else if (SurveyMain.isPhaseFinalTesting() && !UserRegistry.userIsTC(subCtx.session.user)) {
+                subCtx.println("(SurveyTool is in the Final Testing phase; you may not vote.)");
             }
             if((subCtx.session != null) && (subCtx.session.user != null) && (SurveyMain.isPhaseVettingClosed() && subCtx.session.user.userIsSpecialForCLDR15(null))) {
-                subCtx.println("<br/><b class='selected'> you have been granted extended privileges for the CLDR "+subCtx.sm.getNewVersion()+" vetting period.</b><br>");
+                subCtx.println("<br/><b class='selected'> you have been granted extended privileges for the CLDR "+SurveyMain.getNewVersion()+" vetting period.</b><br>");
             }
             %>
          <h3>Forum</h3>

--- a/tools/scripts/ansible/templates/cldr-properties.j2
+++ b/tools/scripts/ansible/templates/cldr-properties.j2
@@ -22,9 +22,6 @@ CLDR_OLDVERSION={{ surveytooldeploy.oldversion }}
 ## 'new'  version
 CLDR_NEWVERSION={{ surveytooldeploy.newversion }}
 
-## Current SurveyTool phase 
-CLDR_PHASE=BETA
-
 ## CLDR trunk. Default value shown
 CLDR_DIR={{ cldr_trunk_path }}
 


### PR DESCRIPTION
-New function SurveyMain.isPhaseFinalTesting called by userCanModifyLocaleWhy and manage.jsp

-New message ModifyDenial.DENY_PHASE_FINAL_TESTING

-Clean up formatting of enum ModifyDenial

-Fix compiler warnings about static SurveyMain.QUERY_DO and SurveyMain.getNewVersion

-Fix compiler warning about UserRegistry.writeUserFile, call out.close before return

-Remove superfluously duplicated CLDR_PHASE setting in cldr-properties.j2

-Delete some dead code

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14057
- [x] Updated PR title and link in previous line to include Issue number

