### PR TITLE
CLDR-14258 JSON build improvements: add cldr-segments-full

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrItem.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrItem.java
@@ -241,7 +241,7 @@ public class CldrItem implements Comparable<CldrItem> {
         XPathParts untransformedxpp = XPathParts.getFrozenInstance(untransformedPath);
         XPathParts untransformedfullxpp = XPathParts.getFrozenInstance(untransformedFullPath);
 
-        for (SplittableAttributeSpec s : LdmlConvertRules.SPLITTABLE_ATTRS) {
+        for (SplittableAttributeSpec s : LdmlConvertRules.getSplittableAttrs()) {
             if (fullxpp.containsElement(s.element) && fullxpp.containsAttribute(s.attribute)) {
                 ArrayList<CldrItem> list = new ArrayList<>();
                 String wordString = fullxpp.findAttributeValue(s.element, s.attribute);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrNode.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrNode.java
@@ -142,7 +142,7 @@ public class CldrNode {
     public Map<String, String> getAttrAsValueMap() {
         Map<String, String> attributesAsValues = new HashMap<>();
         for (String key : distinguishingAttributes.keySet()) {
-            String keyStr = LdmlConvertRules.getKeyStr(parent, name, key);
+            String keyStr = LdmlConvertRules.getKeyStr(getParent(), name, key);
             String keyStr2 = LdmlConvertRules.getKeyStr(name, key);
             if (LdmlConvertRules.ATTR_AS_VALUE_SET.contains(keyStr) || LdmlConvertRules.ATTR_AS_VALUE_SET.contains(keyStr2)) {
                 if (LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStr)) {
@@ -158,7 +158,7 @@ public class CldrNode {
             if (LdmlConvertRules.IGNORABLE_NONDISTINGUISHING_ATTR_SET.contains(key)) {
                 continue;
             }
-            String keyStr = LdmlConvertRules.getKeyStr(parent, name, key);
+            String keyStr = LdmlConvertRules.getKeyStr(getParent(), name, key);
             if (LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStr)) {
                 attributesAsValues.put(LdmlConvertRules.ANONYMOUS_KEY,
                     nondistinguishingAttributes.get(key));
@@ -229,7 +229,7 @@ public class CldrNode {
         StringBuffer strbuf = new StringBuffer();
         String lastKey = null; // for err message
         for (String key : distinguishingAttributes.keySet()) {
-            String attrIdStr = LdmlConvertRules.getKeyStr(parent, name, key);
+            String attrIdStr = LdmlConvertRules.getKeyStr(getParent(), name, key);
             String attrIdStr2 = LdmlConvertRules.getKeyStr(name, key);
             if (LdmlConvertRules.IsSuppresedAttr(attrIdStr)) {
                 continue;
@@ -257,7 +257,7 @@ public class CldrNode {
 
         // append distinguishing attributes
         for (String key : distinguishingAttributes.keySet()) {
-            String attrIdStr = LdmlConvertRules.getKeyStr(parent, name, key);
+            String attrIdStr = LdmlConvertRules.getKeyStr(getParent(), name, key);
             String attrIdStr2 = LdmlConvertRules.getKeyStr(name, key);
             if (LdmlConvertRules.IsSuppresedAttr(attrIdStr)) {
                 continue;
@@ -321,6 +321,10 @@ public class CldrNode {
 
     @Override
     public String toString() {
-        return "[CldrNode "+parent+"/"+getNodeDistinguishingName()+"]";
+        return "[CldrNode "+getParent()+"/"+getNodeDistinguishingName()+"]";
+    }
+
+    public String getParent() {
+        return parent;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -60,6 +60,7 @@ class LdmlConvertRules {
         "weekData:firstDay:territories",
         "weekData:weekendStart:territories",
         "weekData:weekendEnd:territories",
+        "supplemental:dayPeriodRuleSet:type",
         // units
         "unitPreferenceDataData:unitPreferences:category",
        // grammatical features
@@ -298,7 +299,7 @@ class LdmlConvertRules {
      * <weekendStart day="thu" territories="AF"/>
      * <weekendStart day="thu" territories="IR"/>
      */
-    public static final SplittableAttributeSpec[] SPLITTABLE_ATTRS = {
+    private static final SplittableAttributeSpec[] SPLITTABLE_ATTRS = {
         new SplittableAttributeSpec("calendarPreference", "territories", null),
         new SplittableAttributeSpec("pluralRanges", "locales", null),
         new SplittableAttributeSpec("pluralRules", "locales", null),
@@ -306,7 +307,9 @@ class LdmlConvertRules {
         new SplittableAttributeSpec("firstDay", "territories", "day"),
         new SplittableAttributeSpec("weekendStart", "territories", "day"),
         new SplittableAttributeSpec("weekendEnd", "territories", "day"),
+        new SplittableAttributeSpec("weekOfPreference", "locales", "ordering"),
         new SplittableAttributeSpec("measurementSystem", "territories", "type"),
+        // this is deprecated, so no need to generalize this exception.
         new SplittableAttributeSpec("measurementSystem-category-temperature", "territories", "type"),
         new SplittableAttributeSpec("paperSize", "territories", "type"),
         new SplittableAttributeSpec("parentLocale", "locales", "parent"),
@@ -331,7 +334,7 @@ class LdmlConvertRules {
      * as a single string.
      */
     public static final Set<String> ATTRVALUE_AS_ARRAY_SET = Builder.with(new HashSet<String>())
-        .add("territories").add("scripts").add("contains").freeze();
+        .add("territories").add("scripts").add("contains").add("systems").freeze();
 
     /**
      * Following is the list of elements that need to be sorted before output.
@@ -376,6 +379,10 @@ class LdmlConvertRules {
      */
     public static final Pattern VALUE_IS_SPACESEP_ARRAY = PatternCache.get(
         "(grammaticalCase|grammaticalGender|grammaticalDefiniteness)"
+    );
+    public static final Set<String> CHILD_VALUE_IS_SPACESEP_ARRAY = ImmutableSet.of(
+        "weekOfPreference",
+        "calendarPreferenceData"
     );
 
     /**
@@ -556,5 +563,14 @@ class LdmlConvertRules {
     public final static String getKeyStr(String parent, String name, String key) {
         String keyStr = parent + ":" + name + ":" + key;
         return keyStr;
+    }
+
+    public static SplittableAttributeSpec[] getSplittableAttrs() {
+        return SPLITTABLE_ATTRS;
+    }
+
+    public static final boolean valueIsSpacesepArray(final String nodeName, String parent) {
+        return VALUE_IS_SPACESEP_ARRAY.matcher(nodeName).matches()
+            || (parent!=null && CHILD_VALUE_IS_SPACESEP_ARRAY.contains(parent));
     }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -1,5 +1,5 @@
 section=characterFallbacks ; path=//cldr/supplemental/characters/.* ; package=core
-section=dayPeriods ; path=//cldr/supplemental/dayPeriodRuleSet/.* ; package=core
+section=dayPeriods ; path=//cldr/supplemental/(dayPeriodRuleSet).* ; package=core
 section=gender ; path=//cldr/supplemental/gender/.* ; package=core
 section=languageInfo ; path=//cldr/supplemental/languageInfo/.* ; package=core
 section=likelySubtags ; path=//cldr/supplemental/likelySubtags/.* ; package=core
@@ -20,7 +20,7 @@ section=calendarData ; path=//cldr/supplemental/calendarData/.* ; package=core
 section=calendarPreferenceData ; path=//cldr/supplemental/calendarPreferenceData/.* ; package=core
 section=unitPreferenceData ; path=//cldr/supplemental/unitPreferenceData/.* ; package=core
 section=grammaticalFeatures ; path=//cldr/supplemental/(grammaticalData)/.* ; package=core
-section=grammaticalGenderFeatures ; path=//cldr/supplemental/(grammaticalGenderData)/.* ; package=core
+section=grammaticalGenderFeatures ; path=//cldr/supplemental/(grammaticalGenderData).* ; package=core
 section=weekData ; path=//cldr/supplemental/weekData/.* ; package=core
 section=timeData ; path=//cldr/supplemental/timeData/.* ; package=core
 section=measurementData ; path=//cldr/supplemental/measurementData/.* ; package=core
@@ -30,3 +30,12 @@ section=references ; path=//cldr/supplemental/references/.* ; package=core
 section=telephoneCodeData ; path=//cldr/supplemental/telephoneCodeData/.* ; package=core
 section=windowsZones ; path=//cldr/supplemental/windowsZones/.* ; package=core
 section=aliases ; path=//cldr/supplemental/metadata/alias/(language|script|subdivision|territory|variant|zone)Alias.* ; package=core
+section=units ; path=//cldr/supplemental/(unitConstants|unitQuantities|convertUnits).* ; package=core
+section=unitsMetadata ; path=//cldr/supplemental/metadata/.*/(unitAlias|usageAlias).* ; package=core
+
+# ignored items
+section=IGNORE ; path=//cldr/supplemental/metadata/serialElements.* ; package=IGNORE
+section=IGNORE ; path=//cldr/supplemental/metadata/suppress.* ; package=IGNORE
+# defaultContent is not really ignored, but is handled by special code in Ldml2JsonConverter
+section=IGNORE ; path=//cldr/supplemental/metadata/defaultContent.* ; package=IGNORE
+#

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
@@ -1,0 +1,104 @@
+package org.unicode.cldr.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.json.LdmlConvertRules.SplittableAttributeSpec;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.DtdData;
+import org.unicode.cldr.util.DtdData.Attribute;
+import org.unicode.cldr.util.DtdData.Element;
+import org.unicode.cldr.util.DtdType;
+import org.unicode.cldr.util.MatchValue;
+import org.unicode.cldr.util.Pair;
+
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+
+class LdmlConvertRulesTest {
+    final File cldrDir = CLDRConfig.getInstance().getCldrBaseDirectory();
+    final DtdData dtds[] = {
+        DtdData.getInstance(DtdType.supplementalData, cldrDir),
+        DtdData.getInstance(DtdType.ldml, cldrDir)
+    };
+
+    @Test
+    void testSplittableAttributes() {
+        // collect JSON list
+        Set<Pair<String,String>> jsonSplittableAttrs = new TreeSet<>();
+        for(final SplittableAttributeSpec e : LdmlConvertRules.getSplittableAttrs()) {
+            if(e.element.equals("measurementSystem-category-temperature")) continue; // skip this deprecated item
+            jsonSplittableAttrs.add(Pair.of(e.element, e.attribute));
+        }
+
+        LdmlConvertRules.ATTR_AS_VALUE_SET.forEach(s -> {
+                final String triple[] = s.split(":");
+                jsonSplittableAttrs.add(Pair.of(triple[1],triple[2]));
+            });
+
+        // collect DTD list
+        Set<Pair<String,String>> dtdSplittableAttrs = new TreeSet<>();
+        for(final DtdData dtd: dtds) {
+            for(final Element element : dtd.getElements()) {
+                if(element.getAttributes() == null) continue; // ?
+                for(final Entry<Attribute, Integer> q : element.getAttributes().entrySet()) {
+                    Attribute attr = q.getKey();
+                    if(attr.matchValue != null && attr.matchValue instanceof MatchValue.SetMatchValue) {
+                        boolean isSpacesepArray = LdmlConvertRules.CHILD_VALUE_IS_SPACESEP_ARRAY.contains(element.name);
+                        boolean childIsSpacesepArray = LdmlConvertRules.VALUE_IS_SPACESEP_ARRAY.matcher(element.name).matches();
+                        boolean attrValueIsArraySet = LdmlConvertRules.ATTRVALUE_AS_ARRAY_SET.contains(attr.name);
+
+                        if(isSpacesepArray ||
+                           childIsSpacesepArray ||
+                           attrValueIsArraySet) {
+                            jsonSplittableAttrs.add(Pair.of(element.name, attr.name));
+                        }
+                        dtdSplittableAttrs.add(Pair.of(element.name, attr.name));
+                    }
+                }
+            }
+        }
+
+
+        // ** Add some exceptions
+
+        // Handled manually
+        jsonSplittableAttrs.add(Pair.of("defaultContent", "locales"));
+
+        // handled as calendarPreferenceData
+        jsonSplittableAttrs.add(Pair.of("calendarPreference", "ordering"));
+
+        // These aren't a set, in practice.
+        dtdSplittableAttrs.remove(Pair.of("grammaticalFeatures", "targets"));
+        dtdSplittableAttrs.remove(Pair.of("territoryAlias", "replacement"));
+        dtdSplittableAttrs.remove(Pair.of("subdivisionAlias", "replacement"));
+        dtdSplittableAttrs.remove(Pair.of("territoryAlias", "type"));
+        dtdSplittableAttrs.remove(Pair.of("deriveCompound", "feature"));
+        dtdSplittableAttrs.remove(Pair.of("deriveComponent", "feature"));
+        dtdSplittableAttrs.remove(Pair.of("deriveCompound", "structure"));
+        dtdSplittableAttrs.remove(Pair.of("deriveComponent", "structure"));
+        dtdSplittableAttrs.remove(Pair.of("deriveCompound", "value"));
+
+        //Keep these as not-a-set for compatibility
+        jsonSplittableAttrs.add(Pair.of("paradigmLocales", "locales"));
+
+
+        SetView<Pair<String, String>> onlyInDtd = Sets.difference(dtdSplittableAttrs, jsonSplittableAttrs);
+
+
+//        SetView<Pair<String, String>> onlyInJson = Sets.difference(jsonSplittableAttrs, dtdSplittableAttrs);
+//        if(!onlyInJson.isEmpty()) {
+//            System.err.println("Only in JSON, missing from DTD (!): " + onlyInJson); // just noise
+//        }
+
+        assertEquals(Collections.emptySet(), onlyInDtd, "set items missing from JSON configuration");
+
+    }
+
+}


### PR DESCRIPTION
CLDR-14258 JSON build improvements: add cldr-segments-full

- add a -V option to specify the version, overriding the CLDR version
- restructuring for more clarity on the package calculation process
- reduce the default text output verbosity
- cause the "other" package to not overwrite if multiple "other" sections.
- make sure all tiered (full/modern) modules have files present in full if they are in modern
(only affected module: segments)
- change output format to spend less time in synchronized block:
One output per input file with a summary.
Percentage progress inspired by ninja-build.

Also changes from:

CLDR-14313 compare JSON config to DTD Data

- JSON config was not easily derivable from DTD, however, this commit now
runs a test comparing especially "@MATCH:set" annotations against items treated as
sets in JSON (LdmlConvertRulesTest#testSplittableAttributes) with some exceptions.

JSON output changes caused by this PR
- These items are now arrays instead of strings:
  - supplemental/calendarPreferenceData
  - supplemental/weekData (now grouped by territory)
- Previously MISSING data now added
  - cldr-core/dayPeriods.json:    dayPeriodRuleSet-type-selection"
  - cldr-core/units.json:         unitConstants, unitQuantities
  - cldr-core/unitsMetadata.json: unit deprecations
