### PR TITLE
CLDR-13498 Language name Root should not have translations in xml

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -332,7 +332,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="rn">Rundi</language>
 			<language type="ro">Roemeens</language>
 			<language type="rof">Rombo</language>
-			<language type="root">Root</language>
 			<language type="ru">Russies</language>
 			<language type="rup">Aromanies</language>
 			<language type="rw">Rwandees</language>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -378,7 +378,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">ሮማኒያን</language>
 			<language type="ro_MD">ሞልዳቪያንኛ</language>
 			<language type="rof">ሮምቦ</language>
-			<language type="root">ሩት</language>
 			<language type="ru">ራሽያኛ</language>
 			<language type="rup">አሮማንያን</language>
 			<language type="rw">ኪንያርዋንድኛ</language>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -421,7 +421,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">المولدوفية</language>
 			<language type="rof">الرومبو</language>
 			<language type="rom">الغجرية</language>
-			<language type="root">الجذر</language>
 			<language type="ru">الروسية</language>
 			<language type="rup">الأرومانيان</language>
 			<language type="rw">الكينيارواندا</language>

--- a/common/main/ar_SA.xml
+++ b/common/main/ar_SA.xml
@@ -398,7 +398,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">↑↑↑</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rup">↑↑↑</language>
 			<language type="rw">↑↑↑</language>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -314,7 +314,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">ৰোমানীয়</language>
 			<language type="ro_MD">মোল্ডাভিয়ান</language>
 			<language type="rof">ৰোম্বো</language>
-			<language type="root">ৰুট</language>
 			<language type="ru">ৰাছিয়ান</language>
 			<language type="rup">আৰোমানীয়</language>
 			<language type="rw">কিনয়াৰোৱাণ্ডা</language>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -404,7 +404,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldav</language>
 			<language type="rof">rombo</language>
 			<language type="rom">roman</language>
-			<language type="root">rut</language>
 			<language type="ru">rus</language>
 			<language type="rup">aroman</language>
 			<language type="rw">kinyarvanda</language>

--- a/common/main/az_Cyrl.xml
+++ b/common/main/az_Cyrl.xml
@@ -300,7 +300,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="rn">рунди</language>
 			<language type="ro">румын</language>
 			<language type="rof">ромбо</language>
-			<language type="root">рут</language>
 			<language type="ru">рус</language>
 			<language type="rup">ароман</language>
 			<language type="rw">кинјарванда</language>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -336,7 +336,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">румынская</language>
 			<language type="ro_MD">малдаўская</language>
 			<language type="rof">ромба</language>
-			<language type="root">корань</language>
 			<language type="ru">руская</language>
 			<language type="rup">арумунская</language>
 			<language type="rw">руанда</language>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -403,7 +403,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">молдовски</language>
 			<language type="rof">ромбо</language>
 			<language type="rom">ромски</language>
-			<language type="root">роот</language>
 			<language type="ru">руски</language>
 			<language type="rup">арумънски</language>
 			<language type="rw">киняруанда</language>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -407,7 +407,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">মলদাভিয়</language>
 			<language type="rof">রম্বো</language>
 			<language type="rom">রোমানি</language>
-			<language type="root">মূল</language>
 			<language type="ru">রুশ</language>
 			<language type="rup">আরমেনিয়ান</language>
 			<language type="rw">কিনয়ারোয়ান্ডা</language>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -423,7 +423,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">moldoveg</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romanieg</language>
-			<language type="root">gwrizienn</language>
 			<language type="ru">rusianeg</language>
 			<language type="rup">aroumaneg</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -337,7 +337,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">रूमानीयन्</language>
 			<language type="ro_MD">मोल्डेवियन्</language>
 			<language type="rom">रुमानी</language>
-			<language type="root">रुट</language>
 			<language type="ru">रुसी</language>
 			<language type="rup">आरोमानी</language>
 			<language type="rw">किन्यारुआण्डा</language>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -416,7 +416,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavski</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">korijenski</language>
 			<language type="ru">ruski</language>
 			<language type="rup">arumunski</language>
 			<language type="rw">kinjaruanda</language>

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -378,7 +378,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">молдавски</language>
 			<language type="rof">ромбо</language>
 			<language type="rom">романи</language>
-			<language type="root">рут</language>
 			<language type="ru">руски</language>
 			<language type="rup">ароманијски</language>
 			<language type="rw">кинјаруанда</language>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -452,7 +452,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldau</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romaní</language>
-			<language type="root">arrel</language>
 			<language type="ru">rus</language>
 			<language type="rup">aromanès</language>
 			<language type="rw">ruandès</language>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -397,7 +397,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">𑄟𑄧𑄣𑄴𑄘𑄞𑄨𑄠𑄧</language>
 			<language type="rof">𑄢𑄧𑄟𑄴𑄝𑄮</language>
 			<language type="rom">𑄢𑄮𑄟𑄚𑄨</language>
