### PR TITLE
CLDR-13987 improve @CLDRTool annotation, default CLDR_DIR in tools

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRConfigImpl.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRConfigImpl.java
@@ -165,7 +165,7 @@ public class CLDRConfigImpl extends CLDRConfig implements JSONString {
 
         // The git version of the cldr-apps.war file.
         survprops.put("CLDR_SURVEYTOOL_HASH", getGitHashForSlug("CLDR-Apps")); // Not available until init() is called.
-        // The git version of the cldr.jar file embedded in cldr-apps.
+        // The git version of the cldr-code.jar file embedded in cldr-apps.
         survprops.put("CLDR_UTILITIES_HASH", getGitHashForSlug("CLDR-Tools"));
         // The git version of the CLDR_DIR currently in use.
         survprops.put("CLDR_DATA_HASH", CldrUtility.getGitHashForDir(survprops.getProperty("CLDR_DIR", null)));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Main.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Main.java
@@ -8,27 +8,29 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRTool;
 
 /**
- *
- * Implement a 'main' for the CLDR jar.
+ * Implement a 'main' for the cldr-code jar.
  */
-@CLDRTool(alias = "main", description = "The 'main' class invoked when java -jar or doubleclicking the jar.", hidden = "Hidden so as not to list itself",
+@CLDRTool(alias = "main", description = "The 'main' class invoked when java -jar or double-clicking the jar.", hidden = "Hidden so as not to list itself",
     url = Main.TOOLSURL)
 class Main {
     private static final String CLASS_SUFFIX = ".class";
     private static final String MAIN = "main";
     public static final String TOOLSURL = "http://cldr.unicode.org/tools/";
+    private static final boolean DEBUG = false;
 
     public static void main(String args[]) throws Throwable {
         if (args.length == 0) {
             System.out.println("Usage:  [ -l | [class|alias] args ...]");
             System.out.println("Example usage:");
-            System.out.println(" (java -jar cldr.jar ) -l          -- prints a list of ALL tool/util/test classes with a 'main()' function.");
-            System.out.println(" (java -jar cldr.jar ) org.unicode.cldr.util.XMLValidator  somefile.xml ...");
-            System.out.println(" (java -jar cldr.jar ) validate  somefile.xml ...");
+            System.out.println(" (java -jar cldr-code.jar ) -l          -- prints a list of ALL tool/util/test classes with a 'main()' function.");
+            System.out.println(" (java -jar cldr-code.jar ) org.unicode.cldr.util.XMLValidator  somefile.xml ...");
+            System.out.println(" (java -jar cldr-code.jar ) validate  somefile.xml ...");
             System.out.println("For more info: " + TOOLSURL);
             System.out.println("CLDRFile.GEN_VERSION=" + CLDRFile.GEN_VERSION);
             System.out.println("(Use the -l option to list hidden/undocumented tools)");
             System.out.println();
+
+            // Go ahead and list out classes while we're at it
             listClasses(false, null);
         } else if (args.length == 1 && args[0].equals("-l")) {
             listClasses(true, null);
@@ -37,6 +39,17 @@ class Main {
             final String args2[] = new String[args.length - 1];
             System.arraycopy(args, 1, args2, 0, args2.length);
             Class<?> c = null;
+
+            try {
+                if(System.getProperty("CLDR_DIR") == null) {
+                    if(new java.io.File("./common/main/root.xml").exists()) {
+                        System.err.println("Note: CLDR_DIR was unset but you seem to be in a CLDR directory. Setting -DCLDR_DIR=.");
+                        System.setProperty("CLDR_DIR", ".");
+                    }
+                }
+            } catch(SecurityException t) {
+                // ignore
+            }
 
             try {
                 c = Class.forName(mainClass);
@@ -170,7 +183,7 @@ class Main {
             System.out.println("(Not inside a .jar file - no listing available.)");
             return null;
         }
-        if (false) System.out.println("Classes in " + url.getPath());
+        if (DEBUG) System.out.println("Classes in " + url.getPath());
         final java.util.jar.JarInputStream jis = new java.util.jar.JarInputStream(new java.io.FileInputStream(url.getPath()));
         java.util.jar.JarEntry je = null;
         return jis;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CLDRTool;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.PathHeader;
@@ -29,6 +30,7 @@ import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
 
+@CLDRTool(alias = "searchxml", description = "Search CLDR XML for matching paths or values")
 public class SearchXml {
 
     // TODO Use options

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTool.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTool.java
@@ -11,7 +11,8 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to mark CLDR Tools that are runnable by users.
  * All CLDR Tools should be so annotated.
- * Running "java -jar cldr.jar" will list all annotated tools.
+ * Running "java -jar cldr-code.jar" will list all annotated tools.
+ * See: http://cldr.unicode.org/development/coding-cldr-tools/documenting-cldr-tools
  *
  * @author srl
  */


### PR DESCRIPTION
CLDR-13987

- use a default CLDR_DIR if the jar is launched from a CLDR dir
- add docs for SearchXML
- correct cldr.jar to cldr-code.jar

Also see rewrites to http://cldr.unicode.org/tools