### PR TITLE
CLDR-14361 Fix quarter format narrow typo

### DIFF
--- a/common/main/sd_Deva.xml
+++ b/common/main/sd_Deva.xml
@@ -319,7 +319,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="1">1</quarter>
 							<quarter type="2">2</quarter>
 							<quarter type="3">3</quarter>
-							<quarter type="4">1</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">पहिरों पाड़ो</quarter>


### PR DESCRIPTION
Quarter 4 was "1" in the format version, but "4" in the stand-alone version.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14361
- [x] Updated PR title and link in previous line to include Issue number