-			<language type="root">𑄥𑄨𑄠𑄮𑄢𑄴</language>
 			<language type="ru">𑄢𑄪𑄌𑄴</language>
 			<language type="rup">𑄃𑄢𑄴𑄟𑄬𑄚𑄨𑄠𑄚𑄴</language>
 			<language type="rw">𑄇𑄨𑄚𑄴𑄠𑄢𑄮𑄠𑄚𑄴𑄓</language>

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -311,7 +311,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">румынийн</language>
 			<language type="ro_MD">молдавийн</language>
 			<language type="rof">ромбо</language>
-			<language type="root">ораман мотт</language>
 			<language type="ru">оьрсийн</language>
 			<language type="rup">аруминийн</language>
 			<language type="rw">киньяруанда</language>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -313,7 +313,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">ᎶᎹᏂᎠᏂ</language>
 			<language type="ro_MD">ᎹᎵᏙᏫᎠ ᏣᎹᏂᎠᏂ</language>
 			<language type="rof">ᎶᎹᏉ</language>
-			<language type="root">ᎤᎾᏍᎦᎸ</language>
 			<language type="ru">ᏲᏅᎯ</language>
 			<language type="rup">ᎠᏬᎹᏂᎠᏂ</language>
 			<language type="rw">ᎩᏂᏯᏩᏂᏓ</language>

--- a/common/main/ckb.xml
+++ b/common/main/ckb.xml
@@ -304,7 +304,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">ڕۆمانی</language>
 			<language type="ro_MD">مۆڵداڤی</language>
 			<language type="rof">ڕۆمبۆ</language>
-			<language type="root">ڕووت</language>
 			<language type="ru">ڕووسی</language>
 			<language type="rup">ئارمۆمانی</language>
 			<language type="rw">کینیارواندا</language>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -480,7 +480,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavština</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romština</language>
-			<language type="root">kořen</language>
 			<language type="rtm">rotumanština</language>
 			<language type="ru">ruština</language>
 			<language type="rue">rusínština</language>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -414,7 +414,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Moldofeg</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romani</language>
-			<language type="root">Y Gwraidd</language>
 			<language type="rtm">Rotumaneg</language>
 			<language type="ru">Rwseg</language>
 			<language type="rup">Aromaneg</language>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -423,7 +423,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldovisk</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">rod</language>
 			<language type="ru">russisk</language>
 			<language type="rup">arumænsk</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -480,7 +480,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Moldauisch</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romani</language>
-			<language type="root">Root</language>
 			<language type="rtm">Rotumanisch</language>
 			<language type="ru">Russisch</language>
 			<language type="rue">Russinisch</language>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -417,7 +417,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Μολδαβικά</language>
 			<language type="rof">Ρόμπο</language>
 			<language type="rom">Ρομανί</language>
-			<language type="root">Ρίζα</language>
 			<language type="ru">Ρωσικά</language>
 			<language type="rup">Αρομανικά</language>
 			<language type="rw">Κινιαρουάντα</language>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -488,7 +488,6 @@ annotations.
 			<language type="ro_MD">Moldavian</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romany</language>
-			<language type="root">Root</language>
 			<language type="rtm">Rotuman</language>
 			<language type="ru">Russian</language>
 			<language type="rue">Rusyn</language>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -482,7 +482,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">Moldovan</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="rtm">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rue">↑↑↑</language>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -479,7 +479,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">Moldovan</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom" draft="contributed">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="rtm" draft="contributed">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rue" draft="contributed">↑↑↑</language>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -470,7 +470,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">Moldavian</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">Root</language>
 			<language type="rtm">↑↑↑</language>
 			<language type="ru">Russian</language>
 			<language type="rue">↑↑↑</language>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -481,7 +481,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">Moldavian</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="rtm">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rue">↑↑↑</language>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -422,7 +422,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavo</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romaní</language>
-			<language type="root">raíz</language>
 			<language type="ru">ruso</language>
 			<language type="rup">arrumano</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -419,7 +419,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavo</language>
 			<language type="rof">rombo</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">raíz</language>
 			<language type="ru">ruso</language>
 			<language type="rup">arrumano</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -419,7 +419,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">↑↑↑</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rup">↑↑↑</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -421,7 +421,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">↑↑↑</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rup">↑↑↑</language>
 			<language type="rw" draft="contributed">kinyarwanda</language>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -320,7 +320,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">errumaniera</language>
 			<language type="ro_MD">moldaviera</language>
 			<language type="rof">rombo</language>
-			<language type="root">erroa</language>
 			<language type="ru">errusiera</language>
 			<language type="rup">aromaniera</language>
 			<language type="rw">kinyaruanda</language>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -419,7 +419,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">مولداویایی</language>
 			<language type="rof">رومبویی</language>
 			<language type="rom">رومانویی</language>
