### PR TITLE
CLDR-14363 Use PathUtilities for normalized file names (as opposed to getCanonicalPath()).

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLNormalizingLoader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLNormalizingLoader.java
@@ -152,7 +152,7 @@ public class XMLNormalizingLoader{
         try (
             InputStream fis = new FileInputStream(f);
         ) {
-            String fullFileName = f.getCanonicalPath();
+            String fullFileName = PathUtilities.getNormalizedPathString(f);
             XMLSource source = new SimpleXMLSource(localeId);
             XMLNormalizingHandler XML_HANDLER = new XMLNormalizingHandler(source, minimalDraftStatus);
             XMLFileReader.read(fullFileName, fis, -1, true, XML_HANDLER);


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14363
- [x] Updated PR title and link in previous line to include Issue number