-			<language type="root">ریشه</language>
 			<language type="ru">روسی</language>
 			<language type="rup">آرومانی</language>
 			<language type="rw">کینیارواندایی</language>

--- a/common/main/fa_AF.xml
+++ b/common/main/fa_AF.xml
@@ -286,7 +286,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="rn">↑↑↑</language>
 			<language type="ro">↑↑↑</language>
 			<language type="rof">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rup">↑↑↑</language>
 			<language type="rw">↑↑↑</language>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -483,7 +483,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldova</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">juuri</language>
 			<language type="rtm">rotuma</language>
 			<language type="ru">venäjä</language>
 			<language type="rue">ruteeni</language>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -324,7 +324,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">Romanian</language>
 			<language type="ro_MD">Moldavian</language>
 			<language type="rof">Rombo</language>
-			<language type="root">Root</language>
 			<language type="ru">Russian</language>
 			<language type="rup">Aromanian</language>
 			<language type="rw">Kinyarwanda</language>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -481,7 +481,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldave</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">racine</language>
 			<language type="rtm">rotuman</language>
 			<language type="ru">russe</language>
 			<language type="rue">ruthène</language>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -479,7 +479,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">moldave</language>
 			<language type="rof">rombo</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="rtm">↑↑↑</language>
 			<language type="ru">russe</language>
 			<language type="rue">↑↑↑</language>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -397,7 +397,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD" draft="contributed">Moldavysk</language>
 			<language type="rof" draft="contributed">Rombo</language>
 			<language type="rom" draft="contributed">Romani</language>
-			<language type="root" draft="contributed">Root</language>
 			<language type="ru" draft="contributed">Russysk</language>
 			<language type="rup" draft="contributed">Aromaniaansk</language>
 			<language type="rw" draft="contributed">Kinyarwanda</language>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -299,7 +299,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Moldáivis</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romainis</language>
-			<language type="root" draft="contributed">Root</language>
 			<language type="ru">Rúisis</language>
 			<language type="rup">Arómáinis</language>
 			<language type="rw">Ciniaruaindis</language>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -467,7 +467,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">Moldobhais</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romanais</language>
-			<language type="root">Root</language>
 			<language type="ru">Ruisis</language>
 			<language type="rue">Rusyn</language>
 			<language type="rug">Roviana</language>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -323,7 +323,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">romanés</language>
 			<language type="ro_MD">moldavo</language>
 			<language type="rof">rombo</language>
-			<language type="root">raíz</language>
 			<language type="ru">ruso</language>
 			<language type="rup">aromanés</language>
 			<language type="rw">kiñaruanda</language>

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -348,7 +348,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">Rumänisch</language>
 			<language type="ro_MD">Moldawisch</language>
 			<language type="rom">Zigüünerschpraach</language>
-			<language type="root">Root</language>
 			<language type="ru">Russisch</language>
 			<language type="rup">Aromunisch</language>
 			<language type="rw">Ruandisch</language>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -417,7 +417,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">મોલડાવિયન</language>
 			<language type="rof">રોમ્બો</language>
 			<language type="rom">રોમાની</language>
-			<language type="root">રૂટ</language>
 			<language type="ru">રશિયન</language>
 			<language type="rup">અરોમેનિયન</language>
 			<language type="rw">કિન્યારવાન્ડા</language>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -423,7 +423,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">מולדבית</language>
 			<language type="rof">רומבו</language>
 			<language type="rom">רומאני</language>
-			<language type="root">רוט</language>
 			<language type="ru">רוסית</language>
 			<language type="rup">ארומנית</language>
 			<language type="rw">קנירואנדית</language>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -408,7 +408,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">मोलडावियन</language>
 			<language type="rof">रोम्बो</language>
 			<language type="rom">रोमानी</language>
-			<language type="root">रूट</language>
 			<language type="ru">रूसी</language>
 			<language type="rup">अरोमानियन</language>
 			<language type="rw">किन्यारवांडा</language>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -424,7 +424,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavski</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romski</language>
-			<language type="root">korijenski</language>
 			<language type="ru">ruski</language>
 			<language type="rup">aromunski</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -422,7 +422,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldvai</language>
 			<language type="rof">rombo</language>
 			<language type="rom">roma</language>
-			<language type="root">ősi</language>
 			<language type="ru">orosz</language>
 			<language type="rup">aromán</language>
 			<language type="rw">kinyarvanda</language>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -361,7 +361,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">մոլդովերեն</language>
 			<language type="rof">ռոմբո</language>
 			<language type="rom">ռոմաներեն</language>
-			<language type="root">ռուտերեն</language>
 			<language type="rtm">ռոտուման</language>
 			<language type="ru">ռուսերեն</language>
 			<language type="rue">ռուսիներեն</language>

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -308,7 +308,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">romaniano</language>
 			<language type="ro_MD">moldavo</language>
 			<language type="rof">rombo</language>
-			<language type="root">radice</language>
 			<language type="ru">russo</language>
 			<language type="rup">aromaniano</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -436,7 +436,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Moldavia</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romani</language>
-			<language type="root">Root</language>
 			<language type="rtm">Rotuma</language>
 			<language type="ru">Rusia</language>
 			<language type="rup">Aromania</language>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -408,7 +408,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldóvska</language>
 			<language type="rof">rombó</language>
 			<language type="rom">romaní</language>
-			<language type="root">rót</language>
 			<language type="ru">rússneska</language>
 			<language type="rup">arúmenska</language>
 			<language type="rw">kínjarvanda</language>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -481,7 +481,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">モルダビア語</language>
 			<language type="rof">ロンボ語</language>
 			<language type="rom">ロマーニー語</language>
-			<language type="root">ルート</language>
 			<language type="rtm">ロツマ語</language>
 			<language type="ru">ロシア語</language>
 			<language type="rue">ルシン語</language>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -384,7 +384,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">მოლდავური</language>
 			<language type="rof">რომბო</language>
 			<language type="rom">ბოშური</language>
-			<language type="root">ძირეული ენა</language>
 			<language type="ru">რუსული</language>
 			<language type="rup">არომანული</language>
 			<language type="rw">კინიარუანდა</language>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -307,7 +307,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">Tarumanit</language>
 			<language type="ro_MD" draft="unconfirmed">Tamuldavt</language>
 			<language type="rof" draft="unconfirmed">Tarumbut</language>
-			<language type="root" draft="unconfirmed">Aẓar</language>
 			<language type="ru">Tarusit</language>
 			<language type="rup" draft="unconfirmed">Tavalakt</language>
 			<language type="rw">Taruwandit</language>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -319,7 +319,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">румын тілі</language>
 			<language type="ro_MD">молдован тілі</language>
 			<language type="rof">ромбо тілі</language>
-			<language type="root">ата тіл</language>
 			<language type="ru">орыс тілі</language>
 			<language type="rup">арумын тілі</language>
 			<language type="rw">киньяруанда тілі</language>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -319,7 +319,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">រូម៉ានី</language>
 			<language type="ro_MD">ម៉ុលដាវី</language>
 			<language type="rof">រុមបូ</language>
-			<language type="root">រូត</language>
 			<language type="ru">រុស្ស៊ី</language>
 			<language type="rup">អារ៉ូម៉ានី</language>
 			<language type="rw">គិនយ៉ាវ៉ាន់ដា</language>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -409,7 +409,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">ಮಾಲ್ಡೇವಿಯನ್</language>
 			<language type="rof">ರೊಂಬೊ</language>
 			<language type="rom">ರೋಮಾನಿ</language>
-			<language type="root">ರೂಟ್</language>
 			<language type="ru">ರಷ್ಯನ್</language>
 			<language type="rup">ಅರೋಮಾನಿಯನ್</language>
 			<language type="rw">ಕಿನ್ಯಾರ್‌ವಾಂಡಾ</language>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -434,7 +434,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">몰도바어</language>
 			<language type="rof">롬보어</language>
 			<language type="rom">집시어</language>
-			<language type="root">어근</language>
 			<language type="ru">러시아어</language>
 			<language type="rue">루신어</language>
 			<language type="rup">아로마니아어</language>

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -314,7 +314,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">रोमानियन</language>
 			<language type="ro_MD">मोल्डावियन्</language>
 			<language type="rof">रोम्बो</language>
-			<language type="root">रूट</language>
 			<language type="ru">रशियन</language>
 			<language type="rup">आरोमेनियन</language>
 			<language type="rw">किन्यार्वान्डा</language>

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -344,7 +344,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">رومٲنی</language>
 			<language type="ro_MD">مولداوِیَن</language>
 			<language type="rom">رومَنی</language>
-			<language type="root">روٗٹ</language>
 			<language type="ru">روٗسی</language>
 			<language type="rup">اَرومانی</language>
 			<language type="rw">کِنیاوِندا</language>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -321,7 +321,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">румынча</language>
 			<language type="ro_MD">молдованча</language>
 			<language type="rof">ромбочо</language>
-			<language type="root">түпкү</language>
 			<language type="ru">орусча</language>
 			<language type="rup">аромунча</language>
 			<language type="rw">руандача</language>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -469,7 +469,6 @@ terms of use, see http://www.unicode.org/copyright.html
 			<language type="ro_MD">Moldawesch</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romani</language>
-			<language type="root">Root</language>
 			<language type="rtm">Rotumanesch</language>
 			<language type="ru">Russesch</language>
 			<language type="rue">Russinesch</language>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -414,7 +414,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">ໂມດາວຽນ</language>
 			<language type="rof">ຣົມໂບ</language>
 			<language type="rom">ໂຣເມນີ</language>
-			<language type="root">ລູດ</language>
 			<language type="ru">ລັດເຊຍ</language>
 			<language type="rup">ອາໂຣມານຽນ</language>
 			<language type="rw">ຄິນຢາວານດາ</language>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -479,7 +479,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavų</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romų</language>
-			<language type="root">rūt</language>
 			<language type="rtm">rotumanų</language>
 			<language type="ru">rusų</language>
 			<language type="rue">rusinų</language>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -417,7 +417,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldāvu</language>
 			<language type="rof">rombo</language>
 			<language type="rom">čigānu</language>
-			<language type="root">sakne</language>
 			<language type="ru">krievu</language>
 			<language type="rup">aromūnu</language>
 			<language type="rw">kiņaruanda</language>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -478,7 +478,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">молдавски</language>
 			<language type="rof">ромбо</language>
 			<language type="rom">ромски</language>
-			<language type="root">корен</language>
 			<language type="rtm">ротумански</language>
 			<language type="ru">руски</language>
 			<language type="rue">русински</language>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -421,7 +421,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">മോൾഡാവിയൻ</language>
 			<language type="rof">റോംബോ</language>
 			<language type="rom">റൊമാനി</language>
-			<language type="root">മൂലഭാഷ</language>
 			<language type="ru">റഷ്യൻ</language>
 			<language type="rup">ആരോമാനിയൻ</language>
 			<language type="rw">കിന്യാർവാണ്ട</language>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -318,7 +318,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">румын</language>
 			<language type="ro_MD">молдав</language>
 			<language type="rof">ромбо</language>
-			<language type="root">рут</language>
 			<language type="ru">орос</language>
 			<language type="rup">ароманы</language>
 			<language type="rw">киньяруанда</language>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -409,7 +409,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">मोल्डाव्हियन</language>
 			<language type="rof">रोम्बो</language>
 			<language type="rom">रोमानी</language>
-			<language type="root">रूट</language>
 			<language type="ru">रशियन</language>
 			<language type="rup">अरोमानियन</language>
 			<language type="rw">किन्यार्वान्डा</language>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -360,7 +360,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">Romania</language>
 			<language type="ro_MD">Moldavia</language>
 			<language type="rof">Rombo</language>
-			<language type="root">Root</language>
 			<language type="ru">Rusia</language>
 			<language type="rup">Aromanian</language>
 			<language type="rw">Kinyarwanda</language>

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -391,7 +391,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">Moldovan</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romanesk</language>
-			<language type="root">Root</language>
 			<language type="ru">Russu</language>
 			<language type="rup">Aromanjan</language>
 			<language type="rw">Kinjarwanda</language>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -337,7 +337,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">ရိုမေနီယား</language>
 			<language type="ro_MD">မော်လဒိုဗာ</language>
 			<language type="rof">ရွမ်ဘို</language>
-			<language type="root">မူလရင်းမြစ်</language>
 			<language type="ru">ရုရှ</language>
 			<language type="rup">အာရိုမန်းနီးယန်း</language>
 			<language type="rw">ကင်ရာဝန်ဒါ</language>

--- a/common/main/nb.xml
+++ b/common/main/nb.xml
@@ -482,7 +482,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldovsk</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">rot</language>
 			<language type="rtm">rotumansk</language>
 			<language type="ru">russisk</language>
 			<language type="rue">rusinsk</language>

--- a/common/main/nds.xml
+++ b/common/main/nds.xml
@@ -353,7 +353,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro" draft="unconfirmed">Rumäänsch</language>
 			<language type="ro_MD" draft="unconfirmed">Moldaawsch</language>
 			<language type="rom" draft="unconfirmed">Romani</language>
-			<language type="root" draft="unconfirmed">Wortel</language>
 			<language type="ru" draft="unconfirmed">Russ’sch</language>
 			<language type="rup" draft="unconfirmed">Aromuunsch</language>
 			<language type="rw" draft="unconfirmed">Ruandsch</language>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -467,7 +467,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">रोमानियाली</language>
 			<language type="ro_MD">मोल्डाभियाली</language>
 			<language type="rof">रोम्बो</language>
-			<language type="root">रुट</language>
 			<language type="ru">रसियाली</language>
 			<language type="rup">अरोमानीयाली</language>
 			<language type="rw">किन्यारवान्डा</language>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -482,7 +482,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">↑↑↑</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romani</language>
-			<language type="root">Root</language>
 			<language type="rtm">Rotumaans</language>
 			<language type="ru">Russisch</language>
 			<language type="rue">Roetheens</language>

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -399,7 +399,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">moldavisk</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">rot</language>
 			<language type="ru">russisk</language>
 			<language type="rup">arumensk</language>
 			<language type="rw">kinjarwanda</language>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -397,7 +397,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">ମୋଲଡୋଭିଆନ୍</language>
 			<language type="rof">ରୋମ୍ବୋ</language>
 			<language type="rom">ରୋମାନି</language>
-			<language type="root">ରୋଟ୍</language>
 			<language type="ru">ରୁଷିୟ</language>
 			<language type="rup">ଆରୋମାନିଆନ୍</language>
 			<language type="rw">କିନ୍ୟାରୱାଣ୍ଡା</language>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -331,7 +331,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">ਰੋਮਾਨੀਆਈ</language>
 			<language type="ro_MD">ਮੋਲਡਾਵੀਆਈ</language>
 			<language type="rof">ਰੋਮਬੋ</language>
-			<language type="root">ਰੂਟ</language>
 			<language type="ru">ਰੂਸੀ</language>
 			<language type="rup">ਅਰੋਮੀਨੀਆਈ</language>
 			<language type="rw">ਕਿਨਿਆਰਵਾਂਡਾ</language>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -481,7 +481,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">mołdawski</language>
 			<language type="rof">rombo</language>
 			<language type="rom">cygański</language>
-			<language type="root">język rdzenny</language>
 			<language type="rtm">rotumański</language>
 			<language type="ru">rosyjski</language>
 			<language type="rue">rusiński</language>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -311,7 +311,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">رومانیایی</language>
 			<language type="ro_MD">مولداویایی</language>
 			<language type="rof">رومبو</language>
-			<language type="root">روټ</language>
 			<language type="ru">روسي</language>
 			<language type="rup">اروماني</language>
 			<language type="rw">کینیارونډا</language>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -423,7 +423,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldávio</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">raiz</language>
 			<language type="ru">russo</language>
 			<language type="rup">aromeno</language>
 			<language type="rw">quiniaruanda</language>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -422,7 +422,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldávio</language>
 			<language type="rof">rombo</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="ru">russo</language>
 			<language type="rup">↑↑↑</language>
 			<language type="rw">quiniaruanda</language>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -421,7 +421,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">română</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root" draft="contributed">rădăcină</language>
 			<language type="ru">rusă</language>
 			<language type="rup">aromână</language>
 			<language type="rw">kinyarwanda</language>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -422,7 +422,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">молдавский</language>
 			<language type="rof">ромбо</language>
 			<language type="rom">цыганский</language>
-			<language type="root">праязык</language>
 			<language type="ru">русский</language>
 			<language type="rup">арумынский</language>
 			<language type="rw">киньяруанда</language>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -311,7 +311,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">روماني</language>
 			<language type="ro_MD">مالديوي</language>
 			<language type="rof">رومبو</language>
-			<language type="root">روٽ</language>
 			<language type="ru">روسي</language>
 			<language type="rup">ارومينين</language>
 			<language type="rw">ڪنيار وانڊا</language>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -322,7 +322,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">රොමේනියානු</language>
 			<language type="ro_MD">මොල්ඩවිආනු</language>
 			<language type="rof">රෝම්බෝ</language>
-			<language type="root">රූට්</language>
 			<language type="ru">රුසියානු</language>
 			<language type="rup">ඇරොමානියානු</language>
 			<language type="rw">කින්යර්වන්ඩා</language>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -417,7 +417,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavčina</language>
 			<language type="rof">rombo</language>
 			<language type="rom">rómčina</language>
-			<language type="root">koreň</language>
 			<language type="ru">ruština</language>
 			<language type="rup">arumunčina</language>
 			<language type="rw">rwandčina</language>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -403,7 +403,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldavščina</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romščina</language>
-			<language type="root">rootščina</language>
 			<language type="ru">ruščina</language>
 			<language type="rup">aromunščina</language>
 			<language type="rw">ruandščina</language>

--- a/common/main/smn.xml
+++ b/common/main/smn.xml
@@ -309,7 +309,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">romaniakielâ</language>
 			<language type="rof">rombo</language>
 			<language type="rom">roomaankielâ</language>
-			<language type="root">ruotâs</language>
 			<language type="ru">ruošâkielâ</language>
 			<language type="rup">aromaniakielâ</language>
 			<language type="rw">ruandakielâ</language>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -207,7 +207,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">Romanka</language>
 			<language type="ro_MD">↑↑↑</language>
 			<language type="rof">Rombo</language>
-			<language type="root">Xidid</language>
 			<language type="ru">Ruush</language>
 			<language type="rw">Ruwaandha</language>
 			<language type="rwk">Raawa</language>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -319,7 +319,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">rumanisht</language>
 			<language type="ro_MD">moldavisht</language>
 			<language type="rof">romboisht</language>
-			<language type="root">rutisht</language>
 			<language type="ru">rusisht</language>
 			<language type="rup">vllahisht</language>
 			<language type="rw">kiniaruandisht</language>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -406,7 +406,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">молдавски</language>
 			<language type="rof">ромбо</language>
 			<language type="rom">ромски</language>
-			<language type="root">рут</language>
 			<language type="ru">руски</language>
 			<language type="rup">цинцарски</language>
 			<language type="rw">кињаруанда</language>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -396,7 +396,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">moldavski</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romski</language>
-			<language type="root">rut</language>
 			<language type="ru">ruski</language>
 			<language type="rup">cincarski</language>
 			<language type="rw">kinjaruanda</language>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -482,7 +482,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">moldaviska</language>
 			<language type="rof">rombo</language>
 			<language type="rom">romani</language>
-			<language type="root">rot</language>
 			<language type="rtm">rotumänska</language>
 			<language type="ru">ryska</language>
 			<language type="rue">rusyn</language>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -351,7 +351,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">Kiromania</language>
 			<language type="ro_MD">Kimoldova cha Romania</language>
 			<language type="rof">Kirombo</language>
-			<language type="root">Kiroot</language>
 			<language type="ru">Kirusi</language>
 			<language type="rup">Kiaromania</language>
 			<language type="rw">Kinyarwanda</language>

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -347,7 +347,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">↑↑↑</language>
 			<language type="ro_MD">Kimoldova cha Romania</language>
 			<language type="rof">↑↑↑</language>
-			<language type="root">Kiroot</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rup">↑↑↑</language>
 			<language type="rw">↑↑↑</language>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -414,7 +414,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">மோல்டாவியன்</language>
 			<language type="rof">ரோம்போ</language>
 			<language type="rom">ரோமானி</language>
-			<language type="root">ரூட்</language>
 			<language type="ru">ரஷியன்</language>
 			<language type="rup">அரோமானியன்</language>
 			<language type="rw">கின்யாருவான்டா</language>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -412,7 +412,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">మొల్డావియన్</language>
 			<language type="rof">రోంబో</language>
 			<language type="rom">రోమానీ</language>
-			<language type="root">రూట్</language>
 			<language type="ru">రష్యన్</language>
 			<language type="rup">ఆరోమేనియన్</language>
 			<language type="rw">కిన్యర్వాండా</language>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -481,7 +481,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">มอลโดวา</language>
 			<language type="rof">รอมโบ</language>
 			<language type="rom">โรมานี</language>
-			<language type="root">รูท</language>
 			<language type="rtm" draft="contributed">โรทูมัน</language>
 			<language type="ru">รัสเซีย</language>
 			<language type="rue" draft="contributed">รูซิน</language>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -309,7 +309,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">rumyn dili</language>
 			<language type="ro_MD">moldaw dili</language>
 			<language type="rof">rombo dili</language>
-			<language type="root">kök</language>
 			<language type="ru">rus dili</language>
 			<language type="rup">arumyn dili</language>
 			<language type="rw">kinýaruanda dili</language>

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -475,7 +475,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">lea fakamolitāvia</language>
 			<language type="rof">lea fakalomipō</language>
 			<language type="rom">lea fakalomani</language>
-			<language type="root">lea fakaʻilonga-tefito</language>
 			<language type="rtm">lea fakalotuma</language>
 			<language type="ru">lea fakalūsia</language>
 			<language type="rue">lea fakalusini</language>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -482,7 +482,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Moldovaca</language>
 			<language type="rof">Rombo</language>
 			<language type="rom">Romanca</language>
-			<language type="root">Köken</language>
 			<language type="rtm">Rotuman</language>
 			<language type="ru">Rusça</language>
 			<language type="rue">Rusince</language>

--- a/common/main/ug.xml
+++ b/common/main/ug.xml
@@ -395,7 +395,6 @@ Reviewed by Waris Abdukerim Janbaz <oyghan@gmail.com> of the Uyghur Computer Sci
 			<language type="ro">رومىنچە</language>
 			<language type="rof" draft="contributed">رومبوچە</language>
 			<language type="rom" draft="contributed">سىگانچە</language>
-			<language type="root" draft="contributed">غول تىل</language>
 			<language type="ru">رۇسچە</language>
 			<language type="rup" draft="contributed">ئارومانچە</language>
 			<language type="rw">كېنىيەرىۋانداچە</language>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -435,7 +435,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">молдавська</language>
 			<language type="rof">ромбо</language>
 			<language type="rom">циганська</language>
-			<language type="root">коренева</language>
 			<language type="ru">російська</language>
 			<language type="rup">арумунська</language>
 			<language type="rw">кіньяруанда</language>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -324,7 +324,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">رومینین</language>
 			<language type="ro_MD">مالدووا</language>
 			<language type="rof">رومبو</language>
-			<language type="root">روٹ</language>
 			<language type="ru">روسی</language>
 			<language type="rup">ارومانی</language>
 			<language type="rw">کینیاروانڈا</language>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -318,7 +318,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">rumincha</language>
 			<language type="ro_MD">moldovan</language>
 			<language type="rof">rombo</language>
-			<language type="root">tub aholi tili</language>
 			<language type="ru">ruscha</language>
 			<language type="rup">arumin</language>
 			<language type="rw">kinyaruanda</language>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -451,7 +451,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">Tiếng Moldova</language>
 			<language type="rof">Tiếng Rombo</language>
 			<language type="rom">Tiếng Romany</language>
-			<language type="root">Tiếng Root</language>
 			<language type="ru">Tiếng Nga</language>
 			<language type="rup">Tiếng Aromania</language>
 			<language type="rw">Tiếng Kinyarwanda</language>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -474,7 +474,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">摩爾多瓦文</language>
 			<language type="rof">蘭博文</language>
 			<language type="rom">吉普賽文</language>
-			<language type="root">根語言</language>
 			<language type="rtm">羅圖馬島文</language>
 			<language type="ru">俄文</language>
 			<language type="rue">盧森尼亞文</language>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -461,7 +461,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">摩尔多瓦文</language>
 			<language type="rof">兰博文</language>
 			<language type="rom">吉普赛文</language>
-			<language type="root">根语言</language>
 			<language type="rtm">罗图马岛文</language>
 			<language type="ru">俄文</language>
 			<language type="rue">卢森尼亚文</language>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -423,7 +423,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">摩尔多瓦语</language>
 			<language type="rof">兰博语</language>
 			<language type="rom">吉普赛语</language>
-			<language type="root">根语言</language>
 			<language type="ru">俄语</language>
 			<language type="rup">阿罗马尼亚语</language>
 			<language type="rw">卢旺达语</language>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -482,7 +482,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro_MD">摩爾多瓦文</language>
 			<language type="rof">蘭博文</language>
 			<language type="rom">吉普賽文</language>
-			<language type="root">根語言</language>
 			<language type="rtm">羅圖馬島文</language>
 			<language type="ru">俄文</language>
 			<language type="rue">盧森尼亞文</language>

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -483,7 +483,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro_MD">摩爾多瓦羅馬尼亞文</language>
 			<language type="rof">↑↑↑</language>
 			<language type="rom">↑↑↑</language>
-			<language type="root">↑↑↑</language>
 			<language type="rtm">↑↑↑</language>
 			<language type="ru">↑↑↑</language>
 			<language type="rue">↑↑↑</language>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -329,7 +329,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ro">isi-Romanian</language>
 			<language type="ro_MD">isi-Moldavian</language>
 			<language type="rof">isi-Rombo</language>
-			<language type="root">isi-Root</language>
 			<language type="ru">isi-Russian</language>
 			<language type="rup">isi-Aromanian</language>
 			<language type="rw">isi-Kinyarwanda</language>

--- a/seed/main/bgn.xml
+++ b/seed/main/bgn.xml
@@ -303,7 +303,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro">رومانی</language>
 			<language type="ro_MD">مالداوی</language>
 			<language type="rof">رومبویی</language>
-			<language type="root">رووٹی</language>
 			<language type="ru">اوروسی</language>
 			<language type="rup">آرومانی</language>
 			<language type="rw">کینیارواندی</language>

--- a/seed/main/sc.xml
+++ b/seed/main/sc.xml
@@ -207,7 +207,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro" draft="unconfirmed">rumenu</language>
 			<language type="ro_MD" draft="unconfirmed">moldavu</language>
 			<language type="rof" draft="unconfirmed">rombo</language>
-			<language type="root" draft="unconfirmed">raighina</language>
 			<language type="ru" draft="unconfirmed">russu</language>
 			<language type="rw" draft="unconfirmed">kinyarwanda</language>
 			<language type="rwk" draft="unconfirmed">rwa</language>

--- a/seed/main/szl.xml
+++ b/seed/main/szl.xml
@@ -199,7 +199,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ro" draft="unconfirmed">rumuński</language>
 			<language type="ro_MD" draft="unconfirmed">mołdawski</language>
 			<language type="rof" draft="unconfirmed">rōmbo</language>
-			<language type="root" draft="unconfirmed">jynzyk rdzynny</language>
 			<language type="ru" draft="unconfirmed">ruski</language>
 			<language type="rw" draft="unconfirmed">kinya-ruanda</language>
 			<language type="rwk" draft="unconfirmed">rwa</language>


### PR DESCRIPTION
-Delete translations such as рут from `common/main/*.xml` and `seed/main/*.xml`

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13498
- [x] Updated PR title and link in previous line to include Issue number

