### PR TITLE
CLDR-14251 Modernize: start a new version of the front end without dojo

### DIFF
--- a/tools/cldr-apps/js-unittest/Test.html
+++ b/tools/cldr-apps/js-unittest/Test.html
@@ -19,25 +19,25 @@
       mocha.setup('bdd');
       mocha.checkLeaks();
     </script>
-    <script src="../src/main/webapp/js/CldrStBulkClosePosts.js"></script>
-    <script src="../src/main/webapp/js/CldrStForumParticipation.js"></script>
-    <script src="../src/main/webapp/js/CldrStForumFilter.js"></script>
-    <script src="../src/main/webapp/js/CldrStForum.js"></script>
-    <script src="../src/main/webapp/js/CldrSurveyVettingTable.js"></script>
-    <script src="../src/main/webapp/js/CldrStCsvFromTable.js"></script>
-    <script src="../src/main/webapp/js/CldrStatus.js"></script>
-    <script src="../src/main/webapp/js/CldrGui.js"></script>
-    <script src="../src/main/webapp/js/CldrText.js"></script>
+    <script src="../src/main/webapp/js/new/cldrBulkClosePosts.js"></script>
+    <script src="../src/main/webapp/js/new/cldrTable.js"></script>
+    <script src="../src/main/webapp/js/new/cldrForumParticipation.js"></script>
+    <script src="../src/main/webapp/js/new/cldrForumFilter.js"></script>
+    <script src="../src/main/webapp/js/new/cldrForum.js"></script>
+    <script src="../src/main/webapp/js/new/cldrCsvFromTable.js"></script>
+    <script src="../src/main/webapp/js/new/cldrStatus.js"></script>
+    <script src="../src/main/webapp/js/new/cldrGui.js"></script>
+    <script src="../src/main/webapp/js/new/cldrText.js"></script>
     <script src="data/forum_fr.js"></script>
     <script src="data/forum_participation_json.js"></script>
     <script src="data/bulk_close_posts_json.js"></script>
     <script src="TestCldrTest.js"></script>
-    <script src="TestCldrStForum.js"></script>
-    <script src="TestCldrStForumFilter.js"></script>
-    <script src="TestCldrStForumParticipation.js"></script>
-    <script src="TestCldrStChecksum.js"></script>
-    <script src="TestCldrStCsvFromTable.js"></script>
-    <script src="TestCldrStBulkClosePosts.js"></script>
+    <script src="TestCldrForum.js"></script>
+    <script src="TestCldrForumFilter.js"></script>
+    <script src="TestCldrForumParticipation.js"></script>
+    <script src="TestCldrChecksum.js"></script>
+    <script src="TestCldrCsvFromTable.js"></script>
+    <script src="TestCldrBulkClosePosts.js"></script>
     <script src="TestCldrStatus.js"></script>
     <script src="TestCldrGui.js"></script>
     <script src="TestCldrText.js"></script>

--- a/tools/cldr-apps/js-unittest/TestCldrBulkClosePosts.js
+++ b/tools/cldr-apps/js-unittest/TestCldrBulkClosePosts.js
@@ -3,7 +3,7 @@
 {
   const assert = chai.assert;
 
-  describe("cldrStBulkClosePosts.makeHtmlFromJson", function () {
+  describe("cldrBulkClosePosts.makeHtmlFromJson", function () {
     /*
      * bulkClosePostsJson has been defined in bulk_close_posts_json.js
      */
@@ -13,7 +13,7 @@
       assert(json != null);
     });
 
-    const html = cldrStBulkClosePosts.test.makeHtmlFromJson(json);
+    const html = cldrBulkClosePosts.test.makeHtmlFromJson(json);
 
     it("should not return null or empty", function () {
       assert(html != null && html !== "", "html is neither null nor empty");

--- a/tools/cldr-apps/js-unittest/TestCldrChecksum.js
+++ b/tools/cldr-apps/js-unittest/TestCldrChecksum.js
@@ -103,13 +103,13 @@
     '"value":"Chinesisch (traditionell)",' +
     '"example":"<div class=\'cldr_example\'>Chinesisch (traditionell)"}}}';
 
-  describe("cldrSurveyTable.test.cldrChecksum", function () {
+  describe("cldrTable.test.cldrChecksum", function () {
     const s1 = "animal=猫";
     const s2 = "animal=狗";
-    const c1 = cldrSurveyTable.test.cldrChecksum(s1);
-    const c2 = cldrSurveyTable.test.cldrChecksum(s1); // c2 should equal c1
-    const c3 = cldrSurveyTable.test.cldrChecksum(s2); // c3 should not equal c1
-    const cLong = cldrSurveyTable.test.cldrChecksum(sLong);
+    const c1 = cldrTable.test.cldrChecksum(s1);
+    const c2 = cldrTable.test.cldrChecksum(s1); // c2 should equal c1
+    const c3 = cldrTable.test.cldrChecksum(s2); // c3 should not equal c1
+    const cLong = cldrTable.test.cldrChecksum(sLong);
 
     it("should not return null or undefined", function () {
       assert(
@@ -133,7 +133,7 @@
     it("should be fast enough", function () {
       const startTime = Date.now();
       for (let i = 0; i < ITERATIONS; i++) {
-        const c = cldrSurveyTable.test.cldrChecksum(sLong);
+        const c = cldrTable.test.cldrChecksum(sLong);
         assert(c === cLong, "c should equal cLong");
       }
       const duration = Date.now() - startTime; // typically 15 ms

--- a/tools/cldr-apps/js-unittest/TestCldrCsvFromTable.js
+++ b/tools/cldr-apps/js-unittest/TestCldrCsvFromTable.js
@@ -2,7 +2,7 @@
 {
   const assert = chai.assert;
 
-  describe("cldrStCsvFromTable.getCsvFromTable", function () {
+  describe("cldrCsvFromTable.get", function () {
     const table = document.createElement("table");
 
     table.innerHTML =
@@ -11,7 +11,7 @@
 
     const expectedOutput = "a,b,c\nd,e,f\n";
 
-    const actualOutput = cldrStCsvFromTable.getCsvFromTable(table);
+    const actualOutput = cldrCsvFromTable.test.get(table);
 
     it("should not return null", function () {
       assert(actualOutput != null, "actualOutput should not be null.");

--- a/tools/cldr-apps/js-unittest/TestCldrForum.js
+++ b/tools/cldr-apps/js-unittest/TestCldrForum.js
@@ -3,7 +3,7 @@
 {
   const assert = chai.assert;
 
-  describe("cldrStForum.parseContent", function () {
+  describe("cldrForum.parseContent", function () {
     let json = null;
 
     it("should get json", function () {
@@ -20,9 +20,9 @@
       const posts = json.ret;
       assert(posts != null, "posts is not null");
 
-      cldrStForum.test.setDisplayUtc(true); // so test can pass regardless of time zone
+      cldrForum.test.setDisplayUtc(true); // so test can pass regardless of time zone
 
-      const content = cldrStForum.parseContent(posts, "info");
+      const content = cldrForum.parseContent(posts, "info");
       assert(content != null, "content is not null");
 
       assert.equal(
@@ -85,8 +85,8 @@
     });
   });
 
-  describe("cldrStForum.getForumSummaryHtml", function () {
-    const html = cldrStForum.getForumSummaryHtml("aa", 1, true);
+  describe("cldrForum.getForumSummaryHtml", function () {
+    const html = cldrForum.getForumSummaryHtml("aa", 1, true);
 
     it("should not return null or empty", function () {
       assert(html != null && html !== "", "html is neither null nor empty");

--- a/tools/cldr-apps/js-unittest/TestCldrForumFilter.js
+++ b/tools/cldr-apps/js-unittest/TestCldrForumFilter.js
@@ -2,22 +2,22 @@
 {
   const assert = chai.assert;
 
-  describe("cldrStForumFilter.createMenu", function () {
+  describe("cldrForumFilter.createMenu", function () {
     it("should not return null", function () {
-      cldrStForumFilter.setUserId(1);
-      const actualOutput = cldrStForumFilter.createMenu(null);
+      cldrForumFilter.setUserId(1);
+      const actualOutput = cldrForumFilter.createMenu(null);
       assert(actualOutput != null, "not null");
     });
   });
 
-  describe("cldrStForumFilter.getFilteredThreadIds", function () {
+  describe("cldrForumFilter.getFilteredThreadIds", function () {
     it("should return one thread for two related posts", function () {
       const posts = [
         { id: 1, parent: -1, poster: 100, locale: "am" },
         { id: 2, parent: 1, poster: 200, locale: "am" },
       ];
-      const threadHash = cldrStForum.test.getThreadHash(posts);
-      const actualOutput = cldrStForumFilter.getFilteredThreadIds(
+      const threadHash = cldrForum.test.getThreadHash(posts);
+      const actualOutput = cldrForumFilter.getFilteredThreadIds(
         threadHash,
         false
       );
@@ -30,8 +30,8 @@
         { id: 2, parent: 1, poster: 200, locale: "zh" },
         { id: 3, parent: 2, poster: 300, locale: "zh" },
       ];
-      const threadHash = cldrStForum.test.getThreadHash(posts);
-      const actualOutput = cldrStForumFilter.getFilteredThreadIds(
+      const threadHash = cldrForum.test.getThreadHash(posts);
+      const actualOutput = cldrForumFilter.getFilteredThreadIds(
         threadHash,
         false
       );
@@ -43,8 +43,8 @@
         { id: 1, parent: -1, poster: 100, locale: "pt_PT" },
         { id: 2, parent: -1, poster: 200, locale: "pt_PT" },
       ];
-      const threadHash = cldrStForum.test.getThreadHash(posts);
-      const actualOutput = cldrStForumFilter.getFilteredThreadIds(
+      const threadHash = cldrForum.test.getThreadHash(posts);
+      const actualOutput = cldrForumFilter.getFilteredThreadIds(
         threadHash,
         false
       );

--- a/tools/cldr-apps/js-unittest/TestCldrForumParticipation.js
+++ b/tools/cldr-apps/js-unittest/TestCldrForumParticipation.js
@@ -3,7 +3,7 @@
 {
   const assert = chai.assert;
 
-  describe("cldrStForumParticipation.makeHtmlFromJson", function () {
+  describe("cldrForumParticipation.makeHtmlFromJson", function () {
     /*
      * forumParticipationJson has been defined in forum_participation_json.js
      */
@@ -13,7 +13,7 @@
       assert(json != null);
     });
 
-    const html = cldrStForumParticipation.test.makeHtmlFromJson(json);
+    const html = cldrForumParticipation.test.makeHtmlFromJson(json);
 
     it("should not return null or empty", function () {
       assert(html != null && html !== "", "html is neither null nor empty");

--- a/tools/cldr-apps/src/main/webapp/browse.jsp
+++ b/tools/cldr-apps/src/main/webapp/browse.jsp
@@ -43,7 +43,7 @@ SurveyTool.includeJavaScript(request, out);
 	   var r = document.getElementById('whatis_answer');
 	   if(v.length==0) { r.innerHTML = ''; return; }
 	   r.innerHTML = '<i>Looking up ' + v + '...</i>';
-	   cldrStAjax.sendXhr({
+	   cldrAjax.sendXhr({
 	        url:"<%= request.getContextPath() %>/browse_results.jsp?loc=<%= pageLocale.getBaseName() %>&q=" + v,
 	        load: function(h){
 	        	  r.innerHTML = h;
@@ -59,7 +59,7 @@ SurveyTool.includeJavaScript(request, out);
 	       if(v.length==0) { return; }
 	       var r = document.getElementById('xpath_answer');
 	       r.innerHTML = '<i>Looking up xpath ' + v + '...</i>';
-	       cldrStAjax.sendXhr({
+	       cldrAjax.sendXhr({
 	            url:"<%= request.getContextPath() %>/xpath_results.jsp?from="+ from + "&q=" + v,
 	           handleAs:"json",
 	           load: function(h){

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoBulkClosePosts.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoBulkClosePosts.js
@@ -1,0 +1,167 @@
+"use strict";
+
+/**
+ * cldrBulkClosePosts: Survey Tool feature for bulk-closing forum posts
+ * This is the dojo version. For non-dojo, see cldrBulkClosePosts.js.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ *
+ * Dependencies: showInPop2, hideLoader
+ */
+const cldrBulkClosePosts = (function () {
+  let saveParamsForExecute = null;
+
+  let contentDiv = null;
+
+  /**
+   * Fetch the Bulk Close Posts data from the server, and "load" it
+   *
+   * @param params an object with various properties; see SpecialPage.js
+   */
+  function load(params) {
+    saveParamsForExecute = params;
+    /*
+     * Set up the 'right sidebar'; cf. bulk_close_postsGuidance
+     */
+    showInPop2(cldrText.get(params.name + "Guidance"), null, null, null, true);
+
+    const url = getBulkClosePostsUrl();
+    const errorHandler = function (err) {
+      params.special.showError(params, null, {
+        err: err,
+        what: "Loading Forum Bulk Close Posts data",
+      });
+    };
+    const loadHandler = function (json) {
+      if (json.err) {
+        if (params.special) {
+          params.special.showError(params, json, {
+            what: "Loading Forum Bulk Close Posts data",
+          });
+        }
+        return;
+      }
+      const html = makeHtmlFromJson(json);
+      contentDiv = document.createElement("div");
+      contentDiv.innerHTML = html;
+
+      // No longer loading
+      hideLoader(null);
+      params.flipper.flipTo(params.pages.other, contentDiv);
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  /**
+   * Respond to button press
+   */
+  function execute() {
+    const params = saveParamsForExecute;
+
+    contentDiv.innerHTML = "<div><p>Bulk closing, in progress...</p></div>";
+
+    const url = getBulkClosePostsUrl() + "&execute=true";
+    const errorHandler = function (err) {
+      params.special.showError(params, null, {
+        err: err,
+        what: "Executing Forum Bulk Close Posts",
+      });
+    };
+    const loadHandler = function (json) {
+      if (json.err) {
+        params.special.showError(params, json, {
+          what: "Executing Forum Bulk Close Posts",
+        });
+        return;
+      }
+      contentDiv.innerHTML = makeHtmlFromJson(json);
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  /**
+   * Get the URL to use for loading the Forum Bulk Close Posts page
+   */
+  function getBulkClosePostsUrl() {
+    const sessionId = cldrStatus.getSessionId();
+    if (!sessionId) {
+      console.log("Error: sessionId falsy in getBulkClosePostsUrl");
+      return "";
+    }
+    return "SurveyAjax?what=bulk_close_posts&s=" + sessionId;
+  }
+
+  /**
+   * Make the html, given the json for Forum Bulk Close Posts
+   *
+   * @param json
+   * @return the html
+   */
+  function makeHtmlFromJson(json) {
+    let html = "<div>\n";
+    if (
+      typeof json.threadCount === "undefined" ||
+      typeof json.status === "undefined" ||
+      (json.status !== "ready" && json.status !== "done")
+    ) {
+      html +=
+        "<p>An error occurred: status = " +
+        json.status +
+        "; err = " +
+        json.err +
+        "</p>\n";
+    } else if (json.status === "ready") {
+      html +=
+        "<p>Total threads matching criteria for bulk closing: " +
+        json.threadCount +
+        "</p>\n";
+      if (json.threadCount > 0) {
+        html +=
+          "<h4><a onclick='cldrBulkClosePosts.execute()'>Close Threads!</a></h4>\n";
+        html += "<p>This action cannot be undone.</p>";
+        html +=
+          "<p>It should normally be done after a new version of CLDR is published, before opening Survey Tool.</p>\n";
+      }
+    } else if (json.status === "done") {
+      html += "<p>Total threads closed: " + json.threadCount + "</p>\n";
+      if (typeof json.postCount !== "undefined") {
+        html +=
+          "<p>Total posts closed (including replies): " +
+          json.postCount +
+          "</p>\n";
+      }
+    }
+    html += "</div>";
+    return html;
+  }
+
+  /*
+   * Make only these functions accessible from other files
+   */
+  return {
+    load: load,
+    execute: execute,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      makeHtmlFromJson: makeHtmlFromJson,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoDeferHelp.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoDeferHelp.js
@@ -1,6 +1,8 @@
 // © 2020 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 
+// This version is for use with dojo. For the non-dojo version, see cldrDeferHelp.js
+
 deferredHelp = (function () {
   const defaultEndpoint = "https://dbpedia.org/sparql/";
   const format = "JSON";
@@ -53,7 +55,6 @@ WHERE {
         );
       },
       (err) => {
-        // absDiv.addClass('err') ?
         absContent.text(`Err loading ${resource}: ${err}`);
       }
     );

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoForum.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoForum.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /**
- * cldrStForum: encapsulate main Survey Tool Forum code.
+ * cldrForum: encapsulate main Survey Tool Forum code
+ * This is the dojo version; see cldrForum.js for non-dojo
  *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
@@ -17,7 +18,7 @@
  * TODO: possibly move these functions here from survey.js: showForumStuff, havePosts,
  * updateInfoPanelForumPosts, appendForumStuff; also some/all code from forum.js
  */
-const cldrStForum = (function () {
+const cldrForum = (function () {
   const FORUM_DEBUG = false;
 
   function forumDebug(s) {
@@ -109,7 +110,7 @@ const cldrStForum = (function () {
       const ourDiv = document.createElement("div");
       ourDiv.appendChild(forumCreateChunk(forumMessage, "h4", ""));
 
-      const filterMenu = cldrStForumFilter.createMenu(reloadV);
+      const filterMenu = cldrForumFilter.createMenu(reloadV);
       const summaryDiv = document.createElement("div");
       summaryDiv.innerHTML = "";
       ourDiv.appendChild(summaryDiv);
@@ -136,7 +137,7 @@ const cldrStForum = (function () {
       load: loadHandler,
       error: errorHandler,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**
@@ -387,7 +388,7 @@ const cldrStForum = (function () {
       error: errorHandler,
       postData: postData,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**
@@ -1203,7 +1204,7 @@ const cldrStForum = (function () {
     applyFilter,
     showThreadCount
   ) {
-    let filteredArray = cldrStForumFilter.getFilteredThreadIds(
+    let filteredArray = cldrForumFilter.getFilteredThreadIds(
       threadHash,
       applyFilter
     );
@@ -1275,13 +1276,13 @@ const cldrStForum = (function () {
    * Get a piece of html text summarizing the current Forum statistics
    *
    * @param locale the locale string
-   * @param userId the current user's id, for cldrStForumFilter
+   * @param userId the current user's id, for cldrForumFilter
    * @param getTable true to get a table, false to get a one-liner
    * @return the html
    */
   function getForumSummaryHtml(locale, userId, getTable) {
     setLocale(locale);
-    cldrStForumFilter.setUserId(userId);
+    cldrForumFilter.setUserId(userId);
     return reallyGetForumSummaryHtml(true /* canDoAjax */, getTable);
   }
 
@@ -1311,7 +1312,7 @@ const cldrStForum = (function () {
       if (FORUM_DEBUG && getTable) {
         html += "<p>Retrieved " + fmtDateTime(forumUpdateTime) + "</p>\n";
       }
-      const c = cldrStForumFilter.getFilteredThreadCounts();
+      const c = cldrForumFilter.getFilteredThreadCounts();
       if (getTable) {
         html += "<ul>\n";
         Object.keys(c).forEach(function (k) {
@@ -1341,7 +1342,7 @@ const cldrStForum = (function () {
    * @param getTable true to get a table, false to get a one-liner
    */
   function loadForumForSummaryOnly(locale, id, getTable) {
-    if (typeof cldrStAjax === "undefined") {
+    if (typeof cldrAjax === "undefined") {
       return;
     }
     setLocale(locale);
@@ -1374,7 +1375,7 @@ const cldrStForum = (function () {
       load: loadHandler,
       error: errorHandler,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoForumParticipation.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoForumParticipation.js
@@ -1,0 +1,144 @@
+"use strict";
+
+/**
+ * cldrForumParticipation: encapsulate Survey Tool Forum Participation code.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ *
+ * Dependencies: SpecialPage; hideLoader; showInPop2
+ */
+const cldrForumParticipation = (function () {
+  const tableId = "participationTable";
+  const fileName = "participation.csv";
+  const onclick =
+    "cldrCsvFromTable.download(" +
+    '"' +
+    tableId +
+    '"' +
+    ", " +
+    '"' +
+    fileName +
+    '"' +
+    ")";
+
+  /**
+   * Fetch the Forum Participation data from the server, and "load" it
+   *
+   * @param params an object with various properties; see SpecialPage.js
+   */
+  function load(params) {
+    /*
+     * Set up the 'right sidebar'; cf. forum_participationGuidance
+     */
+    showInPop2(cldrText.get(params.name + "Guidance"), null, null, null, true);
+
+    const url = getForumParticipationUrl();
+    const errorHandler = function (err) {
+      params.special.showError(params, null, {
+        err: err,
+        what: "Loading forum participation data",
+      });
+    };
+    const loadHandler = function (json) {
+      if (json.err) {
+        if (params.special) {
+          params.special.showError(params, json, {
+            what: "Loading forum participation data",
+          });
+        }
+        return;
+      }
+      const html = makeHtmlFromJson(json);
+      const ourDiv = document.createElement("div");
+      ourDiv.innerHTML = html;
+
+      // No longer loading
+      hideLoader(null);
+      params.flipper.flipTo(params.pages.other, ourDiv);
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  /**
+   * Get the URL to use for loading the Forum Participation page
+   */
+  function getForumParticipationUrl() {
+    const sessionId = cldrStatus.getSessionId();
+    if (!sessionId) {
+      console.log("Error: sessionId falsy in getForumParticipationUrl");
+      return "";
+    }
+    return "SurveyAjax?what=forum_participation&s=" + sessionId;
+  }
+
+  /**
+   * Make the html, given the json for Forum Participation
+   *
+   * @param json
+   * @return the html
+   */
+  function makeHtmlFromJson(json) {
+    let html = "<div>\n";
+    if (json.org) {
+      html += "<h4>Organization: " + json.org + "</h4>\n";
+    }
+    if (json.rows && json.rows.header && json.rows.data) {
+      const myheaders = [
+        "LOC", // headers in order
+        "FORUM_TOTAL",
+        "FORUM_ORG",
+        "FORUM_REQUEST",
+        "FORUM_DISCUSS",
+        "FORUM_ACT",
+      ];
+      html += "<h4><a onclick='" + onclick + "'>Download CSV</a></h4>\n";
+      html += "<table border='1' id='" + tableId + "'>\n";
+      html += "<tr>\n";
+      for (let header of [
+        // same order as above
+        cldrText.get("recentLoc"),
+        cldrText.get("forum_participation_TOTAL"),
+        cldrText.get("forum_participation_ORG"),
+        cldrText.get("forum_participation_REQUEST"),
+        cldrText.get("forum_participation_DISCUSS"),
+        cldrText.get("forum_participation_ACT"),
+      ]) {
+        html += "<th>" + header + "</th>\n";
+      }
+      html += "</tr>\n";
+      for (let row of json.rows.data) {
+        html += "<tr>\n";
+        for (let header of myheaders) {
+          html += "<td>" + row[json.rows.header[header]] + "</td>\n";
+        }
+        html += "</tr>\n";
+      }
+      html += "</table>\n";
+    }
+    html += "</div>";
+    return html;
+  }
+
+  /*
+   * Make only these functions accessible from other files
+   */
+  return {
+    load: load,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      makeHtmlFromJson: makeHtmlFromJson,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoGui.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoGui.js
@@ -1,0 +1,488 @@
+"use strict";
+
+/**
+ * cldrGui: encapsulate GUI functions, assuming we're using Dojo Toolkit.
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ * 
+ * This is the dojo version. See cldrGui.js for the non-dojo version.
+ */
+const cldrGui = (function () {
+  const GUI_DEBUG = true;
+
+  /**
+   * Set up the DOM and start executing Survey Tool as a single page app
+   */
+  function run() {
+    if (GUI_DEBUG) {
+      console.log("Hello my name is cldrGui.run");
+      debugParse();
+    }
+
+    if (!document.getElementById("st-run-gui")) {
+      if (GUI_DEBUG) {
+        console.log("cldrGui.run doing nothing since 'st-run-gui' not found");
+      }
+      return;
+    }
+
+    document.body.innerHTML = getBodyHtml();
+
+    if (GUI_DEBUG) {
+      debugElements();
+    }
+
+    require(["dojo/parser"], function (parser) {
+      parser.parse(); // parseOnLoad is false; call parse() after we populate the body
+    });
+
+    showV(); // in CldrSurveyVettingLoader.js
+    updateStatus(); // for the first time; in survey.js
+  }
+
+  const vhtml1 =
+    "<div data-dojo-type='dijit/Dialog' data-dojo-id='ariDialog' title='CLDR Survey Tool'\n" +
+    '    data-dojo-props=\'onHide: function(){ariReload.style.display="";ariRetry.style.display="none";\n' +
+    "      if (disconnected) {unbust();}}'>\n" +
+    "\n" +
+    "  <div id='ariContent' class='dijitDialogPaneContentArea'>\n" +
+    "    <div id='ariHelp'><a href='http://cldr.unicode.org/index/survey-tool#disconnected'>Help</a></div>\n" +
+    "    <p id='ariMessage'>This page is still loading.</p>\n" +
+    "    <p id='ariSubMessage'>Please wait for this page to load.</p>\n" +
+    "    <div id='ariDetails' data-dojo-type='dijit/TitlePane' data-dojo-props='title: \"Details\", open: false '>\n" +
+    "      <p id='ariScroller'></p>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "  <div class='dijitDialogPaneActionBar'>\n" +
+    "    <button id='ariMain' style='display: none; margin-right: 2em;' data-dojo-type='dijit/form/Button'\n" +
+    "        type='button' onClick='window.location = /cldr-apps/survey;'>\n" +
+    "        Back to Locales\n" +
+    "    </button>\n" +
+    "    <button id='ariRetryBtn' data-dojo-type='dijit/form/Button' type='button' onClick='ariRetry()'>\n" +
+    "      <b>Reload</b>\n" +
+    "    </button>\n" +
+    "  </div>\n" +
+    "</div>\n";
+  const vhtml2 =
+    "<div class='navbar navbar-fixed-top' role='navigation'>\n" +
+    "  <div class='container-fluid'>\n" +
+    "    <div class='collapse navbar-collapse'>\n" +
+    "      <p id='st-version-phase' class='nav navbar-text'>Survey Tool ...</p>\n" +
+    "      <ul class='nav navbar-nav'>\n" +
+    "        <li class='pull-menu'>\n" +
+    "          <a href='#'><span class='glyphicon glyphicon-cog'></span> <b class='caret'></b></a>\n" +
+    "          <ul id='manage-list' class='nav nav-pills nav-stacked' style='display:none'>\n" +
+    "            <li>\n" +
+    "              <button type='button' class='btn btn-default toggle-right'>Toggle Sidebar\n" +
+    "                <span class='glyphicon glyphicon-align-right'></span></button>\n" +
+    "            </li>\n" +
+    "          </ul>\n" +
+    "        </li>\n" +
+    "        <li class='dropdown' id='title-coverage' style='display:none'>\n" +
+    "          <a href='#' class='dropdown-toggle' data-toggle='dropdown'>Coverage: <span id='coverage-info'></span></a>\n" +
+    "          <ul class='dropdown-menu'></ul>\n" +
+    "        </li>\n" +
+    "        <li>\n" +
+    "          <a href='https://sites.google.com/site/cldr/translation' target='_blank'>Instructions</a>\n" +
+    "        </li>\n" +
+    "      </ul>\n" +
+    "      <p class='navbar-text navbar-right'>\n" +
+    "        <span id='flag-info'></span>\n" +
+    "        <span id='st-session-message' class='v-status'></span>\n" +
+    "        <span id='st-user-name' class='hasTooltip' title='ctx.session.user.email'></span>\n" +
+    "        <span class='glyphicon glyphicon-user tip-log' title='ctx.session.user.org'></span>\n" +
+    "        <span id='st-vote-count-menu'></span>\n" +
+    "        | <a id='st-loginout-link' class='navbar-link'></a>\n" +
+    "      </p>\n" +
+    "      <p class='navbar-text navbar-right'>" +
+    "        <a href='https://www.unicode.org/policies/privacy_policy.html'>This site uses cookies.</a>\n" +
+    "      </p>\n" +
+    "      <p id='st-special-header' class='specialmessage navbar-text navbar-right'></p>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "</div>\n";
+  const vhtml3 =
+    "<div id='left-sidebar'>\n" +
+    "  <div id='content-sidebar'>\n" +
+    "    <div id='locale-info'>\n" +
+    "      <div class='input-group input-group-sm'>\n" +
+    "        <span class='input-group-addon  refresh-search'><span class='glyphicon glyphicon-search'></span></span>\n" +
+    "        <input type='text' class='form-control local-search' placeholder='Locale' />\n" +
+    "      </div>\n" +
+    "      <span id='locale-clear' class='refresh-search'>x</span>\n" +
+    "      \n" +
+    "      <div class='input-group input-group-sm' id='locale-check-group'>\n" +
+    "        <label class='checkbox-inline'>\n" +
+    "          <input type='checkbox' id='show-read' /> Show read-only\n" +
+    "        </label>\n" +
+    "        <label class='checkbox-inline'>\n" +
+    "          <input type='checkbox' id='show-locked' /> Show locked\n" +
+    "        </label>\n" +
+    "      </div>\n" +
+    "    </div>\n" +
+    "    <div id='locale-list'></div>\n" +
+    "    <div id='locale-menu'></div>\n" +
+    "  </div>\n" +
+    "  <div id='dragger'>\n" +
+    "    <span class='glyphicon glyphicon-chevron-right'></span>\n" +
+    "    <div id='dragger-info'></div>\n" +
+    "  </div>\n" +
+    "</div>\n";
+
+  const st_notices =
+    /* start stnotices.jspf */
+    "          <div class='topnotices'>\n" +
+    "            <div class='unofficial' title='Not an official SurveyTool' >\n" +
+    "              <img alt='[warn]' style='width: 16px; height: 16px; border: 0;' src='/cldr-apps/warn.png' title='Unofficial Site' />Unofficial\n" +
+    "            </div>\n" +
+    "            <div id='stchanged' style='display:none;' class='stchanged' title='st has changed'>\n" +
+    "              <img alt='[warn]' style='width: 16px; height: 16px; border: 0;' src='/cldr-apps/warn.png' title='Locale Changed' />\n" +
+    "              The locale, <span id='stchanged_loc'>YOUR LOCALE</span>, has changed due to your or other's actions.\n" +
+    "              Please <a href='javascript:window.location.reload(true);'>refresh</a> the page to \n" +
+    "              view the new changes..\n" +
+    "              <button type='button' onclick='window.location.reload(true)'>Refresh</button>\n" +
+    "            </div>\n" +
+    "            <div id='betadiv' class='beta' style='display: none'></div>\n" +
+    "          </div>\n" /* end of topnotices */ +
+    "          <div id='st_err'></div>\n" +
+    "          <div class='alert alert-warning alert-dismissable' id='alert-info' style='display:none;'>\n" +
+    "            <button type='button' class='close'>&#xD7;</button>\n" +
+    "            <div id='progress' class='progress-connecting'>\n" +
+    "              <span style='display:none' id='specialHeader'>(Your message here)</span>\n" +
+    "              <span id='progress_oneword' class='oneword'>Online</span>\n" +
+    "              <span id='progress_ajax' class='ajaxword'>&#xA0;</span>\n" +
+    "              <button id='progress-refresh' onclick='javascript:window.location.reload(true);'>Refresh</button>\n" +
+    "            </div>\n" +
+    "          </div>\n";
+  /* end stnotices.jspf */
+
+  const vhtml4 =
+    "<div class='container-fluid' id='main-container'>\n" +
+    "  <div class='row menu-position'>\n" +
+    "    <div class='col-md-12'>\n" +
+    "      <div id='toptitle'>\n" +
+    "        <div id='additional-top'>\n" +
+    st_notices +
+    "        </div>\n" +
+    "        <!-- top info -->\n" +
+    "        <div id='title-locale-container' class='menu-container' style='display:none'>\n" +
+    "          <h1><a href='#locales///' id='title-locale'></a></h1>\n" +
+    "          <span id='title-dcontent-container'><a href='http://cldr.unicode.org/translation/default-content' id='title-content'></a></span>\n" +
+    "        </div>\n" +
+    "        <div id='title-section-container' class='menu-container'>\n" +
+    "          <h1 id='section-current'></h1>\n" +
+    "          <div style='display:none' id='title-section' data-dojo-type='dijit/form/DropDownButton'>\n" +
+    "            <span>(section)</span>\n" +
+    "            <div id='menu-section' data-dojo-type='dijit/DropDownMenu'></div>\n" +
+    "          </div>\n" +
+    "        </div> \n" +
+    "        <div id='title-page-container' class='menu-container'></div>\n" +
+    "        <div class='row' id='nav-page'>\n" +
+    "          <div class='col-md-9'>\n" +
+    "            <p class='nav-button'>\n" +
+    "              <button type='button' class='btn btn-primary btn-xs' onclick='chgPage(-1)'><span class='glyphicon glyphicon-arrow-left'></span> Previous</button>\n" +
+    "              <button type='button' class='btn btn-primary btn-xs' onclick='chgPage(1)'>Next <span class='glyphicon glyphicon-arrow-right'></span></button>\n" +
+    "              <button type='button' class='btn btn-default btn-xs toggle-right'>Toggle Sidebar <span class='glyphicon glyphicon-align-right'></span></button>\n" +
+    "            </p>\n" +
+    "            <div class='progress nav-progress'>\n" +
+    "              <div id='progress-voted' class='progress-bar progress-bar-info tip-log' title='Votes' style='width: 0%'></div>\n" +
+    "              <div id='progress-abstain' class='progress-bar progress-bar-warning tip-log' title='Abstain' style='width: 0%'></div>\n" +
+    "            </div>\n" +
+    "            <div class='counter-infos'><a onclick='cldrForum.reload();'>Forum:</a>\n" +
+    "              <span id='vForum'>...</span> ●\n" +
+    "              Votes: <span id='count-voted'></span>\n" +
+    "              - Abstain: <span id='count-abstain'></span>\n" +
+    "              - Total: <span id='count-total'></span>\n" +
+    "            </div>\n" +
+    "          </div>\n" +
+    "        </div>\n" +
+    "      </div>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "  <div class='row' id='main-row' style='padding-top:147px;'>\n" +
+    "    <div class='col-md-9'>\n" +
+    "      <div data-dojo-type='dijit/layout/ContentPane' id='MainContentPane' data-dojo-props=\"splitter:true, region:'center'\" >\n" +
+    "        <div id='LoadingMessageSection'>Please Wait<img src='loader.gif' alt='Please Wait' /></div>\n" +
+    "        <div id='DynamicDataSection'></div>\n" +
+    "        <div id='nav-page-footer'>\n" +
+    "          <p class='nav-button'>\n" +
+    "            <button type='button' class='btn btn-primary btn-xs' onclick='chgPage(-1)'><span class='glyphicon glyphicon-arrow-left'></span> Previous</button>\n" +
+    "            <button type='button' class='btn btn-primary btn-xs' onclick='chgPage(1)'>Next <span class='glyphicon glyphicon-arrow-right'></span></button>\n" +
+    "            <button type='button' class='btn btn-default btn-xs toggle-right'>Toggle Sidebar <span class='glyphicon glyphicon-align-right'></span></button>\n" +
+    "          </p>\n" +
+    "        </div>\n" +
+    "        <div id='OtherSection'></div>\n" +
+    "      </div>\n" +
+    "    </div>\n" +
+    "    <div class='col-md-3'>\n" +
+    "      <div id='itemInfo' class='right-info' data-dojo-type='dijit/layout/ContentPane' data-dojo-props=\"splitter:true, region:'trailing'\" ></div>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "  <div id='ressources' style='display:none'></div>\n" +
+    "</div>\n";
+
+  const vhtml5 = "<div id='overlay'></div>\n";
+
+  const vhtml6 =
+    "<div class='modal fade' id='post-modal' tabindex='-1' role='dialog' aria-hidden='true'>\n" +
+    "  <div class='modal-dialog modal-lg'>\n" +
+    "    <div class='modal-content'>\n" +
+    "      <div class='modal-header'>\n" +
+    "        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&#xD7;</button>\n" +
+    "        <h4 class='modal-title'>Post</h4>\n" +
+    "      </div>\n" +
+    "      <div class='modal-body'></div>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "</div>\n";
+
+  const hiddenHtml =
+    "<div style='display: none' id='hidden-stuff'>\n" +
+    "  <!--  hidden.html - prototypes for some things -->\n" +
+    "  <h1>Hidden Stuff</h1>\n" +
+    "  <h3>Prototype datarow:</h3>\n" +
+    "  <table>\n" +
+    "    <tbody>\n" +
+    "      <tr id='proto-datarow' class='vother'>\n" +
+    "        <td class='d-code codecell'></td>\n" +
+    "        <td title='$flyovercomparison' class='d-disp comparisoncell'></td>\n" +
+    "        <td title='$flyovernoopinion' class='d-no nocell'></td>\n" +
+    "        <td class='d-dr statuscell'></td>\n" +
+    "        <td title='$flyoverproposed' class='d-win proposedcell'></td>\n" +
+    "        <td title='$flyoveradd' class='d-win addcell'></td>\n" +
+    "        <td title='$flyoverother' class='d-win othercell'></td>\n" +
+    "      </tr>\n" +
+    "      <tr id='proto-parrow' class='d-parrow' >\n" +
+    "        <th class='partsection' colspan='7'><a>Partition</a></th>\n" +
+    "      </tr>\n" +
+    "    </tbody>\n" +
+    "  </table>\n" +
+    "  <input id='proto-button' class='ichoice' type='radio' title='click to vote' />\n" +
+    "  <button id='cancel-button' class='cancelbutton tip btn btn-danger' title='Delete'><span class='glyphicon glyphicon-minus'></span></button>\n" +
+    "  <span id='proto-item'></span>\n" +
+    "  <div id='proto-sortmode' class='d-sortmode'></div>\n" +
+    "  <input id='proto-inputbox' class='inputbox' />\n" +
+    "  <div id='proto-loading' class='loading' style='display:none;'>\n" +
+    "    <p>Your message here.</p>\n" +
+    "    <hr/>\n" +
+    "    <span style='background-color: white; float: right;' class='loadbot'>(Stuck? <a href='javascript:window.location.reload(true);'>Refresh</a> the page.)</span>\n" +
+    "  </div>\n" +
+    "  <table>\n" +
+    "    <thead id='voteInfoHead'>\n" +
+    "      <tr>\n" +
+    "        <th title='$flyovervorg' id='stui-htmlvorg'></th>\n" +
+    "        <th title='$flyovervorgvote' id='stui-htmlvorgvote'></th>\n" +
+    "       <th title='$flyovervdissenting' id='stui-htmlvdissenting'></th>\n" +
+    "     </tr>\n" +
+    "    </thead>\n" +
+    "  </table>\n" +
+    "  <table id='proto-datatable' class='data table table-bordered'>\n" +
+    "    <thead>\n" +
+    "      <tr class='headingb active'>\n" +
+    /*  see CldrText.js for the following */
+    "        <th title='$flyovercode' id='stui-htmlcode'></th>\n" +
+    "        <th title='$flyovercomparison' id='stui-htmltranshint'></th>\n" +
+    "        <th title='$flyovernoopinion' id='stui-htmlnoopinion' class='d-no'></th>\n" +
+    "        <th title='$flyoverdraft' id='stui-htmldraft' class='d-status'></th>\n" +
+    "        <th title='$flyoverproposed' id='stui-htmlproposed'></th>\n" +
+    "        <th title='$flyoveradd' id='stui-htmltoadd'></th>\n" +
+    "        <th title='$flyoverothers' id='stui-htmlothers'></th>\n" +
+    "      </tr>\n" +
+    "    </thead>\n" +
+    "    <tbody>\n" +
+    "    </tbody>\n" +
+    "  </table>\n" +
+    "  <div id='proto-datafix' class='data'>\n" +
+    "    <div class='data-vertical'>\n" +
+    "      <div class='d-disp comparisoncell'></div>\n" +
+    "      <hr/>\n" +
+    "      <div class='d-win proposedcell'></div>\n" +
+    "      <div class='d-dr statuscell'></div>\n" +
+    "      <hr/>\n" +
+    "      <div class='d-win othercell'></div>\n" +
+    "      <hr/>\n" +
+    "      <div class='d-no nocell'></div>\n" +
+    "    </div>\n" +
+    "    <div class='data-vote'></div>\n" +
+    "    <button type='button' class='close'>&#xD7;</button>\n" +
+    "  </div>\n" +
+    "  <div id='proto-datarowfix' class='vother'>\n" +
+    "    <div class='d-disp comparisoncell'></div>\n" +
+    "    <hr/>\n" +
+    "    <div class='d-win proposedcell'></div>\n" +
+    "    <div class='d-dr statuscell'></div>\n" +
+    "    <hr/>\n" +
+    "    <div class='d-win othercell'></div>\n" +
+    "    <hr/>\n" +
+    "    <div class='d-no nocell'></div>\n" +
+    "  </div>\n" +
+    "</div>\n";
+
+  function getBodyHtml() {
+    return vhtml1 + vhtml2 + vhtml3 + vhtml4 + vhtml5 + vhtml6 + hiddenHtml;
+  }
+
+  function updateWithStatus() {
+    displayVersionPhase();
+    displaySpecialHeader();
+    displaySessionMessage();
+    displayUserName();
+    displayVoteCountMenu();
+    displayLogInOutLink();
+  }
+
+  function displayVersionPhase() {
+    const el = document.getElementById("st-version-phase");
+    if (el) {
+      el.innerHTML =
+        "Survey Tool " +
+        cldrStatus.getNewVersion() +
+        " " +
+        cldrStatus.getPhase();
+    }
+  }
+
+  function displaySpecialHeader() {
+    const el = document.getElementById("st-special-header");
+    if (el) {
+      el.innerHTML = cldrStatus.getSpecialHeader();
+    }
+  }
+
+  function displaySessionMessage() {
+    const el = document.getElementById("st-session-message");
+    if (el) {
+      el.innerHTML = cldrStatus.getSessionMessage();
+    }
+  }
+
+  function displayUserName() {
+    const el = document.getElementById("st-user-name");
+    if (el) {
+      const user = cldrStatus.getSurveyUser();
+      if (user && user.name) {
+        el.innerHTML = user.name;
+      }
+    }
+  }
+
+  function displayVoteCountMenu() {
+    const el = document.getElementById("st-vote-count-menu");
+    if (el) {
+      el.innerHTML = makeVoteCountMenu();
+    }
+  }
+
+  function makeVoteCountMenu() {
+    let html = "";
+    const user = cldrStatus.getSurveyUser();
+    if (user && user.voteCountMenu) {
+      html +=
+        "<select id='voteLevelChanged' title='vote with a different number of votes'>\n";
+      for (let n of user.voteCountMenu) {
+        const selectedOrNot = (user.votecount === n) ? " selected='selected'" : "";
+        html += "<option value='" + n + "'" + selectedOrNot + ">" + n + " votes</option>\n";
+      }
+      html += "</select>\n";
+    }
+    return html;
+  }
+
+  function displayLogInOutLink() {
+    const el = document.getElementById("st-loginout-link");
+    if (el) {
+      const path = cldrStatus.getContextPath();
+      if (cldrStatus.getSurveyUser()) {
+        el.setAttribute("href", path + "/survey?do=logout");
+        el.innerHTML =
+          "<span class='glyphicon glyphicon-log-out tip-log' title='Logout'></span>";
+      } else {
+        el.setAttribute("href", path + "/login.jsp");
+        el.innerHTML = "Login...";
+      }
+    }
+  }
+
+  function debugParse() {
+    for (let h of [
+      vhtml1,
+      vhtml2,
+      vhtml3,
+      vhtml4,
+      vhtml5,
+      vhtml6,
+      hiddenHtml,
+    ]) {
+      if (!parseAsMimeType(h, "text/html")) {
+        console.log("🐧 BAD HTML:\n" + h + "\n");
+      }
+      if (!parseAsMimeType(h, "application/xml")) {
+        console.log("🐧 INVALID XML:\n" + h + "\n");
+      }
+    }
+  }
+
+  // Temporary debugging (cf. parseAsMimeType in TestCldrTest.js):
+  function parseAsMimeType(inputString, mimeType) {
+    const doc = new DOMParser().parseFromString(inputString, mimeType);
+    if (!doc) {
+      console.log("no doc for " + mimeType + ", " + inputString);
+      return null;
+    }
+    const outputString = new XMLSerializer().serializeToString(doc);
+    if (!outputString) {
+      console.log("no output string for " + mimeType + ", " + inputString);
+      return null;
+    }
+    if (outputString.indexOf("error") !== -1) {
+      console.log(
+        "parser error for " +
+          mimeType +
+          ", " +
+          inputString +
+          ", " +
+          outputString
+      );
+      return null;
+    }
+    return outputString;
+  }
+
+  function debugElements() {
+    for (let id of [
+      "ariContent",
+      "DynamicDataSection",
+      "nav-page",
+      "progress",
+      "progress-refresh",
+      "st-loginout-link",
+      "st-special-header",
+      "st-session-message",
+      "st-user-name",
+      "st-version-phase",
+      "st-vote-count-menu",
+      "title-section-container",
+    ]) {
+      if (!document.getElementById(id)) {
+        console.log(id + " is MISSING 🐞🐞🐞");
+      }
+    }
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    run: run,
+    updateWithStatus: updateWithStatus,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      getBodyHtml: getBodyHtml,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoLoad.js
@@ -1,6 +1,8 @@
 /*
- * CldrSurveyVettingLoader.js - split off from survey.js, for CLDR Survey Tool
+ * CldrDojoLoad.js (formerly CldrSurveyVettingLoader.js) - split off from survey.js, for CLDR Survey Tool
  * showV() and reloadV() and related functions
+ * 
+ * This is the dojo version. For non-dojo, see cldrLoad.js
  */
 
 /*
@@ -28,8 +30,8 @@ function showV() {
     "dojox/form/BusyButton",
     "dojo/hash",
     "dojo/topic",
-  ], // HANDLES
-  function (
+  ], function (
+    // HANDLES
     dijitDropDownMenu,
     dijitDropDownButton,
     dijitMenuSeparator,
@@ -403,7 +405,7 @@ function showV() {
      *
      * @param doPush {Boolean} if true, do a push (instead of replace)
      *
-     * Called by cldrStForum.parseContent, as well as locally.
+     * Called by cldrForum.parseContent, as well as locally.
      *
      * TODO: avoid attaching this, or anything, to "window"! Define our own objects instead.
      */
@@ -515,7 +517,7 @@ function showV() {
         postData: postData,
         headers: headers,
       };
-      cldrStAjax.queueXhr(xhrArgs);
+      cldrAjax.queueXhr(xhrArgs);
     };
 
     /**
@@ -1738,7 +1740,7 @@ function showV() {
                 }
                 if (!isInputBusy()) {
                   showLoader(theDiv.loader, cldrText.get("loading3"));
-                  cldrSurveyTable.insertRows(
+                  cldrTable.insertRows(
                     theDiv,
                     json.pageId,
                     cldrStatus.getSessionId(),
@@ -2265,7 +2267,7 @@ function showV() {
                 load: loadHandler,
                 error: errFunction,
               };
-              cldrStAjax.queueXhr(xhrArgs);
+              cldrAjax.queueXhr(xhrArgs);
             } else {
               alert("Please login to access Dashboard");
               cldrStatus.setCurrentSpecial("");
@@ -2287,7 +2289,7 @@ function showV() {
               load: loadHandler,
               error: errFunction,
             };
-            cldrStAjax.queueXhr(xhrArgs);
+            cldrAjax.queueXhr(xhrArgs);
           }
         } else if (cldrStatus.getCurrentSpecial() == "none") {
           // for now - redirect

--- a/tools/cldr-apps/src/main/webapp/js/CldrDojoTable.js
+++ b/tools/cldr-apps/src/main/webapp/js/CldrDojoTable.js
@@ -1,0 +1,1463 @@
+/*
+ * CldrDojoTable.js (formerly CldrSurveyVettingTable.js) - split off from survey.js, for CLDR Survey Tool.
+ * This is the dojo version. For non-dojo, see cldrTable.js
+ *
+ * Functions for populating the main table in the vetting page:
+ * 		cldrTable.insertRows
+ * 		cldrTable.updateRow
+ *
+ * cldrTable.updateRow is also used for the Dashboard (see review.js).
+ *
+ * TODO: identify and reduce dependencies; add unit tests that don't depend on server or browser.
+ */
+"use strict";
+
+/*
+ * Use an IIFE module pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ */
+const cldrTable = (function () {
+  /*
+   * ALWAYS_REMOVE_ALL_CHILD_NODES and NEVER_REUSE_TABLE should both be false for efficiency,
+   * but if necessary they can be made true to revert to old less efficient behavior.
+   * Reference: https://unicode.org/cldr/trac/ticket/11571
+   */
+  const ALWAYS_REMOVE_ALL_CHILD_NODES = false;
+  const NEVER_REUSE_TABLE = false;
+
+  /*
+   * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
+   * It must match NO_WINNING_VALUE in the server Java code.
+   */
+  const NO_WINNING_VALUE = "no-winning-value";
+
+  /**
+   * Prepare rows to be inserted into the table
+   *
+   * @param theDiv the division (typically or always? with id='DynamicDataSection') that contains, or will contain, the table
+   * @param xpath = json.pageId; e.g., "Alphabetic_Information"
+   * @param session the session id; e.g., "DEF67BCAAFED4332EBE742C05A8D1161"
+   * @param json the json received from the server; including (among much else):
+   * 			json.locale, e.g., "aa"
+   *  		json.section.rows, with info for each row
+   */
+  function insertRows(theDiv, xpath, session, json) {
+    if (ALWAYS_REMOVE_ALL_CHILD_NODES) {
+      removeAllChildNodes(theDiv); // maybe superfluous if always recreate the table, and wrong if we don't always recreate the table
+    }
+
+    $(".warnText").remove(); // remove any pre-existing "special notes", before insertLocaleSpecialNote
+    window.insertLocaleSpecialNote(theDiv);
+
+    var theTable = null;
+    const reuseTable =
+      !NEVER_REUSE_TABLE &&
+      theDiv.theTable &&
+      theDiv.theTable.json &&
+      tablesAreCompatible(json, theDiv.theTable.json);
+    if (reuseTable) {
+      /*
+       * Re-use the old table, just update contents of individual cells
+       */
+      // console.log('🦋🦋🦋 re-use table, ' + Object.keys(json.section.rows).length + ' rows');
+      theTable = theDiv.theTable;
+    } else {
+      /*
+       * Re-create the table from scratch
+       */
+      // console.log('🦞🦞🦞 make new table, ' + Object.keys(json.section.rows).length + ' rows');
+      theTable = cloneLocalizeAnon(document.getElementById("proto-datatable"));
+      /*
+       * Note: isDashboard() is currently never true here; see comments in insertRowsIntoTbody and updateRow
+       */
+      if (isDashboard()) {
+        theTable.className += " dashboard";
+      } else {
+        theTable.className += " vetting-page";
+      }
+      /*
+       * Give our table the unique id, 'vetting-table'. This is needed by the test SurveyDriverVettingTable.
+       * Otherwise its id would be 'null' (the string 'null', not null!), and there is risk of confusion
+       * with other table such as 'proto-datarow'.
+       */
+      theTable.id = "vetting-table";
+      /*
+       * This code seems to merge parts of two prototype tables,
+       * in a complicated way. The two tables are both in hidden.html:
+       * (1) a table with no id, which contains tr id='proto-datarow', which in turn contains multiple td;
+       * (2) table id='proto-datatable', which contains multiple th.
+       * The result of the merger is theTable.toAdd, which is eventually used as
+       * a prototype for each row that gets added to the real (not hidden) table.
+       * TODO: simplify.
+       */
+      localizeFlyover(theTable); // Replace titles starting with $ with strings from cldrText
+      const headChildren = getTagChildren(
+        theTable.getElementsByTagName("tr")[0]
+      );
+      var toAdd = document.getElementById("proto-datarow"); // loaded from "hidden.html", which see.
+      var rowChildren = getTagChildren(toAdd);
+      for (var c in rowChildren) {
+        rowChildren[c].title = headChildren[c].title;
+      }
+      theTable.toAdd = toAdd;
+    }
+    updateCoverage(theDiv);
+    if (!json.canModify) {
+      /*
+       * Remove the "Abstain" column from the header since user can't modify.
+       */
+      const headAbstain = theTable.querySelector("th.d-no");
+      if (headAbstain) {
+        setDisplayed(headAbstain, false);
+      }
+    }
+    theDiv.theTable = theTable;
+    theTable.theDiv = theDiv;
+
+    theTable.json = json;
+    theTable.xpath = xpath;
+    theTable.session = session;
+
+    if (!theTable.curSortMode) {
+      theTable.curSortMode = theTable.json.displaySets["default"]; // typically (always?) "ph"
+      // hack - choose one of these
+      /*
+       * TODO: is this no longer used? Cf. PREF_SORTMODE_CODE_CALENDAR and PREF_SORTMODE_METAZONE in SurveyMain.java
+       * Cf. identical code in review.js
+       */
+      if (theTable.json.displaySets.codecal) {
+        theTable.curSortMode = "codecal";
+      } else if (theTable.json.displaySets.metazon) {
+        theTable.curSortMode = "metazon";
+      }
+    }
+    if (!reuseTable || !theDiv.contains(theTable)) {
+      // reference: CLDR-13727 and CLDR-13885
+      theDiv.appendChild(theTable);
+    }
+    insertRowsIntoTbody(theTable, reuseTable);
+    hideLoader(theDiv.loader);
+  }
+
+  /**
+   * Are the new (to-be-built) table and old (already-built) table compatible, in the
+   * sense that we can re-use the old table structure, just replacing the contents of
+   * individual cells, rather than rebuilding the table from scratch?
+   *
+   * @param json1 the json for one table
+   * @param json2 the json for the other table
+   * @returns true if compatible, else false
+   *
+   * Reference: https://unicode.org/cldr/trac/ticket/11571
+   */
+  function tablesAreCompatible(json1, json2) {
+    if (
+      json1.section &&
+      json2.section &&
+      json1.pageId === json2.pageId &&
+      json1.locale === json2.locale &&
+      json1.canModify === json2.canModify &&
+      Object.keys(json1.section.rows).length ===
+        Object.keys(json2.section.rows).length
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Insert rows into the table
+   *
+   * @param theTable the table in which to insert the rows
+   * @param reuseTable boolean, true if theTable already has rows and we're updating them,
+   *                            false if we need to insert new rows
+   *
+   * Called by insertRows only.
+   *
+   * This function is not currently used for the Dashboard, only for the main vetting table.
+   * Still we may want to keep the calls to isDashboard for future use. Also note that updateRow,
+   * which is called from here, IS also used for the Dashboard.
+   */
+  function insertRowsIntoTbody(theTable, reuseTable) {
+    var tbody = theTable.getElementsByTagName("tbody")[0];
+    var theRows = theTable.json.section.rows;
+    var toAdd = theTable.toAdd;
+    var parRow = document.getElementById("proto-parrow");
+
+    if (ALWAYS_REMOVE_ALL_CHILD_NODES) {
+      removeAllChildNodes(tbody);
+    }
+
+    var theSort = theTable.json.displaySets[theTable.curSortMode]; // typically (always?) curSortMode = "ph"
+    var partitions = theSort.partitions;
+    var rowList = theSort.rows;
+    var partitionList = Object.keys(partitions);
+    var curPartition = null;
+    for (var i in rowList) {
+      var k = rowList[i];
+      var theRow = theRows[k];
+      var dir = theRow.dir;
+      overridedir = dir != null ? dir : null;
+      /*
+       * There is no partition (section headings) in the Dashboard.
+       * Also we don't regenerate the headings if we're re-using an existing table.
+       */
+      if (!reuseTable && !isDashboard()) {
+        var newPartition = findPartition(
+          partitions,
+          partitionList,
+          curPartition,
+          i
+        );
+
+        if (newPartition != curPartition) {
+          if (newPartition.name != "") {
+            var newPar = cloneAnon(parRow);
+            var newTd = getTagChildren(newPar);
+            var newHeading = getTagChildren(newTd[0]);
+            newHeading[0].innerHTML = newPartition.name;
+            newHeading[0].id = newPartition.name;
+            tbody.appendChild(newPar);
+            newPar.origClass = newPar.className;
+            newPartition.tr = newPar; // heading
+          }
+          curPartition = newPartition;
+        }
+
+        var theRowCov = parseInt(theRow.coverageValue);
+        if (!newPartition.minCoverage || newPartition.minCoverage > theRowCov) {
+          newPartition.minCoverage = theRowCov;
+          if (newPartition.tr) {
+            // only set coverage of the header if there's a header
+            newPartition.tr.className =
+              newPartition.origClass + " cov" + newPartition.minCoverage;
+          }
+        }
+      }
+
+      /*
+       * If tbody already contains tr with this id, re-use it
+       * Cf. in updateRow: tr.id = "r@"+tr.xpstrid;
+       */
+      var tr = reuseTable
+        ? document.getElementById("r@" + theRow.xpstrid)
+        : null;
+      if (!tr) {
+        tr = cloneAnon(toAdd);
+        tbody.appendChild(tr);
+        // console.log("🦞 make new table row for " + theRow.xpstrid);
+      } else {
+        // console.log("🦋 re-use table row for " + theRow.xpstrid);
+      }
+      tr.rowHash = k;
+      tr.theTable = theTable;
+
+      /*
+       * Update the xpath map, unless re-using the table. If we're re-using the table, then
+       * curPartition.name isn't defined, and anyway xpathMap shouldn't need changing.
+       */
+      if (!reuseTable) {
+        xpathMap.put({
+          id: theRow.xpathId,
+          hex: theRow.xpstrid,
+          path: theRow.xpath,
+          ph: {
+            section: cldrStatus.getCurrentSection(), // Section: Timezones
+            page: cldrStatus.getCurrentPage(), // Page: SEAsia ( id, not name )
+            header: curPartition.name, // Header: Borneo
+            code: theRow.code, // Code: standard-long
+          },
+        });
+      }
+
+      /*
+       * Update the row's contents, unless it has an individual update pending.
+       * We're working with a multiple-row response from the server, and should not use
+       * this response to update any row(s) in which the user has just voted and for which
+       * we're still waiting for single-row response(s).
+       */
+      if (tr.className === "tr_checking1" || tr.className === "tr_checking2") {
+        // console.log("Skipping updateRow for tr.className === " + tr.className);
+      } else {
+        /*
+         * TODO: for performance, if reuseTable and new data matches old data for this row, leave the DOM as-is.
+         * Figure out an efficient way to test whether this row's data has changed.
+         */
+        updateRow(tr, theRow);
+      }
+    }
+    // downloadObjectAsHtml(tbody);
+    // downloadObjectAsJson(tbody);
+    // downloadObjectAsJson(theTable);
+  }
+
+  /**
+   * Find the specified partition.
+   *
+   * @param partitions
+   * @param partitionList
+   * @param curPartition
+   * @param i
+   * @returns the partition, or null
+   */
+  function findPartition(partitions, partitionList, curPartition, i) {
+    if (curPartition && i >= curPartition.start && i < curPartition.limit) {
+      return curPartition;
+    }
+    for (var j in partitionList) {
+      var p = partitions[j];
+      if (i >= p.start && i < p.limit) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Update one row using data received from server.
+   *
+   * @param tr the table row
+   * @param theRow the data for the row
+   *
+   * Cells (columns) in each row:
+   * Code    English    Abstain    A    Winning    Add    Others
+   *
+   * IMPORTANT: this function is used for the Dashboard as well as the main Vetting table.
+   * Mostly the Dashboard tables are currently created by review.js showReviewPage
+   * (invoked through writeVettingViewerOutput);
+   * they're not created here. Nevertheless the calls here to isDashboard() do serve a purpose,
+   * isDashboard() is true here when called by insertFixInfo in review.js. To see this, put
+   * a breakpoint in this function, go to Dashboard, and click on a "Fix" button, whose pop-up
+   * window then will include portions of the item's row as well as a version of the Info Panel.
+   *
+   * Dashboard columns are:
+   * Code    English    CLDR 33    Winning 34    Action
+   * -- but we don't add those here; instead, for Dashboard, this function is used
+   * only for the "Fix" pop-up window, in which the "columns" aren't really in a table,
+   * they're div elements.
+   *
+   * Called by insertRowsIntoTbody and loadHandler (in refreshSingleRow),
+   * AND by insertFixInfo in review.js (Dashboard "Fix")!
+   */
+  function updateRow(tr, theRow) {
+    if (!tr || !theRow) {
+      return;
+    }
+    const rowChecksum = cldrChecksum(JSON.stringify(theRow));
+    if (tr.checksum !== undefined && rowChecksum === tr.checksum) {
+      return; // already up to date
+    }
+    tr.checksum = rowChecksum;
+    tr.theRow = theRow;
+    checkRowConsistency(theRow);
+    reallyUpdateRow(tr, theRow);
+  }
+
+  /**
+   * Get a checksum for the given string
+   *
+   * @param s the string
+   * @return the checksum
+   */
+  function cldrChecksum(s) {
+    let checksum = 0;
+    for (let i = 0; i < s.length; i++) {
+      checksum = (checksum << 5) - checksum + s.charCodeAt(i);
+      checksum |= 0; // convert possible float to integer
+    }
+    return checksum;
+  }
+
+  /**
+   * Update one row using data received from server.
+   *
+   * @param tr the table row
+   * @param theRow the data for the row
+   */
+  function reallyUpdateRow(tr, theRow) {
+    /*
+     * For convenience, set up a hash for reverse mapping from rawValue to item.
+     */
+    tr.rawValueToItem = {}; // hash:  string value to item (which has a div)
+    for (var k in theRow.items) {
+      var item = theRow.items[k];
+      if (item.value) {
+        tr.rawValueToItem[item.rawValue] = item; // back link by value
+      }
+    }
+
+    /*
+     * Update the vote info.
+     */
+    if (theRow.voteResolver) {
+      updateRowVoteInfo(tr, theRow);
+    } else {
+      tr.voteDiv = null;
+    }
+
+    tr.statusAction = parseStatusAction(theRow.statusAction);
+    tr.canModify = tr.theTable.json.canModify && tr.statusAction.vote;
+    tr.ticketOnly = tr.theTable.json.canModify && tr.statusAction.ticket;
+    tr.canChange = tr.canModify && tr.statusAction.change;
+
+    if (!theRow.xpathId) {
+      tr.innerHTML = "<td><i>ERROR: missing row</i></td>";
+      return;
+    }
+    if (!tr.xpstrid) {
+      tr.xpathId = theRow.xpathId;
+      tr.xpstrid = theRow.xpstrid;
+      if (tr.xpstrid) {
+        /*
+         * TODO: usage of '@' in tr.id appears to be problematic for jQuery:
+         * if we try to use selectors like $('#' + tr.id), we get
+         * "Syntax error, unrecognized expression: #r@f3d4397b739b287"
+         * Is there a good reason to keep '@'?
+         */
+        tr.id = "r@" + tr.xpstrid;
+        tr.sethash = tr.xpstrid;
+        // const test = $('#' + tr.id);
+      }
+    }
+
+    var protoButton = null; // no voting at all, unless tr.canModify
+    if (tr.canModify) {
+      protoButton = document.getElementById("proto-button");
+    }
+
+    const statusCell = tr.querySelector(".statuscell");
+    const abstainCell = tr.querySelector(".nocell");
+    const codeCell = tr.querySelector(".codecell");
+    const comparisonCell = tr.querySelector(".comparisoncell");
+    const proposedCell = tr.querySelector(".proposedcell");
+    const otherCell = tr.querySelector(".othercell");
+    const addCell = tr.canModify ? tr.querySelector(".addcell") : null;
+
+    /*
+     * "Add" button, potentially used by updateRowOthersCell and/or by otherCell or addCell
+     */
+    const formAdd = document.createElement("form");
+
+    /*
+     * Update the "status cell", a.k.a. the "A" column.
+     */
+    if (statusCell) {
+      updateRowStatusCell(tr, theRow, statusCell);
+    }
+
+    /*
+     * Update part of the "no cell", cf. updateRowNoAbstainCell; should this code be moved to updateRowNoAbstainCell?
+     */
+    if (abstainCell) {
+      if (theRow.hasVoted) {
+        abstainCell.title = cldrText.get("voTrue");
+        abstainCell.className = "d-no-vo-true nocell";
+      } else {
+        abstainCell.title = cldrText.get("voFalse");
+        abstainCell.className = "d-no-vo-false nocell";
+      }
+    }
+
+    /*
+     * Assemble the "code cell", a.k.a. the "Code" column.
+     */
+    if (codeCell) {
+      updateRowCodeCell(tr, theRow, codeCell);
+    }
+
+    /*
+     * Set up the "comparison cell", a.k.a. the "English" column.
+     */
+    if (comparisonCell && !comparisonCell.isSetup) {
+      updateRowEnglishComparisonCell(tr, theRow, comparisonCell);
+    }
+
+    /*
+     * Set up the "proposed cell", a.k.a. the "Winning" column.
+     *
+     * Column headings are: Code    English    Abstain    A    Winning    Add    Others
+     * TODO: are we going out of order here, from English to Winning, skipping Abstain and A?
+     */
+    if (proposedCell) {
+      updateRowProposedWinningCell(tr, theRow, proposedCell, protoButton);
+    }
+
+    /*
+     * Set up the "other cell", a.k.a. the "Others" column.
+     */
+    if (otherCell) {
+      updateRowOthersCell(tr, theRow, otherCell, protoButton, formAdd);
+    }
+
+    /*
+     * If the user can make changes, add "+" button for adding new candidate item.
+     *
+     * This code is for Dashboard as well as the basic vetting table.
+     * This block concerns the "other" cell if isDashboard(), otherwise it concerns the "add" cell.
+     */
+    if (tr.canChange) {
+      if (isDashboard()) {
+        if (otherCell) {
+          otherCell.appendChild(document.createElement("hr"));
+          otherCell.appendChild(formAdd);
+        }
+      } else {
+        if (addCell) {
+          removeAllChildNodes(addCell);
+          addCell.appendChild(formAdd);
+        }
+      }
+    }
+
+    /*
+     * Set up the "no cell", a.k.a. the "Abstain" column.
+     * If the user can make changes, add an "abstain" button;
+     * else, possibly add a ticket link, or else hide the column.
+     */
+    updateRowNoAbstainCell(tr, theRow, abstainCell, proposedCell, protoButton);
+
+    /*
+     * Set className for this row to "vother" and "cov..." based on the coverage value.
+     * Elsewhere className can get values including "ferrbox", "tr_err", "tr_checking2".
+     */
+    tr.className = "vother cov" + theRow.coverageValue;
+
+    /*
+     * Show the current ID.
+     * TODO: explain.
+     */
+    const curId = cldrStatus.getCurrentId();
+    if (curId !== "" && curId === tr.id) {
+      window.showCurrentId(); // refresh again - to get the updated voting status.
+    }
+  }
+
+  /**
+   * Check whether the data for this row is consistent, and report to console error
+   * if it isn't.
+   *
+   * @param theRow the data from the server for this row
+   *
+   * Called by updateRow.
+   *
+   * Inconsistencies should primarily be detected/reported/fixed on server (DataSection.java)
+   * rather than here on the client, but better late than never, and these checks may be useful
+   * for automated testing with WebDriver.
+   */
+  function checkRowConsistency(theRow) {
+    if (!theRow) {
+      console.error("theRow is null or undefined in checkRowConsistency");
+      return;
+    }
+    if (!theRow.winningVhash) {
+      /*
+       * The server is responsible for ensuring that a winning item is present, or using
+       * the placeholder NO_WINNING_VALUE, which is not null.
+       */
+      console.error("For " + theRow.xpstrid + " - there is no winningVhash");
+    } else if (!theRow.items) {
+      console.error("For " + theRow.xpstrid + " - there are no items");
+    } else if (!theRow.items[theRow.winningVhash]) {
+      console.error(
+        "For " + theRow.xpstrid + " - there is winningVhash but no item for it"
+      );
+    }
+
+    for (var k in theRow.items) {
+      var item = theRow.items[k];
+      if (item.value === INHERITANCE_MARKER) {
+        if (!theRow.inheritedValue) {
+          /*
+           * In earlier implementation, essentially the same error was reported as "... there is no Bailey Target item!").
+           */
+          if (!extraPathAllowsNullValue(theRow.xpath)) {
+            console.error(
+              "For " +
+                theRow.xpstrid +
+                " - there is INHERITANCE_MARKER without inheritedValue"
+            );
+          }
+        } else if (!theRow.inheritedLocale && !theRow.inheritedXpid) {
+          /*
+           * It is probably a bug if item.value === INHERITANCE_MARKER but theRow.inheritedLocale and
+           * theRow.inheritedXpid are both undefined (null on server).
+           * This happens with "example C" in
+           *     https://unicode.org/cldr/trac/ticket/11299#comment:15
+           */
+          console.log(
+            "For " +
+              theRow.xpstrid +
+              " - there is INHERITANCE_MARKER without inheritedLocale or inheritedXpid"
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Is the given path exceptional in the sense that null value is allowed?
+   *
+   * @param path the path
+   * @return true if null value is allowed for path, else false
+   *
+   * This function is nearly identical to the Java function with the same name in TestPaths.java.
+   * Keep it consistent with that function. It would be more ideal if this knowledge were encapsulated
+   * on the server and the client didn't need to know about it. The server could send the client special
+   * fallback values instead of null.
+   *
+   * Unlike the Java version on the server, here on the client we don't actually check that the path is an "extra" path.
+   *
+   * Example: http://localhost:8080/cldr-apps/v#/pa_Arab/Gregorian/35b886c9d25c9cb7
+   * //ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="midnight"]
+   *
+   * Reference: https://unicode-org.atlassian.net/browse/CLDR-11238
+   */
+  function extraPathAllowsNullValue(path) {
+    if (
+      path.includes("timeZoneNames/metazone") ||
+      path.includes("timeZoneNames/zone") ||
+      path.includes("dayPeriods/dayPeriodContext")
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Update the "status cell", a.k.a. the "A" column.
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   * @param cell the table cell
+   */
+  function updateRowStatusCell(tr, theRow, cell) {
+    const statusClass = getRowApprovalStatusClass(theRow);
+    cell.className = "d-dr-" + statusClass + " d-dr-status statuscell";
+
+    if (!cell.isSetup) {
+      listenToPop("", tr, cell);
+      cell.isSetup = true;
+    }
+
+    const statusTitle = cldrText.get(statusClass);
+    cell.title = cldrText.sub("draftStatus", [statusTitle]);
+  }
+
+  /**
+   * On the client only, make further status distinctions when winning value is INHERITANCE_MARKER,
+   * "inherited-unconfirmed" (red up-arrow icon) and "inherited-provisional" (orange up-arrow icon).
+   * Reference: http://unicode.org/cldr/trac/ticket/11103
+   *
+   * @param theRow the data from the server for this row
+   */
+  function getRowApprovalStatusClass(theRow) {
+    var statusClass = theRow.confirmStatus;
+
+    if (theRow.winningValue === INHERITANCE_MARKER) {
+      if (statusClass === "unconfirmed") {
+        statusClass = "inherited-unconfirmed";
+      } else if (statusClass === "provisional") {
+        statusClass = "inherited-provisional";
+      }
+    }
+    return statusClass;
+  }
+
+  /**
+   * Update the vote info for this row.
+   *
+   * Set up the "vote div".
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   *
+   * Called by updateRow.
+   *
+   * TODO: shorten this function by using subroutines.
+   */
+  function updateRowVoteInfo(tr, theRow) {
+    if (!theRow) {
+      console.error("theRow is null or undefined in updateRowVoteInfo");
+      return;
+    }
+    var vr = theRow.voteResolver;
+    tr.voteDiv = document.createElement("div");
+    tr.voteDiv.className = "voteDiv";
+    const surveyUser = cldrStatus.getSurveyUser();
+    if (theRow.voteVhash && theRow.voteVhash !== "" && surveyUser) {
+      var voteForItem = theRow.items[theRow.voteVhash];
+      if (
+        voteForItem &&
+        voteForItem.votes &&
+        voteForItem.votes[surveyUser.id] &&
+        voteForItem.votes[surveyUser.id].overridedVotes
+      ) {
+        tr.voteDiv.appendChild(
+          createChunk(
+            cldrText.sub("override_explain_msg", {
+              overrideVotes: voteForItem.votes[surveyUser.id].overridedVotes,
+              votes: surveyUser.votecount,
+            }),
+            "p",
+            "helpContent"
+          )
+        );
+      }
+      if (theRow.voteVhash !== theRow.winningVhash && theRow.canFlagOnLosing) {
+        if (!theRow.rowFlagged) {
+          addIcon(tr.voteDiv, "i-stop");
+          tr.voteDiv.appendChild(
+            createChunk(
+              cldrText.sub("mustflag_explain_msg", {}),
+              "p",
+              "helpContent"
+            )
+          );
+        } else {
+          addIcon(tr.voteDiv, "i-flag");
+          tr.voteDiv.appendChild(
+            createChunk(cldrText.get("flag_desc", "p", "helpContent"))
+          );
+        }
+      }
+    }
+    if (!theRow.rowFlagged && theRow.canFlagOnLosing) {
+      addIcon(tr.voteDiv, "i-flag-d");
+      tr.voteDiv.appendChild(
+        createChunk(cldrText.get("flag_d_desc", "p", "helpContent"))
+      );
+    }
+    /*
+     * The value_vote array has an even number of elements,
+     * like [value0, vote0, value1, vote1, value2, vote2, ...].
+     */
+    var n = 0;
+    while (n < vr.value_vote.length) {
+      var value = vr.value_vote[n++];
+      var vote = vr.value_vote[n++];
+      if (value == null /* TODO: impossible? */ || value === NO_WINNING_VALUE) {
+        continue;
+      }
+      var item = tr.rawValueToItem[value]; // backlink to specific item in hash
+      if (item == null) {
+        continue;
+      }
+      var vdiv = createChunk(
+        null,
+        "table",
+        "voteInfo_perValue table table-vote"
+      );
+      var valdiv = createChunk(
+        null,
+        "div",
+        n > 2 ? "value-div" : "value-div first"
+      );
+      // heading row
+      var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_tr_heading");
+      if (
+        item.rawValue === INHERITANCE_MARKER ||
+        (item.votes && Object.keys(item.votes).length > 0)
+      ) {
+        vrow.appendChild(
+          createChunk(
+            cldrText.get("voteInfo_orgColumn"),
+            "td",
+            "voteInfo_orgColumn voteInfo_td"
+          )
+        );
+      }
+      var isection = createChunk(null, "div", "voteInfo_iconBar");
+      var isectionIsUsed = false;
+      var vvalue = createChunk("User", "td", "voteInfo_valueTitle voteInfo_td");
+      var vbadge = createChunk(vote, "span", "badge");
+
+      /*
+       * Note: we can't just check for item.pClass === "winner" here, since, for example, the winning value may
+       * have value = INHERITANCE_MARKER and item.pClass = "alias".
+       */
+      if (value === theRow.winningValue) {
+        const statusClass = getRowApprovalStatusClass(theRow);
+        const statusTitle = cldrText.get(statusClass);
+        appendIcon(
+          isection,
+          "voteInfo_winningItem d-dr-" + statusClass,
+          cldrText.sub("draftStatus", [statusTitle])
+        );
+        isectionIsUsed = true;
+      }
+      if (item.isBaselineValue) {
+        appendIcon(isection, "i-star", cldrText.get("voteInfo_baseline_desc"));
+        isectionIsUsed = true;
+      }
+      setLang(valdiv);
+      if (value === INHERITANCE_MARKER) {
+        /*
+         * theRow.inheritedValue can be undefined here; then do not append
+         */
+        if (theRow.inheritedValue) {
+          appendItem(valdiv, theRow.inheritedValue, item.pClass, tr);
+          valdiv.appendChild(
+            createChunk(cldrText.get("voteInfo_votesForInheritance"), "p")
+          );
+        }
+      } else {
+        appendItem(
+          valdiv,
+          value,
+          value === theRow.winningValue ? "winner" : "value",
+          tr
+        );
+        if (value === theRow.inheritedValue) {
+          valdiv.appendChild(
+            createChunk(cldrText.get("voteInfo_votesForSpecificValue"), "p")
+          );
+        }
+      }
+      if (isectionIsUsed) {
+        valdiv.appendChild(isection);
+      }
+      vrow.appendChild(vvalue);
+      var cell = createChunk(
+        null,
+        "td",
+        "voteInfo_voteTitle voteInfo_voteCount voteInfo_td" + ""
+      );
+      cell.appendChild(vbadge);
+      vrow.appendChild(cell);
+      vdiv.appendChild(vrow);
+      const itemVotesLength = item.votes ? Object.keys(item.votes).length : 0;
+      const anon =
+        itemVotesLength == 1 &&
+        item.votes[Object.keys(item.votes)[0]].level === "anonymous";
+      if (itemVotesLength == 0 || anon) {
+        var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_orgHeading");
+        vrow.appendChild(
+          createChunk(
+            cldrText.get("voteInfo_noVotes"),
+            "td",
+            "voteInfo_noVotes voteInfo_td"
+          )
+        );
+        const anonVoter = anon ? cldrText.get("voteInfo_anon") : null;
+        vrow.appendChild(
+          createChunk(anonVoter, "td", "voteInfo_noVotes voteInfo_td")
+        );
+        vdiv.appendChild(vrow);
+      } else {
+        updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv);
+      }
+      tr.voteDiv.appendChild(valdiv);
+      tr.voteDiv.appendChild(vdiv);
+    }
+    if (vr.valueIsLocked) {
+      tr.voteDiv.appendChild(
+        createChunk(
+          cldrText.get("valueIsLocked"),
+          "p",
+          "alert alert-warning fix-popover-help"
+        )
+      );
+    } else if (vr.requiredVotes) {
+      var msg = cldrText.sub("explainRequiredVotes", {
+        requiredVotes: vr.requiredVotes,
+      });
+      tr.voteDiv.appendChild(
+        createChunk(msg, "p", "alert alert-warning fix-popover-help")
+      );
+    }
+    // done with voteresolver table
+    if (stdebug_enabled) {
+      tr.voteDiv.appendChild(createChunk(vr.raw, "p", "debugStuff"));
+    }
+  }
+
+  /**
+   * Update the vote info for one candidate item in this row, looping through all the orgs.
+   * Information will be displayed in the Information Panel (right edge of window).
+   *
+   * @param theRow the row
+   * @param vr the vote resolver
+   * @param value the value of the candidate item
+   * @param item the candidate item
+   * @param vdiv a table created by the caller as vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote")
+   */
+  function updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv) {
+    for (let org in vr.orgs) {
+      var theOrg = vr.orgs[org];
+      var vrRaw = {};
+      var orgVoteValue = theOrg.votes[value];
+      /*
+       * We should display something under "Org." and "User" even when orgVoteValue is zero (not undefined),
+       * for "anonymous" imported losing votes. Therefore do not require orgVoteValue > 0 here.
+       * There does not appear to be any circumstance where we need to hide a zero vote count (on the client).
+       * If we do discover such a circumstance, we could display 0 vote only if voter is "anonymous";
+       * currently such voters have org = "cldr"; but if we don't need such a dependency here, don't add it.
+       * Reference: https://unicode.org/cldr/trac/ticket/11517
+       */
+      if (orgVoteValue !== undefined) {
+        // someone in the org actually voted for it
+        var topVoter = null; // top voter for this item
+        var orgsVote = theOrg.orgVote == value; // boolean
+        var topVoterTime = 0; // Calculating the latest time for a user from same org
+        if (orgsVote) {
+          // find a top-ranking voter to use for the top line
+          for (var voter in item.votes) {
+            if (
+              item.votes[voter].org == org &&
+              item.votes[voter].votes == theOrg.votes[value]
+            ) {
+              if (topVoterTime != 0) {
+                // Get the latest time vote only
+                if (
+                  vr.nameTime[item.votes[topVoter].name] <
+                  vr.nameTime[item.votes[voter].name]
+                ) {
+                  topVoter = voter;
+                  topVoterTime = vr.nameTime[item.votes[topVoter].name];
+                }
+              } else {
+                topVoter = voter;
+                topVoterTime = vr.nameTime[item.votes[topVoter].name];
+              }
+            }
+          }
+        } else {
+          // just find someone in the right org..
+          for (var voter in item.votes) {
+            if (item.votes[voter].org == org) {
+              topVoter = voter;
+              break;
+            }
+          }
+        }
+        // ORG SUBHEADING row
+
+        /*
+         * This only affects cells ("td" elements) with style "voteInfo_voteCount", which appear in the info panel,
+         * and which have contents like '<span class="badge">12</span>'. If the "fallback" style is added, then
+         * these circled numbers are surrounded (outside the circle) by a colored background.
+         *
+         * TODO: see whether the colored background is actually wanted in this context, around the numbers.
+         * For now, display it, and use item.pClass rather than literal "fallback" so the color matches when
+         * item.pClass is "alias", "fallback_root", etc.
+         */
+        var baileyClass =
+          item.rawValue === INHERITANCE_MARKER ? " " + item.pClass : "";
+        var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_orgHeading");
+        vrow.appendChild(
+          createChunk(org, "td", "voteInfo_orgColumn voteInfo_td")
+        );
+        if (item.votes[topVoter]) {
+          vrow.appendChild(createVoter(item.votes[topVoter])); // voteInfo_td
+        } else {
+          vrow.appendChild(createVoter(null));
+        }
+        if (orgsVote) {
+          var cell = createChunk(
+            null,
+            "td",
+            "voteInfo_orgsVote voteInfo_voteCount voteInfo_td" + baileyClass
+          );
+          cell.appendChild(createChunk(orgVoteValue, "span", "badge"));
+          vrow.appendChild(cell);
+        } else {
+          vrow.appendChild(
+            createChunk(
+              orgVoteValue,
+              "td",
+              "voteInfo_orgsNonVote voteInfo_voteCount voteInfo_td" +
+                baileyClass
+            )
+          );
+        }
+        vdiv.appendChild(vrow);
+        // now, other rows:
+        for (var voter in item.votes) {
+          if (
+            item.votes[voter].org != org || // wrong org or
+            voter == topVoter
+          ) {
+            // already done
+            continue; // skip
+          }
+          // OTHER VOTER row
+          var vrow = createChunk(null, "tr", "voteInfo_tr");
+          vrow.appendChild(
+            createChunk("", "td", "voteInfo_orgColumn voteInfo_td")
+          ); // spacer
+          vrow.appendChild(createVoter(item.votes[voter])); // voteInfo_td
+          vrow.appendChild(
+            createChunk(
+              item.votes[voter].votes,
+              "td",
+              "voteInfo_orgsNonVote voteInfo_voteCount voteInfo_td" +
+                baileyClass
+            )
+          );
+          vdiv.appendChild(vrow);
+        }
+      }
+    }
+  }
+
+  /**
+   * Create an element representing a voter, including a link to the voter's email
+   *
+   * @param v the voter
+   * @return the element
+   */
+  function createVoter(v) {
+    if (v == null) {
+      return createChunk("(missing information)!", "i", "stopText");
+    }
+    var div = createChunk(
+      v.name || cldrText.get("emailHidden"),
+      "td",
+      "voteInfo_voterInfo voteInfo_td"
+    );
+    div.setAttribute("data-name", v.name || cldrText.get("emailHidden"));
+    div.setAttribute("data-email", v.email || "");
+    return div;
+  }
+
+  /*
+   * Update the "Code" cell (column) of this row
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   * @param cell the table cell
+   *
+   * Called by updateRow.
+   */
+  function updateRowCodeCell(tr, theRow, cell) {
+    removeAllChildNodes(cell);
+    var codeStr = theRow.code;
+    if (theRow.coverageValue == 101 && !stdebug_enabled) {
+      codeStr = codeStr + " (optional)";
+    }
+    cell.appendChild(createChunk(codeStr));
+    if (cldrStatus.getSurveyUser()) {
+      cell.className = "d-code codecell";
+      if (!tr.forumDiv) {
+        tr.forumDiv = document.createElement("div");
+        tr.forumDiv.className = "forumDiv";
+      }
+      appendForumStuff(tr, theRow, tr.forumDiv);
+    }
+    // extra attributes
+    if (
+      theRow.extraAttributes &&
+      Object.keys(theRow.extraAttributes).length > 0
+    ) {
+      appendExtraAttributes(cell, theRow);
+    }
+    if (stdebug_enabled) {
+      var anch = document.createElement("i");
+      anch.className = "anch";
+      anch.id = theRow.xpathId;
+      cell.appendChild(anch);
+      anch.appendChild(document.createTextNode("#"));
+      var go = document.createElement("a");
+      go.className = "anch-go";
+      go.appendChild(document.createTextNode("zoom"));
+      go.href =
+        window.location.pathname +
+        "?_=" +
+        cldrStatus.getCurrentLocale() +
+        "&x=r_rxt&xp=" +
+        theRow.xpathId;
+      cell.appendChild(go);
+      var js = document.createElement("a");
+      js.className = "anch-go";
+      js.appendChild(document.createTextNode("{JSON}"));
+      js.popParent = tr;
+      listenToPop(JSON.stringify(theRow), tr, js);
+      cell.appendChild(js);
+      cell.appendChild(createChunk(" c=" + theRow.coverageValue));
+    }
+    if (!cell.isSetup) {
+      var xpathStr = "";
+      if (stdebug_enabled) {
+        xpathStr = "XPath: " + theRow.xpath;
+      }
+      listenToPop(xpathStr, tr, cell);
+      cell.isSetup = true;
+    }
+  }
+
+  /**
+   * Update the "comparison cell", a.k.a. the "English" column, of this row
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   * @param cell the table cell
+   *
+   * Called by updateRow.
+   */
+  function updateRowEnglishComparisonCell(tr, theRow, cell) {
+    if (theRow.displayName) {
+      var hintPos = theRow.displayName.indexOf("[translation hint");
+      var hasExample = false;
+      if (theRow.displayExample) {
+        hasExample = true;
+      }
+      if (hintPos != -1) {
+        theRow.displayExample =
+          theRow.displayName.substr(hintPos, theRow.displayName.length) +
+          (theRow.displayExample
+            ? theRow.displayExample.replace(/\[translation hint.*?\]/g, "")
+            : "");
+        theRow.displayName = theRow.displayName.substr(0, hintPos);
+      }
+      cell.appendChild(createChunk(theRow.displayName, "span", "subSpan"));
+      const TRANS_HINT_ID = "en_ZZ"; // must match SurveyMain.TRANS_HINT_ID
+      setLang(cell, TRANS_HINT_ID);
+      if (theRow.displayExample) {
+        appendExample(cell, theRow.displayExample, TRANS_HINT_ID);
+      }
+      if (hintPos != -1 || hasExample) {
+        var infos = document.createElement("div");
+        infos.className = "infos-code";
+        if (hintPos != -1) {
+          var img = document.createElement("img");
+          img.src = "hint.png";
+          img.alt = "Translation hint";
+          infos.appendChild(img);
+        }
+        if (hasExample) {
+          var img = document.createElement("img");
+          img.src = "example.png";
+          img.alt = "Example";
+          infos.appendChild(img);
+        }
+        cell.appendChild(infos);
+      }
+    } else {
+      cell.appendChild(document.createTextNode(""));
+    }
+    /* The next line (listenToPop...) had been commented out, for unknown reasons.
+     * Restored (uncommented) for http://unicode.org/cldr/trac/ticket/10573 so that
+     * the right-side panel info changes when you click on the English column.
+     */
+    listenToPop(null, tr, cell);
+    cell.isSetup = true;
+  }
+
+  /**
+   * Update the "proposed cell", a.k.a. the "Winning" column, of this row
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   * @param cell the table cell
+   * @param protoButton
+   *
+   * Called by updateRow.
+   */
+  function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
+    removeAllChildNodes(cell); // win
+    if (theRow.rowFlagged) {
+      var flagIcon = addIcon(cell, "s-flag");
+      flagIcon.title = cldrText.get("flag_desc");
+    } else if (theRow.canFlagOnLosing) {
+      var flagIcon = addIcon(cell, "s-flag-d");
+      flagIcon.title = cldrText.get("flag_d_desc");
+    }
+    setLang(cell);
+    tr.proposedcell = cell;
+
+    /*
+     * If server doesn't do its job properly, theRow.items[theRow.winningVhash] may be undefined.
+     * Check for that here to prevent crash in addVitem. An error message might be appropriate here
+     * in that case, though the consistency checking really should happen earlier, see checkRowConsistency.
+     */
+    if (getValidWinningValue(theRow) !== null) {
+      addVitem(
+        cell,
+        tr,
+        theRow,
+        theRow.items[theRow.winningVhash],
+        cloneAnon(protoButton)
+      );
+    } else {
+      cell.showFn = function () {}; // nothing else to show
+    }
+    listenToPop(null, tr, cell, cell.showFn);
+  }
+
+  /**
+   * Update the "Others" cell (column) of this row
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   * @param cell the table cell
+   * @param protoButton
+   * @param formAdd
+   *
+   * Called by updateRow.
+   */
+  function updateRowOthersCell(tr, theRow, cell, protoButton, formAdd) {
+    var hadOtherItems = false;
+    removeAllChildNodes(cell); // other
+    setLang(cell);
+
+    if (tr.canModify) {
+      formAdd.role = "form";
+      formAdd.className = "form-inline";
+      var buttonAdd = document.createElement("div");
+      var btn = document.createElement("button");
+      buttonAdd.className = "button-add form-group";
+
+      toAddVoteButton(btn);
+
+      buttonAdd.appendChild(btn);
+      formAdd.appendChild(buttonAdd);
+
+      var input = document.createElement("input");
+      var popup;
+      input.className = "form-control input-add";
+      input.placeholder = "Add a translation";
+      var copyWinning = document.createElement("button");
+      copyWinning.className = "copyWinning btn btn-info btn-xs";
+      copyWinning.title = "Copy Winning";
+      copyWinning.type = "button";
+      copyWinning.innerHTML =
+        '<span class="glyphicon glyphicon-arrow-right"></span> Winning';
+      copyWinning.onclick = function (e) {
+        var theValue = getValidWinningValue(theRow);
+        if (theValue === INHERITANCE_MARKER || theValue === null) {
+          theValue = theRow.inheritedValue;
+        }
+        input.value = theValue || null;
+        input.focus();
+      };
+      var copyEnglish = document.createElement("button");
+      copyEnglish.className = "copyEnglish btn btn-info btn-xs";
+      copyEnglish.title = "Copy English";
+      copyEnglish.type = "button";
+      copyEnglish.innerHTML =
+        '<span class="glyphicon glyphicon-arrow-right"></span> English';
+      copyEnglish.onclick = function (e) {
+        input.value = theRow.displayName || null;
+        input.focus();
+      };
+      btn.onclick = function (e) {
+        //if no input, add one
+        if ($(buttonAdd).parent().find("input").length == 0) {
+          //hide other
+          $.each($("button.vote-submit"), function () {
+            toAddVoteButton(this);
+          });
+
+          //transform the button
+          toSubmitVoteButton(btn);
+          $(buttonAdd)
+            .popover({
+              content: " ",
+            })
+            .popover("show");
+          popup = $(buttonAdd).parent().find(".popover-content");
+          popup.append(input);
+          if (theRow.displayName) {
+            popup.append(copyEnglish);
+          }
+          const winVal = getValidWinningValue(theRow);
+          if (winVal || theRow.inheritedValue) {
+            popup.append(copyWinning);
+          }
+          popup
+            .closest(".popover")
+            .css("top", popup.closest(".popover").position().top - 19);
+          input.focus();
+
+          //enter pressed
+          $(input).keydown(function (e) {
+            var newValue = $(this).val();
+            if (e.keyCode == 13) {
+              //enter pressed
+              if (newValue) {
+                addValueVote(
+                  cell,
+                  tr,
+                  theRow,
+                  newValue,
+                  cloneAnon(protoButton)
+                );
+              } else {
+                toAddVoteButton(btn);
+              }
+            } else if (e.keyCode === 27) {
+              toAddVoteButton(btn);
+            }
+          });
+        } else {
+          var newValue = input.value;
+
+          if (newValue) {
+            addValueVote(cell, tr, theRow, newValue, cloneAnon(protoButton));
+          } else {
+            toAddVoteButton(btn);
+          }
+          stStopPropagation(e);
+          return false;
+        }
+        stStopPropagation(e);
+        return false;
+      };
+    }
+    /*
+     * Add the other vote info -- that is, vote info for the "Others" column.
+     */
+    for (let k in theRow.items) {
+      if (k === theRow.winningVhash) {
+        // skip vote for winner
+        continue;
+      }
+      hadOtherItems = true;
+      addVitem(cell, tr, theRow, theRow.items[k], cloneAnon(protoButton));
+      cell.appendChild(document.createElement("hr"));
+    }
+
+    if (!hadOtherItems /*!onIE*/) {
+      listenToPop(null, tr, cell);
+    }
+    if (
+      tr.myProposal &&
+      tr.myProposal.value &&
+      !findItemByValue(theRow.items, tr.myProposal.value)
+    ) {
+      // add back my proposal
+      cell.appendChild(tr.myProposal);
+    } else {
+      tr.myProposal = null; // not needed
+    }
+  }
+
+  /**
+   * Update the "no cell", a.k.a, the "Abstain" column, of this row
+   * Also possibly make changes to the "proposed" (winning) cell
+   *
+   * If the user can make changes, add an "abstain" button;
+   * else, possibly add a ticket link, or else hide the column.
+   *
+   * @param tr the table row
+   * @param theRow the data from the server for this row
+   * @param noCell the table "no" (abstain) cell
+   * @param proposedCell the table "proposed" (winning) cell
+   * @param protoButton
+   *
+   * Called by updateRow.
+   */
+  function updateRowNoAbstainCell(
+    tr,
+    theRow,
+    noCell,
+    proposedCell,
+    protoButton
+  ) {
+    if (tr.canModify) {
+      removeAllChildNodes(noCell); // no opinion
+      var noOpinion = cloneAnon(protoButton);
+      wireUpButton(noOpinion, tr, theRow, null);
+      noOpinion.value = null;
+      var wrap = wrapRadio(noOpinion);
+      noCell.appendChild(wrap);
+      listenToPop(null, tr, noCell);
+    } else if (tr.ticketOnly) {
+      // ticket link
+      if (!tr.theTable.json.canModify) {
+        // only if hidden in the header
+        setDisplayed(noCell, false);
+      }
+      proposedCell.className = "d-change-confirmonly";
+      var surlink = document.createElement("div");
+      surlink.innerHTML =
+        '<span class="glyphicon glyphicon-list-alt"></span>&nbsp;&nbsp;';
+      surlink.className = "alert alert-info fix-popover-help";
+      var link = createChunk(cldrText.get("file_a_ticket"), "a");
+      const curLocale = cldrStatus.getCurrentLocale();
+      var newUrl =
+        "http://unicode.org/cldr/trac" +
+        "/newticket?component=data&summary=" +
+        curLocale +
+        ":" +
+        theRow.xpath +
+        "&locale=" +
+        curLocale +
+        "&xpath=" +
+        theRow.xpstrid +
+        "&version=" +
+        cldrStatus.getNewVersion();
+      link.href = newUrl;
+      link.target = "cldr-target-trac";
+      theRow.proposedResults = createChunk(
+        cldrText.get("file_ticket_must"),
+        "a",
+        "fnotebox"
+      );
+      theRow.proposedResults.href = newUrl;
+      if (cldrStatus.getIsUnofficial()) {
+        link.appendChild(
+          createChunk(
+            " (Note: this is not the production SurveyTool! Do not submit a ticket!) ",
+            "p"
+          )
+        );
+        link.href = link.href + "&description=NOT+PRODUCTION+SURVEYTOOL!";
+      }
+      proposedCell.appendChild(
+        createChunk(cldrText.get("file_ticket_notice"), "i", "fnotebox")
+      );
+      surlink.appendChild(link);
+      tr.ticketLink = surlink;
+    } else {
+      // no change possible
+      if (!tr.theTable.json.canModify) {
+        // only if hidden in the header
+        setDisplayed(noCell, false);
+      }
+    }
+  }
+
+  /**
+   * Get the winning value for the given row, if it's a valid value.
+   * Null and NO_WINNING_VALUE ('no-winning-value') are not valid.
+   * See NO_WINNING_VALUE in VoteResolver.java.
+   *
+   * @param theRow
+   * @returns the winning value, or null if there is not a valid winning value
+   */
+  function getValidWinningValue(theRow) {
+    if (!theRow) {
+      console.error("theRow is null or undefined in getValidWinningValue");
+      return null;
+    }
+    if (
+      theRow.items &&
+      theRow.winningVhash &&
+      theRow.items[theRow.winningVhash]
+    ) {
+      const item = theRow.items[theRow.winningVhash];
+      if (item.value) {
+        const val = item.value;
+        if (val !== NO_WINNING_VALUE) {
+          return val;
+        }
+      }
+    }
+    return null;
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    insertRows: insertRows,
+    updateRow: updateRow,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      cldrChecksum: cldrChecksum,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrBulkClosePosts.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrBulkClosePosts.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /**
- * cldrStBulkClosePosts: Survey Tool feature for bulk-closing forum posts
+ * cldrBulkClosePosts: Survey Tool feature for bulk-closing forum posts
+ * This is the new non-dojo version. For dojo, see CldrDojoBulkClosePosts.js.
  *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
@@ -9,7 +10,7 @@
  * but not all Survey Tool JavaScript code is capable yet of being in modules
  * and running in strict mode.
  */
-const cldrStBulkClosePosts = (function () {
+const cldrBulkClosePosts = (function () {
   let saveParamsForExecute = null;
 
   let contentDiv = null;
@@ -24,7 +25,13 @@ const cldrStBulkClosePosts = (function () {
     /*
      * Set up the 'right sidebar'; cf. bulk_close_postsGuidance
      */
-    showInPop2(cldrText.get(params.name + "Guidance"), null, null, null, true);
+    cldrSurvey.showInPop2(
+      cldrText.get(params.name + "Guidance"),
+      null,
+      null,
+      null,
+      true
+    );
 
     const url = getBulkClosePostsUrl();
     const errorHandler = function (err) {
@@ -47,7 +54,7 @@ const cldrStBulkClosePosts = (function () {
       contentDiv.innerHTML = html;
 
       // No longer loading
-      hideLoader(null);
+      cldrSurvey.hideLoader(null);
       params.flipper.flipTo(params.pages.other, contentDiv);
     };
     const xhrArgs = {
@@ -56,7 +63,7 @@ const cldrStBulkClosePosts = (function () {
       load: loadHandler,
       error: errorHandler,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**
@@ -89,7 +96,7 @@ const cldrStBulkClosePosts = (function () {
       load: loadHandler,
       error: errorHandler,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**
@@ -130,7 +137,7 @@ const cldrStBulkClosePosts = (function () {
         "</p>\n";
       if (json.threadCount > 0) {
         html +=
-          "<h4><a onclick='cldrStBulkClosePosts.execute()'>Close Threads!</a></h4>\n";
+          "<h4><a onclick='cldrBulkClosePosts.execute()'>Close Threads!</a></h4>\n";
         html += "<p>This action cannot be undone.</p>";
         html +=
           "<p>It should normally be done after a new version of CLDR is published, before opening Survey Tool.</p>\n";

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrCsvFromTable.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrCsvFromTable.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /**
- * cldrStCsvFromTable: enable downloading a table as a CSV file.
+ * cldrCsvFromTable: enable downloading a table as a CSV file.
+ * This works with or without dojo; no dependency on dojo.
  *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
@@ -9,16 +10,16 @@
  * but not all Survey Tool JavaScript code is capable yet of being in modules
  * and running in strict mode.
  */
-const cldrStCsvFromTable = (function () {
+const cldrCsvFromTable = (function () {
   /**
    * Download the table as CSV
    */
-  function downloadCsv(tableId, fileName) {
+  function download(tableId, fileName) {
     const table = document.getElementById(tableId);
     if (!table) {
       return;
     }
-    const csv = getCsvFromTable(table);
+    const csv = get(table);
     if (!csv) {
       return;
     }
@@ -29,7 +30,7 @@ const cldrStCsvFromTable = (function () {
     link.click();
   }
 
-  function getCsvFromTable(table) {
+  function get(table) {
     let csv = "";
     for (let row of table.rows) {
       let columnsRemaining = row.cells.length;
@@ -44,7 +45,12 @@ const cldrStCsvFromTable = (function () {
    * Make only these functions accessible from other files
    */
   return {
-    downloadCsv: downloadCsv,
-    getCsvFromTable: getCsvFromTable,
+    download: download,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      get: get,
+    },
   };
 })();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrDeferHelp.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrDeferHelp.js
@@ -1,0 +1,118 @@
+"use strict";
+
+/**
+ * cldrDeferHelp: encapsulate code related to showing language descriptions in the Info Panel
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ *
+ * This is the new non-dojo version. For dojo, see CldrDojoDeferHelp.js
+ */
+
+const cldrDeferHelp = (function () {
+  const defaultEndpoint = "https://dbpedia.org/sparql/";
+  const format = "JSON";
+  const abstractLang = "en";
+
+  /**
+   * run a sparql query
+   * @param query - SPARQL query
+   * @param endpoint - endpoint, defaults to defaultEndpoint
+   * @returns Promise<Object>
+   */
+  const sparqlQuery = function sparqlQuery(query, endpoint) {
+    endpoint = endpoint || defaultEndpoint;
+    return $.getJSON(endpoint, { query, format });
+  };
+
+  const subloadAbstract = function subloadAbstract(resource) {
+    const absDiv = $("<div/>", { class: "helpAbstract" });
+    const absContent = $("<p/>", { text: `Loading ${resource}` });
+    absDiv.append(absContent);
+
+    // This query simply returns the abstract result for the specific resource.
+    // The query is so small that browsers persistently cache the GET request.
+    sparqlQuery(
+      `PREFIX  dbo:  <http://dbpedia.org/ontology/>
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  SELECT ?abstract ?primaryTopic
+  WHERE {
+      <${resource}> dbo:abstract ?abstract .
+      <${resource}> foaf:isPrimaryTopicOf ?primaryTopic
+      FILTER langMatches(lang(?abstract), "${abstractLang}")
+  } LIMIT 1`
+    ).then(
+      ({ results }) => {
+        let seeAlso = resource;
+        if (
+          results.bindings[0].primaryTopic &&
+          results.bindings[0].primaryTopic.value
+        ) {
+          seeAlso = results.bindings[0].primaryTopic.value;
+        }
+        absContent.text(results.bindings[0].abstract.value);
+        absDiv.append(
+          $("<a/>", {
+            text: "(more)",
+            title: resource,
+            target: "_blank",
+            href: seeAlso,
+          })
+        );
+      },
+      (err) => {
+        absContent.text(`Err loading ${resource}: ${err}`);
+      }
+    );
+
+    return absDiv;
+  };
+
+  /**
+   */
+  const addDeferredHelpTo = function addDeferredHelpTo(
+    fragment,
+    helpHtml,
+    resource
+  ) {
+    // Always have help (if available).
+    const theHelp = $("<div/>", {
+      class: "alert alert-info fix-popover-help vote-help",
+    });
+    // helpHtml is loaded immediately in the DataSection, no separate query needed
+    if (helpHtml) {
+      theHelp.append(
+        $("<span/>", {
+          html: helpHtml,
+          class: "helpHtml",
+        })
+      );
+    }
+
+    // fetch the abstract- may be cached.
+    if (resource) {
+      const absDiv = subloadAbstract(resource);
+      theHelp.append(absDiv);
+    }
+
+    $(fragment).append(theHelp);
+  };
+
+  // TODO: defaultEndpoint and sparqlQuery are unused outside this file, so don't export them;
+  // if they are to be shared, make getter/setter functions. Also, make this file consistent with
+  // our other files that use the IIFE pattern: instead of
+  // "const addDeferredHelpTo = function addDeferredHelpTo"
+  // make it simply
+  // "function addDeferredHelpTo"
+  // and call it as cldrDeferHelp.addDeferredHelpTo().
+  // addDeferredHelpTo: addDeferredHelpTo
+
+  return {
+    addDeferredHelpTo,
+    defaultEndpoint,
+    sparqlQuery,
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrFlip.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrFlip.js
@@ -1,0 +1,94 @@
+"use strict";
+
+/**
+ * Section flipping class
+ * @class Flipper
+ */
+function Flipper(ids) {
+  this._panes = [];
+  this._killfn = [];
+  this._map = {};
+  for (var k in ids) {
+    var id = ids[k];
+    var node = document.getElementById(id);
+    // TODO if node==null throw
+    if (this._panes.length > 0) {
+      cldrSurvey.setDisplayed(node, false); // hide it
+    } else {
+      this._visible = id;
+    }
+    this._panes.push(node);
+    this._map[id] = node;
+  }
+}
+
+/**
+ * @param {String} id
+ * @param {Node} node - if non null - replace new page with this
+ */
+Flipper.prototype.flipTo = function (id, node) {
+  if (!this._map[id]) {
+    return; // TODO throw
+  }
+  if (this._visible == id && node === null) {
+    return; // noop - unless adding s'thing
+  }
+  cldrSurvey.setDisplayed(this._map[this._visible], false);
+  for (var k in this._killfn) {
+    this._killfn[k]();
+  }
+  this._killfn = []; // pop?
+  if (node !== null && node !== undefined) {
+    removeAllChildNodes(this._map[id]);
+    if (node.nodeType > 0) {
+      this._map[id].appendChild(node);
+    } else {
+      for (var kk in node) {
+        // it's an array, add all
+        this._map[id].appendChild(node[kk]);
+      }
+    }
+  }
+  cldrSurvey.setDisplayed(this._map[id], true);
+  this._visible = id;
+  return this._map[id];
+};
+
+/**
+ * @param id page id or null for current
+ * @returns
+ */
+Flipper.prototype.get = function (id) {
+  if (id) {
+    return this._map[id];
+  } else {
+    return this._map[this._visible];
+  }
+};
+
+/**
+ * @param id
+ */
+Flipper.prototype.flipToEmpty = function (id) {
+  return this.flipTo(id, []);
+};
+
+/**
+ * killFn is called on next flip
+ *
+ * @param killFn the function to call. No params.
+ */
+Flipper.prototype.addKillFn = function (killFn) {
+  this._killfn.push(killFn);
+};
+
+/**
+ * showfn is called, result is added to the div.  killfn is called when page is flipped.
+ *
+ * @param showFn
+ * @param killFn
+ */
+Flipper.prototype.addUntilFlipped = function addUntilFlipped(showFn, killFn) {
+  this.get().appendChild(showFn());
+  this.addKillFn(killFn);
+};

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrForum.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrForum.js
@@ -1,0 +1,1446 @@
+"use strict";
+
+/**
+ * cldrForum: encapsulate main Survey Tool Forum code.
+ * This is the new non-dojo version; it depends on cldrSurvey.createGravitar. For dojo, see CldrDojoForum.js
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ *
+ * Dependencies on external code:
+ * window.locmap,
+ * listenFor, bootstrap.js, reloadV,
+ *
+ * TODO: possibly move these functions here from survey.js: showForumStuff, havePosts,
+ * updateInfoPanelForumPosts, appendForumStuff; also some/all code from forum.js
+ */
+const cldrForum = (function () {
+  const FORUM_DEBUG = false;
+
+  function forumDebug(s) {
+    if (FORUM_DEBUG) {
+      console.log(s);
+    }
+  }
+
+  /**
+   * The locale, like "fr_CA", for which to show Forum posts.
+   * This module has persistent data for only one locale at a time, except that sublocales may be
+   * combined, such as "fr_CA" combined with "fr".
+   * Caution: the locale for a reply must exactly match the locale for the post to which it's a reply,
+   * so the locale for a particular post might for example be "fr" even though forumLocale is "fr_CA",
+   * or vice-versa.
+   */
+  let forumLocale = null;
+
+  /**
+   * The time when the posts were last updated from the server
+   */
+  let forumUpdateTime = null;
+
+  /**
+   * Mapping from post id to post object, describing the most recently parsed
+   * full set of posts from the server
+   */
+  let postHash = {};
+
+  /**
+   * Mapping from thread id to array of post objects, describing the most recently parsed
+   * full set of posts from the server
+   */
+  let threadHash = {};
+
+  /**
+   * Whether the current user can make posts
+   */
+  let userCanPost = false;
+
+  /**
+   * Whether to use UTC for displaying date/time
+   * Helpful for unit tests
+   */
+  let displayUtc = false;
+
+  /**
+   * Fetch the Forum data from the server, and "load" it
+   *
+   * @param locale the locale string, like "fr_CA" (cldrStatus.getCurrentLocale())
+   * @param userId the id of the current user
+   * @param forumMessage the forum message
+   * @param params an object with various properties such as exports, special, flipper, otherSpecial, name, ...
+   */
+  function loadForum(locale, userId, forumMessage, params) {
+    setLocale(locale);
+    const url = getLoadForumUrl();
+    const errorHandler = function (err) {
+      params.special.showError(params, null, {
+        err: err,
+        what: "Loading forum data",
+      });
+    };
+    const loadHandler = function (json) {
+      if (json.err) {
+        if (params.special) {
+          params.special.showError(params, json, {
+            what: "Loading forum data",
+          });
+        }
+        return;
+      }
+      /*
+       * The server has already confirmed that the user is logged in and has permission to view the forum.
+       * Note: the criteria (here) for posting in the main forum window are less strict than in the info
+       * panel; see the other call to setUserCanPost. Here, we have no "json.canModify" set by the server.
+       */
+      setUserCanPost(true);
+
+      // set up the 'right sidebar'
+      cldrSurvey.showInPop2(
+        cldrText.get(params.name + "Guidance"),
+        null,
+        null,
+        null,
+        true
+      ); /* show the box the first time */
+
+      const ourDiv = document.createElement("div");
+      ourDiv.appendChild(forumCreateChunk(forumMessage, "h4", ""));
+
+      const filterMenu = cldrForumFilter.createMenu(reloadV);
+      const summaryDiv = document.createElement("div");
+      summaryDiv.innerHTML = "";
+      ourDiv.appendChild(summaryDiv);
+      ourDiv.appendChild(filterMenu);
+      ourDiv.appendChild(document.createElement("hr"));
+      const posts = json.ret;
+      if (posts.length == 0) {
+        ourDiv.appendChild(
+          forumCreateChunk(cldrText.get("forum_noposts"), "p", "helpContent")
+        );
+      } else {
+        const content = parseContent(posts, "main");
+        ourDiv.appendChild(content);
+        summaryDiv.innerHTML = getForumSummaryHtml(forumLocale, userId, true); // after parseContent
+      }
+      // No longer loading
+      cldrSurvey.hideLoader(null);
+      params.flipper.flipTo(params.pages.other, ourDiv);
+      params.special.handleIdChanged(cldrStatus.getCurrentId()); // rescroll.
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  /**
+   * Set whether the user is allowed to make posts
+   */
+  function setUserCanPost(canPost) {
+    userCanPost = canPost ? true : false;
+  }
+
+  /**
+   * Make a new forum post or a reply.
+   *
+   * @param params the object containing various parameters: locale, xpath, replyTo, replyData, ...
+   */
+  function openPostOrReply(params) {
+    const isReply = params.replyTo && params.replyTo >= 0 ? true : false;
+    const replyTo = isReply ? params.replyTo : -1;
+    const parentPost = isReply && params.replyData ? params.replyData : null;
+    const rootPost = parentPost ? getThreadRootPost(parentPost) : null;
+    const locale = isReply
+      ? rootPost.locale
+      : params.locale
+      ? params.locale
+      : "";
+    const xpath = isReply ? rootPost.xpath : params.xpath ? params.xpath : "";
+    const subjectParam = params.subject ? params.subject : "";
+    const postType = params.postType ? params.postType : null;
+    const subject = makePostSubject(isReply, rootPost, subjectParam);
+    const value = params.value
+      ? params.value
+      : rootPost && rootPost.value
+      ? rootPost.value
+      : null;
+    const root = isReply ? rootPost.id : -1;
+    const open = isReply ? rootPost.open : true;
+    const typeLabel = makePostTypeLabel(postType, isReply);
+    const html = makePostHtml(
+      postType,
+      typeLabel,
+      locale,
+      xpath,
+      subject,
+      replyTo,
+      root,
+      open,
+      value
+    );
+    const text = prefillPostText(postType, value);
+
+    openPostWindow(html, text, parentPost);
+  }
+
+  /**
+   * Assemble the form and related html elements for creating a forum post
+   *
+   * @param postType the post type, such as 'Discuss'
+   * @param typeLabel the post type label, such as 'Comment'
+   * @param locale the locale string
+   * @param xpath the xpath string
+   * @param subject the subject string (path-header)
+   * @param replyTo the post id of the post being replied to, or -1
+   * @param root the post id of the original post in the thread, or -1
+   * @param open true or false, is this thread open
+   * @param value the value that was requested in the root post, or null
+   * @return the html
+   */
+  function makePostHtml(
+    postType,
+    typeLabel,
+    locale,
+    xpath,
+    subject,
+    replyTo,
+    root,
+    open,
+    value
+  ) {
+    let html = "";
+
+    html +=
+      '<div id="postSubject" class="topicSubject">' + subject + "</div>\n";
+    html += '<div class="postTypeLabel">' + typeLabel + "</div>\n";
+    html += '<form role="form" id="post-form">\n';
+    html += '<div class="form-group">\n';
+    html +=
+      '<textarea name="text" class="postTextArea" placeholder="Write your post here"></textarea>\n';
+    html +=
+      '<button class="btn btn-success submit-post btn-block">Submit</button>\n';
+    html += '<input type="hidden" name="forum" value="true">\n';
+    html += '<input type="hidden" name="_" value="' + locale + '">\n';
+    html += '<input type="hidden" name="xpath" value="' + xpath + '">\n';
+    html += '<input type="hidden" name="replyTo" value="' + replyTo + '">\n';
+    html += '<input type="hidden" name="root" value="' + root + '">\n';
+    html += '<input type="hidden" name="open" value="' + open + '">\n';
+    html += '<input type="hidden" name="value" value="' + value + '">\n';
+    html += '<input type="hidden" name="postType" value="' + postType + '">\n';
+    html += "</form>\n";
+
+    html += '<div class="post"></div>\n';
+    html += '<div class="forumDiv"></div>\n';
+
+    return html;
+  }
+
+  /**
+   * Make the subject string for a forum post
+   *
+   * @param isReply is this a reply? True or false
+   * @param rootPost the original post in the thread, or null
+   * @param subjectParam the subject for this post supplied in parameters
+   * @return the string
+   */
+  function makePostSubject(isReply, rootPost, subjectParam) {
+    if (isReply && rootPost) {
+      return post2text(rootPost.subject);
+    }
+    return subjectParam;
+  }
+
+  /**
+   * Make the text (body) string for a forum post
+   *
+   * @param postType the verb such as 'Request', 'Discuss', ...
+   * @param value the value that was requested in the root post, or null
+   * @return the string
+   */
+  function prefillPostText(postType, value) {
+    if (postType === "Close") {
+      return "I'm closing this thread";
+    } else if (postType === "Request") {
+      if (value) {
+        return "Please consider voting for “" + value + "”. My reasons are:\n";
+      }
+    } else if (postType === "Agree") {
+      return "I agree. I am changing my vote to the requested “" + value + "”";
+    } else if (postType === "Decline") {
+      return (
+        "I decline changing my vote to the requested “" +
+        value +
+        "”. My reasons are:\n"
+      );
+    }
+    return "";
+  }
+
+  /**
+   * Open a window displaying the form for creating a post
+   *
+   * @param html the main html for the form
+   * @param parentPost the post object, if any, to which this is a reply, for display at the bottom of the window
+   *
+   * Reference: Bootstrap.js post-modal: https://getbootstrap.com/docs/4.1/components/modal/
+   */
+  function openPostWindow(html, text, parentPost) {
+    const postModal = $("#post-modal");
+    postModal.find(".modal-body").html(html);
+    $("#post-form textarea[name=text]").val(text);
+    if (parentPost) {
+      const forumDiv = parseContent([parentPost], "parent");
+      const postHolder = postModal.find(".modal-body").find(".forumDiv");
+      postHolder[0].appendChild(forumDiv);
+    }
+    postModal.modal();
+    postModal.find("textarea").autosize();
+    postModal.find(".submit-post").click(submitPost);
+    setTimeout(function () {
+      postModal.find("textarea").focus();
+    }, 1000 /* one second */);
+  }
+
+  /**
+   * Submit a forum post
+   *
+   * @param event
+   */
+  function submitPost(event) {
+    const text = $("#post-form textarea[name=text]").val();
+    if (text) {
+      reallySubmitPost(text);
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Submit a forum post
+   *
+   * @param text the non-empty body of the message
+   */
+  function reallySubmitPost(text) {
+    $("#post-form button").fadeOut();
+
+    const xpath = $("#post-form input[name=xpath]").val();
+    const locale = $("#post-form input[name=_]").val();
+    const replyTo = $("#post-form input[name=replyTo]").val();
+    const root = $("#post-form input[name=root]").val();
+    const open = $("#post-form input[name=open]").val();
+    const value = $("#post-form input[name=value]").val();
+    const postType = $("#post-form input[name=postType]").val();
+
+    const subj = document.getElementById("postSubject").innerHTML;
+
+    const url = cldrStatus.getContextPath() + "/SurveyAjax";
+
+    const errorHandler = function (err) {
+      const post = $(".post").first();
+      post.before("<p class='warn'>error! " + err + "</p>");
+    };
+    const loadHandler = function (data) {
+      if (data.err) {
+        const post = $(".post").first();
+        post.before("<p class='warn'>error: " + data.err + "</p>");
+      } else if (data.ret && data.ret.length > 0) {
+        const postModal = $("#post-modal");
+        postModal.modal("hide");
+        const curSpecial = cldrStatus.getCurrentSpecial();
+        if (curSpecial && curSpecial === "forum") {
+          reloadV();
+        } else {
+          updateInfoPanelForumPosts(null);
+        }
+      } else {
+        const post = $(".post").first();
+        post.before(
+          "<i>Your post was added, #" +
+            data.postId +
+            " but could not be shown.</i>"
+        );
+      }
+    };
+    const postData = {
+      s: cldrStatus.getSessionId(),
+      _: locale,
+      replyTo: replyTo,
+      xpath: xpath,
+      text: text,
+      subj: subj,
+      postType: postType,
+      value: value,
+      open: open,
+      root: root,
+      what: "forum_post",
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+      postData: postData,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  /**
+   * Create a DOM object referring to this set of forum posts
+   *
+   * @param posts the array of forum post objects, newest first
+   * @param context the string defining the context
+   *
+   * @return new DOM object
+   *
+   * TODO: shorten this function by moving code into subroutines. Also, postpone creating
+   * DOM elements until finished constructing the filtered list of threads, to make the code
+   * cleaner, faster, and more testable. If context is 'summary', all DOM element creation here
+   * is a waste of time.
+   *
+   * Threading has been revised, so that the same locale+path can have multiple distinct threads,
+   * rather than always combining posts with the same locale+path into a single "thread".
+   * Reference: https://unicode-org.atlassian.net/browse/CLDR-13695
+   */
+  function parseContent(posts, context) {
+    const opts = getOptionsForContext(context);
+
+    updateForumData(posts, opts.fullSet);
+
+    const postDivs = {}; //  postid -> div
+    const topicDivs = {}; // xpath -> div or "#123" -> div
+
+    /*
+     * create the topic (thread) divs -- populate topicDivs with DOM elements
+     *
+     * TODO: skip this loop if opts.createDomElements is false. Currently we have to do this even
+     * if opts.createDomElements if false, since filterAndAssembleForumThreads depends on topicDivs.
+     */
+    for (let num in posts) {
+      const post = posts[num];
+      if (!topicDivs[post.threadId]) {
+        // add the topic div
+        const topicDiv = document.createElement("div");
+        topicDiv.className = "well well-sm postTopic";
+        const rootPost = getThreadRootPost(post);
+        if (opts.showItemLink) {
+          const topicInfo = forumCreateChunk("", "h4", "postTopicInfo");
+          topicDiv.appendChild(topicInfo);
+          if (post.locale) {
+            const localeLink = forumCreateChunk(
+              locmap.getLocaleName(post.locale),
+              "a",
+              "localeName"
+            );
+            if (post.locale != cldrStatus.getCurrentLocale()) {
+              localeLink.href = linkToLocale(post.locale);
+            }
+            topicInfo.appendChild(localeLink);
+          }
+          if (post.xpath) {
+            topicInfo.appendChild(makeItemLink(post));
+          }
+          addThreadSubjectSpan(topicInfo, rootPost);
+        }
+        if (opts.createDomElements) {
+          if (rootPost.postType === "Request" && rootPost.value) {
+            const requestInfo = forumCreateChunk(
+              "Requesting “" + rootPost.value + "”",
+              "h4",
+              "postTopicInfo"
+            );
+            topicDiv.appendChild(requestInfo);
+          }
+        }
+        topicDivs[post.threadId] = topicDiv;
+        topicDiv.id = "fthr_" + post.threadId;
+      }
+    }
+    // Now, top to bottom, just create the post divs
+    for (let num in posts) {
+      const post = posts[num];
+
+      const subpost = forumCreateChunk("", "div", "post");
+      postDivs[post.id] = subpost;
+      subpost.id = "fp" + post.id;
+
+      const headingLine = forumCreateChunk("", "h4", "selected");
+
+      // If post.posterInfo is undefined, don't crash; insert "[Poster no longer active]".
+      if (!post.posterInfo) {
+        headingLine.appendChild(
+          forumCreateChunk("[Poster no longer active]", "span", "")
+        );
+      } else {
+        let gravitar;
+        if (typeof cldrSurvey !== "undefined") {
+          // cldrSurvey isn't defined if we're running mocha unit test, due to dependency on jquery
+          gravitar = cldrSurvey.createGravitar(post.posterInfo);
+        } else {
+          gravitar = document.createTextNode("");
+        }
+        gravitar.className = "gravitar pull-left";
+        subpost.appendChild(gravitar);
+        const surveyUser = cldrStatus.getSurveyUser();
+        if (surveyUser && post.posterInfo.id === surveyUser.id) {
+          headingLine.appendChild(
+            forumCreateChunk(cldrText.get("user_me"), "span", "forum-me")
+          );
+        } else {
+          const usera = forumCreateChunk(post.posterInfo.name + " ", "a", "");
+          if (post.posterInfo.email) {
+            usera.appendChild(
+              forumCreateChunk("", "span", "glyphicon glyphicon-envelope")
+            );
+            usera.href = "mailto:" + post.posterInfo.email;
+          }
+          headingLine.appendChild(usera);
+          headingLine.appendChild(
+            document.createTextNode(" (" + post.posterInfo.org + ") ")
+          );
+        }
+        const userLevelKey = "userlevel_" + post.posterInfo.userlevelName;
+        const userLevelStr = cldrText.get(userLevelKey);
+        const userLevelChunk = forumCreateChunk(
+          userLevelStr,
+          "span",
+          "userLevelName label-info label"
+        );
+        userLevelChunk.title = cldrText.get(userLevelKey + "_desc");
+        headingLine.appendChild(userLevelChunk);
+      }
+      let date = fmtDateTime(post.date_long);
+      if (post.version) {
+        date = "[v" + post.version + "] " + date;
+      }
+      const dateChunk = forumCreateChunk(
+        date,
+        "span",
+        "label label-primary pull-right forumLink"
+      );
+      (function (post) {
+        /*
+         * TODO: encapsulate "listenFor" and "reloadV" dependencies
+         */
+        if (typeof listenFor === "undefined") {
+          return;
+        }
+        listenFor(dateChunk, "click", function (e) {
+          if (
+            post.locale &&
+            locmap.getLanguage(cldrStatus.getCurrentLocale()) !=
+              locmap.getLanguage(post.locale)
+          ) {
+            cldrStatus.setCurrentLocale(locmap.getLanguage(post.locale));
+          }
+          cldrStatus.setCurrentPage("");
+          cldrStatus.setCurrentId(post.id);
+          replaceHash(false);
+          if (cldrStatus.getCurrentSpecial() != "forum") {
+            cldrStatus.setCurrentSpecial("forum");
+            reloadV();
+          }
+          return stStopPropagation(e);
+        });
+      })(post);
+      headingLine.appendChild(dateChunk);
+      subpost.appendChild(headingLine);
+
+      const subChunk = forumCreateChunk("", "div", "");
+      subpost.appendChild(subChunk);
+      const isReply = post.parent !== -1;
+      const typeLabel = makePostTypeLabel(post.postType, isReply);
+      if (!isReply) {
+        const openOrClosed = post.open ? "Open" : "Closed";
+        const comboChunk = forumCreateChunk(
+          openOrClosed,
+          "div",
+          "forumThreadStatus"
+        );
+        comboChunk.appendChild(
+          forumCreateChunk(typeLabel, "span", "postTypeComboLabel")
+        );
+        subChunk.appendChild(comboChunk);
+      } else {
+        subChunk.appendChild(
+          forumCreateChunk(typeLabel, "div", "postTypeLabel")
+        );
+      }
+
+      // actual text
+      const postText = post2text(post.text);
+      const postContent = forumCreateChunk(
+        postText,
+        "div",
+        "postContent postTextBorder"
+      );
+      subpost.appendChild(postContent);
+    }
+    appendPostDivsToTopicDivs(posts, topicDivs, postDivs);
+    if (opts.showReplyButton) {
+      addReplyButtonsToEachTopic(topicDivs);
+    }
+    return filterAndAssembleForumThreads(
+      posts,
+      topicDivs,
+      opts.applyFilter,
+      opts.showThreadCount
+    );
+  }
+
+  /**
+   * Update several persistent data structures to describe the given set of posts
+   *
+   * @param posts the array of post objects, from newest to oldest
+   * @param fullSet true if we should start fresh with these posts
+   */
+  function updateForumData(posts, fullSet) {
+    if (fullSet) {
+      postHash = {};
+      threadHash = {};
+    }
+    updatePostHash(posts);
+    addThreadIds(posts);
+    updateThreadHash(posts);
+    forumUpdateTime = Date.now();
+  }
+
+  /**
+   * Update the postHash mapping from post id to post object
+   *
+   * @param posts the array of post objects, from newest to oldest
+   */
+  function updatePostHash(posts) {
+    posts.forEach(function (post) {
+      postHash[post.id] = post;
+    });
+  }
+
+  /**
+   * Add a "threadId" attribute to each post object in the given array
+   *
+   * For a post without a parent, the thread id is like "aa|1234", where aa is the locale and 1234 is the post id.
+   *
+   * For a post without a parent, the thread id is the same as the root post id.
+   *
+   * Make sure that the thread id uses the locale of the original post in its thread, for consistency.
+   * Formerly, a post could have a different locale than the original post. For example, even though
+   * post 32034 is fr_CA, its child 32036 was fr. That bug is believed to have been fixed, in the
+   * code and in the db.
+   *
+   * @param posts the array of post objects
+   *
+   * TODO: simplify this and related code, given that post objects from server now have
+   * post.root. Probably there is no longer any reason to include locale in thread id,
+   * nor to distinguish between thread id and rootPost.id.
+   */
+  function addThreadIds(posts) {
+    posts.forEach(function (post) {
+      const rootPost = getThreadRootPost(post);
+      post.threadId = rootPost.locale + "|" + rootPost.id;
+    });
+  }
+
+  /**
+   * Update the threadHash mapping from threadId to an array of all the posts in that thread
+   *
+   * @param posts the array of post objects, from newest to oldest
+   *
+   * The posts are assumed to have threadId set already by addThreadIds.
+   */
+  function updateThreadHash(posts) {
+    posts.forEach(function (post) {
+      const threadId = post.threadId;
+      if (!(threadId in threadHash)) {
+        threadHash[threadId] = [];
+      }
+      threadHash[threadId].push(post);
+    });
+  }
+
+  /**
+   * Make a hyperlink from the given post to the the same post in the main Forum window
+   *
+   * @param post the post object
+   * @return the DOM element
+   */
+  function makeItemLink(post) {
+    const itemLink = forumCreateChunk(
+      cldrText.get("forum_item"),
+      "a",
+      "pull-right postItem glyphicon glyphicon-zoom-in"
+    );
+    itemLink.href = "#/" + post.locale + "//" + post.xpath;
+    return itemLink;
+  }
+
+  /**
+   * Make a span containing a subject line for the specified thread
+   *
+   * @param topicInfo the DOM element to which to attach the span
+   * @param rootPost the oldest post in the thread
+   */
+  function addThreadSubjectSpan(topicInfo, rootPost) {
+    /*
+     * Starting with CLDR v38, posts should all have post.xpath, and post.subject
+     * should be like "Characters | Typography | Style | wght-900-heavy" (recognizable
+     * by containing the character '|'), constructed from the xpath and path-header when
+     * the post is created.
+     *
+     * In such normal cases (or if there is no xpath), the thread subject is the same as
+     * the subject of the oldest post in the thread.
+     */
+    if (rootPost.subject.indexOf("|") >= 0 || !rootPost.xpath) {
+      topicInfo.appendChild(
+        forumCreateChunk(post2text(rootPost.subject), "span", "topicSubject")
+      );
+      return;
+    }
+    /*
+     * Some old posts have subjects like "Review" or "Flag Removed".
+     * In this case, construct a new subject based on the xpath and path-header.
+     * This is awkward since xpathMap.get is asynchronous. Display the word
+     * "Loading" as a place-holder while waiting for the result.
+     */
+    const loadingMsg = forumCreateChunk(
+      cldrText.get("loading"),
+      "i",
+      "loadingMsg"
+    );
+    topicInfo.appendChild(loadingMsg);
+    xpathMap.get(
+      {
+        hex: rootPost.xpath,
+      },
+      function (o) {
+        if (o.result) {
+          topicInfo.removeChild(loadingMsg);
+          const itemPh = forumCreateChunk(
+            xpathMap.formatPathHeader(o.result.ph),
+            "span",
+            "topicSubject"
+          );
+          itemPh.title = o.result.path;
+          topicInfo.appendChild(itemPh);
+        }
+      }
+    );
+  }
+
+  /**
+   * Append post divs to their topic divs.
+   * Within each thread, put old posts before new posts.
+   * Go through the posts array in reverse order, old before new.
+   *
+   * @param posts the array of forum post objects, newest first
+   * @param topicDivs the map from threadId to DOM elements
+   * @param postDivs the map from post id to DOM elements
+   */
+  function appendPostDivsToTopicDivs(posts, topicDivs, postDivs) {
+    const SIMPLE_REPLY_STYLE = true;
+    const USE_HORIZONTAL_RULE = false;
+    for (let i = posts.length - 1; i >= 0; i--) {
+      const post = posts[i];
+      if (post.root === -1) {
+        // this post is the root of its thread, not a reply
+        topicDivs[post.threadId].appendChild(postDivs[post.id]);
+      } else {
+        // this is a reply
+        if (SIMPLE_REPLY_STYLE) {
+          if (USE_HORIZONTAL_RULE) {
+            const horizontalRule = forumCreateChunk("", "hr", "postRule");
+            topicDivs[post.threadId].appendChild(horizontalRule);
+          }
+          topicDivs[post.threadId].appendChild(postDivs[post.id]);
+        } else {
+          if (postDivs[post.root]) {
+            if (!postDivs[post.root].replies) {
+              // add the "replies" area
+              forumDebug("Adding replies area to " + post.root);
+              postDivs[post.root].replies = forumCreateChunk(
+                "",
+                "div",
+                "postReplies"
+              );
+              postDivs[post.root].appendChild(postDivs[post.root].replies);
+            }
+            // add to new location
+            postDivs[post.root].replies.appendChild(postDivs[post.id]);
+          } else {
+            // The root of this post was deleted.
+            forumDebug(
+              "The root of post #" +
+                post.id +
+                " is " +
+                post.root +
+                " but it was deleted or not visible"
+            );
+            // link it in somewhere
+            topicDivs[post.threadId].appendChild(postDivs[post.id]);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Add a set of reply buttons for each div in topicDivs
+   *
+   * @param topicDivs the map from threadId to DOM elements
+   */
+  function addReplyButtonsToEachTopic(topicDivs) {
+    if (!userCanPost) {
+      return;
+    }
+    Object.keys(topicDivs).forEach(function (threadId) {
+      const rootPost = getRootPostFromThreadId(threadId);
+      if (rootPost) {
+        addReplyButtons(topicDivs[threadId], rootPost);
+      }
+    });
+  }
+
+  /**
+   * Make one or more new-post buttons for the given post, and append them to the given element
+   *
+   * @param el the DOM element to append to
+   * @param locale the locale
+   * @param couldFlag true if the user could add a flag for this path, else false
+   * @param xpstrid the xpath string id
+   * @param code the "code" for the xpath
+   * @param value the value the current user voted for, or null
+   */
+  function addNewPostButtons(el, locale, couldFlag, xpstrid, code, value) {
+    if (!userCanPost) {
+      return;
+    }
+    const options = getPostTypeOptions(
+      false /* isReply */,
+      null /* rootPost */,
+      value
+    );
+
+    Object.keys(options).forEach(function (postType) {
+      el.appendChild(
+        makeOneNewPostButton(
+          postType,
+          options[postType],
+          locale,
+          couldFlag,
+          xpstrid,
+          code,
+          value
+        )
+      );
+    });
+  }
+
+  /**
+   * Make one or more reply buttons for the given post, and append them to the given element
+   *
+   * @param el the DOM element to append to
+   * @param rootPost the original post in the thread
+   */
+  function addReplyButtons(el, rootPost) {
+    if (!userCanPost) {
+      return;
+    }
+    const options = getPostTypeOptions(
+      true /* isReply */,
+      rootPost,
+      rootPost.value
+    );
+
+    Object.keys(options).forEach(function (postType) {
+      el.appendChild(makeOneReplyButton(rootPost, postType, options[postType]));
+    });
+  }
+
+  function makeOneNewPostButton(
+    postType,
+    label,
+    locale,
+    couldFlag,
+    xpstrid,
+    code,
+    value
+  ) {
+    const buttonTitle = couldFlag
+      ? "forumNewPostFlagButton"
+      : "forumNewPostButton";
+
+    const buttonClass = couldFlag
+      ? "addPostButton forumNewPostFlagButton btn btn-default btn-sm"
+      : "addPostButton forumNewButton btn btn-default btn-sm";
+
+    const newButton = forumCreateChunk(label, "button", buttonClass);
+    if (postType === "Request" && value === null) {
+      newButton.disabled = true;
+    } else if (typeof listenFor !== "undefined") {
+      listenFor(newButton, "click", function (e) {
+        xpathMap.get(
+          {
+            hex: xpstrid,
+          },
+          function (o) {
+            let subj = code + " " + xpstrid;
+            if (o.result && o.result.ph) {
+              subj = xpathMap.formatPathHeader(o.result.ph);
+            }
+            if (couldFlag) {
+              subj += " (Flag for review)";
+            }
+            openPostOrReply({
+              locale: locale,
+              xpath: xpstrid,
+              subject: subj,
+              postType: postType,
+              value: value,
+            });
+          }
+        );
+        stStopPropagation(e);
+        return false;
+      });
+    }
+    return newButton;
+  }
+
+  function makeOneReplyButton(post, postType, label) {
+    const replyButton = forumCreateChunk(
+      label,
+      "button",
+      "addPostButton btn btn-default btn-sm"
+    );
+    /*
+     * TODO: encapsulate "listenFor" dependency
+     */
+    if (typeof listenFor !== "undefined") {
+      listenFor(replyButton, "click", function (e) {
+        openPostOrReply({
+          /*
+           * Don't specify locale/xpath/subject/value/open for reply. Instead they will be set to
+           * match the original post in the thread.
+           */
+          replyTo: post.id,
+          replyData: post,
+          postType: postType,
+        });
+        stStopPropagation(e);
+        return false;
+      });
+    }
+    return replyButton;
+  }
+
+  /**
+   * Get an object defining the currently allowed post-type values
+   * for making a new post, for the current user and given parameters
+   *
+   * @param isReply true if this post is a reply, else false
+   * @param rootPost the original post in the thread, or null if not replying
+   * @param value the value the root post requested, or null
+   * @return the object mapping verbs like 'Request' to label strings like 'Request'
+   *         (Currently the labels are the same as the verbs)
+   *
+   * Compare SurveyForum.ForumStatus on server
+   */
+  function getPostTypeOptions(isReply, rootPost, value) {
+    const options = {};
+    if (rootPost === null || rootPost.open) {
+      if (!isReply) {
+        /*
+         * Show Request button even if value is null. It will be visible but disabled if value is null.
+         */
+        options["Request"] = "Request";
+      }
+      if (
+        value &&
+        isReply &&
+        rootPost &&
+        !userIsPoster(rootPost) &&
+        rootPost.postType === "Request"
+      ) {
+        options["Agree"] = "Agree";
+        options["Decline"] = "Decline";
+      }
+      options["Discuss"] = makePostTypeLabel("Discuss", isReply);
+      if (userCanClose(isReply, rootPost)) {
+        options["Close"] = "Close";
+      }
+    }
+    return options;
+  }
+
+  /**
+   * For replies, label 'Comment' instead of 'Discuss'
+   *
+   * @param postType the post type
+   * @param isReply true if this post is a reply, else false
+   * @return the label
+   */
+  function makePostTypeLabel(postType, isReply) {
+    if (postType === "Discuss" && isReply) {
+      return "Comment";
+    }
+    return postType;
+  }
+
+  /**
+   * Is this user allowed to close the thread now?
+   *
+   * The user is only allowed if they are the original poster of the thread,
+   * or a TC (technical committee) member.
+   *
+   * @param isReply true if this post is a reply, else false
+   * @param rootPost the original post in the thread, or null
+   * @return true if this user is allowed to close, else false
+   */
+  function userCanClose(isReply, rootPost) {
+    return isReply && rootPost.open && (userIsPoster(rootPost) || userIsTC());
+  }
+
+  /**
+   * Is the current user the poster of this post?
+   *
+   * @param post the post, or null
+   * @returns true or false
+   */
+  function userIsPoster(post) {
+    if (post) {
+      const surveyUser = cldrStatus.getSurveyUser();
+      if (surveyUser && surveyUser.id === post.poster) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Is the current user a TC (Technical Committee) member?
+   *
+   * @return true or false
+   */
+  function userIsTC() {
+    const surveyUserPerms = cldrStatus.getPermissions();
+    return surveyUserPerms && surveyUserPerms.userIsTC;
+  }
+
+  /**
+   * Get an object whose properties define the parseContent options to be used for a particular
+   * context in which parseContent is called
+   *
+   * @param context the string defining the context:
+   *
+   *   'main' for the context in which "Forum" is chosen from the left sidebar
+   *
+   *   'summary' for the context of getForumSummaryHtml
+   *
+   *   'info' for the "Info Panel" context (either main vetting view row, or Dashboard "Fix" button)
+   *
+   *   'parent' for the replied-to post at the bottom of the create-reply dialog
+   *
+   * @return an object with these properties:
+   *
+   *   showItemLink = true if there should be an "item" (xpath) link
+   *
+   *   showReplyButton = true if there should be a reply button
+   *
+   *   fullSet = true if this is a full set of posts
+   *
+   *   applyFilter = true if the currently menu-selected filter should be applied
+   *
+   *   showThreadCount = true to display the number of threads
+   *
+   *   createDomElements = true to create the DOM objects (false for summary)
+   */
+  function getOptionsForContext(context) {
+    const opts = getDefaultParseOptions();
+    if (context === "main") {
+      opts.showItemLink = true;
+      opts.showReplyButton = true;
+      opts.applyFilter = true;
+      opts.showThreadCount = true;
+    } else if (context === "summary") {
+      opts.applyFilter = true;
+      opts.createDomElements = false;
+    } else if (context === "info") {
+      opts.showReplyButton = true;
+    } else if (context === "parent") {
+      opts.fullSet = false;
+    } else {
+      console.log("Unrecognized context in getOptionsForContext: " + context);
+    }
+    return opts;
+  }
+
+  /**
+   * Get the default parseContent options
+   *
+   * @return a new object with the default properties
+   */
+  function getDefaultParseOptions() {
+    const opts = {};
+    opts.showItemLink = false;
+    opts.showReplyButton = false;
+    opts.fullSet = true;
+    opts.applyFilter = false;
+    opts.showThreadCount = false;
+    opts.createDomElements = true;
+    return opts;
+  }
+
+  /**
+   * Convert the given text by replacing some html with plain text
+   *
+   * @param the plain text
+   */
+  function post2text(text) {
+    if (text === undefined || text === null) {
+      text = "(empty)";
+    }
+    let out = text;
+    out = out.replace(/<p>/g, "\n");
+    out = out.replace(/&quot;/g, '"');
+    out = out.replace(/&lt;/g, "<");
+    out = out.replace(/&gt;/g, ">");
+    out = out.replace(/&amp;/g, "&");
+    return out;
+  }
+
+  /**
+   * Create a DOM object with the specified text, tag, and HTML class.
+   *
+   * @param text textual content of the new object, or null for none
+   * @param tag which element type to create, or null for "span"
+   * @param className CSS className, or null for none.
+   * @return new DOM object
+   *
+   * This duplicated a function in survey.js; copied here to avoid the dependency
+   */
+  function forumCreateChunk(text, tag, className) {
+    if (!tag) {
+      tag = "span";
+    }
+    const chunk = document.createElement(tag);
+    if (className) {
+      chunk.className = className;
+    }
+    if (text) {
+      chunk.appendChild(document.createTextNode(text));
+    }
+    return chunk;
+  }
+
+  /**
+   * Get the root (original) post in the thread, i.e., the last one in the array
+   *
+   * @param threadId the thread id
+   * @return the root post, or null if not found
+   */
+  function getRootPostFromThreadId(threadId) {
+    const threadPosts = threadHash[threadId];
+    if (threadPosts.length < 1) {
+      return null;
+    }
+    return threadPosts[threadPosts.length - 1];
+  }
+
+  /**
+   * Get the first (original) post in the thread containing this post
+   *
+   * @param post the post object
+   * @return the original post in the thread
+   */
+  function getThreadRootPost(post) {
+    if (postHash[post.root]) {
+      return postHash[post.root];
+    }
+    /*
+     * The following shouldn't be necessary unless data is missing/corrupted
+     */
+    while (post.parent >= 0 && postHash[post.parent]) {
+      post = postHash[post.parent];
+    }
+    return post;
+  }
+
+  /**
+   * Get the last (most recent) post in the thread containing this post
+   *
+   * @param post the post object
+   * @return the original post in the thread
+   */
+  function getNewestPostInThread(post) {
+    const threadPosts = threadHash[post.threadId];
+    /*
+     * threadPosts is ordered from newest to oldest
+     */
+    return threadPosts[0];
+  }
+
+  /**
+   * Filter the forum threads and assemble them into a new document fragment,
+   * ordering threads from newest to oldest, determining the time of each thread
+   * by the newest post it contains
+   *
+   * @param posts the array of post objects, from newest to oldest
+   * @param topicDivs the array of thread elements, indexed by threadId
+   * @param applyFilter true if the currently menu-selected filter should be applied
+   * @param showThreadCount true to display the number of threads
+   * @return the new document fragment
+   */
+  function filterAndAssembleForumThreads(
+    posts,
+    topicDivs,
+    applyFilter,
+    showThreadCount
+  ) {
+    let filteredArray = cldrForumFilter.getFilteredThreadIds(
+      threadHash,
+      applyFilter
+    );
+    const forumDiv = document.createDocumentFragment();
+    let countEl = null;
+    if (showThreadCount) {
+      countEl = document.createElement("h4");
+      forumDiv.append(countEl);
+    }
+    let threadCount = 0;
+    posts.forEach(function (post) {
+      if (filteredArray.includes(post.threadId)) {
+        ++threadCount;
+        /*
+         * Append the div for this threadId, then remove this threadId
+         * from filteredArray to prevent appending the same div again
+         * (which would move the div to the bottom, not duplicate it).
+         */
+        forumDiv.append(topicDivs[post.threadId]);
+        filteredArray = filteredArray.filter((id) => id !== post.threadId);
+      }
+    });
+    if (showThreadCount) {
+      countEl.innerHTML =
+        threadCount + (threadCount === 1 ? " topic" : " topics");
+    }
+    return forumDiv;
+  }
+
+  /**
+   * Format a date and time for display in a forum post
+   *
+   * @param x the number of seconds since 1970-01-01
+   * @returns the formatted date and time as a string, like "2018-05-16 13:45"
+   */
+  function fmtDateTime(x) {
+    const d = new Date(x);
+
+    function pad(n) {
+      return n < 10 ? "0" + n : n;
+    }
+    if (displayUtc) {
+      return (
+        d.getUTCFullYear() +
+        "-" +
+        pad(d.getUTCMonth() + 1) +
+        "-" +
+        pad(d.getUTCDate()) +
+        " " +
+        pad(d.getUTCHours()) +
+        ":" +
+        pad(d.getUTCMinutes() + " UTC")
+      );
+    }
+    return (
+      d.getFullYear() +
+      "-" +
+      pad(d.getMonth() + 1) +
+      "-" +
+      pad(d.getDate()) +
+      " " +
+      pad(d.getHours()) +
+      ":" +
+      pad(d.getMinutes())
+    );
+  }
+
+  /**
+   * Get a piece of html text summarizing the current Forum statistics
+   *
+   * @param locale the locale string
+   * @param userId the current user's id, for cldrForumFilter
+   * @param getTable true to get a table, false to get a one-liner
+   * @return the html
+   */
+  function getForumSummaryHtml(locale, userId, getTable) {
+    setLocale(locale);
+    cldrForumFilter.setUserId(userId);
+    return reallyGetForumSummaryHtml(true /* canDoAjax */, getTable);
+  }
+
+  /**
+   * Get a piece of html text summarizing the current Forum statistics
+   *
+   * @param canDoAjax true to call loadForumForSummaryOnly if needed, false otherwise; should
+   *                  be false if the caller is the loadHandler for loadForumForSummaryOnly,
+   *                  to prevent endless back-and-forth if things go wrong
+   * @param getTable true to get a table, false to get a one-liner like "27/0/27"
+   * @return the html
+   */
+  function reallyGetForumSummaryHtml(canDoAjax, getTable) {
+    const id = "forumSummary";
+    const tag = getTable ? "div" : "span";
+    let html = "<" + tag + " id='" + id + "'>\n";
+    if (!forumUpdateTime) {
+      if (canDoAjax) {
+        if (getTable) {
+          html += "<p>Loading Forum Summary...</p>\n";
+        }
+        loadForumForSummaryOnly(forumLocale, id, getTable);
+      } else if (getTable) {
+        html += "<p>Load failed</p>n";
+      }
+    } else {
+      if (FORUM_DEBUG && getTable) {
+        html += "<p>Retrieved " + fmtDateTime(forumUpdateTime) + "</p>\n";
+      }
+      const c = cldrForumFilter.getFilteredThreadCounts();
+      if (getTable) {
+        html += "<ul>\n";
+        Object.keys(c).forEach(function (k) {
+          html += "<li>" + k + ": " + c[k] + "</li>\n";
+        });
+        html += "</ul>\n";
+      } else {
+        let first = true;
+        Object.keys(c).forEach(function (k) {
+          if (!first) {
+            html += "/";
+          }
+          html += c[k];
+          first = false;
+        });
+      }
+    }
+    html += "</" + tag + ">\n";
+    return html;
+  }
+
+  /**
+   * Fetch the Forum data from the server, and show a summary
+   *
+   * @param locale the locale
+   * @param id the id of the element to display the summary
+   * @param getTable true to get a table, false to get a one-liner
+   */
+  function loadForumForSummaryOnly(locale, id, getTable) {
+    if (typeof cldrAjax === "undefined") {
+      return;
+    }
+    setLocale(locale);
+    const url = getLoadForumUrl();
+    const errorHandler = function (err) {
+      const el = document.getElementById(id);
+      if (el) {
+        el.innerHTML = err;
+      }
+    };
+    const loadHandler = function (json) {
+      const el = document.getElementById(id);
+      if (!el) {
+        return;
+      }
+      if (json.err) {
+        el.innerHTML = "Error";
+        return;
+      }
+      const posts = json.ret;
+      parseContent(posts, "summary");
+      el.innerHTML = reallyGetForumSummaryHtml(
+        false /* do not reload recursively */,
+        getTable
+      ); // after parseContent
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  /**
+   * Load or reload the main Forum page
+   */
+  function reload() {
+    cldrStatus.setCurrentSpecial("forum");
+    cldrStatus.setCurrentId("");
+    cldrStatus.setCurrentPage("");
+    reloadV();
+  }
+
+  /**
+   * Get the URL to use for loading the Forum
+   */
+  function getLoadForumUrl() {
+    const sessionId = cldrStatus.getSessionId();
+    if (!sessionId) {
+      console.log("Error: sessionId falsy in getLoadForumUrl");
+      return "";
+    }
+    return (
+      "SurveyAjax?what=forum_fetch&xpath=0&_=" + forumLocale + "&s=" + sessionId
+    );
+  }
+
+  /**
+   * If the given locale is not the one we've already loaded, switch to it,
+   * initializing data to avoid using data for the wrong locale
+   *
+   * @param locale the locale string, like "fr_CA" (cldrStatus.getCurrentLocale())
+   */
+  function setLocale(locale) {
+    if (locale !== forumLocale) {
+      forumLocale = locale;
+      forumUpdateTime = null;
+      postHash = {};
+    }
+  }
+
+  function getThreadHash(posts) {
+    updateForumData(posts, true /* fullSet */);
+    return threadHash;
+  }
+
+  /**
+   * Set whether to use UTC for displaying date/time
+   */
+  function setDisplayUtc(utc) {
+    displayUtc = utc ? true : false;
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    parseContent: parseContent,
+    getForumSummaryHtml: getForumSummaryHtml,
+    loadForum: loadForum,
+    reload: reload,
+    addNewPostButtons: addNewPostButtons,
+    setUserCanPost: setUserCanPost,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      getThreadHash: getThreadHash,
+      setDisplayUtc: setDisplayUtc,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrForumFilter.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrForumFilter.js
@@ -1,15 +1,16 @@
 "use strict";
 
 /**
- * cldrStForumFilter: encapsulate filtering of forum threads.
+ * cldrForumFilter: encapsulate filtering of forum threads.
+ * This is for both dojo and non-dojo versions.
  *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
- * Ideally cldrStForumFilter should be a module (in the sense of using import/export),
+ * Ideally this should be a module (in the sense of using import/export),
  * but not all Survey Tool JavaScript code is capable yet of being in modules
  * and running in strict mode.
  */
-const cldrStForumFilter = (function () {
+const cldrForumFilter = (function () {
   /**
    * The zero-based index of 'Open threads' in the filters array
    */

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrForumParticipation.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrForumParticipation.js
@@ -1,7 +1,8 @@
 "use strict";
 
 /**
- * cldrStForumParticipation: encapsulate Survey Tool Forum Participation code.
+ * cldrForumParticipation: encapsulate Survey Tool Forum Participation code.
+ * This is the non-dojo version. For dojo, see CldrDojoForumParticipation.js
  *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
@@ -9,13 +10,13 @@
  * but not all Survey Tool JavaScript code is capable yet of being in modules
  * and running in strict mode.
  *
- * Dependencies: SpecialPage; hideLoader; showInPop2
+ * Dependencies: SpecialPage
  */
-const cldrStForumParticipation = (function () {
+const cldrForumParticipation = (function () {
   const tableId = "participationTable";
   const fileName = "participation.csv";
   const onclick =
-    "cldrStCsvFromTable.downloadCsv(" +
+    "cldrCsvFromTable.download(" +
     '"' +
     tableId +
     '"' +
@@ -34,7 +35,13 @@ const cldrStForumParticipation = (function () {
     /*
      * Set up the 'right sidebar'; cf. forum_participationGuidance
      */
-    showInPop2(cldrText.get(params.name + "Guidance"), null, null, null, true);
+    cldrSurvey.showInPop2(
+      cldrText.get(params.name + "Guidance"),
+      null,
+      null,
+      null,
+      true
+    );
 
     const url = getForumParticipationUrl();
     const errorHandler = function (err) {
@@ -57,7 +64,7 @@ const cldrStForumParticipation = (function () {
       ourDiv.innerHTML = html;
 
       // No longer loading
-      hideLoader(null);
+      cldrSurvey.hideLoader(null);
       params.flipper.flipTo(params.pages.other, ourDiv);
     };
     const xhrArgs = {
@@ -66,7 +73,7 @@ const cldrStForumParticipation = (function () {
       load: loadHandler,
       error: errorHandler,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrGui.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrGui.js
@@ -1,5 +1,4 @@
 "use strict";
-// this file has been formatted using "npx prettier" with default settings
 
 /**
  * cldrGui: encapsulate GUI functions.
@@ -34,12 +33,10 @@ const cldrGui = (function () {
       debugElements();
     }
 
-    require(["dojo/parser"], function (parser) {
-      parser.parse(); // parseOnLoad is false; call parse() after we populate the body
-    });
+    cldrStatus.setCurrentLocale("aa"); // until we have a left sidebar locale chooser
 
-    showV(); // in CldrSurveyVettingLoader.js
-    updateStatus(); // for the first time; in survey.js
+    // showV(); // in CldrSurveyVettingLoader.js
+    cldrLoad.showV(); // for the first time
   }
 
   const vhtml1 =
@@ -190,7 +187,7 @@ const cldrGui = (function () {
     "              <div id='progress-voted' class='progress-bar progress-bar-info tip-log' title='Votes' style='width: 0%'></div>\n" +
     "              <div id='progress-abstain' class='progress-bar progress-bar-warning tip-log' title='Abstain' style='width: 0%'></div>\n" +
     "            </div>\n" +
-    "            <div class='counter-infos'><a onclick='cldrStForum.reload();'>Forum:</a>\n" +
+    "            <div class='counter-infos'><a onclick='cldrForum.reload();'>Forum:</a>\n" +
     "              <span id='vForum'>...</span> ●\n" +
     "              Votes: <span id='count-voted'></span>\n" +
     "              - Abstain: <span id='count-abstain'></span>\n" +
@@ -382,7 +379,16 @@ const cldrGui = (function () {
       html +=
         "<select id='voteLevelChanged' title='vote with a different number of votes'>\n";
       for (let n of user.voteCountMenu) {
-        html += "<option value='" + n + "'>" + n + " votes</option>\n";
+        const selectedOrNot =
+          user.votecount === n ? " selected='selected'" : "";
+        html +=
+          "<option value='" +
+          n +
+          "'" +
+          selectedOrNot +
+          ">" +
+          n +
+          " votes</option>\n";
       }
       html += "</select>\n";
     }

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
@@ -1,0 +1,2806 @@
+"use strict";
+
+/**
+ * cldrLoad: encapsulate functions for loading GUI content for Survey Tool
+ * This is the non-dojo version. For dojo, see CldrDojoLoad.js
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+
+const cldrLoad = (function () {
+  const CLDR_LOAD_DEBUG = true;
+
+  /**
+   * haveDialog: when true, it means a "dialog" of some kind is displayed.
+   * Used for inhibiting $('#left-sidebar').hover in redesign.js.
+   * Currently there are only two such dialogs, both for auto-import.
+   */
+  let haveDialog = false;
+
+  const dijitDropDownMenu = null;
+  const dijitDropDownButton = null;
+  const dijitMenuSeparator = null;
+  const dijitMenuItem = null;
+  const dijitButton = null;
+  const dijitDialog = null;
+  const dijitRegistry = null;
+  const dojoxBusyButton = null;
+  const dojoHash = null;
+  const dojoTopic = null;
+  /**
+   * Call this once in the page. It expects to find a node #DynamicDataSection
+   */
+  function showV() {
+    var appendLocaleLink = function appendLocaleLink(
+      subLocDiv,
+      subLoc,
+      subInfo,
+      fullTitle
+    ) {
+      var name = locmap.getRegionAndOrVariantName(subLoc);
+      if (fullTitle) {
+        name = locmap.getLocaleName(subLoc);
+      }
+      var clickyLink = cldrSurvey.createChunk(name, "a", "locName");
+      clickyLink.href = linkToLocale(subLoc);
+      subLocDiv.appendChild(clickyLink);
+      if (subInfo == null) {
+        console.log("* internal: subInfo is null for " + name + " / " + subLoc);
+      }
+      if (subInfo.name_var) {
+        cldrSurvey.addClass(clickyLink, "name_var");
+      }
+      clickyLink.title = subLoc; // remove auto generated "locName.title"
+
+      if (subInfo.readonly) {
+        cldrSurvey.addClass(clickyLink, "locked");
+        cldrSurvey.addClass(subLocDiv, "hide");
+
+        if (subInfo.special_comment) {
+          clickyLink.title = subInfo.special_comment;
+        } else if (subInfo.dcChild) {
+          clickyLink.title = cldrText.sub("defaultContentChild_msg", {
+            name: subInfo.name,
+            dcChild: subInfo.dcChild,
+            dcChildName: locmap.getLocaleName(subInfo.dcChild),
+          });
+        } else {
+          clickyLink.title = cldrText.get("readonlyGuidance");
+        }
+      } else if (subInfo.special_comment) {
+        // could be the sandbox locale, or some other comment.
+        clickyLink.title = subInfo.special_comment;
+      }
+
+      if (window.canmodify && subLoc in window.canmodify) {
+        cldrSurvey.addClass(clickyLink, "canmodify");
+      } else {
+        cldrSurvey.addClass(subLocDiv, "hide"); // not modifiable
+      }
+      return clickyLink;
+    };
+
+    /**
+     * list of pages to use with the flipper
+     * @property pages
+     */
+    var pages = {
+      loading: "LoadingMessageSection",
+      data: "DynamicDataSection",
+      other: "OtherSection",
+    };
+    var flipper = new Flipper([pages.loading, pages.data, pages.other]);
+
+    var pucontent = document.getElementById("itemInfo");
+    var theDiv = flipper.get(pages.data);
+    theDiv.pucontent = pucontent;
+
+    pucontent.appendChild(
+      cldrSurvey.createChunk(cldrText.get("itemInfoBlank"), "i")
+    );
+
+    /**
+     * List of buttons/titles to set.
+     * @property menubuttons
+     */
+    var menubuttons = {
+      locale: "title-locale",
+      section: "title-section",
+      page: "title-page",
+      dcontent: "title-dcontent",
+
+      // menubuttons.set is called by updateLocaleMenu and updateHashAndMenus
+      set: function (x, y) {
+        stdebug("menuset " + x + " = " + y);
+        var cnode = document.getElementById(x + "-container");
+        var wnode = dijitRegistry.byId(x);
+        var dnode = document.getElementById(x);
+        if (!cnode) {
+          cnode = dnode; // for Elements that do their own stunts
+        }
+        if (y && y !== "-" && y !== "") {
+          if (wnode != null) {
+            wnode.set("label", y);
+          } else {
+            cldrSurvey.updateIf(x, y); // non widget
+          }
+          setDisplayed(cnode, true);
+        } else {
+          setDisplayed(cnode, false);
+          if (wnode != null) {
+            wnode.set("label", "-");
+          } else {
+            cldrSurvey.updateIf(x, "-"); // non widget
+          }
+        }
+      },
+    };
+
+    /**
+     * Manage additional special pages
+     * @class OtherSpecial
+     */
+    function OtherSpecial() {
+      // cached page list
+      this.pages = {};
+    }
+
+    /**
+     * @function getSpecial
+     */
+    OtherSpecial.prototype.getSpecial = function getSpecial(name) {
+      return this.pages[name];
+    };
+
+    /**
+     * @function loadSpecial
+     */
+    OtherSpecial.prototype.loadSpecial = function loadSpecial(
+      name,
+      onSuccess,
+      onFailure
+    ) {
+      var special = this.getSpecial(name);
+      var otherThis = this;
+      if (special) {
+        stdebug("OS: Using cached special: " + name);
+        onSuccess(special);
+      } else if (special === null) {
+        stdebug("OS: cached NULL: " + name);
+        onFailure("Special page failed to load: " + name);
+      } else {
+        stdebug("OS: Attempting load.." + name);
+        /***
+        try {
+          require(["js/special/" + name + ".js"], function (specialFn) {
+            stdebug("OS: Loaded, instantiatin':" + name);
+            var special = new specialFn();
+            special.name = name;
+            otherThis.pages[name] = special; // cache for next time
+
+            stdebug("OS: SUCCESS! " + name);
+            onSuccess(special);
+          });
+        } catch (e) {
+          stdebug("OS: Load FAIL!:" + name + " - " + e.message + " - " + e);
+          if (!otherThis.pages[name]) {
+            // if the load didn't complete:
+            otherThis.pages[name] = null; // mark as don't retry load.
+          }
+          onFailure(e);
+        }
+        ***/
+      }
+    };
+
+    /**
+     * @function parseHash
+     */
+    OtherSpecial.prototype.parseHash = function parseHash(name, hash, pieces) {
+      this.loadSpecial(
+        name,
+        function onSuccess(special) {
+          special.parseHash(hash, pieces);
+        },
+        function onFailure(e) {
+          /*
+           * TODO: get rid of this console warning for name = "oldvotes".
+           * There's not a known problem with old votes. It's not clear why
+           * the warning occurs. See "window.parseHash(dojoHash())"
+           */
+          console.log(
+            "OtherSpecial.parseHash: Failed to load " + name + " - " + e
+          );
+        }
+      );
+    };
+
+    /**
+     * @function handleIdChanged
+     */
+    OtherSpecial.prototype.handleIdChanged = function handleIdChanged(
+      name,
+      id
+    ) {
+      this.loadSpecial(
+        name,
+        function onSuccess(special) {
+          special.handleIdChanged(id);
+        },
+        function onFailure(e) {
+          console.log(
+            "OtherSpecial.handleIdChanged: Failed to load " + name + " - " + e
+          );
+        }
+      );
+    };
+
+    /**
+     * @function showPage
+     */
+    OtherSpecial.prototype.show = function show(name, params) {
+      this.loadSpecial(
+        name,
+        function onSuccess(special) {
+          // populate the params a little more
+          params.otherSpecial = this;
+          params.name = name;
+          params.special = special;
+
+          // add anything from scope..
+
+          params.exports = {
+            // All things that should be separate AMD modules..
+            appendLocaleLink: appendLocaleLink,
+            handleDisconnect: handleDisconnect,
+            clickToSelect: cldrSurvey.clickToSelect,
+          };
+
+          special.show(params);
+        },
+        function onFailure(err) {
+          // extended error
+          var loadingChunk;
+          var msg_fmt = cldrText.sub("v_bad_special_msg", {
+            special: name,
+          });
+          params.flipper.flipTo(
+            params.pages.loading,
+            (loadingChunk = cldrSurvey.createChunk(msg_fmt, "p", "errCodeMsg"))
+          );
+          isLoading = false;
+        }
+      );
+    };
+
+    /**
+     * instance of otherSpecial manager
+     * @property otherSpecial
+     */
+    var otherSpecial = new OtherSpecial();
+
+    /**
+     * Parse the hash string into surveyCurrent___ variables.
+     * Expected to update document.title also.
+     *
+     * @param {String} id
+     */
+    window.parseHash = function parseHash(hash) {
+      function updateWindowTitle() {
+        var t = cldrText.get("survey_title");
+        const curLocale = cldrStatus.getCurrentLocale();
+        if (curLocale && curLocale != "") {
+          t = t + ": " + locmap.getLocaleName(curLocale);
+        }
+        const curSpecial = cldrStatus.getCurrentSpecial();
+        if (curSpecial && curSpecial != "") {
+          t = t + ": " + cldrText.get("special_" + curSpecial);
+        }
+        const curPage = cldrStatus.getCurrentPage();
+        if (curPage && curPage != "") {
+          t = t + ": " + curPage;
+        }
+        document.title = t;
+      }
+      if (hash) {
+        var pieces = hash.substr(0).split("/");
+        if (pieces.length > 1) {
+          cldrStatus.setCurrentLocale(pieces[1]); // could be null
+          /*
+           * TODO: find a way if possible to fix here when cldrStatus.getCurrentLocale() === "USER".
+           * It may be necessary (and sufficient) to wait for server response, see "USER" elsewhere
+           * in this file. cachedJson.loc and _thePages.loc are generally (always?) undefined here.
+           * Reference: https://unicode.org/cldr/trac/ticket/11161
+           */
+        } else {
+          cldrStatus.setCurrentLocale("");
+        }
+        const curLocale = cldrStatus.getCurrentLocale();
+        if (pieces[0].length == 0 && curLocale != "" && curLocale != null) {
+          if (pieces.length > 2) {
+            cldrStatus.setCurrentPage(pieces[2]);
+            if (pieces.length > 3) {
+              let id = pieces[3];
+              if (id.substr(0, 2) == "x@") {
+                id = id.substr(2);
+              }
+              cldrStatus.setCurrentId(id);
+            } else {
+              cldrStatus.setCurrentId("");
+            }
+          } else {
+            cldrStatus.setCurrentPage("");
+            cldrStatus.setCurrentId("");
+          }
+          cldrStatus.setCurrentSpecial(null);
+        } else {
+          cldrStatus.setCurrentSpecial(pieces[0]);
+          if (cldrStatus.getCurrentSpecial() == "") {
+            cldrStatus.setCurrentSpecial("locales");
+          }
+          if (cldrStatus.getCurrentSpecial() == "locales") {
+            // allow locales list to retain ID / Page string for passthrough.
+            cldrStatus.setCurrentLocale("");
+            if (pieces.length > 2) {
+              cldrStatus.setCurrentPage(pieces[2]);
+              if (pieces.length > 3) {
+                let id = pieces[3];
+                if (id.substr(0, 2) == "x@") {
+                  id = id.substr(2);
+                }
+                cldrStatus.setCurrentId(id);
+              } else {
+                cldrStatus.setCurrentId("");
+              }
+            } else {
+              cldrStatus.setCurrentPage("");
+              cldrStatus.setCurrentId("");
+            }
+          } else if (cldrSurvey.isReport(cldrStatus.getCurrentSpecial())) {
+            // allow page and ID to fall through.
+            if (pieces.length > 2) {
+              cldrStatus.setCurrentPage(pieces[2]);
+              if (pieces.length > 3) {
+                cldrStatus.setCurrentId(pieces[3]);
+              } else {
+                cldrStatus.setCurrentId("");
+              }
+            } else {
+              cldrStatus.setCurrentPage("");
+              cldrStatus.setCurrentId("");
+            }
+          } else {
+            otherSpecial.parseHash(
+              cldrStatus.getCurrentSpecial(),
+              hash,
+              pieces
+            );
+          }
+        }
+      } else {
+        cldrStatus.setCurrentLocale("");
+        cldrStatus.setCurrentSpecial("locales");
+        cldrStatus.setCurrentId("");
+        cldrStatus.setCurrentPage("");
+        cldrStatus.setCurrentSection("");
+      }
+      updateWindowTitle();
+
+      // if there is no locale id, refresh the search.
+      if (!cldrStatus.getCurrentLocale()) {
+        searchRefresh();
+      }
+    };
+
+    /**
+     * Update hash (and title)
+     *
+     * @param doPush {Boolean} if true, do a push (instead of replace)
+     *
+     * Called by cldrForum.parseContent, as well as locally.
+     *
+     * TODO: avoid attaching this, or anything, to "window"! Define our own objects instead.
+     */
+    window.replaceHash = function replaceHash(doPush) {
+      if (!doPush) {
+        doPush = false; // by default -replace.
+      }
+      var theId = cldrStatus.getCurrentId();
+      if (theId == null) {
+        theId = "";
+      }
+      var theSpecial = cldrStatus.getCurrentSpecial();
+      if (theSpecial == null) {
+        theSpecial = "";
+      }
+      var thePage = cldrStatus.getCurrentPage();
+      if (thePage == null) {
+        thePage = "";
+      }
+      var theLocale = cldrStatus.getCurrentLocale();
+      if (theLocale == null) {
+        theLocale = "";
+      }
+      var newHash =
+        "#" + theSpecial + "/" + theLocale + "/" + thePage + "/" + theId;
+      if (newHash != dojoHash()) {
+        dojoHash(newHash, !doPush);
+      }
+    };
+
+    window.updateCurrentId = function updateCurrentId(id) {
+      if (id == null) {
+        id = "";
+      }
+      if (cldrStatus.getCurrentId() != id) {
+        // don't set if already set.
+        cldrStatus.setCurrentId(id);
+        replaceHash(false); // usually don't want to save
+      }
+    };
+
+    // (back to showV) some setup.
+    // click on the title to copy (permalink)
+    cldrSurvey.clickToSelect(document.getElementById("ariScroller"));
+    cldrSurvey.updateIf(
+      "title-dcontent-link",
+      cldrText.get("defaultContent_titleLink")
+    );
+
+    // TODO - rewrite using AMD
+    /**
+     * @param postData optional - makes this a POST
+     */
+    window.myLoad = function myLoad(url, message, handler, postData, headers) {
+      var otime = new Date().getTime();
+      console.log("MyLoad: " + url + " for " + message);
+      var errorHandler = function (err) {
+        console.log("Error: " + err);
+        handleDisconnect(
+          "Could not fetch " +
+            message +
+            " - error " +
+            err +
+            "\n url: " +
+            url +
+            "\n",
+          null,
+          "disconnect"
+        );
+      };
+      var loadHandler = function (json) {
+        console.log(
+          "        " +
+            url +
+            " loaded in " +
+            (new Date().getTime() - otime) +
+            "ms"
+        );
+        try {
+          handler(json);
+          //resize height
+          $("#main-row").css({
+            height: $("#main-row>div").height(),
+          });
+        } catch (e) {
+          console.log(
+            "Error in ajax post [" +
+              message +
+              "]  " +
+              e.message +
+              " / " +
+              e.name
+          );
+          handleDisconnect(
+            "Exception while loading: " +
+              message +
+              " - " +
+              e.message +
+              ", n=" +
+              e.name +
+              " \nStack:\n" +
+              (e.stack || "[none]"),
+            null
+          ); // in case the 2nd line doesn't work
+        }
+      };
+      var xhrArgs = {
+        url: url,
+        handleAs: "json",
+        load: loadHandler,
+        error: errorHandler,
+        postData: postData,
+        headers: headers,
+      };
+      cldrAjax.queueXhr(xhrArgs);
+    };
+
+    /**
+     * Verify that the JSON returned is as expected.
+     *
+     * @param json the returned json
+     * @param subkey the key to look for,  json.subkey
+     * @return true if OK, false if bad
+     */
+    function verifyJson(json, subkey) {
+      if (!json) {
+        console.log("!json");
+        showLoader(
+          null,
+          "Error while  loading " +
+            subkey +
+            ":  <br><div style='border: 1px solid red;'>" +
+            "no data!" +
+            "</div>"
+        );
+        return false;
+      } else if (json.err_code) {
+        var msg_fmt = formatErrMsg(json, subkey);
+        var loadingChunk;
+        flipper.flipTo(
+          pages.loading,
+          (loadingChunk = cldrSurvey.createChunk(msg_fmt, "p", "errCodeMsg"))
+        );
+        var retryButton = cldrSurvey.createChunk(
+          cldrText.get("loading_reload"),
+          "button"
+        );
+        loadingChunk.appendChild(retryButton);
+        retryButton.onclick = function () {
+          window.location.reload(true);
+        };
+        return false;
+      } else if (json.err) {
+        console.log("json.err!" + json.err);
+        showLoader(
+          null,
+          "Error while  loading " +
+            subkey +
+            ": <br><div style='border: 1px solid red;'>" +
+            json.err +
+            "</div>"
+        );
+        handleDisconnect("while loading " + subkey + "", json);
+        return false;
+      } else if (!json[subkey]) {
+        console.log("!json.oldvotes");
+        showLoader(
+          null,
+          "Error while  loading " +
+            subkey +
+            ": <br><div style='border: 1px solid red;'>" +
+            "no data" +
+            "</div>"
+        );
+        handleDisconnect("while loading- no " + subkey + "", json);
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    window.showCurrentId = function () {
+      const curSpecial = cldrStatus.getCurrentSpecial();
+      if (curSpecial && curSpecial != "" && !isDashboard()) {
+        otherSpecial.handleIdChanged(curSpecial, showCurrentId);
+      } else {
+        const curId = cldrStatus.getCurrentId();
+        if (curId != "") {
+          var xtr = document.getElementById("r@" + curId);
+          if (!xtr) {
+            console.log(
+              "Warning could not load id " + curId + " does not exist"
+            );
+            window.updateCurrentId(null);
+          } else if (xtr.proposedcell && xtr.proposedcell.showFn) {
+            // TODO: visible? coverage?
+            cldrSurvey.showInPop(
+              "",
+              xtr,
+              xtr.proposedcell,
+              xtr.proposedcell.showFn,
+              true
+            );
+            console.log("Changed to " + cldrStatus.getCurrentId());
+            if (!isDashboard()) scrollToItem();
+          } else {
+            console.log(
+              "Warning could not load id " +
+                curId +
+                " - not setup - " +
+                xtr.toString() +
+                " pc=" +
+                xtr.proposedcell +
+                " sf = " +
+                xtr.proposedcell.showFn
+            );
+          }
+        }
+      }
+    };
+
+    // https://dojotoolkit.org/reference-guide/1.10/dijit/Dialog.html
+    const ariDialog = {
+      show: function () {
+        console.log("ariDialog.show not implemented yet!");
+      },
+      hide: function () {
+        console.log("ariDialog.hide not implemented yet!");
+      },
+    };
+
+    window.ariRetry = function () {
+      if (!ariDialog) {
+        console.log("Error: no ariDialog in window.ariRetry");
+      } else {
+        ariDialog.hide();
+      }
+      window.location.reload(true);
+    };
+
+    window.showARIDialog = function (why, json, word, oneword, p, what) {
+      console.log("showARIDialog");
+      p.parentNode.removeChild(p);
+
+      if (didUnbust) {
+        why = why + "\n\n" + cldrText.get("ari_force_reload");
+      }
+
+      // setup with why
+      var ari_message;
+
+      if (json && json.session_err) {
+        ari_message = cldrText.get("ari_sessiondisconnect_message");
+      } else {
+        ari_message = cldrText.get("ari_message");
+      }
+
+      var ari_submessage = formatErrMsg(json, what);
+
+      cldrSurvey.updateIf("ariMessage", ari_message.replace(/\n/g, "<br>"));
+      cldrSurvey.updateIf(
+        "ariSubMessage",
+        ari_submessage.replace(/\n/g, "<br>")
+      );
+      cldrSurvey.updateIf(
+        "ariScroller",
+        window.location + "<br>" + why.replace(/\n/g, "<br>")
+      );
+      // TODO: update  ariMain and ariRetryBtn
+      hideOverlayAndSidebar();
+
+      if (!ariDialog) {
+        console.log("Error: no ariDialog in window.showARIDialog 1");
+      } else {
+        ariDialog.show();
+      }
+
+      var oneword = document.getElementById("progress_oneword");
+      oneword.onclick = function () {
+        if (cldrStatus.isDisconnected()) {
+          if (!ariDialog) {
+            console.log(
+              "Error: no ariDialog in window.showARIDialog 2 onclick"
+            );
+          } else {
+            ariDialog.show();
+          }
+        }
+      };
+    };
+
+    function updateCoverageMenuTitle() {
+      if (surveyUserCov) {
+        $("#coverage-info").text(cldrText.get("coverage_" + surveyUserCov));
+      } else {
+        $("#coverage-info").text(
+          cldrText.sub("coverage_auto_msg", {
+            surveyOrgCov: cldrText.get("coverage_" + surveyOrgCov),
+          })
+        );
+      }
+    }
+
+    function updateLocaleMenu() {
+      const curLocale = cldrStatus.getCurrentLocale();
+      if (curLocale != null && curLocale != "" && curLocale != "-") {
+        cldrStatus.setCurrentLocaleName(locmap.getLocaleName(curLocale));
+        var bund = locmap.getLocaleInfo(curLocale);
+        if (bund) {
+          if (bund.readonly) {
+            cldrSurvey.addClass(
+              document.getElementById(menubuttons.locale),
+              "locked"
+            );
+          } else {
+            cldrSurvey.removeClass(
+              document.getElementById(menubuttons.locale),
+              "locked"
+            );
+          }
+
+          if (bund.dcChild) {
+            menubuttons.set(
+              menubuttons.dcontent,
+              cldrText.sub("defaultContent_header_msg", {
+                info: bund,
+                locale: cldrStatus.getCurrentLocale(),
+                dcChild: locmap.getLocaleName(bund.dcChild),
+              })
+            );
+          } else {
+            menubuttons.set(menubuttons.dcontent);
+          }
+        } else {
+          cldrSurvey.removeClass(
+            document.getElementById(menubuttons.locale),
+            "locked"
+          );
+          menubuttons.set(menubuttons.dcontent);
+        }
+      } else {
+        cldrStatus.setCurrentLocaleName("");
+        cldrSurvey.removeClass(
+          document.getElementById(menubuttons.locale),
+          "locked"
+        );
+        menubuttons.set(menubuttons.dcontent);
+      }
+      menubuttons.set(menubuttons.locale, cldrStatus.getCurrentLocaleName());
+    }
+
+    /**
+     * Update the #hash and menus to the current settings.
+     *
+     * @param doPush {Boolean} if false, do not add to history
+     */
+    function updateHashAndMenus(doPush) {
+      const sessionId = cldrStatus.getSessionId();
+      const surveyUser = cldrStatus.getSurveyUser();
+      const userID = surveyUser && surveyUser.id ? surveyUser.id : 0;
+      const surveyUserPerms = cldrStatus.getPermissions();
+      const surveyUserURL = {
+        myAccountSetting: "survey?do=listu",
+        disableMyAccount: "lock.jsp",
+        recentActivity: "myvotes.jsp?user=" + userID + "&s=" + sessionId,
+        xmlUpload: "upload.jsp?a=/cldr-apps/survey&s=" + sessionId,
+        manageUser: "survey?do=list",
+        flag: "tc-flagged.jsp?s=" + sessionId,
+        about: "about.jsp",
+        browse: "browse.jsp",
+        adminPanel: "SurveyAjax?what=admin_panel&s=" + sessionId,
+      };
+
+      /**
+       * 'name' - the js/special/___.js name
+       * 'hidden' - true to hide the item
+       * 'title' - override of menu name
+       * @property specialItems
+       */
+      var specialItems = new Array();
+      if (surveyUser != null) {
+        specialItems = [
+          {
+            divider: true,
+          },
+
+          {
+            title: "Admin Panel",
+            url: surveyUserURL.adminPanel,
+            display: surveyUser && surveyUser.userlevelName === "ADMIN",
+          },
+          {
+            divider: true,
+            display: surveyUser && surveyUser.userlevelName === "ADMIN",
+          },
+
+          {
+            title: "My Account",
+          }, // My Account section
+
+          {
+            title: "Settings",
+            level: 2,
+            url: surveyUserURL.myAccountSetting,
+            display: surveyUser && true,
+          },
+          {
+            title: "Lock (Disable) My Account",
+            level: 2,
+            url: surveyUserURL.disableMyAccount,
+            display: surveyUser && true,
+          },
+
+          {
+            divider: true,
+          },
+          {
+            title: "My Votes",
+          }, // My Votes section
+
+          /*
+           * This indirectly references "special_oldvotes" in cldrText.js
+           */
+          {
+            special: "oldvotes",
+            level: 2,
+            display: surveyUserPerms && surveyUserPerms.userCanImportOldVotes,
+          },
+          {
+            title: "See My Recent Activity",
+            level: 2,
+            url: surveyUserURL.recentActivity,
+          },
+          {
+            title: "Upload XML",
+            level: 2,
+            url: surveyUserURL.xmlUpload,
+          },
+
+          {
+            divider: true,
+          },
+          {
+            title: "My Organization(" + cldrStatus.getOrganizationName() + ")",
+          }, // My Organization section
+
+          {
+            special: "vsummary" /* Cf. special_vsummary */,
+            level: 2,
+            display:
+              surveyUserPerms && surveyUserPerms.userCanUseVettingSummary,
+          },
+          {
+            title: "List " + cldrStatus.getOrganizationName() + " Users",
+            level: 2,
+            url: surveyUserURL.manageUser,
+            display:
+              surveyUserPerms &&
+              (surveyUserPerms.userIsTC || surveyUserPerms.userIsVetter),
+          },
+          {
+            special:
+              "forum_participation" /* Cf. special_forum_participation */,
+            level: 2,
+            display: surveyUserPerms && surveyUserPerms.userCanMonitorForum,
+          },
+          {
+            special:
+              "vetting_participation" /* Cf. special_vetting_participation */,
+            level: 2,
+            display:
+              surveyUserPerms &&
+              (surveyUserPerms.userIsTC || surveyUserPerms.userIsVetter),
+          },
+          {
+            title: "LOCKED: Note: your account is currently locked.",
+            level: 2,
+            display: surveyUserPerms && surveyUserPerms.userIsLocked,
+            bold: true,
+          },
+
+          {
+            divider: true,
+          },
+          {
+            title: "Forum",
+          }, // Forum section
+
+          {
+            special: "flagged",
+            level: 2,
+            hasFlag: true,
+          },
+          {
+            special: "mail",
+            level: 2,
+            display: cldrStatus.getIsUnofficial(),
+          },
+          {
+            special: "bulk_close_posts" /* Cf. special_bulk_close_posts */,
+            level: 2,
+            display: surveyUser && surveyUser.userlevelName === "ADMIN",
+          },
+
+          {
+            divider: true,
+          },
+          {
+            title: "Informational",
+          }, // Informational section
+
+          {
+            special: "statistics",
+            level: 2,
+          },
+          {
+            title: "About",
+            level: 2,
+            url: surveyUserURL.about,
+          },
+          {
+            title: "Lookup a code or xpath",
+            level: 2,
+            url: surveyUserURL.browse,
+          },
+          {
+            title: "Error Subtypes",
+            level: 2,
+            url: "./tc-all-errors.jsp",
+            display: surveyUserPerms && surveyUserPerms.userIsTC,
+          },
+          {
+            divider: true,
+          },
+        ];
+      }
+      if (!doPush) {
+        doPush = false;
+      }
+      replaceHash(doPush); // update the hash
+      updateLocaleMenu();
+
+      if (cldrStatus.getCurrentLocale() == null) {
+        menubuttons.set(menubuttons.section);
+        const curSpecial = cldrStatus.getCurrentSpecial();
+        if (curSpecial != null) {
+          var specialId = "special_" + curSpecial;
+          menubuttons.set(menubuttons.page, cldrText.get(specialId));
+        } else {
+          menubuttons.set(menubuttons.page);
+        }
+        return; // nothing to do.
+      }
+      var titlePageContainer = document.getElementById("title-page-container");
+
+      /**
+       * Just update the titles of the menus. Internal to updateHashAndMenus
+       */
+      function updateMenuTitles(menuMap) {
+        if (menubuttons.lastspecial === undefined) {
+          menubuttons.lastspecial = null;
+
+          // Set up the menu here?
+          var parMenu = document.getElementById("manage-list");
+          for (var k = 0; k < specialItems.length; k++) {
+            var item = specialItems[k];
+            (function (item) {
+              if (item.display != false) {
+                var subLi = document.createElement("li");
+                if (item.special) {
+                  // special items so look up in cldrText.js
+                  item.title = cldrText.get("special_" + item.special);
+                  item.url = "#" + item.special;
+                  item.blank = false;
+                }
+                if (item.url) {
+                  var subA = document.createElement("a");
+
+                  if (item.hasFlag) {
+                    // forum may need images attached to it
+                    var Img = document.createElement("img");
+                    Img.setAttribute("src", "flag.png");
+                    Img.setAttribute("alt", "flag");
+                    Img.setAttribute("title", "flag.png");
+                    Img.setAttribute("border", 0);
+
+                    subA.appendChild(Img);
+                  }
+                  subA.appendChild(document.createTextNode(item.title + " "));
+                  subA.href = item.url;
+
+                  if (item.blank != false) {
+                    subA.target = "_blank";
+                    subA.appendChild(
+                      cldrSurvey.createChunk(
+                        "",
+                        "span",
+                        "glyphicon glyphicon-share manage-list-icon"
+                      )
+                    );
+                  }
+
+                  if (item.level) {
+                    // append it to appropriate levels
+                    var level = item.level;
+                    for (var i = 0; i < level - 1; i++) {
+                      /*
+                       * Indent by creating lists within lists, each list containing only one item.
+                       * TODO: indent by a better method. Note that for valid html, ul should contain li;
+                       * ul directly containing element other than li is generally invalid.
+                       */
+                      let ul = document.createElement("ul");
+                      let li = document.createElement("li");
+                      ul.setAttribute("style", "list-style-type:none");
+                      ul.appendChild(li);
+                      li.appendChild(subA);
+                      subA = ul;
+                    }
+                  }
+                  subLi.appendChild(subA);
+                }
+                if (!item.url && !item.divider) {
+                  // if it is pure text/html & not a divider
+                  if (!item.level) {
+                    subLi.appendChild(
+                      document.createTextNode(item.title + " ")
+                    );
+                  } else {
+                    var subA = null;
+                    if (item.bold) {
+                      subA = document.createElement("b");
+                    } else if (item.italic) {
+                      subA = document.createElement("i");
+                    } else {
+                      subA = document.createElement("span");
+                    }
+                    subA.appendChild(document.createTextNode(item.title + " "));
+
+                    var level = item.level;
+                    for (var i = 0; i < level - 1; i++) {
+                      let ul = document.createElement("ul");
+                      let li = document.createElement("li");
+                      ul.setAttribute("style", "list-style-type:none");
+                      ul.appendChild(li);
+                      li.appendChild(subA);
+                      subA = ul;
+                    }
+                    subLi.appendChild(subA);
+                  }
+                }
+                if (item.divider) {
+                  subLi.className = "nav-divider";
+                }
+                parMenu.appendChild(subLi);
+              }
+            })(item);
+          }
+        }
+
+        if (menubuttons.lastspecial) {
+          cldrSurvey.removeClass(menubuttons.lastspecial, "selected");
+        }
+
+        updateLocaleMenu(menuMap);
+        const curSpecial = cldrStatus.getCurrentSpecial();
+        if (curSpecial != null && curSpecial != "") {
+          var specialId = "special_" + curSpecial;
+          $("#section-current").html(cldrText.get(specialId));
+          setDisplayed(titlePageContainer, false);
+        } else if (!menuMap) {
+          setDisplayed(titlePageContainer, false);
+        } else {
+          const curPage = cldrStatus.getCurrentPage();
+          if (menuMap.sectionMap[curPage]) {
+            const curSection = curPage; // section = page
+            cldrStatus.setCurrentSection(curSection);
+            $("#section-current").html(menuMap.sectionMap[curSection].name);
+            setDisplayed(titlePageContainer, false); // will fix title later
+          } else if (menuMap.pageToSection[curPage]) {
+            var mySection = menuMap.pageToSection[curPage];
+            cldrStatus.setCurrentSection(mySection.id);
+            $("#section-current").html(mySection.name);
+            setDisplayed(titlePageContainer, false); // will fix title later
+          } else {
+            $("#section-current").html(cldrText.get("section_general"));
+            setDisplayed(titlePageContainer, false);
+          }
+        }
+      }
+
+      /**
+       * Update the menus
+       */
+      function updateMenus(menuMap) {
+        // initialize menus
+        if (!menuMap.menusSetup) {
+          menuMap.menusSetup = true;
+          menuMap.setCheck = function (menu, checked, disabled) {
+            menu.set(
+              "iconClass",
+              checked ? "dijitMenuItemIcon menu-x" : "dijitMenuItemIcon menu-o"
+            );
+            menu.set("disabled", disabled);
+          };
+          var menuSection = dijitRegistry.byId("menu-section");
+          menuMap.section_general = new dijitMenuItem({
+            label: cldrText.get("section_general"),
+            iconClass: "dijitMenuItemIcon ",
+            disabled: true,
+            onClick: function () {
+              if (
+                cldrStatus.getCurrentPage() != "" ||
+                (cldrStatus.getCurrentSpecial() != "" &&
+                  cldrStatus.getCurrentSpecial() != null)
+              ) {
+                cldrStatus.setCurrentId(""); // no id if jumping pages
+                cldrStatus.setCurrentPage("");
+                cldrStatus.setCurrentSection("");
+                cldrStatus.setCurrentSpecial("");
+                updateMenuTitles(menuMap);
+                reloadV();
+              }
+            },
+          });
+          menuSection.addChild(menuMap.section_general);
+          for (var j in menuMap.sections) {
+            (function (aSection) {
+              aSection.menuItem = new dijitMenuItem({
+                label: aSection.name,
+                iconClass: "dijitMenuItemIcon",
+                onClick: function () {
+                  cldrStatus.setCurrentId("!"); // no id if jumping pages
+                  cldrStatus.setCurrentPage(aSection.id);
+                  cldrStatus.setCurrentSpecial("");
+                  updateMenus(menuMap);
+                  updateMenuTitles(menuMap);
+                  reloadV();
+                },
+                disabled: true,
+              });
+
+              menuSection.addChild(aSection.menuItem);
+            })(menuMap.sections[j]);
+          }
+
+          menuSection.addChild(new dijitMenuSeparator());
+
+          menuMap.forumMenu = new dijitMenuItem({
+            label: cldrText.get("section_forum"),
+            iconClass: "dijitMenuItemIcon", // menu-chat
+            disabled: true,
+            onClick: function () {
+              cldrStatus.setCurrentId("!"); // no id if jumping pages
+              cldrStatus.setCurrentPage("");
+              cldrStatus.setCurrentSpecial("forum");
+              updateMenus(menuMap);
+              updateMenuTitles(menuMap);
+              reloadV();
+            },
+          });
+          menuSection.addChild(menuMap.forumMenu);
+        }
+
+        updateMenuTitles(menuMap);
+
+        var myPage = null;
+        var mySection = null;
+        const curSpecial = cldrStatus.getCurrentSpecial();
+        if (curSpecial == null || curSpecial == "") {
+          // first, update display names
+          const curPage = cldrStatus.getCurrentPage();
+          if (menuMap.sectionMap[curPage]) {
+            // page is really a section
+            mySection = menuMap.sectionMap[curPage];
+            myPage = null;
+          } else if (menuMap.pageToSection[curPage]) {
+            mySection = menuMap.pageToSection[curPage];
+            myPage = mySection.pageMap[curPage];
+          }
+          if (mySection !== null) {
+            // update menus under 'page' - peer pages
+            if (!titlePageContainer.menus) {
+              titlePageContainer.menus = {};
+            }
+
+            // hide all. TODO use a foreach model?
+            for (var zz in titlePageContainer.menus) {
+              var aMenu = titlePageContainer.menus[zz];
+              aMenu.set("label", "-");
+            }
+
+            var showMenu = titlePageContainer.menus[mySection.id];
+
+            if (!showMenu) {
+              // doesn't exist - add it.
+              var menuPage = new dijitDropDownMenu();
+              for (var k in mySection.pages) {
+                // use given order
+                (function (aPage) {
+                  var pageMenu = (aPage.menuItem = new dijitMenuItem({
+                    label: aPage.name,
+                    iconClass:
+                      aPage.id == cldrStatus.getCurrentPage()
+                        ? "dijitMenuItemIcon menu-x"
+                        : "dijitMenuItemIcon menu-o",
+                    onClick: function () {
+                      cldrStatus.setCurrentId(""); // no id if jumping pages
+                      cldrStatus.setCurrentPage(aPage.id);
+                      updateMenuTitles(menuMap);
+                      reloadV();
+                    },
+                    disabled:
+                      effectiveCoverage() <
+                      parseInt(aPage.levs[cldrStatus.getCurrentLocale()]),
+                  }));
+                })(mySection.pages[k]);
+              }
+
+              showMenu = new dijitDropDownButton({
+                label: "-",
+                dropDown: menuPage,
+              });
+
+              titlePageContainer.menus[
+                mySection.id
+              ] = mySection.pagesMenu = showMenu;
+            }
+
+            if (myPage !== null) {
+              /*
+               * TODO: if 'use strict' in this file, we get:
+               * Ignoring get or set of property that has [LenientThis] because the “this” object is incorrect.
+               */
+              $("#title-page-container")
+                .html("<h1>" + myPage.name + "</h1>")
+                .show();
+            } else {
+              $("#title-page-container").html("").hide();
+            }
+            setDisplayed(showMenu, true);
+            setDisplayed(titlePageContainer, true); // will fix title later
+          }
+        }
+
+        stdebug("Updating menus.. ecov = " + effectiveCoverage());
+
+        menuMap.setCheck(
+          menuMap.section_general,
+          cldrStatus.getCurrentPage() == "" &&
+            (cldrStatus.getCurrentSpecial() == "" ||
+              cldrStatus.getCurrentSpecial() == null),
+          false
+        );
+
+        // Update the status of the items in the Section menu
+        for (var j in menuMap.sections) {
+          var aSection = menuMap.sections[j];
+          // need to see if any items are visible @ current coverage
+          const curLocale = cldrStatus.getCurrentLocale();
+          stdebug(
+            "for " +
+              aSection.name +
+              " minLev[" +
+              curLocale +
+              "] = " +
+              aSection.minLev[curLocale]
+          );
+          const curSection = cldrStatus.getCurrentSection();
+          menuMap.setCheck(
+            aSection.menuItem,
+            curSection == aSection.id,
+            effectiveCoverage() < aSection.minLev[curLocale]
+          );
+
+          // update the items in that section's Page menu
+          if (curSection == aSection.id) {
+            for (var k in aSection.pages) {
+              var aPage = aSection.pages[k];
+              if (!aPage.menuItem) {
+                console.log("Odd - " + aPage.id + " has no menuItem");
+              } else {
+                menuMap.setCheck(
+                  aPage.menuItem,
+                  aPage.id == cldrStatus.getCurrentPage(),
+                  effectiveCoverage() < parseInt(aPage.levs[curLocale])
+                );
+              }
+            }
+          }
+        }
+        menuMap.setCheck(
+          menuMap.forumMenu,
+          cldrStatus.getCurrentSpecial() == "forum",
+          cldrStatus.getSurveyUser() === null
+        );
+        resizeSidebar();
+      }
+
+      const curLocale = cldrStatus.getCurrentLocale();
+      if (_thePages == null || _thePages.loc != curLocale) {
+        // show the raw IDs while loading.
+        updateMenuTitles(null);
+
+        if (curLocale != null && curLocale != "") {
+          var needLocTable = false;
+
+          var url =
+            cldrStatus.getContextPath() +
+            "/SurveyAjax?what=menus&_=" +
+            curLocale +
+            "&locmap=" +
+            needLocTable +
+            "&s=" +
+            cldrStatus.getSessionId() +
+            cacheKill();
+          myLoad(url, "menus", function (json) {
+            if (!verifyJson(json, "menus")) {
+              return; // busted?
+            }
+
+            if (json.locmap) {
+              locmap = new LocaleMap(locmap); // overwrite with real data
+            }
+
+            // make this into a hashmap.
+            if (json.canmodify) {
+              var canmodify = {};
+              for (var k in json.canmodify) {
+                canmodify[json.canmodify[k]] = true;
+              }
+              window.canmodify = canmodify;
+            }
+
+            updateCovFromJson(json);
+            updateCoverageMenuTitle();
+            updateCoverage(flipper.get(pages.data)); // update CSS and auto menu title
+
+            function unpackMenus(json) {
+              var menus = json.menus;
+
+              if (_thePages) {
+                stdebug("Updating cov info into menus for " + json.loc);
+                for (var k in menus.sections) {
+                  var oldSection = _thePages.sectionMap[menus.sections[k].id];
+                  for (var j in menus.sections[k].pages) {
+                    var oldPage =
+                      oldSection.pageMap[menus.sections[k].pages[j].id];
+
+                    // copy over levels
+                    oldPage.levs[json.loc] =
+                      menus.sections[k].pages[j].levs[json.loc];
+                  }
+                }
+              } else {
+                stdebug("setting up new hashes for " + json.loc);
+                // set up some hashes
+                menus.haveLocs = {};
+                menus.sectionMap = {};
+                menus.pageToSection = {};
+                for (var k in menus.sections) {
+                  menus.sectionMap[menus.sections[k].id] = menus.sections[k];
+                  menus.sections[k].pageMap = {};
+                  menus.sections[k].minLev = {};
+                  for (var j in menus.sections[k].pages) {
+                    menus.sections[k].pageMap[menus.sections[k].pages[j].id] =
+                      menus.sections[k].pages[j];
+                    menus.pageToSection[menus.sections[k].pages[j].id] =
+                      menus.sections[k];
+                  }
+                }
+                _thePages = menus;
+              }
+
+              stdebug("Calculating minimum section coverage for " + json.loc);
+              for (var k in _thePages.sectionMap) {
+                var min = 200;
+                for (var j in _thePages.sectionMap[k].pageMap) {
+                  var thisLev = parseInt(
+                    _thePages.sectionMap[k].pageMap[j].levs[json.loc]
+                  );
+                  if (min > thisLev) {
+                    min = thisLev;
+                  }
+                }
+                _thePages.sectionMap[k].minLev[json.loc] = min;
+              }
+
+              _thePages.haveLocs[json.loc] = true;
+            }
+
+            unpackMenus(json);
+            unpackMenuSideBar(json);
+            updateMenus(_thePages);
+          });
+        }
+      } else {
+        // go ahead and update
+        updateMenus(_thePages);
+      }
+    }
+
+    window.insertLocaleSpecialNote = function insertLocaleSpecialNote(theDiv) {
+      var bund = locmap.getLocaleInfo(cldrStatus.getCurrentLocale());
+      let msg = null;
+
+      if (bund) {
+        if (bund.readonly || bund.special_comment_raw) {
+          if (bund.readonly) {
+            if (bund.special_comment_raw) {
+              msg = bund.special_comment_raw;
+            } else {
+              msg = cldrText.get("readonly_unknown");
+            }
+            msg = cldrText.sub("readonly_msg", {
+              info: bund,
+              locale: cldrStatus.getCurrentLocale(),
+              msg: msg,
+            });
+          } else {
+            // Not readonly, could be a scratch locale
+            msg = bund.special_comment_raw;
+          }
+          if (msg) {
+            msg = locmap.linkify(msg);
+            var theChunk = cldrDomConstruct(msg);
+            var subDiv = document.createElement("div");
+            subDiv.appendChild(theChunk);
+            subDiv.className = "warnText";
+            theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
+          }
+        } else if (bund.dcChild) {
+          const html = cldrText.sub("defaultContentChild_msg", {
+            name: bund.name,
+            dcChild: bund.dcChild,
+            locale: cldrStatus.getCurrentLocale(),
+            dcChildName: locmap.getLocaleName(bund.dcChild),
+          });
+          var theChunk = cldrDomConstruct(html);
+          var subDiv = document.createElement("div");
+          subDiv.appendChild(theChunk);
+          subDiv.className = "warnText";
+          theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
+        }
+      }
+      if (cldrStatus.getIsPhaseBeta()) {
+        const html = cldrText.sub("beta_msg", {
+          info: bund,
+          locale: cldrStatus.getCurrentLocale(),
+          msg: msg,
+        });
+        var theChunk = cldrDomConstruct(html);
+        var subDiv = document.createElement("div");
+        subDiv.appendChild(theChunk);
+        subDiv.className = "warnText";
+        theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
+      }
+    };
+
+    /**
+     * Show the "possible problems" section which has errors for the locale
+     */
+    function showPossibleProblems(
+      flipper,
+      flipPage,
+      loc,
+      session,
+      effectiveCov,
+      requiredCov
+    ) {
+      cldrStatus.setCurrentLocale(loc);
+
+      var url =
+        cldrStatus.getContextPath() +
+        "/SurveyAjax?what=possibleProblems&_=" +
+        cldrStatus.getCurrentLocale() +
+        "&s=" +
+        session +
+        "&eff=" +
+        effectiveCov +
+        "&req=" +
+        requiredCov +
+        cacheKill();
+      myLoad(url, "possibleProblems", function (json) {
+        if (verifyJson(json, "possibleProblems")) {
+          stdebug("json.possibleProblems OK..");
+          if (json.dataLoadTime) {
+            cldrSurvey.updateIf("dynload", json.dataLoadTime);
+          }
+
+          var theDiv = flipper.flipToEmpty(flipPage);
+
+          insertLocaleSpecialNote(theDiv);
+
+          if (json.possibleProblems.length > 0) {
+            var subDiv = cldrSurvey.createChunk("", "div");
+            subDiv.className = "possibleProblems";
+
+            var h3 = cldrSurvey.createChunk(
+              cldrText.get("possibleProblems"),
+              "h3"
+            );
+            subDiv.appendChild(h3);
+
+            var div3 = document.createElement("div");
+            var newHtml = "";
+            newHtml += testsToHtml(json.possibleProblems);
+            div3.innerHTML = newHtml;
+            subDiv.appendChild(div3);
+            theDiv.appendChild(subDiv);
+          }
+          var theInfo = cldrSurvey.createChunk("", "p", "special_general");
+          theDiv.appendChild(theInfo);
+          theInfo.innerHTML = cldrText.get("special_general"); // TODO replace with … ?
+          hideLoader(null);
+        }
+      });
+    }
+
+    var isLoading = false;
+
+    window.reloadV = function reloadV() {
+      if (cldrStatus.isDisconnected()) {
+        unbust();
+      }
+
+      document.getElementById("DynamicDataSection").innerHTML = ""; //reset the data
+      $("#nav-page").hide();
+      $("#nav-page-footer").hide();
+      isLoading = false;
+
+      /*
+       * Scroll back to top when loading a new page, to avoid a bug where, for
+       * example, having scrolled towards bottom, we switch from a Section page
+       * to the Forum page and the scrollbar stays where it was, making the new
+       * content effectively invisible.
+       */
+      window.scrollTo(0, 0);
+
+      /*
+       * TODO: explain code related to "showers".
+       */
+      showers[flipper.get(pages.data).id] = function () {
+        console.log(
+          "reloadV()'s shower - ignoring reload request, we are in the middle of a load!"
+        );
+      };
+
+      // assume parseHash was already called, if we are taking input from the hash
+      if (!ariDialog) {
+        console.log("Error: no ariDialog in window.reloadV");
+      } else {
+        ariDialog.hide();
+      }
+
+      updateHashAndMenus(true);
+
+      const curLocale = cldrStatus.getCurrentLocale();
+      if (curLocale != null && curLocale != "" && curLocale != "-") {
+        var bund = locmap.getLocaleInfo(curLocale);
+        if (bund !== null && bund.dcParent) {
+          const html = cldrText.sub("defaultContent_msg", {
+            name: bund.name,
+            dcParent: bund.dcParent,
+            locale: curLocale,
+            dcParentName: locmap.getLocaleName(bund.dcParent),
+          });
+          var theChunk = cldrDomConstruct(html);
+          var theDiv = document.createElement("div");
+          theDiv.appendChild(theChunk);
+          theDiv.className = "ferrbox";
+          flipper.flipTo(pages.other, theDiv);
+          return;
+        }
+      }
+
+      // TODO: don't even flip if it's quick.
+      var loadingChunk;
+      flipper.flipTo(
+        pages.loading,
+        (loadingChunk = cldrSurvey.createChunk(
+          cldrText.get("loading"),
+          "i",
+          "loadingMsg"
+        ))
+      );
+
+      var itemLoadInfo = cldrSurvey.createChunk("", "div", "itemLoadInfo");
+
+      // Create a little spinner to spin "..." so the user knows we are doing something..
+      var spinChunk = cldrSurvey.createChunk("...", "i", "loadingMsgSpin");
+      var spin = 0;
+      var timerToKill = window.setInterval(function () {
+        var spinTxt = "";
+        spin++;
+        switch (spin % 3) {
+          case 0:
+            spinTxt = ".  ";
+            break;
+          case 1:
+            spinTxt = " . ";
+            break;
+          case 2:
+            spinTxt = "  .";
+            break;
+        }
+        removeAllChildNodes(spinChunk);
+        spinChunk.appendChild(document.createTextNode(spinTxt));
+      }, 1000);
+
+      // Add the "..." until the Flipper flips
+      flipper.addUntilFlipped(
+        function () {
+          var frag = document.createDocumentFragment();
+          frag.appendChild(spinChunk);
+          return frag;
+        },
+        function () {
+          window.clearInterval(timerToKill);
+        }
+      );
+
+      // now, load. Use a show-er function for indirection.
+      var shower = function () {
+        if (isLoading) {
+          console.log("reloadV inner shower: already isLoading, exitting.");
+          return;
+        }
+        isLoading = true;
+        var theDiv = flipper.get(pages.data);
+        var theTable = theDiv.theTable;
+
+        if (!theTable) {
+          var theTableList = theDiv.getElementsByTagName("table");
+          if (theTableList) {
+            theTable = theTableList[0];
+            theDiv.theTable = theTable;
+          }
+        }
+
+        showLoader(null, cldrText.get("loading"));
+
+        const curSpecial = cldrStatus.getCurrentSpecial();
+        const curLocale = cldrStatus.getCurrentLocale();
+        if (
+          (curSpecial == null || curSpecial == "") &&
+          curLocale != null &&
+          curLocale != ""
+        ) {
+          const curPage = cldrStatus.getCurrentPage();
+          if (
+            (curPage == null || curPage == "") &&
+            (cldrStatus.getCurrentId() == null ||
+              cldrStatus.getCurrentId() == "")
+          ) {
+            // the 'General Info' page.
+            itemLoadInfo.appendChild(
+              document.createTextNode(locmap.getLocaleName(curLocale))
+            );
+            showPossibleProblems(
+              flipper,
+              pages.other,
+              curLocale,
+              cldrStatus.getSessionId(),
+              covName(effectiveCoverage()),
+              covName(effectiveCoverage())
+            );
+            cldrSurvey.showInPop2(
+              cldrText.get("generalPageInitialGuidance"),
+              null,
+              null,
+              null,
+              true
+            ); /* show the box the first time */
+            isLoading = false;
+          } else if (cldrStatus.getCurrentId() == "!") {
+            var frag = document.createDocumentFragment();
+            frag.appendChild(
+              cldrSurvey.createChunk(
+                cldrText.get("section_help"),
+                "p",
+                "helpContent"
+              )
+            );
+            var infoHtml = cldrText.get("section_info_" + curPage);
+            var infoChunk = document.createElement("div");
+            infoChunk.innerHTML = infoHtml;
+            frag.appendChild(infoChunk);
+            flipper.flipTo(pages.other, frag);
+            hideLoader(null);
+            isLoading = false;
+          } else if (!cldrSurvey.isInputBusy()) {
+            /*
+             * Make “all rows” requests only when !isInputBusy, to avoid wasted requests
+             * if the user leaves the input box open for an extended time.
+             */
+            // (common case) this is an actual locale data page.
+            const curId = cldrStatus.getCurrentId();
+            const curPage = cldrStatus.getCurrentPage();
+            const curLocale = cldrStatus.getCurrentLocale();
+            itemLoadInfo.appendChild(
+              document.createTextNode(
+                locmap.getLocaleName(curLocale) + "/" + curPage + "/" + curId
+              )
+            );
+            var url =
+              cldrStatus.getContextPath() +
+              "/SurveyAjax?what=getrow&_=" +
+              curLocale +
+              "&x=" +
+              curPage +
+              "&strid=" +
+              curId +
+              "&s=" +
+              cldrStatus.getSessionId() +
+              cacheKill();
+            $("#nav-page").show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
+            myLoad(url, "section", function (json) {
+              isLoading = false;
+              showLoader(theDiv.loader, cldrText.get("loading2"));
+              if (!verifyJson(json, "section")) {
+                return;
+              } else if (json.section.nocontent) {
+                cldrStatus.setCurrentSection("");
+                if (json.pageId) {
+                  cldrStatus.setCurrentPage(json.pageId);
+                } else {
+                  cldrStatus.setCurrentPage("");
+                }
+                showLoader(null);
+                updateHashAndMenus(); // find out why there's no content. (locmap)
+              } else if (!json.section.rows) {
+                console.log("!json.section.rows");
+                showLoader(
+                  theDiv.loader,
+                  "Error while  loading: <br><div style='border: 1px solid red;'>" +
+                    "no rows" +
+                    "</div>"
+                );
+                handleDisconnect("while loading- no rows", json);
+              } else {
+                stdebug("json.section.rows OK..");
+                showLoader(theDiv.loader, "loading..");
+                if (json.dataLoadTime) {
+                  cldrSurvey.updateIf("dynload", json.dataLoadTime);
+                }
+
+                cldrStatus.setCurrentSection("");
+                cldrStatus.setCurrentPage(json.pageId);
+                updateHashAndMenus(); // now that we have a pageid
+                if (!cldrStatus.getSurveyUser()) {
+                  cldrSurvey.showInPop2(
+                    cldrText.get("loginGuidance"),
+                    null,
+                    null,
+                    null,
+                    true
+                  ); /* show the box the first time */
+                } else if (!json.canModify) {
+                  cldrSurvey.showInPop2(
+                    cldrText.get("readonlyGuidance"),
+                    null,
+                    null,
+                    null,
+                    true
+                  ); /* show the box the first time */
+                } else {
+                  cldrSurvey.showInPop2(
+                    cldrText.get("dataPageInitialGuidance"),
+                    null,
+                    null,
+                    null,
+                    true
+                  ); /* show the box the first time */
+                }
+                if (!cldrSurvey.isInputBusy()) {
+                  showLoader(theDiv.loader, cldrText.get("loading3"));
+                  cldrTable.insertRows(
+                    theDiv,
+                    json.pageId,
+                    cldrStatus.getSessionId(),
+                    json
+                  ); // pageid is the xpath..
+                  updateCoverage(flipper.get(pages.data)); // make sure cov is set right before we show.
+                  flipper.flipTo(pages.data); // TODO now? or later?
+                  window.showCurrentId(); // already calls scroll
+                  refreshCounterVetting();
+                  $("#nav-page-footer").show(); // make bottom "Prev/Next" buttons visible after building table
+                }
+              }
+            });
+          }
+        } else if (cldrStatus.getCurrentSpecial() == "oldvotes") {
+          const curLocale = cldrStatus.getCurrentLocale();
+          var url =
+            cldrStatus.getContextPath() +
+            "/SurveyAjax?what=oldvotes&_=" +
+            curLocale +
+            "&s=" +
+            cldrStatus.getSessionId() +
+            "&" +
+            cacheKill();
+          myLoad(url, "(loading oldvotes " + curLocale + ")", function (json) {
+            isLoading = false;
+            showLoader(null, cldrText.get("loading2"));
+            if (!verifyJson(json, "oldvotes")) {
+              return;
+            } else {
+              showLoader(null, "loading..");
+              if (json.dataLoadTime) {
+                cldrSurvey.updateIf("dynload", json.dataLoadTime);
+              }
+
+              var theDiv = flipper.flipToEmpty(pages.other); // clean slate, and proceed..
+
+              removeAllChildNodes(theDiv);
+
+              var h2txt = cldrText.get("v_oldvotes_title");
+              theDiv.appendChild(
+                cldrSurvey.createChunk(h2txt, "h2", "v-title")
+              );
+
+              if (!json.oldvotes.locale) {
+                cldrStatus.setCurrentLocale("");
+                updateHashAndMenus();
+
+                var ul = document.createElement("div");
+                ul.className = "oldvotes_list";
+                var data = json.oldvotes.locales.data;
+                var header = json.oldvotes.locales.header;
+
+                if (data.length > 0) {
+                  data.sort((a, b) =>
+                    a[header.LOCALE].localeCompare(b[header.LOCALE])
+                  );
+                  for (var k in data) {
+                    var li = document.createElement("li");
+
+                    var link = cldrSurvey.createChunk(
+                      data[k][header.LOCALE_NAME],
+                      "a"
+                    );
+                    link.href = "#" + data[k][header.LOCALE];
+                    (function (loc, link) {
+                      return function () {
+                        var clicky;
+                        listenFor(
+                          link,
+                          "click",
+                          (clicky = function (e) {
+                            cldrStatus.setCurrentLocale(loc);
+                            reloadV();
+                            cldrSurvey.stStopPropagation(e);
+                            return false;
+                          })
+                        );
+                        link.onclick = clicky;
+                      };
+                    })(data[k][header.LOCALE], link)();
+                    li.appendChild(link);
+                    li.appendChild(cldrSurvey.createChunk(" "));
+                    li.appendChild(
+                      cldrSurvey.createChunk("(" + data[k][header.COUNT] + ")")
+                    );
+
+                    ul.appendChild(li);
+                  }
+
+                  theDiv.appendChild(ul);
+
+                  theDiv.appendChild(
+                    cldrSurvey.createChunk(
+                      cldrText.get("v_oldvotes_locale_list_help_msg"),
+                      "p",
+                      "helpContent"
+                    )
+                  );
+                } else {
+                  theDiv.appendChild(
+                    cldrSurvey.createChunk(
+                      cldrText.get("v_oldvotes_no_old"),
+                      "i"
+                    )
+                  ); // TODO fix
+                }
+              } else {
+                cldrStatus.setCurrentLocale(json.oldvotes.locale);
+                updateHashAndMenus();
+                var loclink;
+                theDiv.appendChild(
+                  (loclink = cldrSurvey.createChunk(
+                    cldrText.get("v_oldvotes_return_to_locale_list"),
+                    "a",
+                    "notselected"
+                  ))
+                );
+                listenFor(loclink, "click", function (e) {
+                  cldrStatus.setCurrentLocale("");
+                  reloadV();
+                  cldrSurvey.stStopPropagation(e);
+                  return false;
+                });
+                theDiv.appendChild(
+                  cldrSurvey.createChunk(
+                    json.oldvotes.localeDisplayName,
+                    "h3",
+                    "v-title2"
+                  )
+                );
+                var oldVotesLocaleMsg = document.createElement("p");
+                oldVotesLocaleMsg.className = "helpContent";
+                oldVotesLocaleMsg.innerHTML = cldrText.sub(
+                  "v_oldvotes_locale_msg",
+                  {
+                    version: surveyLastVoteVersion,
+                    locale: json.oldvotes.localeDisplayName,
+                  }
+                );
+                theDiv.appendChild(oldVotesLocaleMsg);
+                if (
+                  (json.oldvotes.contested &&
+                    json.oldvotes.contested.length > 0) ||
+                  (json.oldvotes.uncontested &&
+                    json.oldvotes.uncontested.length > 0)
+                ) {
+                  var frag = document.createDocumentFragment();
+                  const oldVoteCount =
+                    (json.oldvotes.contested
+                      ? json.oldvotes.contested.length
+                      : 0) +
+                    (json.oldvotes.uncontested
+                      ? json.oldvotes.uncontested.length
+                      : 0);
+                  var summaryMsg = cldrText.sub("v_oldvotes_count_msg", {
+                    count: oldVoteCount,
+                  });
+                  frag.appendChild(
+                    cldrSurvey.createChunk(summaryMsg, "div", "")
+                  );
+
+                  var navChunk = document.createElement("div");
+                  navChunk.className = "v-oldVotes-nav";
+                  frag.appendChild(navChunk);
+
+                  var uncontestedChunk = null;
+                  var contestedChunk = null;
+
+                  function addOldvotesType(type, jsondata, frag, navChunk) {
+                    var content = cldrSurvey.createChunk(
+                      "",
+                      "div",
+                      "v-oldVotes-subDiv"
+                    );
+                    content.strid = "v_oldvotes_title_" + type; // v_oldvotes_title_contested or v_oldvotes_title_uncontested
+
+                    /* Normally this interface is for old "losing" (contested) votes only, since old "winning" (uncontested) votes
+                     * are imported automatically. An exception is for TC users, for whom auto-import is disabled. The server-side
+                     * code leaves json.oldvotes.uncontested undefined except for TC users.
+                     * Show headings for "Winning/Losing" only if json.oldvotes.uncontested is defined and non-empty.
+                     */
+                    if (
+                      json.oldvotes.uncontested &&
+                      json.oldvotes.uncontested.length > 0
+                    ) {
+                      var title = cldrText.get(content.strid);
+                      content.title = title;
+                      content.appendChild(
+                        cldrSurvey.createChunk(title, "h2", "v-oldvotes-sub")
+                      );
+                    }
+
+                    content.appendChild(
+                      showVoteTable(jsondata /* voteList */, type, json)
+                    );
+
+                    var submit = dojoxBusyButton({
+                      label: cldrText.get("v_submit_msg"),
+                      busyLabel: cldrText.get("v_submit_busy"),
+                    });
+
+                    submit.on("click", function (e) {
+                      setDisplayed(navChunk, false);
+                      var confirmList = []; // these will be revoted with current params
+
+                      // explicit confirm list -  save us desync hassle
+                      for (var kk in jsondata) {
+                        if (jsondata[kk].box.checked) {
+                          confirmList.push(jsondata[kk].strid);
+                        }
+                      }
+
+                      var saveList = {
+                        locale: cldrStatus.getCurrentLocale(),
+                        confirmList: confirmList,
+                      };
+
+                      console.log(saveList.toString());
+                      console.log(
+                        "Submitting " +
+                          type +
+                          " " +
+                          confirmList.length +
+                          " for confirm"
+                      );
+                      const curLocale = cldrStatus.getCurrentLocale();
+                      var url =
+                        cldrStatus.getContextPath() +
+                        "/SurveyAjax?what=oldvotes&_=" +
+                        curLocale +
+                        "&s=" +
+                        cldrStatus.getSessionId() +
+                        "&doSubmit=true&" +
+                        cacheKill();
+                      myLoad(
+                        url,
+                        "(submitting oldvotes " + curLocale + ")",
+                        function (json) {
+                          showLoader(theDiv.loader, cldrText.get("loading2"));
+                          if (!verifyJson(json, "oldvotes")) {
+                            handleDisconnect(
+                              "Error submitting votes!",
+                              json,
+                              "Error"
+                            );
+                            return;
+                          } else {
+                            reloadV();
+                          }
+                        },
+                        JSON.stringify(saveList),
+                        {
+                          "Content-Type": "application/json",
+                        }
+                      );
+                    });
+
+                    submit.placeAt(content);
+                    // hide by default
+                    setDisplayed(content, false);
+
+                    frag.appendChild(content);
+                    return content;
+                  }
+
+                  if (
+                    json.oldvotes.uncontested &&
+                    json.oldvotes.uncontested.length > 0
+                  ) {
+                    uncontestedChunk = addOldvotesType(
+                      "uncontested",
+                      json.oldvotes.uncontested,
+                      frag,
+                      navChunk
+                    );
+                  }
+                  if (
+                    json.oldvotes.contested &&
+                    json.oldvotes.contested.length > 0
+                  ) {
+                    contestedChunk = addOldvotesType(
+                      "contested",
+                      json.oldvotes.contested,
+                      frag,
+                      navChunk
+                    );
+                  }
+
+                  if (contestedChunk == null && uncontestedChunk != null) {
+                    setDisplayed(uncontestedChunk, true); // only item
+                  } else if (
+                    contestedChunk != null &&
+                    uncontestedChunk == null
+                  ) {
+                    setDisplayed(contestedChunk, true); // only item
+                  } else {
+                    // navigation
+                    navChunk.appendChild(
+                      cldrSurvey.createChunk(cldrText.get("v_oldvotes_show"))
+                    );
+                    navChunk.appendChild(
+                      cldrSurvey.createLinkToFn(
+                        uncontestedChunk.strid,
+                        function () {
+                          setDisplayed(contestedChunk, false);
+                          setDisplayed(uncontestedChunk, true);
+                        },
+                        "button"
+                      )
+                    );
+                    navChunk.appendChild(
+                      cldrSurvey.createLinkToFn(
+                        contestedChunk.strid,
+                        function () {
+                          setDisplayed(contestedChunk, true);
+                          setDisplayed(uncontestedChunk, false);
+                        },
+                        "button"
+                      )
+                    );
+
+                    contestedChunk.appendChild(
+                      cldrSurvey.createLinkToFn(
+                        "v_oldvotes_hide",
+                        function () {
+                          setDisplayed(contestedChunk, false);
+                        },
+                        "button"
+                      )
+                    );
+                    uncontestedChunk.appendChild(
+                      cldrSurvey.createLinkToFn(
+                        "v_oldvotes_hide",
+                        function () {
+                          setDisplayed(uncontestedChunk, false);
+                        },
+                        "button"
+                      )
+                    );
+                  }
+
+                  theDiv.appendChild(frag);
+                } else {
+                  theDiv.appendChild(
+                    cldrSurvey.createChunk(
+                      cldrText.get("v_oldvotes_no_old_here"),
+                      "i",
+                      ""
+                    )
+                  );
+                }
+              }
+            }
+            hideLoader(null);
+          });
+        } else if (cldrStatus.getCurrentSpecial() == "mail") {
+          var url =
+            cldrStatus.getContextPath() +
+            "/SurveyAjax?what=mail&s=" +
+            cldrStatus.getSessionId() +
+            "&fetchAll=true&" +
+            cacheKill();
+          myLoad(
+            url,
+            "(loading mail " + cldrStatus.getCurrentLocale() + ")",
+            function (json) {
+              hideLoader(null, cldrText.get("loading2"));
+              isLoading = false;
+              if (!verifyJson(json, "mail")) {
+                return;
+              } else {
+                if (json.dataLoadTime) {
+                  cldrSurvey.updateIf("dynload", json.dataLoadTime);
+                }
+
+                var theDiv = flipper.flipToEmpty(pages.other); // clean slate, and proceed..
+
+                removeAllChildNodes(theDiv);
+
+                var listDiv = cldrSurvey.createChunk(
+                  "",
+                  "div",
+                  "mailListChunk"
+                );
+                var contentDiv = cldrSurvey.createChunk(
+                  "",
+                  "div",
+                  "mailContentChunk"
+                );
+
+                theDiv.appendChild(listDiv);
+                theDiv.appendChild(contentDiv);
+
+                setDisplayed(contentDiv, false);
+                var header = json.mail.header;
+                var data = json.mail.data;
+
+                if (data.length == 0) {
+                  listDiv.appendChild(
+                    cldrSurvey.createChunk(
+                      cldrText.get("mail_noMail"),
+                      "p",
+                      "helpContent"
+                    )
+                  );
+                } else {
+                  for (var ii in data) {
+                    var row = data[ii];
+                    var li = cldrSurvey.createChunk(
+                      row[header.QUEUE_DATE] + ": " + row[header.SUBJECT],
+                      "li",
+                      "mailRow"
+                    );
+                    if (row[header.READ_DATE]) {
+                      cldrSurvey.addClass(li, "readMail");
+                    }
+                    if (header.USER !== undefined) {
+                      li.appendChild(
+                        document.createTextNode("(to " + row[header.USER] + ")")
+                      );
+                    }
+                    if (row[header.SENT_DATE] !== false) {
+                      li.appendChild(
+                        cldrSurvey.createChunk("(sent)", "span", "winner")
+                      );
+                    } else if (row[header.TRY_COUNT] >= 3) {
+                      li.appendChild(
+                        cldrSurvey.createChunk(
+                          "(try#" + row[header.TRY_COUNT] + ")",
+                          "span",
+                          "loser"
+                        )
+                      );
+                    } else if (row[header.TRY_COUNT] > 0) {
+                      li.appendChild(
+                        cldrSurvey.createChunk(
+                          "(try#" + row[header.TRY_COUNT] + ")",
+                          "span",
+                          "warning"
+                        )
+                      );
+                    }
+                    listDiv.appendChild(li);
+
+                    li.onclick = (function (li, row, header) {
+                      return function () {
+                        if (!row[header.READ_DATE]) {
+                          myLoad(
+                            cldrStatus.getContextPath() +
+                              "/SurveyAjax?what=mail&s=" +
+                              cldrStatus.getSessionId() +
+                              "&markRead=" +
+                              row[header.ID] +
+                              "&" +
+                              cacheKill(),
+                            "Marking mail read",
+                            function (json) {
+                              if (!verifyJson(json, "mail")) {
+                                return;
+                              } else {
+                                cldrSurvey.addClass(li, "readMail"); // mark as read when server answers
+                                row[header.READ_DATE] = true; // close enough
+                              }
+                            }
+                          );
+                        }
+                        setDisplayed(contentDiv, false);
+
+                        removeAllChildNodes(contentDiv);
+
+                        contentDiv.appendChild(
+                          cldrSurvey.createChunk(
+                            "Date: " + row[header.QUEUE_DATE],
+                            "h2",
+                            "mailHeader"
+                          )
+                        );
+                        contentDiv.appendChild(
+                          cldrSurvey.createChunk(
+                            "Subject: " + row[header.SUBJECT],
+                            "h2",
+                            "mailHeader"
+                          )
+                        );
+                        contentDiv.appendChild(
+                          cldrSurvey.createChunk(
+                            "Message-ID: " + row[header.ID],
+                            "h2",
+                            "mailHeader"
+                          )
+                        );
+                        if (header.USER !== undefined) {
+                          contentDiv.appendChild(
+                            cldrSurvey.createChunk(
+                              "To: " + row[header.USER],
+                              "h2",
+                              "mailHeader"
+                            )
+                          );
+                        }
+                        contentDiv.appendChild(
+                          cldrSurvey.createChunk(
+                            row[header.TEXT],
+                            "p",
+                            "mailContent"
+                          )
+                        );
+
+                        setDisplayed(contentDiv, true);
+                      };
+                    })(li, row, header);
+                  }
+                }
+              }
+            }
+          );
+        } else if (cldrSurvey.isReport(cldrStatus.getCurrentSpecial())) {
+          showLoader(theDiv.loader);
+          cldrSurvey.showInPop2(
+            cldrText.get("reportGuidance"),
+            null,
+            null,
+            null,
+            true,
+            true
+          ); /* show the box the first time */
+          var url =
+            cldrStatus.getContextPath() +
+            "/SurveyAjax?what=report&x=" +
+            cldrStatus.getCurrentSpecial() +
+            "&_=" +
+            cldrStatus.getCurrentLocale() +
+            "&s=" +
+            cldrStatus.getSessionId() +
+            cacheKill();
+          var errFunction = function errFunction(err) {
+            console.log("Error: loading " + url + " -> " + err);
+            hideLoader(null, cldrText.get("loading2"));
+            isLoading = false;
+            const html =
+              "<div style='padding-top: 4em; font-size: x-large !important;' class='ferrorbox warning'>" +
+              "<span class='icon i-stop'>" +
+              " &nbsp; &nbsp;</span>Error: could not load: " +
+              err +
+              "</div>";
+            const frag = cldrDomConstruct(html);
+            flipper.flipTo(pages.other, frag);
+          };
+          if (isDashboard()) {
+            if (!cldrStatus.isVisitor()) {
+              const loadHandler = function (json) {
+                hideLoader(null, cldrText.get("loading2"));
+                isLoading = false;
+                // further errors are handled in JSON
+                showReviewPage(json, function () {
+                  // show function - flip to the 'other' page.
+                  flipper.flipTo(pages.other, null);
+                });
+              };
+              const xhrArgs = {
+                url: url,
+                handleAs: "json",
+                load: loadHandler,
+                error: errFunction,
+              };
+              cldrAjax.queueXhr(xhrArgs);
+            } else {
+              alert("Please login to access Dashboard");
+              cldrStatus.setCurrentSpecial("");
+              cldrStatus.setCurrentLocale("");
+              reloadV();
+            }
+          } else {
+            hideLoader(null, cldrText.get("loading2"));
+            const loadHandler = function (html) {
+              hideLoader(null, cldrText.get("loading2"));
+              isLoading = false;
+              const frag = cldrDomConstruct(html);
+              flipper.flipTo(pages.other, frag);
+              hideRightPanel(); // CLDR-14365
+            };
+            const xhrArgs = {
+              url: url,
+              handleAs: "html",
+              load: loadHandler,
+              error: errFunction,
+            };
+            cldrAjax.queueXhr(xhrArgs);
+          }
+        } else if (cldrStatus.getCurrentSpecial() == "none") {
+          // for now - redirect
+          hideLoader(null);
+          isLoading = false;
+          window.location = cldrStatus.getSurvUrl(); // redirect home
+        } else if (cldrStatus.getCurrentSpecial() == "locales") {
+          hideLoader(null);
+          isLoading = false;
+          var theDiv = document.createElement("div");
+          theDiv.className = "localeList";
+
+          var addSubLocale = function addSubLocale(parLocDiv, subLoc) {
+            var subLocInfo = locmap.getLocaleInfo(subLoc);
+            var subLocDiv = cldrSurvey.createChunk(null, "div", "subLocale");
+            appendLocaleLink(subLocDiv, subLoc, subLocInfo);
+
+            parLocDiv.appendChild(subLocDiv);
+          };
+
+          var addSubLocales = function addSubLocales(parLocDiv, subLocInfo) {
+            if (subLocInfo.sub) {
+              for (var n in subLocInfo.sub) {
+                var subLoc = subLocInfo.sub[n];
+                addSubLocale(parLocDiv, subLoc);
+              }
+            }
+          };
+
+          /*
+           * TODO: there are two functions named addTopLocale, clarify why
+           */
+          var addTopLocale = function addTopLocale(topLoc) {
+            var topLocInfo = locmap.getLocaleInfo(topLoc);
+
+            var topLocRow = document.createElement("div");
+            topLocRow.className = "topLocaleRow";
+
+            var topLocDiv = document.createElement("div");
+            topLocDiv.className = "topLocale";
+            appendLocaleLink(topLocDiv, topLoc, topLocInfo);
+
+            var topLocList = document.createElement("div");
+            topLocList.className = "subLocaleList";
+
+            addSubLocales(topLocList, topLocInfo);
+
+            topLocRow.appendChild(topLocDiv);
+            topLocRow.appendChild(topLocList);
+            theDiv.appendChild(topLocRow);
+          };
+
+          addTopLocale("root");
+          // top locales
+          for (var n in locmap.locmap.topLocales) {
+            var topLoc = locmap.locmap.topLocales[n];
+            addTopLocale(topLoc);
+          }
+          flipper.flipTo(pages.other, null);
+          filterAllLocale(); //filter for init data
+          forceSidebar();
+          cldrStatus.setCurrentLocale(null);
+          cldrStatus.setCurrentSpecial("locales");
+          cldrSurvey.showInPop2(
+            cldrText.get("localesInitialGuidance"),
+            null,
+            null,
+            null,
+            true
+          ); /* show the box the first time */
+          $("#itemInfo").html("");
+        } else {
+          otherSpecial.show(cldrStatus.getCurrentSpecial(), {
+            flipper: flipper,
+            pages: pages,
+          });
+        }
+      }; // end shower
+
+      shower(); // first load
+
+      // set up the "show-er" function so that if this locale gets reloaded,
+      // the page will load again - except for the dashboard, where only the
+      // row get updated
+      /*
+       * TODO: clarify the above comment, and relate it to the usage of "showers" in survey.js
+       * What does "this locale gets reloaded" mean?
+       * Typically (always?) id = "DynamicDataSection" here.
+       */
+      if (!isDashboard()) {
+        showers[flipper.get(pages.data).id] = shower;
+      }
+    }; // end reloadV
+
+    function trimNull(x) {
+      if (x == null) {
+        return "";
+      }
+      try {
+        x = x.toString().trim();
+      } catch (e) {
+        // do nothing
+      }
+      return x;
+    }
+
+    /*
+     * Arrange for getInitialMenusEtc to be called after we've gotten the session id.
+     * There should be a better way to do this. For now, getInitialMenusEtc is deeply
+     * nested in legacy code, and this implementation avoids any complex linkage between
+     * this code and the code that's responsible for getting the session id from
+     * the server -- that is, updateStatus() in survey.js, as of 2020-12-10
+     */
+    getM();
+    function getM() {
+      const sessionId = cldrStatus.getSessionId();
+      if (sessionId) {
+        getInitialMenusEtc(sessionId);
+      } else {
+        setTimeout(getM, 100); // try again after 1/10 second
+      }
+    }
+
+    function getInitialMenusEtc(sessionId) {
+      window.parseHash(dojoHash()); // get the initial settings
+      // load the menus - first.
+
+      var theLocale = cldrStatus.getCurrentLocale();
+      if (theLocale === null || theLocale == "") {
+        theLocale = "root"; // Default.
+      }
+      var xurl =
+        cldrStatus.getContextPath() +
+        "/SurveyAjax?what=menus&_=" +
+        theLocale +
+        "&locmap=" +
+        true +
+        "&s=" +
+        sessionId +
+        cacheKill();
+      myLoad(xurl, "initial menus for " + theLocale, function (json) {
+        if (!verifyJson(json, "locmap")) {
+          return;
+        } else {
+          locmap = new LocaleMap(json.locmap);
+          if (cldrStatus.getCurrentLocale() === "USER" && json.loc) {
+            cldrStatus.setCurrentLocale(json.loc);
+          }
+          // make this into a hashmap.
+          if (json.canmodify) {
+            var canmodify = {};
+            for (var k in json.canmodify) {
+              canmodify[json.canmodify[k]] = true;
+            }
+            window.canmodify = canmodify;
+          }
+
+          // update left sidebar with locale data
+          var theDiv = document.createElement("div");
+          theDiv.className = "localeList";
+
+          var addSubLocale;
+
+          addSubLocale = function addSubLocale(parLocDiv, subLoc) {
+            var subLocInfo = locmap.getLocaleInfo(subLoc);
+            var subLocDiv = cldrSurvey.createChunk(null, "div", "subLocale");
+            appendLocaleLink(subLocDiv, subLoc, subLocInfo);
+
+            parLocDiv.appendChild(subLocDiv);
+          };
+
+          var addSubLocales = function addSubLocales(parLocDiv, subLocInfo) {
+            if (subLocInfo.sub) {
+              for (var n in subLocInfo.sub) {
+                var subLoc = subLocInfo.sub[n];
+                addSubLocale(parLocDiv, subLoc);
+              }
+            }
+          };
+
+          var addTopLocale = function addTopLocale(topLoc) {
+            var topLocInfo = locmap.getLocaleInfo(topLoc);
+
+            var topLocRow = document.createElement("div");
+            topLocRow.className = "topLocaleRow";
+
+            var topLocDiv = document.createElement("div");
+            topLocDiv.className = "topLocale";
+            appendLocaleLink(topLocDiv, topLoc, topLocInfo);
+
+            var topLocList = document.createElement("div");
+            topLocList.className = "subLocaleList";
+
+            addSubLocales(topLocList, topLocInfo);
+
+            topLocRow.appendChild(topLocDiv);
+            topLocRow.appendChild(topLocList);
+            theDiv.appendChild(topLocRow);
+          };
+
+          addTopLocale("root");
+          // top locales
+          for (var n in locmap.locmap.topLocales) {
+            var topLoc = locmap.locmap.topLocales[n];
+            addTopLocale(topLoc);
+          }
+          $("#locale-list").html(theDiv.innerHTML);
+
+          if (cldrStatus.isVisitor()) $("#show-read").prop("checked", true);
+          //tooltip locale
+          $("a.locName").tooltip();
+
+          filterAllLocale();
+          //end of adding the locale data
+
+          updateCovFromJson(json);
+          // setup coverage level
+          window.surveyLevels = json.menus.levels;
+
+          var titleCoverage = document.getElementById("title-coverage"); // coverage label
+
+          var levelNums = []; // numeric levels
+          for (var k in window.surveyLevels) {
+            levelNums.push({
+              num: parseInt(window.surveyLevels[k].level),
+              level: window.surveyLevels[k],
+            });
+          }
+          levelNums.sort(function (a, b) {
+            return a.num - b.num;
+          });
+
+          var store = [];
+
+          store.push({
+            label: "Auto",
+            value: "auto",
+            title: cldrText.get("coverage_auto_desc"),
+          });
+
+          store.push({
+            type: "separator",
+          });
+
+          for (var j in levelNums) {
+            // use given order
+            if (levelNums[j].num == 0) continue; // none - skip
+            if (levelNums[j].num < covValue("minimal")) continue; // don't bother showing these
+            if (
+              cldrStatus.getIsUnofficial() === false &&
+              levelNums[j].num == 101
+            )
+              continue; // hide Optional in production
+            var level = levelNums[j].level;
+            store.push({
+              label: cldrText.get("coverage_" + level.name),
+              value: level.name,
+              title: cldrText.get("coverage_" + level.name + "_desc"),
+            });
+          }
+          //coverage menu
+          var patternCoverage = $("#title-coverage .dropdown-menu");
+          if (store[0].value) {
+            $("#coverage-info").text(store[0].label);
+          }
+          for (var index = 0; index < store.length; ++index) {
+            var data = store[index];
+            if (data.value) {
+              var html =
+                '<li><a class="coverage-list" data-value="' +
+                data.value +
+                '"href="#">' +
+                data.label +
+                "</a></li>";
+              patternCoverage.append(html);
+            }
+          }
+          patternCoverage.find("li a").click(function (event) {
+            event.stopPropagation();
+            event.preventDefault();
+            var newValue = $(this).data("value");
+            var setUserCovTo = null;
+            if (newValue == "auto") {
+              setUserCovTo = null; // auto
+            } else {
+              setUserCovTo = newValue;
+            }
+            if (setUserCovTo === window.surveyUserCov) {
+              console.log("No change in user cov: " + setUserCovTo);
+            } else {
+              window.surveyUserCov = setUserCovTo;
+              var updurl =
+                cldrStatus.getContextPath() +
+                "/SurveyAjax?what=pref&_=" +
+                theLocale +
+                "&pref=p_covlev&_v=" +
+                window.surveyUserCov +
+                "&s=" +
+                cldrStatus.getSessionId() +
+                cacheKill(); // SurveyMain.PREF_COVLEV
+              myLoad(
+                updurl,
+                "updating covlev to  " + surveyUserCov,
+                function (json) {
+                  if (!verifyJson(json, "pref")) {
+                    return;
+                  } else {
+                    unpackMenuSideBar(json);
+                    if (
+                      cldrStatus.getCurrentSpecial() &&
+                      cldrSurvey.isReport(cldrStatus.getCurrentSpecial())
+                    )
+                      reloadV();
+                    console.log("Server set  covlev successfully.");
+                  }
+                }
+              );
+            }
+            // still update these.
+            updateCoverage(flipper.get(pages.data)); // update CSS and 'auto' menu title
+            updateHashAndMenus(false); // TODO: why? Maybe to show an item?
+            $("#coverage-info").text(newValue.ucFirst());
+            $(this).parents(".dropdown-menu").dropdown("toggle");
+            if (!isDashboard()) refreshCounterVetting();
+            return false;
+          });
+
+          /**
+           * Automatically import old winning votes
+           */
+          function doAutoImport() {
+            "use strict";
+            var autoImportProgressDialog = new dijitDialog({
+              title: cldrText.get("v_oldvote_auto_msg"),
+              content: cldrText.get("v_oldvote_auto_progress_msg"),
+            });
+            autoImportProgressDialog.show();
+            window.haveDialog = true;
+            hideOverlayAndSidebar();
+            /*
+             * See WHAT_AUTO_IMPORT = "auto_import" in SurveyAjax.java
+             */
+            var url =
+              cldrStatus.getContextPath() +
+              "/SurveyAjax?what=auto_import&s=" +
+              cldrStatus.getSessionId() +
+              cacheKill();
+            myLoad(url, "auto-importing votes", function (json) {
+              autoImportProgressDialog.hide();
+              window.haveDialog = false;
+              if (json.autoImportedOldWinningVotes) {
+                var vals = {
+                  count: json.autoImportedOldWinningVotes,
+                };
+                var autoImportedDialog = new dijitDialog({
+                  title: cldrText.get("v_oldvote_auto_msg"),
+                  content: cldrText.sub("v_oldvote_auto_desc_msg", vals),
+                });
+                autoImportedDialog.addChild(
+                  new dijitButton({
+                    label: "OK",
+                    onClick: function () {
+                      window.haveDialog = false;
+                      autoImportedDialog.hide();
+                      reloadV();
+                    },
+                  })
+                );
+                autoImportedDialog.show();
+                window.haveDialog = true;
+                hideOverlayAndSidebar();
+              }
+            });
+          }
+
+          if (json.canAutoImport) {
+            doAutoImport();
+          }
+
+          window.reloadV(); // call it
+
+          // watch for hashchange to make other changes..
+          dojoTopic.subscribe("/dojo/hashchange", function (changedHash) {
+            var oldLocale = trimNull(cldrStatus.getCurrentLocale());
+            var oldSpecial = trimNull(cldrStatus.getCurrentSpecial());
+            var oldPage = trimNull(cldrStatus.getCurrentPage());
+            var oldId = trimNull(cldrStatus.getCurrentId());
+
+            window.parseHash(changedHash);
+
+            cldrStatus.setCurrentId(trimNull(cldrStatus.getCurrentId()));
+
+            // did anything change?
+            if (
+              oldLocale != trimNull(cldrStatus.getCurrentLocale()) ||
+              oldSpecial != trimNull(cldrStatus.getCurrentSpecial()) ||
+              oldPage != trimNull(cldrStatus.getCurrentPage())
+            ) {
+              console.log("# hash changed, (loc, etc) reloadingV..");
+              reloadV();
+            } else if (
+              oldId != cldrStatus.getCurrentId() &&
+              cldrStatus.getCurrentId() != ""
+            ) {
+              console.log("# just ID changed, to " + cldrStatus.getCurrentId());
+              // surveyCurrentID and the hash have already changed.
+              // just call showInPop if the item is present. If not present, make sure it's visible.
+              window.showCurrentId();
+            }
+          });
+        }
+      }); // end myLoad
+    } // end getInitialMenusEtc
+  } // end showV
+
+  // replacement for dojo/dom-construct domConstruct.toDom
+  function cldrDomConstruct(html) {
+    const renderer = document.createElement("template");
+    renderer.innerHTML = html;
+    return renderer.content;
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    showV: showV,
+    // updateWithStatus: updateWithStatus,
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    // test: {
+    // getBodyHtml: getBodyHtml,
+    // },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrLocaleMap.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrLocaleMap.js
@@ -1,0 +1,153 @@
+"use strict";
+
+/**
+ * @param aLocmap the map object from json
+ */
+function LocaleMap(aLocmap) {
+  this.locmap = aLocmap;
+}
+
+/**
+ * Run the locale id through the idmap.
+ *
+ * @param menuMap the map
+ * @param locid or null for cldrStatus.getCurrentLocale()
+ * @return canonicalized id, or unchanged
+ */
+LocaleMap.prototype.canonicalizeLocaleId = function canonicalizeLocaleId(
+  locid
+) {
+  if (locid === null) {
+    locid = cldrStatus.getCurrentLocale();
+  }
+  if (locid === null || locid === "") {
+    return null;
+  }
+
+  if (this.locmap) {
+    if (this.locmap.idmap && this.locmap.idmap[locid]) {
+      locid = this.locmap.idmap[locid]; // canonicalize
+    }
+  }
+  return locid;
+};
+
+window.linkToLocale = function linkToLocale(subLoc) {
+  return (
+    "#/" +
+    subLoc +
+    "/" +
+    cldrStatus.getCurrentPage() +
+    "/" +
+    cldrStatus.getCurrentId()
+  );
+};
+
+/**
+ * Linkify text like '@de' into some link to German.
+ *
+ * @param str (html)
+ * @return linkified str (html)
+ */
+LocaleMap.prototype.linkify = function linkify(str) {
+  var out = "";
+  var re = /@([a-zA-Z0-9_]+)/g;
+  var match;
+  var fromLast = 0;
+  while ((match = re.exec(str)) != null) {
+    var bund = this.getLocaleInfo(match[1]);
+    if (bund) {
+      out = out + str.substring(fromLast, match.index); // pre match
+      if (match[1] == cldrStatus.getCurrentLocale()) {
+        out = out + this.getLocaleName(match[1]);
+      } else {
+        out =
+          out +
+          "<a href='" +
+          linkToLocale(match[1]) +
+          "' title='" +
+          match[1] +
+          "'>" +
+          this.getLocaleName(match[1]) +
+          "</a>";
+      }
+    } else {
+      out = out + match[0]; // no link.
+    }
+    fromLast = re.lastIndex;
+  }
+  out = out + str.substring(fromLast, str.length);
+  return out;
+};
+
+/**
+ * Return the locale info entry
+ *
+ * @param menuMap the map
+ * @param locid the id - should already be canonicalized
+ * @return the bundle or null
+ */
+LocaleMap.prototype.getLocaleInfo = function getLocaleInfo(locid) {
+  if (this.locmap && this.locmap.locales && this.locmap.locales[locid]) {
+    return this.locmap.locales[locid];
+  } else {
+    return null;
+  }
+};
+
+/**
+ * Return the locale name,
+ *
+ * @param menuMap the map
+ * @param locid the id - will canonicalize
+ * @return the display name - or else the id
+ */
+LocaleMap.prototype.getLocaleName = function getLocaleName(locid) {
+  locid = this.canonicalizeLocaleId(locid);
+  var bund = this.getLocaleInfo(locid);
+  if (bund && bund.name) {
+    return bund.name;
+  } else {
+    return locid;
+  }
+};
+
+/**
+ * Return the locale name,
+ *
+ * @param menuMap the map
+ * @param locid the id - will canonicalize
+ * @return the display name - or else the id
+ */
+LocaleMap.prototype.getRegionAndOrVariantName = function getRegionAndOrVariantName(
+  locid
+) {
+  locid = this.canonicalizeLocaleId(locid);
+  var bund = this.getLocaleInfo(locid);
+  if (bund) {
+    var ret = "";
+    if (bund.name_rgn) {
+      ret = ret + bund.name_rgn;
+    }
+    if (bund.name_var) {
+      ret = ret + " (" + bund.name_var + ")";
+    }
+    if (ret != "") {
+      return ret; // region OR variant OR both
+    }
+    if (bund.name) {
+      return bund.name; // fallback to name
+    }
+  }
+  return locid; // fallbcak to locid
+};
+
+/**
+ * Return the locale language
+ *
+ * @param locid
+ * @returns the language portion
+ */
+LocaleMap.prototype.getLanguage = function getLanguage(locid) {
+  return locid.split("_")[0].split("-")[0];
+};

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrStatus.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrStatus.js
@@ -2,6 +2,8 @@
 
 /**
  * cldrStatus: encapsulate data defining the current status of SurveyTool.
+ * This works with or without dojo; no dependency on dojo.
+ *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
  * Ideally this should be a module (in the sense of using import/export),
@@ -351,6 +353,19 @@ const cldrStatus = (function () {
     return getSurveyUser() === null;
   }
 
+  /**
+   * Is the ST disconnected?
+   */
+  let disconnected = false;
+
+  function isDisconnected() {
+    return disconnected;
+  }
+
+  function setIsDisconnected(d) {
+    disconnected = d;
+  }
+
   /*
    * Make only these functions accessible from other files:
    */
@@ -417,5 +432,8 @@ const cldrStatus = (function () {
     getSurvUrl: getSurvUrl,
 
     isVisitor: isVisitor,
+
+    isDisconnected: isDisconnected,
+    setIsDisconnected: setIsDisconnected,
   };
 })();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrSurvey.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrSurvey.js
@@ -1,0 +1,4356 @@
+"use strict";
+
+/**
+ * cldrSurvey: encapsulate miscellaneous Survey Tool functions
+ * This is for non-dojo use. For dojo, see survey.js
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+
+const cldrSurvey = (function () {
+  const SURVEY_DEBUG = true;
+
+  /*
+   * INHERITANCE_MARKER indicates that the value of a candidate item is inherited.
+   * Compare INHERITANCE_MARKER in CldrUtility.java.
+   */
+  const INHERITANCE_MARKER = "↑↑↑";
+
+  /**
+   * Is the given string for a report, that is, does it start with "r_"?
+   *
+   * @class GLOBAL
+   *
+   * @param str the string
+   * @return true if starts with "r_", else false
+   */
+  function isReport(str) {
+    return str[0] == "r" && str[1] == "_";
+  }
+
+  /**
+   * Remove a CSS class from a node
+   *
+   * @param {Node} obj
+   * @param {String} className
+   */
+  function removeClass(obj, className) {
+    if (!obj) {
+      return obj;
+    }
+    if (obj.className.indexOf(className) > -1) {
+      obj.className = obj.className.substring(className.length + 1);
+    }
+    return obj;
+  }
+
+  /**
+   * Add a CSS class from a node
+   *
+   * @param {Node} obj
+   * @param {String} className
+   */
+  function addClass(obj, className) {
+    if (!obj) {
+      return obj;
+    }
+    if (obj.className.indexOf(className) == -1) {
+      obj.className = className + " " + obj.className;
+    }
+    return obj;
+  }
+
+  /**
+   * Remove all subnodes
+   *
+   * @param {Node} td
+   */
+  function removeAllChildNodes(td) {
+    if (td == null) {
+      return;
+    }
+    while (td.firstChild) {
+      td.removeChild(td.firstChild);
+    }
+  }
+
+  /**
+   * Set/remove style.display
+   */
+  function setDisplayed(div, visible) {
+    if (div === null) {
+      console.log("cldrSurvey.setDisplayed: called on null");
+      return;
+    } else if (div.domNode) {
+      cldrSurvey.setDisplayed(div.domNode, visible); // recurse, it's a dijit
+    } else if (!div.style) {
+      console.log(
+        "cldrSurvey.setDisplayed: called on malformed node " +
+          div +
+          " - no style! " +
+          Object.keys(div)
+      );
+    } else {
+      if (visible) {
+        div.style.display = "";
+      } else {
+        div.style.display = "none";
+      }
+    }
+  }
+
+  var xpathMap = new XpathMap();
+
+  /**
+   * Is the keyboard or input widget 'busy'? i.e., it's a bad time to change the DOM
+   *
+   * @return true if window.getSelection().anchorNode.className contains "dijitInp" or "popover-content",
+   *		 else false
+   *
+   * "popover-content" identifies the little input window, created using bootstrap, that appears when the
+   * user clicks an add ("+") button. Added "popover-content" per https://unicode.org/cldr/trac/ticket/11265.
+   *
+   * TODO: clarify dependence on "dijitInp"; is that still used here, and if so, when?
+   * Add automated regression testing to anticipate future changes to bootstrap/dojo/dijit/etc.
+   *
+   * Called only from CldrSurveyVettingLoader.js
+   */
+  function isInputBusy() {
+    if (!window.getSelection) {
+      return false;
+    }
+    var sel = window.getSelection();
+    if (sel && sel.anchorNode && sel.anchorNode.className) {
+      if (sel.anchorNode.className.indexOf("dijitInp") != -1) {
+        return true;
+      }
+      if (sel.anchorNode.className.indexOf("popover-content") != -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Create a DOM object with the specified text, tag, and HTML class.
+   *
+   * @param {String} text textual content of the new object, or null for none
+   * @param {String} tag which element type to create, or null for "span"
+   * @param {String} className CSS className, or null for none.
+   * @return {Object} new DOM object
+   */
+  function createChunk(text, tag, className) {
+    if (!tag) {
+      tag = "span";
+    }
+    var chunk = document.createElement(tag);
+    if (className) {
+      chunk.className = className;
+    }
+    if (text) {
+      chunk.appendChild(document.createTextNode(text));
+    }
+    return chunk;
+  }
+
+  /**
+   * Uppercase the first letter of a sentence
+   * @return {String} string with first letter uppercase
+   */
+  String.prototype.ucFirst = function () {
+    return this.charAt(0).toUpperCase() + this.slice(1);
+  };
+
+  /**
+   * Create a 'link' that goes to a function. By default it's an 'a', but could be a button, etc.
+   * @param strid  {String} string to be used with cldrText.get
+   * @param fn {function} function, given the DOM obj as param
+   * @param tag {String}  tag of new obj.  'a' by default.
+   * @return {Element} newobj
+   */
+  function createLinkToFn(strid, fn, tag) {
+    if (!tag) {
+      tag = "a";
+    }
+    var msg = cldrText.get(strid);
+    var obj = document.createElement(tag);
+    obj.appendChild(document.createTextNode(msg));
+    if (tag == "a") {
+      obj.href = "";
+    }
+    listenFor(obj, "click", function (e) {
+      fn(obj);
+      stStopPropagation(e);
+      return false;
+    });
+    return obj;
+  }
+
+  function createGravitar(user) {
+    if (user.emailHash) {
+      var gravatar = document.createElement("img");
+      gravatar.src =
+        "https://www.gravatar.com/avatar/" +
+        user.emailHash +
+        "?d=identicon&r=g&s=32";
+      gravatar.title = "gravatar - http://www.gravatar.com";
+      return gravatar;
+    } else {
+      return document.createTextNode("");
+    }
+  }
+
+  /**
+   * Create a DOM object referring to a user.
+   *
+   * @param {JSON} user - user struct
+   * @return {Object} new DOM object
+   */
+  function createUser(user) {
+    var userLevelLc = user.userlevelName.toLowerCase();
+    var userLevelClass = "userlevel_" + userLevelLc;
+    var userLevelStr = cldrText.get(userLevelClass);
+    var div = createChunk(null, "div", "adminUserUser");
+    div.appendChild(createGravitar(user));
+    div.userLevel = createChunk(userLevelStr, "i", userLevelClass);
+    div.appendChild(div.userLevel);
+    div.appendChild(
+      (div.userName = createChunk(user.name, "span", "adminUserName"))
+    );
+    if (!user.orgName) {
+      user.orgName = user.org;
+    }
+    div.appendChild(
+      (div.userOrg = createChunk(
+        user.orgName + " #" + user.id,
+        "span",
+        "adminOrgName"
+      ))
+    );
+    div.appendChild(
+      (div.userEmail = createChunk(user.email, "address", "adminUserAddress"))
+    );
+    return div;
+  }
+
+  /**
+   * Used from within event handlers. cross platform 'stop propagation'
+   *
+   * @param e event
+   * @returns true or false
+   *
+   * Called from numerous js files
+   */
+  function stStopPropagation(e) {
+    if (!e) {
+      return false;
+    } else if (e.stopPropagation) {
+      return e.stopPropagation();
+    } else if (e.cancelBubble) {
+      return e.cancelBubble();
+    } else {
+      // hope for the best
+      return false;
+    }
+  }
+
+  /**
+   * Is debugging enabled?
+   *
+   * @property stdebug_enabled
+   */
+  var stdebug_enabled = window.location.search.indexOf("&stdebug=") > -1;
+
+  function stdebug(x) {
+    if (stdebug_enabled) {
+      console.log(x);
+    }
+  }
+
+  stdebug("stdebug is enabled.");
+
+  /**
+   * Update the item, if it exists
+   *
+   * @param id ID of DOM node, or a Node itself
+   * @param txt text to replace with - should just be plaintext, but currently can be HTML
+   */
+  function updateIf(id, txt) {
+    var something;
+    if (id instanceof Node) {
+      something = id;
+    } else {
+      something = document.getElementById(id);
+    }
+    if (something != null) {
+      something.innerHTML = txt; // TODO shold only use for plain text
+    }
+  }
+
+  /**
+   * Add an event listener function to the object.
+   *
+   * @param {DOM} what object to listen to (or array of them)
+   * @param {String} what event, bare name such as 'click'
+   * @param {Function} fn function, of the form:  function(e) { 	doSomething();  	stStopPropagation(e);  	return false; }
+   * @param {String} ievent IE name of an event, if not 'on'+what
+   * @return {DOM} returns the object what (or the array)
+   */
+  function listenFor(whatArray, event, fn, ievent) {
+    function listenForOne(what, event, fn, ievent) {
+      if (!what._stlisteners) {
+        what._stlisteners = {};
+      }
+
+      if (what.addEventListener) {
+        if (what._stlisteners[event]) {
+          if (what.removeEventListener) {
+            what.removeEventListener(event, what._stlisteners[event], false);
+          } else {
+            console.log("Err: no removeEventListener on " + what);
+          }
+        }
+        what.addEventListener(event, fn, false);
+      } else {
+        if (!ievent) {
+          ievent = "on" + event;
+        }
+        if (what._stlisteners[event]) {
+          what.detachEvent(ievent, what._stlisteners[event]);
+        }
+        what.attachEvent(ievent, fn);
+      }
+      what._stlisteners[event] = fn;
+
+      return what;
+    }
+
+    if (Array.isArray(whatArray)) {
+      for (var k in whatArray) {
+        listenForOne(whatArray[k], event, fn, ievent);
+      }
+      return whatArray;
+    } else {
+      return listenForOne(whatArray, event, fn, ievent);
+    }
+  }
+
+  /**
+   * On click, select all
+   *
+   * @param {Node} obj to listen to
+   * @param {Node} targ to select
+   */
+  function clickToSelect(obj, targ) {
+    if (!targ) {
+      targ = obj;
+    }
+    listenFor(obj, "click", function (e) {
+      if (window.getSelection) {
+        window.getSelection().selectAllChildren(targ);
+      }
+      stStopPropagation(e);
+      return false;
+    });
+    return obj;
+  }
+
+  var wasBusted = false;
+  var wasOk = false;
+  var loadOnOk = null;
+  var clickContinue = null;
+  var surveyNextLocaleStamp = 0;
+  var surveyNextLocaleStampId = "";
+
+  /**
+   * Mark the page as busted. Don't do any more requests.
+   */
+  function busted() {
+    setIsDisconnected(true);
+    stdebug("disconnected.");
+    addClass(document.getElementsByTagName("body")[0], "disconnected");
+  }
+
+  var didUnbust = false;
+
+  function unbust() {
+    didUnbust = true;
+    console.log("Un-busting");
+    progressWord = "unbusted";
+    setIsDisconnected(false);
+    saidDisconnect = false;
+    removeClass(document.getElementsByTagName("body")[0], "disconnected");
+    wasBusted = false;
+    cldrAjax.clearXhr();
+    hideLoader();
+    saidDisconnect = false;
+    updateStatus(); // will restart regular status updates
+  }
+
+  // hashtable of items already verified
+  var alreadyVerifyValue = {};
+
+  var showers = {};
+
+  /**
+   * Process that the locale has changed under us.
+   *
+   * @param {String} stamp timestamp
+   * @param {String} name locale name
+   */
+  function handleChangedLocaleStamp(stamp, name) {
+    if (cldrStatus.isDisconnected()) {
+      return;
+    }
+    if (stamp <= surveyNextLocaleStamp) {
+      return;
+    }
+    /*
+     * For performance, postpone the all-row WHAT_GETROW update if multiple
+     * requests (e.g., vote or single-row WHAT_GETROW requests) are pending.
+     */
+    if (cldrAjax.queueCount() > 1) {
+      return;
+    }
+    if (Object.keys(showers).length == 0) {
+      /*
+       * TODO: explain this code. When, if ever, is it executed, and why?
+       * Typically Object.keys(showers).length != 0.
+       */
+      updateIf("stchanged_loc", name);
+      var locDiv = document.getElementById("stchanged");
+      if (locDiv) {
+        locDiv.style.display = "block";
+      }
+    } else {
+      for (i in showers) {
+        var fn = showers[i];
+        if (fn) {
+          fn();
+        }
+      }
+    }
+    stdebug("Reloaded due to change: " + stamp);
+    surveyNextLocaleStamp = stamp;
+  }
+  var progressWord = null;
+  var ajaxWord = null;
+  var specialHeader = null;
+
+  /**
+   * Update the 'status' if need be.
+   */
+  function showWord() {
+    var p = document.getElementById("progress");
+    var oneword = document.getElementById("progress_oneword");
+    if (oneword == null) {
+      // nowhere to show
+      return;
+    }
+    if (
+      cldrStatus.isDisconnected() ||
+      (progressWord && progressWord == "disconnected") ||
+      (progressWord && progressWord == "error")
+    ) {
+      // top priority
+      popupAlert("danger", cldrStatus.stopIcon() + cldrText.get(progressWord));
+      busted(); // no further processing.
+    } else if (ajaxWord) {
+      p.className = "progress-ok";
+    } else if (!progressWord || progressWord == "ok") {
+      if (specialHeader) {
+        p.className = "progress-special";
+      } else {
+        p.className = "progress-ok";
+      }
+    } else if (progressWord == "startup") {
+      p.className = "progress-ok";
+      popupAlert("warning", cldrText.get("online"));
+    }
+  }
+
+  /**
+   * Update our progress
+   *
+   * @param {String} prog the status to update
+   */
+  function updateProgressWord(prog) {
+    progressWord = prog;
+    showWord();
+  }
+
+  /**
+   * Update ajax loading status
+   *
+   * @param {String} ajax
+   */
+  function updateAjaxWord(ajax) {
+    ajaxWord = ajax;
+    showWord();
+  }
+
+  var saidDisconnect = false;
+
+  /**
+   * @param why
+   * @param json
+   * @param word
+   * @param oneword
+   * @param p
+   */
+  function showARIDialog(why, json, word, oneword, p) {
+    console.log("Can't recover, not in /v or not loaded yet.");
+    // has not been loaded yet.
+  }
+
+  /**
+   * @param why
+   * @param json
+   * @param word
+   * @param oneword
+   * @param p
+   */
+  function ariRetry() {
+    window.location.reload(true);
+  }
+
+  /**
+   * Handle that ST has disconnected
+   *
+   * @param why
+   * @param json
+   * @param word
+   * @param what - what we were doing
+   */
+  function handleDisconnect(why, json, word, what) {
+    if (json && json.err_code === "E_NOT_LOGGED_IN") {
+      window.location = "login.jsp?operationFailed" + window.location.hash;
+      return;
+    }
+    if (!what) {
+      what = "unknown";
+    }
+    if (!word) {
+      word = "error"; // assume it's an error except for a couple of cases.
+    }
+    updateProgressWord(word);
+    if (!saidDisconnect) {
+      saidDisconnect = true;
+      if (json && json.err) {
+        why = why + "\n The error message was: \n" + json.err;
+        if (json.err.fileName) {
+          why = why + "\nFile: " + json.err.fileName;
+          if (json.err.lineNumber) {
+            why = why + "\nLine: " + json.err.lineNumber;
+          }
+        }
+      }
+      console.log("Disconnect: " + why);
+      var oneword = document.getElementById("progress_oneword");
+      if (oneword) {
+        oneword.title = "Disconnected: " + why;
+        oneword.onclick = function () {
+          var p = document.getElementById("progress");
+          var subDiv = document.createElement("div");
+          var chunk0 = document.createElement("i");
+          chunk0.appendChild(
+            document.createTextNode(cldrText.get("error_restart"))
+          );
+          var chunk = document.createElement("textarea");
+          chunk.className = "errorMessage";
+          chunk.appendChild(document.createTextNode(why));
+          chunk.rows = "10";
+          chunk.cols = "40";
+          subDiv.appendChild(chunk0);
+          subDiv.appendChild(chunk);
+          p.appendChild(subDiv);
+          if (oneword.details) {
+            cldrSurvey.setDisplayed(oneword.details, false);
+          }
+          oneword.onclick = null;
+          return false;
+        };
+        var p = document.getElementById("progress");
+        var subDiv = document.createElement("div");
+        var detailsButton = document.createElement("button");
+        detailsButton.type = "button";
+        detailsButton.id = "progress-details";
+        detailsButton.appendChild(
+          document.createTextNode(cldrText.get("details"))
+        );
+        detailsButton.onclick = oneword.onclick;
+        subDiv.appendChild(detailsButton);
+        oneword.details = detailsButton;
+        p.appendChild(subDiv);
+        showARIDialog(why, json, word, oneword, subDiv, what);
+      }
+      if (json) {
+        stdebug("JSON: " + json.toString());
+      }
+    }
+  }
+
+  var updateParts = null;
+
+  var cacheKillStamp = null;
+
+  /**
+   * Return a string to be used with a URL to avoid caching. Ignored by the server.
+   *
+   * @returns {String} the URL fragment, append to the query
+   */
+  function cacheKill() {
+    if (!cacheKillStamp || cacheKillStamp < cldrStatus.getRunningStamp()) {
+      cacheKillStamp = cldrStatus.getRunningStamp();
+    }
+    cacheKillStamp++;
+
+    return "&cacheKill=" + cacheKillStamp;
+  }
+
+  /**
+   * Note that there is special site news.
+   *
+   * @param {String} newSpecialHeader site news
+   */
+  function updateSpecialHeader(newSpecialHeader) {
+    if (newSpecialHeader && newSpecialHeader.length > 0) {
+      specialHeader = newSpecialHeader;
+    } else {
+      specialHeader = null;
+    }
+    showWord();
+  }
+
+  function trySurveyLoad() {
+    try {
+      var url = cldrStatus.getContextPath() + "/survey?" + cacheKill();
+      console.log("Attempting to restart ST at " + url);
+      cldrAjax.sendXhr({
+        url: url,
+      });
+    } catch (e) {}
+  }
+
+  var lastJsonStatus = null;
+
+  /*
+   * TODO: formatErrMsg is called only in CldrSurveyVettingLoader.js, so move it there
+   */
+  function formatErrMsg(json, subkey) {
+    if (!subkey) {
+      subkey = "unknown";
+    }
+    var theCode = "E_UNKNOWN";
+    if (json && json.session_err) {
+      theCode = "E_SESSION_DISCONNECTED";
+    }
+    var msg_str = theCode;
+    if (json && json.err_code) {
+      msg_str = theCode = json.err_code;
+      if (cldrText.get(json.err_code) == json.err_code) {
+        console.log("** Unknown error code: " + json.err_code);
+        msg_str = "E_UNKNOWN";
+      }
+    }
+    if (json === null) {
+      json = {}; // handle cases with no input data
+    }
+    return cldrText.sub(msg_str, {
+      /* Possibilities include: err_what_section, err_what_locmap, err_what_menus,
+			err_what_status, err_what_unknown, err_what_oldvotes, err_what_vote */
+      what: cldrText.get("err_what_" + subkey),
+      code: theCode,
+      message:
+        json.err_data && json.err_data.message ? json.err_data.message : "",
+      surveyCurrentLocale: cldrStatus.getCurrentLocale(),
+    });
+  }
+
+  /**
+   * Based on the last received packet of JSON, update our status and the DOM
+   *
+   * @param {Object} json received
+   */
+  function updateStatusBox(json) {
+    if (json.disconnected) {
+      json.err_code = "E_DISCONNECTED";
+      handleDisconnect("Misc Disconnect", json, "disconnected"); // unknown
+    } else if (json.err_code) {
+      console.log("json.err_code == " + json.err_code);
+      if (json.err_code == "E_NOT_STARTED") {
+        trySurveyLoad();
+      }
+      handleDisconnect(json.err_code, json, "disconnected", "status");
+    } else if (json.SurveyOK == 0) {
+      console.log("json.surveyOK==0");
+      trySurveyLoad();
+      handleDisconnect(
+        "The SurveyTool server is not ready to accept connections, please retry. ",
+        json,
+        "disconnected"
+      ); // ST has restarted
+    } else if (json.status && json.status.isBusted) {
+      handleDisconnect(
+        "The SurveyTool server has halted due to an error: " +
+          json.status.isBusted,
+        json,
+        "disconnected"
+      ); // Server down- not our fault. Hopefully.
+    } else if (!json.status) {
+      handleDisconnect("The SurveyTool server returned a bad status", json);
+    } else if (cldrStatus.runningStampChanged(json.status.surveyRunningStamp)) {
+      handleDisconnect(
+        "The SurveyTool server restarted since this page was loaded. Please retry.",
+        json,
+        "disconnected"
+      ); // desync
+    } else if (
+      json.status &&
+      json.status.isSetup == false &&
+      json.SurveyOK == 1
+    ) {
+      updateProgressWord("startup");
+    } else {
+      updateProgressWord("ok");
+    }
+
+    if (json.status) {
+      lastJsonStatus = json.status;
+      cldrStatus.updateAll(json.status);
+      cldrGui.updateWithStatus();
+      if (!updateParts) {
+        var visitors = document.getElementById("visitors");
+        updateParts = {
+          visitors: visitors,
+          ug: document.createElement("span"),
+          load: document.createElement("span"),
+          db: document.createElement("span"),
+        };
+      }
+      //"~1 users, 8pg/uptime: 38:44/load:28% db:0/1"
+
+      var ugtext = "~";
+      ugtext = ugtext + json.status.users + " users, ";
+      if (json.status.guests > 0) {
+        ugtext = ugtext + json.status.guests + " guests, ";
+      }
+      ugtext = ugtext + json.status.pages + "pg/" + json.status.uptime;
+      removeAllChildNodes(updateParts.ug);
+      updateParts.ug.appendChild(document.createTextNode(ugtext));
+
+      removeAllChildNodes(updateParts.load);
+      updateParts.load.appendChild(
+        document.createTextNode("Load:" + json.status.sysload)
+      );
+
+      removeAllChildNodes(updateParts.db);
+      updateParts.db.appendChild(
+        document.createTextNode(
+          "db:" + json.status.dbopen + "/" + json.status.dbused
+        )
+      );
+
+      var fragment = document.createDocumentFragment();
+      fragment.appendChild(updateParts.ug);
+      fragment.appendChild(document.createTextNode(" "));
+      fragment.appendChild(updateParts.load);
+      fragment.appendChild(document.createTextNode(" "));
+      fragment.appendChild(updateParts.db);
+
+      if (updateParts.visitors) {
+        removeAllChildNodes(updateParts.visitors);
+        updateParts.visitors.appendChild(fragment);
+      }
+
+      function standOutMessage(txt) {
+        return "<b style='font-size: x-large; color: red;'>" + txt + "</b>";
+      }
+
+      if (window.kickMe) {
+        json.millisTillKick = 0;
+      } else if (window.kickMeSoon) {
+        json.millisTillKick = 5000;
+      }
+
+      const surveyUser = cldrStatus.getSurveyUser();
+      if (
+        surveyUser !== null &&
+        json.millisTillKick &&
+        json.millisTillKick >= 0 &&
+        json.millisTillKick < 60 * 1 * 1000
+      ) {
+        // show countdown when 1 minute to go
+        var kmsg =
+          "Your session will end if not active in about " +
+          (parseInt(json.millisTillKick) / 1000).toFixed(0) +
+          " seconds.";
+        console.log(kmsg);
+        updateSpecialHeader(standOutMessage(kmsg));
+      } else if (
+        surveyUser !== null &&
+        (json.millisTillKick === 0 || json.session_err)
+      ) {
+        var kmsg = cldrText.get("ari_sessiondisconnect_message");
+        console.log(kmsg);
+        updateSpecialHeader(standOutMessage(kmsg));
+        cldrStatus.setDisconnected(true);
+        addClass(document.getElementsByTagName("body")[0], "disconnected");
+        if (!json.session_err) {
+          json.session_err = "disconnected";
+        }
+        handleDisconnect(kmsg, json, "Your session has been disconnected.");
+      } else if (
+        json.status.specialHeader &&
+        json.status.specialHeader.length > 0
+      ) {
+        updateSpecialHeader(json.status.specialHeader);
+      } else {
+        updateSpecialHeader(null);
+      }
+    }
+  }
+
+  /**
+   * How often to fetch updates. Default 15s.
+   * Used only for delay in calling updateStatus.
+   * May be changed by resetTimerSpeed -- but resetTimerSpeed is NEVER called
+   * @property timerSpeed
+   */
+  var timerSpeed = 15000; // 15 seconds
+
+  /**
+   * This is called periodically to fetch latest ST status
+   */
+  function updateStatus() {
+    if (cldrStatus.isDisconnected()) {
+      stdebug("Not updating status - disconnected.");
+      return;
+    }
+
+    var surveyLocaleUrl = "";
+    var surveySessionUrl = "";
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale !== null && curLocale != "") {
+      surveyLocaleUrl = "&_=" + curLocale;
+    }
+    const sessionId = cldrStatus.getSessionId();
+    if (sessionId) {
+      surveySessionUrl = "&s=" + sessionId;
+    }
+
+    cldrAjax.sendXhr({
+      url:
+        cldrStatus.getContextPath() +
+        "/SurveyAjax?what=status" +
+        surveyLocaleUrl +
+        surveySessionUrl +
+        cacheKill(),
+      handleAs: "json",
+      load: function (json) {
+        if (json == null || (json.status && json.status.isBusted)) {
+          wasBusted = true;
+          busted();
+          return; // don't thrash
+        }
+        var st_err = document.getElementById("st_err");
+        if (!st_err) {
+          /*
+           * This happens if updateStatus is called for a page like about.jsp, browse.jsp;
+           * it shouldn't be called in such cases.
+           */
+          return;
+        }
+        if (json.err != null && json.err.length > 0) {
+          st_err.innerHTML = json.err;
+          if (
+            json.status &&
+            cldrStatus.runningStampChanged(json.status.surveyRunningStamp)
+          ) {
+            st_err.innerHTML =
+              st_err.innerHTML +
+              " <b>Note: Lost connection with Survey Tool or it restarted.</b>";
+            updateStatusBox({
+              disconnected: true,
+            });
+          }
+          st_err.className = "ferrbox";
+          wasBusted = true;
+          busted();
+        } else {
+          if (cldrStatus.runningStampChanged(json.status.surveyRunningStamp)) {
+            st_err.className = "ferrbox";
+            st_err.innerHTML =
+              "The SurveyTool has been restarted. Please reload this page to continue.";
+            wasBusted = true;
+            busted();
+            // TODO: show ARI for reconnecting
+          } else if (
+            (wasBusted == true && !json.status.isBusted) ||
+            cldrStatus.runningStampChanged(json.status.surveyRunningStamp)
+          ) {
+            st_err.innerHTML =
+              "Note: Lost connection with Survey Tool or it restarted.";
+            if (clickContinue != null) {
+              st_err.innerHTML =
+                st_err.innerHTML +
+                " Please <a href='" +
+                clickContinue +
+                "'>click here</a> to continue.";
+            } else {
+              st_err.innerHTML =
+                st_err.innerHTML + " Please reload this page to continue.";
+            }
+            st_err.className = "ferrbox";
+            busted();
+          } else {
+            st_err.className = "";
+            removeAllChildNodes(st_err);
+          }
+        }
+        updateStatusBox(json);
+
+        if (json.localeStamp) {
+          if (surveyNextLocaleStamp == 0) {
+            surveyNextLocaleStamp = json.localeStamp;
+            stdebug(
+              "STATUS0: " + json.localeStampName + "=" + json.localeStamp
+            );
+          } else {
+            if (json.localeStamp > surveyNextLocaleStamp) {
+              stdebug(
+                "STATUS=: " +
+                  json.localeStampName +
+                  "=" +
+                  json.localeStamp +
+                  " > " +
+                  surveyNextLocaleStamp
+              );
+              handleChangedLocaleStamp(json.localeStamp, json.localeStampName);
+            } else {
+              stdebug(
+                "STATUS=: " +
+                  json.localeStampName +
+                  "=" +
+                  json.localeStamp +
+                  " <= " +
+                  surveyNextLocaleStamp
+              );
+            }
+          }
+        }
+
+        if (wasBusted == false && json.status.isSetup && loadOnOk != null) {
+          window.location.replace(loadOnOk);
+        } else {
+          setTimeout(updateStatus, timerSpeed);
+        }
+      },
+      error: function (err) {
+        wasBusted = true;
+        updateStatusBox({
+          err: err,
+          disconnected: true,
+        });
+      },
+    });
+  }
+
+  /**
+   * Table mapping CheckCLDR.StatusAction into capabilities
+   * @property statusActionTable
+   */
+  var statusActionTable = {
+    ALLOW: {
+      vote: true,
+      ticket: false,
+      change: true,
+    },
+    ALLOW_VOTING_AND_TICKET: {
+      vote: true,
+      ticket: true,
+      change: false,
+    },
+    ALLOW_VOTING_BUT_NO_ADD: {
+      vote: true,
+      ticket: false,
+      change: false,
+    },
+    ALLOW_TICKET_ONLY: {
+      vote: false,
+      ticket: true,
+      change: true,
+    },
+    DEFAULT: {
+      vote: false,
+      ticket: false,
+      change: false,
+    },
+  };
+
+  /**
+   * Parse a CheckCLDR.StatusAction and return the capabilities table
+   *
+   * @param action
+   * @returns {Object} capabilities
+   */
+  function parseStatusAction(action) {
+    if (!action) {
+      return statusActionTable.DEFAULT;
+    }
+    var result = statusActionTable[action];
+    if (!result) {
+      result = statusActionTable.DEFAULT;
+    }
+    return result;
+  }
+
+  /**
+   * Determine whether a JSONified array of CheckCLDR.CheckStatus is overall a warning or an error.
+   *
+   * @param {Object} testResults - array of CheckCLDR.CheckStatus
+   * @returns {String} 'Warning' or 'Error' or null
+   *
+   * Note: when a user votes, the response to the POST request includes json.testResults,
+   * which often (always?) includes a warning "Needed to meet ... coverage level", possibly
+   * in addition to other warnings or errors. We then return Warning, resulting in
+   * div.className = "d-item-warn" and a temporary yellow background for the cell, which, however,
+   * goes back to normal color (with "d-item") after a multiple-row response is received.
+   * The message "Needed to meet ..." may not actually be displayed, in which case the yellow
+   * background is distracting; its purpose should be clarified.
+   */
+  function getTestKind(testResults) {
+    if (!testResults) {
+      return null;
+    }
+    var theKind = null;
+    for (var i = 0; i < testResults.length; i++) {
+      var tr = testResults[i];
+      if (tr.type == "Warning") {
+        theKind = tr.type;
+      } else if (tr.type == "Error") {
+        return tr.type;
+      }
+    }
+    return theKind;
+  }
+
+  /**
+   * Clone the node, removing the id
+   *
+   * @param {Node} i
+   * @returns {Node} new return, deep clone but with no ids
+   */
+  function cloneAnon(i) {
+    if (i == null) {
+      return null;
+    }
+    var o = i.cloneNode(true);
+    if (o.id) {
+      o.removeAttribute("id");
+    }
+    return o;
+  }
+
+  /**
+   * like cloneAnon, but doing string substitution.
+   *
+   * @param o
+   */
+  function localizeAnon(o) {
+    if (o && o.childNodes) {
+      for (var i = 0; i < o.childNodes.length; i++) {
+        var k = o.childNodes[i];
+        // This is related to elements like <th title='$flyovervorg' id='stui-htmlvorg'>
+        if (k.id && k.id.indexOf("stui-html") == 0) {
+          const key = k.id.slice(5); // e.g., 'htmlvorg'
+          const str = cldrText.get(key); // e.g., "Org"
+          if (str) {
+            k.innerHTML = str;
+          }
+          k.removeAttribute("id");
+        } else {
+          localizeAnon(k);
+        }
+      }
+    }
+  }
+
+  /**
+   * Localize the flyover text by replacing $X with ...
+   *
+   * @param {Node} o
+   */
+  function localizeFlyover(o) {
+    if (o && o.childNodes) {
+      for (var i = 0; i < o.childNodes.length; i++) {
+        var k = o.childNodes[i];
+        if (k.title && k.title.indexOf("$") == 0) {
+          const key = k.title.slice(1);
+          const str = cldrText.get(key);
+          if (str) {
+            k.title = str;
+          } else {
+            k.title = null;
+          }
+        } else {
+          localizeFlyover(k);
+        }
+      }
+    }
+  }
+
+  /**
+   * cloneAnon, then call localizeAnon
+   *
+   * @param {Node} i
+   * @returns {Node}
+   */
+  function cloneLocalizeAnon(i) {
+    var o = cloneAnon(i);
+    if (o) {
+      localizeAnon(o);
+    }
+    return o;
+  }
+
+  /**
+   * Return an array of all children of the item which are tags
+   *
+   * @param {Node} tr
+   * @returns {Array}
+   */
+  function getTagChildren(tr) {
+    var rowChildren = [];
+    for (var k in tr.childNodes) {
+      var t = tr.childNodes[k];
+      if (t.tagName) {
+        rowChildren.push(t);
+      }
+    }
+    return rowChildren;
+  }
+
+  /**
+   * Show the 'loading' sign
+   *
+   * @param loaderDiv ignored
+   * @param {String} text text to use
+   */
+  function showLoader(loaderDiv, text) {
+    updateAjaxWord(text);
+  }
+
+  /**
+   * Hide the 'loading' sign
+   *
+   * @param loaderDiv ignored
+   */
+  function hideLoader(loaderDiv) {
+    updateAjaxWord(null);
+  }
+
+  /**
+   * Wire up the button to perform a submit
+   *
+   * @param button
+   * @param tr
+   * @param theRow
+   * @param vHash
+   * @param box
+   */
+  function wireUpButton(button, tr, theRow, vHash, box) {
+    if (box) {
+      button.id = "CHANGE_" + tr.rowHash;
+      vHash = "";
+      box.onchange = function () {
+        handleWiredClick(tr, theRow, vHash, box, button, "submit");
+        return false;
+      };
+      box.onkeypress = function (e) {
+        if (!e || !e.keyCode) {
+          return true; // not getting the point here.
+        } else if (e.keyCode == 13) {
+          handleWiredClick(tr, theRow, vHash, box, button);
+          return false;
+        } else {
+          return true;
+        }
+      };
+    } else if (vHash == null) {
+      button.id = "NO_" + tr.rowHash;
+      vHash = "";
+    } else {
+      button.id = "v" + vHash + "_" + tr.rowHash;
+    }
+    listenFor(button, "click", function (e) {
+      handleWiredClick(tr, theRow, vHash, box, button);
+      stStopPropagation(e);
+      return false;
+    });
+
+    // proposal issues
+    if (tr.myProposal) {
+      if (button == tr.myProposal.button) {
+        button.className = "ichoice-x";
+        button.checked = true;
+        tr.lastOn = button;
+      } else {
+        button.className = "ichoice-o";
+        button.checked = false;
+      }
+    } else if (theRow.voteVhash == vHash && !box) {
+      button.className = "ichoice-x";
+      button.checked = true;
+      tr.lastOn = button;
+    } else {
+      button.className = "ichoice-o";
+      button.checked = false;
+    }
+  }
+
+  /**
+   * Append an icon to the div
+   *
+   * @param {Node} td
+   * @Param {String} className name of icon's CSS class
+   */
+  function addIcon(td, className) {
+    var star = document.createElement("span");
+    star.className = className;
+    star.innerHTML = "&nbsp; &nbsp;";
+    td.appendChild(star);
+    return star;
+  }
+
+  var gPopStatus = {
+    unShow: null,
+    lastShown: null,
+    lastTr: null,
+    popToken: 0,
+  };
+
+  /**
+   * This is the actual function is called to display the right-hand "info" panel.
+   *
+   * @param {String} str the string to show at the top
+   * @param {Node} tr the <TR> of the row
+   * @param {Boolean} hideIfLast
+   * @param {Function} fn
+   * @param {Boolean} immediate
+   */
+  function showInPop(str, tr, theObj, fn, immediate) {
+    showInPop2(str, tr, hideIfLast, fn);
+  }
+
+  /**
+   * Make the object "theObj" cause the infowindow to show when clicked.
+   *
+   * @param {String} str
+   * @param {Node} tr the TR element that is clicked
+   * @param {Node} theObj to listen to
+   * @param {Function} fn the draw function
+   * @returns {Function}
+   */
+  function listenToPop(str, tr, theObj, fn) {
+    var theFn;
+    listenFor(
+      theObj,
+      "click",
+      (theFn = function (e) {
+        showInPop(str, tr, theObj, fn, true);
+        stStopPropagation(e);
+        return false;
+      })
+    );
+    return theFn;
+  }
+
+  function getPopToken() {
+    return gPopStatus.popToken;
+  }
+
+  function incrPopToken(x) {
+    ++gPopStatus.popToken;
+    return gPopStatus.popToken;
+  }
+
+  /**
+   * Timeout for showing sideways view
+   */
+  var sidewaysShowTimeout = -1;
+
+  /**
+   *  Array storing all only-1 sublocale
+   */
+  var oneLocales = [];
+
+  /**
+   * Called when showing the popup each time
+   *
+   * @param {Node} frag
+   * @param {Node} forumDivClone = tr.forumDiv.cloneNode(true)
+   * @param {Node} tr
+   *
+   * TODO: shorten this function
+   */
+  function showForumStuff(frag, forumDivClone, tr) {
+    var isOneLocale = false;
+    if (oneLocales[cldrStatus.getCurrentLocale()]) {
+      isOneLocale = true;
+    }
+    if (!isOneLocale) {
+      var sidewaysControl = createChunk(
+        cldrText.get("sideways_loading0"),
+        "div",
+        "sidewaysArea"
+      );
+      frag.appendChild(sidewaysControl);
+
+      function clearMyTimeout() {
+        if (sidewaysShowTimeout != -1) {
+          window.clearInterval(sidewaysShowTimeout);
+          sidewaysShowTimeout = -1;
+        }
+      }
+      clearMyTimeout();
+      sidewaysShowTimeout = window.setTimeout(function () {
+        clearMyTimeout();
+        updateIf(sidewaysControl, cldrText.get("sideways_loading1"));
+
+        var url =
+          cldrStatus.getContextPath() +
+          "/SurveyAjax?what=getsideways&_=" +
+          cldrStatus.getCurrentLocale() +
+          "&s=" +
+          cldrStatus.getSessionId() +
+          "&xpath=" +
+          tr.theRow.xpstrid +
+          cacheKill();
+        myLoad(url, "sidewaysView", function (json) {
+          /*
+           * Count the number of unique locales in json.others and json.novalue.
+           */
+          var relatedLocales = json.novalue.slice();
+          for (var s in json.others) {
+            for (var t in json.others[s]) {
+              relatedLocales[json.others[s][t]] = true;
+            }
+          }
+          // if there is 1 sublocale (+ 1 default), we do nothing
+          if (Object.keys(relatedLocales).length <= 2) {
+            oneLocales[cldrStatus.getCurrentLocale()] = true;
+            updateIf(sidewaysControl, "");
+          } else {
+            if (!json.others) {
+              updateIf(sidewaysControl, ""); // no sibling locales (or all null?)
+            } else {
+              updateIf(sidewaysControl, ""); // remove string
+
+              var topLocale = json.topLocale;
+              var curLocale = locmap.getRegionAndOrVariantName(topLocale);
+              var readLocale = null;
+
+              // merge the read-only sublocale to base locale
+              var mergeReadBase = function mergeReadBase(list) {
+                var baseValue = null;
+                // find the base locale, remove it and store its value
+                for (var l = 0; l < list.length; l++) {
+                  var loc = list[l][0];
+                  if (loc === topLocale) {
+                    baseValue = list[l][1];
+                    list.splice(l, 1);
+                    break;
+                  }
+                }
+
+                // replace the default locale(read-only) with base locale, store its name for label
+                for (var l = 0; l < list.length; l++) {
+                  var loc = list[l][0];
+                  var bund = locmap.getLocaleInfo(loc);
+                  if (bund && bund.readonly) {
+                    readLocale = locmap.getRegionAndOrVariantName(loc);
+                    list[l][0] = topLocale;
+                    list[l][1] = baseValue;
+                    break;
+                  }
+                }
+              };
+
+              // compare all sublocale values
+              var appendLocaleList = function appendLocaleList(list, curValue) {
+                var group = document.createElement("optGroup");
+                var br = document.createElement("optGroup");
+                group.appendChild(br);
+
+                group.setAttribute(
+                  "label",
+                  "Regional Variants for " + curLocale
+                );
+                group.setAttribute(
+                  "title",
+                  "Regional Variants for " + curLocale
+                );
+
+                var escape = "\u00A0\u00A0\u00A0";
+                var unequalSign = "\u2260\u00A0";
+
+                for (var l = 0; l < list.length; l++) {
+                  var loc = list[l][0];
+                  var title = list[l][1];
+                  var item = document.createElement("option");
+                  item.setAttribute("value", loc);
+                  if (title == null) {
+                    item.setAttribute("title", "undefined");
+                  } else {
+                    item.setAttribute("title", title);
+                  }
+
+                  var str = locmap.getRegionAndOrVariantName(loc);
+                  if (loc === topLocale) {
+                    str = str + " (= " + readLocale + ")";
+                  }
+
+                  if (loc === cldrStatus.getCurrentLocale()) {
+                    str = escape + str;
+                    item.setAttribute("selected", "selected");
+                    item.setAttribute("disabled", "disabled");
+                  } else if (title != curValue) {
+                    str = unequalSign + str;
+                  } else {
+                    str = escape + str;
+                  }
+                  item.appendChild(document.createTextNode(str));
+                  group.appendChild(item);
+                }
+                popupSelect.appendChild(group);
+              };
+
+              var dataList = [];
+
+              var popupSelect = document.createElement("select");
+              for (var s in json.others) {
+                for (var t in json.others[s]) {
+                  dataList.push([json.others[s][t], s]);
+                }
+              }
+
+              /*
+               * Set curValue = the value for cldrStatus.getCurrentLocale()
+               */
+              var curValue = null;
+              for (var l = 0; l < dataList.length; l++) {
+                var loc = dataList[l][0];
+                if (loc === cldrStatus.getCurrentLocale()) {
+                  curValue = dataList[l][1];
+                  break;
+                }
+              }
+              /*
+               * Force the use of unequalSign in the regional comparison pop-up for locales in
+               * json.novalue, by assigning a value that's different from curValue.
+               *
+               * Formerly the inherited value (based on topLocale) was used here; that was a bug.
+               * If the server doesn't know the winning value, then the client shouldn't pretend to know.
+               * The server code has been fixed to resolve most such cases.
+               *
+               * Reference: https://unicode.org/cldr/trac/ticket/11688
+               */
+              if (json.novalue) {
+                const differentValue = curValue === "A" ? "B" : "A"; // anything different from curValue
+                for (s in json.novalue) {
+                  dataList.push([json.novalue[s], differentValue]);
+                }
+              }
+              mergeReadBase(dataList);
+
+              // then sort by sublocale name
+              dataList = dataList.sort(function (a, b) {
+                return (
+                  locmap.getRegionAndOrVariantName(a[0]) >
+                  locmap.getRegionAndOrVariantName(b[0])
+                );
+              });
+              appendLocaleList(dataList, curValue);
+
+              var group = document.createElement("optGroup");
+              popupSelect.appendChild(group);
+
+              listenFor(popupSelect, "change", function (e) {
+                var newLoc = popupSelect.value;
+                if (newLoc !== cldrStatus.getCurrentLocale()) {
+                  cldrStatus.setCurrentLocale(newLoc);
+                  reloadV();
+                }
+                return stStopPropagation(e);
+              });
+
+              sidewaysControl.appendChild(popupSelect);
+            }
+          }
+        });
+      }, 2000); // wait 2 seconds before loading this.
+    }
+
+    if (tr.theRow) {
+      const theRow = tr.theRow;
+      const couldFlag =
+        theRow.canFlagOnLosing &&
+        theRow.voteVhash !== theRow.winningVhash &&
+        theRow.voteVhash !== "" &&
+        !theRow.rowFlagged;
+      const myValue = theRow.hasVoted ? getUsersValue(theRow) : null;
+      cldrForum.addNewPostButtons(
+        frag,
+        cldrStatus.getCurrentLocale(),
+        couldFlag,
+        theRow.xpstrid,
+        theRow.code,
+        myValue
+      );
+    }
+
+    var loader2 = createChunk(cldrText.get("loading"), "i");
+    frag.appendChild(loader2);
+
+    /**
+     * @param {Integer} nrPosts
+     */
+    function havePosts(nrPosts) {
+      cldrSurvey.setDisplayed(loader2, false); // not needed
+      tr.forumDiv.forumPosts = nrPosts;
+
+      if (nrPosts == 0) {
+        return; // nothing to do,
+      }
+
+      var showButton = createChunk(
+        "Show " + tr.forumDiv.forumPosts + " posts",
+        "button",
+        "forumShow"
+      );
+
+      forumDivClone.appendChild(showButton);
+
+      var theListen = function (e) {
+        cldrSurvey.setDisplayed(showButton, false);
+        updateInfoPanelForumPosts(tr);
+        stStopPropagation(e);
+        return false;
+      };
+      listenFor(showButton, "click", theListen);
+      listenFor(showButton, "mouseover", theListen);
+    }
+
+    // lazy load post count!
+    // load async
+    var ourUrl = tr.forumDiv.url + "&what=forum_count" + cacheKill();
+    window.setTimeout(function () {
+      var xhrArgs = {
+        url: ourUrl,
+        handleAs: "json",
+        load: function (json) {
+          if (json && json.forum_count !== undefined) {
+            havePosts(parseInt(json.forum_count));
+          } else {
+            console.log("Some error loading post count??");
+          }
+        },
+      };
+      cldrAjax.queueXhr(xhrArgs);
+    }, 1900);
+
+    function getUsersValue(theRow) {
+      "use strict";
+      const surveyUser = cldrStatus.getSurveyUser();
+      if (surveyUser && surveyUser.id) {
+        if (theRow.voteVhash && theRow.voteVhash !== "") {
+          const item = theRow.items[theRow.voteVhash];
+          if (item && item.votes && item.votes[surveyUser.id]) {
+            if (item.value === INHERITANCE_MARKER) {
+              return theRow.inheritedValue;
+            }
+            return item.value;
+          }
+        }
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Update the forum posts in the Info Panel
+   *
+   * This includes the version of the Info Panel displayed in the Dashboard "Fix" window
+   *
+   * @param tr the table-row element with which the forum posts are associated,
+   *		and whose info is shown in the Info Panel; or null, to get the
+   *		tr from surveyCurrentId
+   */
+  function updateInfoPanelForumPosts(tr) {
+    if (!tr) {
+      if (cldrStatus.getCurrentId() !== "") {
+        /*
+         * TODO: encapsulate this usage of 'r@' somewhere
+         */
+        tr = document.getElementById("r@" + cldrStatus.getCurrentId());
+      } else {
+        /*
+         * This is normal when adding a post in the main forum interface, which has no Info Panel).
+         */
+        return;
+      }
+    }
+    if (!tr || !tr.forumDiv || !tr.forumDiv.url) {
+      /*
+       * This is normal for updateInfoPanelForumPosts(null) called by success handler
+       * for submitPost, from Dashboard, since Fix window is no longer open
+       */
+      return;
+    }
+    let ourUrl = tr.forumDiv.url + "&what=forum_fetch";
+
+    let errorHandler = function (err) {
+      console.log("Error in showForumStuff: " + err);
+      showInPop(
+        cldrStatus.stopIcon() +
+          " Couldn't load forum post for this row- please refresh the page. <br>Error: " +
+          err +
+          "</td>",
+        tr,
+        null
+      );
+      handleDisconnect("Could not showForumStuff:" + err, null);
+    };
+
+    let loadHandler = function (json) {
+      try {
+        if (json && json.ret) {
+          const posts = json.ret;
+          const content = cldrForum.parseContent(posts, "info");
+          /*
+           * Reality check: the json should refer to the same path as tr, which in practice
+           * always matches cldrStatus.getCurrentId(). If not, log a warning and substitute "Please reload"
+           * for the content.
+           */
+          let xpstrid = posts[0].xpath;
+          if (xpstrid !== tr.xpstrid || xpstrid !== cldrStatus.getCurrentId()) {
+            console.log(
+              "Warning: xpath strid mismatch in updateInfoPanelForumPosts loadHandler:"
+            );
+            console.log("posts[0].xpath = " + posts[0].xpath);
+            console.log("tr.xpstrid = " + tr.xpstrid);
+            console.log("surveyCurrentId = " + cldrStatus.getCurrentId());
+
+            content = "Please reload";
+          }
+          /*
+           * Update the element whose class is 'forumDiv'.
+           * Note: When updateInfoPanelForumPosts is called by the mouseover event handler for
+           * the "Show n posts" button set up by havePosts, a clone of tr.forumDiv is created
+           * (for mysterious reasons) by that event handler, and we could pass forumDivClone
+           * as a parameter to updateInfoPanelForumPosts, then do forumDivClone.appendChild(content)
+           * here, which is essentially how it formerly worked. However, that wouldn't work when
+           * we're called by the success handler for submitPost. This works in all cases.
+           */
+          $(".forumDiv").first().html(content);
+        }
+      } catch (e) {
+        console.log("Error in ajax forum read ", e.message);
+        console.log(" response: " + json);
+        showInPop(
+          cldrStatus.stopIcon() + " exception in ajax forum read: " + e.message,
+          tr,
+          null,
+          true
+        );
+      }
+    };
+
+    let xhrArgs = {
+      url: ourUrl,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.queueXhr(xhrArgs);
+  }
+
+  /**
+   * Called when initially setting up the section.
+   *
+   * @param {Node} tr
+   * @param {Node} theRow
+   * @param {Node} forumDiv
+   */
+  function appendForumStuff(tr, theRow, forumDiv) {
+    cldrForum.setUserCanPost(tr.theTable.json.canModify);
+
+    removeAllChildNodes(forumDiv); // we may be updating.
+    var theForum = locmap.getLanguage(cldrStatus.getCurrentLocale());
+    forumDiv.replyStub =
+      cldrStatus.getContextPath() +
+      "/survey?forum=" +
+      theForum +
+      "&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&replyto=";
+    forumDiv.postUrl = forumDiv.replyStub + "x" + theRow;
+    /*
+     * Note: SurveyAjax requires a "what" parameter for SurveyAjax.
+     * It is not supplied here, but may be added later with code such as:
+     *	var ourUrl = tr.forumDiv.url + "&what=forum_count" + cacheKill() ;
+     *	var ourUrl = tr.forumDiv.url + "&what=forum_fetch";
+     * Unfortunately that means "what" is not the first argument, as it would
+     * be ideally for human readability of request urls.
+     */
+    forumDiv.url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?xpath=" +
+      theRow.xpathId +
+      "&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&fhash=" +
+      theRow.rowHash +
+      "&vhash=" +
+      "&s=" +
+      tr.theTable.session +
+      "&voteinfo=t";
+  }
+
+  /**
+   * Change the current id
+   *
+   * @param id the id to set
+   */
+  window.updateCurrentId = function updateCurrentId(id) {
+    if (id == null) {
+      id = "";
+    }
+    if (cldrStatus.getCurrentId() != id) {
+      // don't set if already set.
+      cldrStatus.setCurrentId(id);
+    }
+  };
+
+  // window loader stuff
+  $(function () {
+    var unShow = null;
+    var pucontent = document.getElementById("itemInfo");
+    if (!pucontent) {
+      return;
+    }
+
+    var hideInterval = null;
+
+    function parentOfType(tag, obj) {
+      if (!obj) return null;
+      if (obj.nodeName === tag) return obj;
+      return parentOfType(tag, obj.parentElement);
+    }
+
+    function setLastShown(obj) {
+      if (gPopStatus.lastShown && obj != gPopStatus.lastShown) {
+        removeClass(gPopStatus.lastShown, "pu-select");
+        var partr = parentOfType("TR", gPopStatus.lastShown);
+        if (partr) {
+          removeClass(partr, "selectShow");
+        }
+      }
+      if (obj) {
+        addClass(obj, "pu-select");
+        var partr = parentOfType("TR", obj);
+        if (partr) {
+          addClass(partr, "selectShow");
+        }
+      }
+      gPopStatus.lastShown = obj;
+    }
+
+    function clearLastShown() {
+      setLastShown(null);
+    }
+
+    /**
+     * This is the actual function called to display the right-hand "info" panel.
+     *
+     * @param {String} str the string to show at the top
+     * @param {Node} tr the <TR> of the row
+     * @param {Boolean} hideIfLast
+     * @param {Function} fn
+     * @param {Boolean} immediate
+     * @returns {Node} a reference to the right hand panel, if not in Dashboard mode
+     */
+    function showInPop2(str, tr, hideIfLast, fn, immediate, hide) {
+      if (unShow) {
+        unShow();
+        unShow = null;
+      }
+      incrPopToken("newShow" + str);
+      if (hideInterval) {
+        clearTimeout(hideInterval);
+        hideInterval = null;
+      }
+
+      if (tr && tr.sethash) {
+        window.updateCurrentId(tr.sethash);
+      }
+      setLastShown(hideIfLast);
+
+      /*
+       * This is the temporary fragment used for the
+       * "info panel" contents.
+       */
+      var fragment = document.createDocumentFragment();
+
+      if (tr && tr.theRow) {
+        const { theRow } = tr;
+        const { helpHtml, rdf } = theRow;
+        if (helpHtml || rdf) {
+          cldrDeferHelp.addDeferredHelpTo(fragment, helpHtml, rdf);
+        }
+        // extra attributes
+        if (
+          theRow.extraAttributes &&
+          Object.keys(theRow.extraAttributes).length > 0
+        ) {
+          var extraHeading = createChunk(
+            cldrText.get("extraAttribute_heading"),
+            "h3",
+            "extraAttribute_heading"
+          );
+          var extraContainer = createChunk("", "div", "extraAttributes");
+          appendExtraAttributes(extraContainer, theRow);
+          theHelp.appendChild(extraHeading);
+          theHelp.appendChild(extraContainer);
+        }
+      }
+
+      if (isDashboard()) {
+        fixPopoverVotePos();
+      }
+
+      if (str) {
+        // If a simple string, clone the string
+        var div2 = document.createElement("div");
+        div2.innerHTML = str;
+        fragment.appendChild(div2);
+      }
+      // If a generator fn (common case), call it.
+      if (fn != null) {
+        unShow = fn(fragment);
+      }
+
+      var theVoteinfo = null;
+      if (tr && tr.voteDiv) {
+        theVoteinfo = tr.voteDiv;
+      }
+      if (theVoteinfo) {
+        fragment.appendChild(theVoteinfo.cloneNode(true));
+      }
+      if (tr && tr.ticketLink) {
+        fragment.appendChild(tr.ticketLink.cloneNode(true));
+      }
+
+      // forum stuff
+      if (tr && tr.forumDiv) {
+        /*
+         * The name forumDivClone is a reminder that forumDivClone !== tr.forumDiv.
+         * TODO: explain the reason for using cloneNode here, rather than using
+         * tr.forumDiv directly. Would it work as well to set tr.forumDiv = forumDivClone,
+         * after cloning?
+         */
+        var forumDivClone = tr.forumDiv.cloneNode(true);
+        showForumStuff(fragment, forumDivClone, tr); // give a chance to update anything else
+        fragment.appendChild(forumDivClone);
+      }
+
+      if (tr && tr.theRow && tr.theRow.xpath) {
+        fragment.appendChild(
+          clickToSelect(createChunk(tr.theRow.xpath, "div", "xpath"))
+        );
+      }
+
+      // Now, copy or append the 'fragment' to the
+      // appropriate spot. This depends on how we were called.
+      if (tr) {
+        if (isDashboard()) {
+          showHelpFixPanel(fragment);
+        } else {
+          removeAllChildNodes(pucontent);
+          pucontent.appendChild(fragment);
+        }
+      } else {
+        if (!isDashboard()) {
+          // show, for example, dataPageInitialGuidance in Info Panel
+          var clone = fragment.cloneNode(true);
+          removeAllChildNodes(pucontent);
+          pucontent.appendChild(clone);
+        }
+      }
+      fragment = null;
+
+      // for the voter
+      $(".voteInfo_voterInfo").hover(
+        function () {
+          var email = $(this).data("email").replace(" (at) ", "@");
+          if (email !== "") {
+            $(this).html(
+              '<a href="mailto:' +
+                email +
+                '" title="' +
+                email +
+                '" style="color:black"><span class="glyphicon glyphicon-envelope"></span></a>'
+            );
+            $(this).closest("td").css("text-align", "center");
+            $(this).children("a").tooltip().tooltip("show");
+          } else {
+            $(this).html($(this).data("name"));
+            $(this).closest("td").css("text-align", "left");
+          }
+        },
+        function () {
+          $(this).html($(this).data("name"));
+          $(this).closest("td").css("text-align", "left");
+        }
+      );
+      if (!isDashboard()) {
+        return pucontent;
+      } else {
+        return null;
+      }
+    }
+
+    /***
+    // delay before show
+    window.showInPop = function (str, tr, hideIfLast, fn, immediate) {
+      if (hideInterval) {
+        clearTimeout(hideInterval);
+        hideInterval = null;
+      }
+      if (immediate) {
+        return showInPop2(str, tr, hideIfLast, fn);
+      }
+    };
+    ***/
+
+    window.resetPop = function () {
+      lastShown = null;
+    };
+  });
+
+  /**
+   * Check if we need LRM/RLM marker to display
+   * @param field choice field to append if needed
+   * @param dir direction of current locale (control float direction0
+   * @param value the value of votes (check &lrm; &rlm)
+   */
+  function checkLRmarker(field, dir, value) {
+    if (value) {
+      if (value.indexOf("\u200E") > -1 || value.indexOf("\u200F") > -1) {
+        value = value
+          .replace(/\u200E/g, '<span class="visible-mark">&lt;LRM&gt;</span>')
+          .replace(/\u200F/g, '<span class="visible-mark">&lt;RLM&gt;</span>');
+        var lrm = document.createElement("div");
+        lrm.className = "lrmarker-container";
+        lrm.innerHTML = value;
+        field.appendChild(lrm);
+      }
+    }
+  }
+
+  /**
+   * Append just an editable span representing a candidate voting item
+   *
+   * @param div {DOM} div to append to
+   * @param value {String} string value
+   * @param pClass {String} html class for the voting item
+   * @param tr {DOM} ignored, but the tr the span belongs to
+   * @return {DOM} the new span
+   */
+  function appendItem(div, value, pClass, tr) {
+    if (!value) {
+      return;
+    }
+    var text = document.createTextNode(value);
+    var span = document.createElement("span");
+    span.appendChild(text);
+    if (!value) {
+      span.className = "selected";
+    } else if (pClass) {
+      span.className = pClass;
+    } else {
+      span.className = "value";
+    }
+    div.appendChild(span);
+    return span;
+  }
+
+  function testsToHtml(tests) {
+    var newHtml = "";
+    if (!tests) {
+      return newHtml;
+    }
+    for (var i = 0; i < tests.length; i++) {
+      var testItem = tests[i];
+      newHtml += "<p class='trInfo tr_" + testItem.type;
+      if (testItem.type == "Warning") {
+        newHtml += " alert alert-warning fix-popover-help";
+      } else if (testItem.type == "Error") {
+        newHtml += " alert alert-danger fix-popover-help";
+      }
+      newHtml +=
+        "' title='" +
+        testItem.type +
+        ": " +
+        (testItem.cause || { class: "Unknown" }).class +
+        "." +
+        testItem.subType +
+        "'>";
+      if (testItem.type == "Warning") {
+        newHtml += cldrStatus.warnIcon();
+      } else if (testItem.type == "Error") {
+        newHtml += cldrStatus.stopIcon();
+      }
+      newHtml += testItem.message;
+      // Add a link
+
+      if (testItem.subTypeUrl) {
+        newHtml += ' <a href="' + testItem.subTypeUrl + '">(how to fix…)</a>';
+      }
+
+      newHtml += "</p>";
+    }
+    return newHtml;
+  }
+
+  function setDivClass(div, testKind) {
+    if (!testKind) {
+      div.className = "d-item";
+    } else if (testKind == "Warning") {
+      div.className = "d-item-warn";
+    } else if (testKind == "Error") {
+      div.className = "d-item-err";
+    } else {
+      div.className = "d-item";
+    }
+  }
+
+  function findItemByValue(items, value) {
+    if (!items) {
+      return null;
+    }
+    for (var i in items) {
+      if (value == items[i].value) {
+        return items[i];
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Show an item that's not in the saved data, but has been proposed newly by the user.
+   * Called only by loadHandler in handleWiredClick.
+   * Used for "+" button, both in Dashboard Fix pop-up window and in regular (non-Dashboard) table.
+   */
+  function showProposedItem(inTd, tr, theRow, value, tests, json) {
+    // Find where our value went.
+    var ourItem = findItemByValue(theRow.items, value);
+    var testKind = getTestKind(tests);
+    var ourDiv = null;
+    var wrap;
+    if (!ourItem) {
+      /*
+       * This may happen if, for example, the user types a space (" ") in
+       * the input pop-up window and presses Enter. The value has been rejected
+       * by the server. Then we show an additional pop-up window with the error message
+       * from the server like "Input Processor Error: DAIP returned a 0 length string"
+       */
+      ourDiv = document.createElement("div");
+      var newButton = cloneAnon(document.getElementById("proto-button"));
+      const otherCell = tr.querySelector(".othercell");
+      if (otherCell && tr.myProposal) {
+        otherCell.removeChild(tr.myProposal);
+      }
+      tr.myProposal = ourDiv;
+      tr.myProposal.value = value;
+      tr.myProposal.button = newButton;
+      if (newButton) {
+        newButton.value = value;
+        if (tr.lastOn) {
+          tr.lastOn.checked = false;
+          tr.lastOn.className = "ichoice-o";
+        }
+        wireUpButton(newButton, tr, theRow, "[retry]", {
+          value: value,
+        });
+        wrap = wrapRadio(newButton);
+        ourDiv.appendChild(wrap);
+      }
+      var h3 = document.createElement("span");
+      var span = appendItem(h3, value, "value", tr);
+      setLang(span);
+      ourDiv.appendChild(h3);
+      if (otherCell) {
+        otherCell.appendChild(tr.myProposal);
+      }
+    } else {
+      ourDiv = ourItem.div;
+    }
+    if (json && !parseStatusAction(json.statusAction).vote) {
+      ourDiv.className = "d-item-err";
+
+      const replaceErrors =
+        json.statusAction === "FORBID_PERMANENT_WITHOUT_FORUM";
+      if (replaceErrors) {
+        /*
+         * Special case: for clarity, replace any warnings/errors that may be
+         * in tests[] with a single error message for this situation.
+         */
+        tests = [
+          {
+            type: "Error",
+            message: cldrText.get("StatusAction_" + json.statusAction),
+          },
+        ];
+      }
+
+      var input = $(inTd).closest("tr").find(".input-add");
+      if (input) {
+        input.closest(".form-group").addClass("has-error");
+        input
+          .popover("destroy")
+          .popover({
+            placement: "bottom",
+            html: true,
+            content: testsToHtml(tests),
+            trigger: "hover",
+          })
+          .popover("show");
+        if (tr.myProposal) tr.myProposal.style.display = "none";
+      }
+      if (ourItem || (replaceErrors && value === "") /* Abstain */) {
+        str = cldrText.sub(
+          "StatusAction_msg",
+          [cldrText.get("StatusAction_" + json.statusAction)],
+          "p",
+          ""
+        );
+        var str2 = cldrText.sub(
+          "StatusAction_popupmsg",
+          [cldrText.get("StatusAction_" + json.statusAction), theRow.code],
+          "p",
+          ""
+        );
+        // show in modal popup (ouch!)
+        alert(str2);
+
+        // show this message in a sidebar also
+        showInPop(cldrStatus.stopIcon() + str, tr, null, null, true);
+      }
+      return;
+    } else if (json && json.didNotSubmit) {
+      ourDiv.className = "d-item-err";
+      showInPop(
+        "(ERROR: Unknown error - did not submit this value.)",
+        tr,
+        null,
+        null,
+        true
+      );
+      return;
+    } else {
+      setDivClass(ourDiv, testKind);
+    }
+
+    if (testKind || !ourItem) {
+      var div3 = document.createElement("div");
+      var newHtml = "";
+      newHtml += testsToHtml(tests);
+
+      if (!ourItem) {
+        var h3 = document.createElement("h3");
+        var span = appendItem(h3, value, "value", tr);
+        setLang(span);
+        h3.className = "span";
+        div3.appendChild(h3);
+      }
+      var newDiv = document.createElement("div");
+      div3.appendChild(newDiv);
+      newDiv.innerHTML = newHtml;
+      if (json && !parseStatusAction(json.statusAction).vote) {
+        div3.appendChild(
+          createChunk(
+            cldrText.sub(
+              "StatusAction_msg",
+              [cldrText.get("StatusAction_" + json.statusAction)],
+              "p",
+              ""
+            )
+          )
+        );
+      }
+
+      div3.popParent = tr;
+
+      // will replace any existing function
+      var ourShowFn = function (showDiv) {
+        var retFn;
+        if (ourItem && ourItem.showFn) {
+          retFn = ourItem.showFn(showDiv);
+        } else {
+          retFn = null;
+        }
+        if (tr.myProposal && value == tr.myProposal.value) {
+          // make sure it wasn't submitted twice
+          showDiv.appendChild(div3);
+        }
+        return retFn;
+      };
+      listenToPop(null, tr, ourDiv, ourShowFn);
+      showInPop(null, tr, ourDiv, ourShowFn, true);
+    }
+
+    return false;
+  }
+
+  /**
+   * Return a function that will show info for the given item in the Info Panel.
+   *
+   * @param theRow the data row
+   * @param item the candidate item
+   * @returns the function
+   *
+   * Called only by addVitem.
+   */
+  function showItemInfoFn(theRow, item) {
+    return function (td) {
+      var h3 = document.createElement("div");
+      var displayValue = item.value;
+      if (item.value === INHERITANCE_MARKER) {
+        displayValue = theRow.inheritedValue;
+      }
+
+      var span = appendItem(
+        h3,
+        displayValue,
+        item.pClass
+      ); /* no need to pass in 'tr' - clicking this span would have no effect. */
+      setLang(span);
+      h3.className = "span";
+      td.appendChild(h3);
+
+      if (item.value) {
+        /*
+         * Strings produced here, used as keys for cldrText.sub(), may include:
+         *  "pClass_winner", "pClass_alias", "pClass_fallback", "pClass_fallback_code", "pClass_fallback_root", "pClass_loser".
+         *  See getPClass in DataSection.java.
+         *
+         *  TODO: why not show stars, etc., here?
+         */
+        h3.appendChild(
+          createChunk(
+            cldrText.sub("pClass_" + item.pClass, item),
+            "p",
+            "pClassExplain"
+          )
+        );
+      }
+
+      if (item.value === INHERITANCE_MARKER) {
+        addJumpToOriginal(theRow, h3);
+      }
+
+      var newDiv = document.createElement("div");
+      td.appendChild(newDiv);
+
+      if (item.tests) {
+        newDiv.innerHTML = testsToHtml(item.tests);
+      } else {
+        newDiv.innerHTML = "<i>no tests</i>";
+      }
+
+      if (item.example) {
+        appendExample(td, item.example);
+      }
+    }; // end function(td)
+  }
+
+  /**
+   * Add a link in the Info Panel for "Jump to Original" (cldrText.get('followAlias')),
+   * if theRow.inheritedLocale or theRow.inheritedXpid is defined.
+   *
+   * Normally at least one of theRow.inheritedLocale and theRow.inheritedXpid should be
+   * defined whenever we have an INHERITANCE_MARKER item. Otherwise an error is reported
+   * by checkRowConsistency.
+   *
+   * This is currently (2018-12-01) the only place inheritedLocale or inheritedXpid is used on the client.
+   * An alternative would be for the server to send the link (clickyLink.href), instead of inheritedLocale
+   * and inheritedXpid, to the client, avoiding the need for the client to know so much, including the need
+   * to replace 'code-fallback' with 'root' or when to use cldrStatus.getCurrentLocale() in place of inheritedLocale
+   * or use xpstrid in place of inheritedXpid.
+   *
+   * @param theRow the row
+   * @param el the element to which to append the link
+   */
+  function addJumpToOriginal(theRow, el) {
+    if (theRow.inheritedLocale || theRow.inheritedXpid) {
+      var loc = theRow.inheritedLocale;
+      var xpstrid = theRow.inheritedXpid || theRow.xpstrid;
+      if (!loc) {
+        loc = cldrStatus.getCurrentLocale();
+      } else if (loc === "code-fallback") {
+        /*
+         * Never use 'code-fallback' in the link, use 'root' instead.
+         * On the server, 'code-fallback' sometimes goes by the name XMLSource.CODE_FALLBACK_ID.
+         * Reference: https://unicode.org/cldr/trac/ticket/11622
+         */
+        loc = "root";
+      }
+      if (
+        xpstrid === theRow.xpstrid && // current hash
+        loc === cldrStatus.getCurrentLocale()
+      ) {
+        // current locale
+        // i.e., following the alias would come back to the current item
+        el.appendChild(
+          createChunk(cldrText.get("noFollowAlias"), "span", "followAlias")
+        );
+      } else {
+        var clickyLink = createChunk(
+          cldrText.get("followAlias"),
+          "a",
+          "followAlias"
+        );
+        clickyLink.href = "#/" + loc + "//" + xpstrid;
+        el.appendChild(clickyLink);
+      }
+    }
+  }
+
+  function appendExample(parent, text, loc) {
+    var div = document.createElement("div");
+    div.className = "d-example well well-sm";
+    div.innerHTML = text;
+    setLang(div, loc);
+    parent.appendChild(div);
+    return div;
+  }
+
+  /**
+   * Append a Vetting item ( vote button, etc ) to the row.
+   *
+   * @param {DOM} td cell to append into
+   * @param {DOM} tr which row owns the items
+   * @param {JSON} theRow JSON content of this row's data
+   * @param {JSON} item JSON of the specific item we are adding
+   * @param {DOM} newButton	 button prototype object
+   */
+  function addVitem(td, tr, theRow, item, newButton) {
+    var displayValue = item.value;
+    if (displayValue === INHERITANCE_MARKER) {
+      displayValue = theRow.inheritedValue;
+    }
+    if (!displayValue) {
+      return;
+    }
+    var div = document.createElement("div");
+    var isWinner = td == tr.proposedcell;
+    var testKind = getTestKind(item.tests);
+    setDivClass(div, testKind);
+    item.div = div; // back link
+
+    var choiceField = document.createElement("div");
+    var wrap;
+    choiceField.className = "choice-field";
+    if (newButton) {
+      newButton.value = item.value;
+      wireUpButton(newButton, tr, theRow, item.valueHash);
+      wrap = wrapRadio(newButton);
+      choiceField.appendChild(wrap);
+    }
+    var subSpan = document.createElement("span");
+    subSpan.className = "subSpan";
+    var span = appendItem(subSpan, displayValue, item.pClass, tr);
+    choiceField.appendChild(subSpan);
+
+    setLang(span);
+    checkLRmarker(choiceField, span.dir, item.value);
+
+    if (item.isBaselineValue == true) {
+      appendIcon(choiceField, "i-star", cldrText.get("voteInfo_baseline_desc"));
+    }
+    if (item.votes && !isWinner) {
+      if (
+        item.valueHash == theRow.voteVhash &&
+        theRow.canFlagOnLosing &&
+        !theRow.rowFlagged
+      ) {
+        var newIcon = addIcon(choiceField, "i-stop"); // DEBUG
+      }
+    }
+
+    /*
+     * Note: history is maybe only defined for debugging; won't normally display it in production.
+     * See DataSection.USE_CANDIDATE_HISTORY which currently should be false for production, so
+     * that item.history will be undefined.
+     */
+    if (item.history) {
+      const historyText = " ☛" + item.history;
+      const historyTag = createChunk(historyText, "span", "");
+      choiceField.appendChild(historyTag);
+      listenToPop(historyText, tr, historyTag);
+    }
+
+    const surveyUser = cldrStatus.getSurveyUser();
+    if (
+      newButton &&
+      theRow.voteVhash == item.valueHash &&
+      theRow.items[theRow.voteVhash].votes &&
+      theRow.items[theRow.voteVhash].votes[surveyUser.id] &&
+      theRow.items[theRow.voteVhash].votes[surveyUser.id].overridedVotes
+    ) {
+      var overrideTag = createChunk(
+        theRow.items[theRow.voteVhash].votes[surveyUser.id].overridedVotes,
+        "span",
+        "i-override"
+      );
+      choiceField.appendChild(overrideTag);
+    }
+
+    div.appendChild(choiceField);
+
+    // wire up the onclick function for the Info Panel
+    td.showFn = item.showFn = showItemInfoFn(theRow, item);
+    div.popParent = tr;
+    listenToPop(null, tr, div, td.showFn);
+    td.appendChild(div);
+
+    if (item.example && item.value != item.examples) {
+      appendExample(div, item.example);
+    }
+  }
+
+  function appendExtraAttributes(container, theRow) {
+    for (var attr in theRow.extraAttributes) {
+      var attrval = theRow.extraAttributes[attr];
+      var extraChunk = createChunk(
+        attr + "=" + attrval,
+        "span",
+        "extraAttribute"
+      );
+      container.appendChild(extraChunk);
+    }
+  }
+
+  /**
+   * Get numeric, given string
+   *
+   * @param {String} lev
+   * @return {Number} or 0
+   */
+  function covValue(lev) {
+    lev = lev.toUpperCase();
+    if (window.surveyLevels && window.surveyLevels[lev]) {
+      return parseInt(window.surveyLevels[lev].level);
+    } else {
+      return 0;
+    }
+  }
+
+  function covName(lev) {
+    if (!window.surveyLevels) {
+      return null;
+    }
+    for (var k in window.surveyLevels) {
+      if (parseInt(window.surveyLevels[k].level) == lev) {
+        return k.toLowerCase();
+      }
+    }
+    return null;
+  }
+
+  function effectiveCoverage() {
+    if (!window.surveyOrgCov) {
+      throw new Error("surveyOrgCov not yet initialized");
+    }
+
+    if (surveyUserCov) {
+      return covValue(surveyUserCov);
+    } else {
+      return covValue(surveyOrgCov);
+    }
+  }
+
+  function updateCovFromJson(json) {
+    if (json.covlev_user && json.covlev_user != "default") {
+      window.surveyUserCov = json.covlev_user;
+    } else {
+      window.surveyUserCov = null;
+    }
+
+    if (json.covlev_org) {
+      window.surveyOrgCov = json.covlev_org;
+    } else {
+      window.surveyOrgCov = null;
+    }
+  }
+
+  /**
+   * Update the coverage classes, show and hide things in and out of coverage
+   */
+  function updateCoverage(theDiv) {
+    if (theDiv == null) return;
+    var theTable = theDiv.theTable;
+    if (theTable == null) return;
+    if (!theTable.origClass) {
+      theTable.origClass = theTable.className;
+    }
+    if (window.surveyLevels != null) {
+      var effective = effectiveCoverage();
+      var newStyle = theTable.origClass;
+      for (var k in window.surveyLevels) {
+        var level = window.surveyLevels[k];
+
+        if (effective < parseInt(level.level)) {
+          newStyle = newStyle + " hideCov" + level.level;
+        }
+      }
+      if (newStyle != theTable.className) {
+        theTable.className = newStyle;
+      }
+    }
+  }
+
+  function firstword(str) {
+    return str.split(" ")[0];
+  }
+
+  function appendIcon(toElement, className, title) {
+    var e = createChunk(null, "div", className);
+    e.title = title;
+    toElement.appendChild(e);
+    return e;
+  }
+
+  function hideAfter(whom, when) {
+    if (!when) {
+      when = 10000;
+    }
+    setTimeout(function () {
+      whom.style.opacity = "0.8";
+    }, when / 3);
+    setTimeout(function () {
+      whom.style.opacity = "0.5";
+    }, when / 2);
+    setTimeout(function () {
+      cldrSurvey.setDisplayed(whom, false);
+    }, when);
+    return whom;
+  }
+
+  function appendInputBox(parent, which) {
+    var label = createChunk(cldrText.get(which), "div", which);
+    var input = document.createElement("input");
+    input.stChange = function (onOk, onErr) {};
+    var change = createChunk(
+      cldrText.get("appendInputBoxChange"),
+      "button",
+      "appendInputBoxChange"
+    );
+    var cancel = createChunk(
+      cldrText.get("appendInputBoxCancel"),
+      "button",
+      "appendInputBoxCancel"
+    );
+    var notify = document.createElement("div");
+    notify.className = "appendInputBoxNotify";
+    input.className = "appendInputBox";
+    label.appendChild(change);
+    label.appendChild(cancel);
+    label.appendChild(notify);
+    label.appendChild(input);
+    parent.appendChild(label);
+    input.label = label;
+
+    var doChange = function () {
+      addClass(label, "d-item-selected");
+      removeAllChildNodes(notify);
+      notify.appendChild(createChunk(cldrText.get("loading"), "i"));
+      var onOk = function (msg) {
+        removeClass(label, "d-item-selected");
+        removeAllChildNodes(notify);
+        notify.appendChild(hideAfter(createChunk(msg, "span", "okayText")));
+      };
+      var onErr = function (msg) {
+        removeClass(label, "d-item-selected");
+        removeAllChildNodes(notify);
+        notify.appendChild(createChunk(msg, "span", "stopText"));
+      };
+
+      input.stChange(onOk, onErr);
+    };
+
+    var changeFn = function (e) {
+      doChange();
+      stStopPropagation(e);
+      return false;
+    };
+    var cancelFn = function (e) {
+      input.value = "";
+      doChange();
+      stStopPropagation(e);
+      return false;
+    };
+    var keypressFn = function (e) {
+      if (!e || !e.keyCode) {
+        return true; // not getting the point here.
+      } else if (e.keyCode == 13) {
+        doChange();
+        return false;
+      } else {
+        return true;
+      }
+    };
+    listenFor(change, "click", changeFn);
+    listenFor(cancel, "click", cancelFn);
+    listenFor(input, "keypress", keypressFn);
+    return input;
+  }
+
+  /**
+   * Show the surveyCurrentId row
+   */
+  function scrollToItem() {
+    const curId = cldrStatus.getCurrentId();
+    if (curId != null && curId != "") {
+      // TODO
+      console.log("scrollToItem not implemented yet; curId = " + curId);
+      /****
+      require(["dojo/window"], function (win) {
+        var xtr = document.getElementById("r@" + curId);
+        if (xtr != null) {
+          console.log("Scrolling to " + curId);
+          win.scrollIntoView("r@" + curId);
+        }
+      });
+      ***/
+    }
+  }
+
+  /**
+   * copy of menu data
+   * @property _thePages
+   */
+  var _thePages = null;
+
+  window.locmap = new LocaleMap(null);
+
+  /**
+   * @param loc  optional
+   * @returns locale bundle
+   */
+  function locInfo(loc) {
+    if (!loc) {
+      loc = cldrStatus.getCurrentLocale();
+    }
+    return locmap.getLocaleInfo(loc);
+  }
+
+  var overridedir = null;
+
+  function setLang(node, loc) {
+    var info = locInfo(loc);
+
+    if (overridedir) {
+      node.dir = overridedir;
+    } else if (info && info.dir) {
+      node.dir = info.dir;
+    }
+
+    if (info && info.bcp47) {
+      node.lang = info.bcp47;
+    }
+  }
+
+  /**
+   * Get a table showing old votes available for importing, along with
+   * controls for choosing which votes to import.
+   *
+   * @param voteList the array of old votes
+   * @param type "contested" for losing votes or "uncontested" for winning votes
+   * @param translationHintsLanguage a string indicating the translation hints language, generally "English"
+   * @param dir the direction, such as "ltr" for left-to-right
+   * @returns a new div element containing the table and controls
+   *
+   * Called only by addOldvotesType
+   */
+  function showVoteTable(voteList, type, json) {
+    "use strict";
+
+    let translationHintsLanguage = json.TRANS_HINT_LANGUAGE_NAME;
+    let dir = json.oldvotes.dir;
+    let lastVoteVersion = json.oldvotes.lastVoteVersion;
+
+    var voteTableDiv = document.createElement("div");
+    var t = document.createElement("table");
+    t.id = "oldVotesAcceptList";
+    voteTableDiv.appendChild(t);
+    var th = document.createElement("thead");
+    var tb = document.createElement("tbody");
+    var tr = document.createElement("tr");
+    tr.appendChild(createChunk(cldrText.get("v_oldvotes_path"), "th", "code"));
+    tr.appendChild(createChunk(translationHintsLanguage, "th", "v-comp"));
+    tr.appendChild(
+      createChunk(
+        cldrText.sub("v_oldvotes_winning_msg", {
+          version: lastVoteVersion,
+        }),
+        "th",
+        "v-win"
+      )
+    );
+    tr.appendChild(
+      createChunk(cldrText.get("v_oldvotes_mine"), "th", "v-mine")
+    );
+    tr.appendChild(
+      createChunk(cldrText.get("v_oldvotes_accept"), "th", "v-accept")
+    );
+    th.appendChild(tr);
+    t.appendChild(th);
+    var oldPath = "";
+    var oldSplit = [];
+    var mainCategories = [];
+    for (var k in voteList) {
+      var row = voteList[k];
+      var tr = document.createElement("tr");
+      var tdp;
+      var rowTitle = "";
+
+      // delete common substring
+      var pathSplit = row.pathHeader.split("	");
+      for (var nn in pathSplit) {
+        if (pathSplit[nn] != oldSplit[nn]) {
+          break;
+        }
+      }
+      if (nn != pathSplit.length - 1) {
+        // need a header row.
+        var trh = document.createElement("tr");
+        trh.className = "subheading";
+        var tdh = document.createElement("th");
+        tdh.colSpan = 5;
+        for (var nn in pathSplit) {
+          if (nn < pathSplit.length - 1) {
+            tdh.appendChild(createChunk(pathSplit[nn], "span", "pathChunk"));
+          }
+        }
+        trh.appendChild(tdh);
+        tb.appendChild(trh);
+      }
+      if (mainCategories.indexOf(pathSplit[0]) === -1) {
+        mainCategories.push(pathSplit[0]);
+      }
+      oldSplit = pathSplit;
+      rowTitle = pathSplit[pathSplit.length - 1];
+
+      tdp = createChunk("", "td", "v-path");
+
+      var dtpl = createChunk(rowTitle, "a");
+      dtpl.href = "v#/" + cldrStatus.getCurrentLocale() + "//" + row.strid;
+      dtpl.target = "_CLDR_ST_view";
+      tdp.appendChild(dtpl);
+
+      tr.appendChild(tdp);
+      var td00 = createChunk(row.baseValue, "td", "v-comp"); // english
+      tr.appendChild(td00);
+      var td0 = createChunk("", "td", "v-win");
+      if (row.winValue) {
+        var span0 = appendItem(td0, row.winValue, "winner");
+        span0.dir = dir;
+      }
+      tr.appendChild(td0);
+      var td1 = createChunk("", "td", "v-mine");
+      var label = createChunk("", "label", "");
+      var span1 = appendItem(label, row.myValue, "value");
+      td1.appendChild(label);
+      span1.dir = dir;
+      tr.appendChild(td1);
+      var td2 = createChunk("", "td", "v-accept");
+      var box = createChunk("", "input", "");
+      box.type = "checkbox";
+      if (type == "uncontested") {
+        // uncontested true by default
+        box.checked = true;
+      }
+      row.box = box; // backlink
+      td2.appendChild(box);
+      tr.appendChild(td2);
+
+      (function (tr, box, tdp) {
+        return function () {
+          // allow click anywhere
+          listenFor(tr, "click", function (e) {
+            box.checked = !box.checked;
+            stStopPropagation(e);
+            return false;
+          });
+          // .. but not on the path.  Also listen to the box and do nothing
+          listenFor([tdp, box], "click", function (e) {
+            stStopPropagation(e);
+            return false;
+          });
+        };
+      })(tr, box, tdp)();
+
+      tb.appendChild(tr);
+    }
+    t.appendChild(tb);
+    addImportVotesFooter(voteTableDiv, voteList, mainCategories);
+    return voteTableDiv;
+  }
+
+  /**
+   * Add to the given div a footer with buttons for choosing all or none
+   * of the old votes, and with checkboxes for choosing all or none within
+   * each of two or more main categories such as "Locale Display Names".
+   *
+   * @param voteTableDiv the div to add to
+   * @param voteList the list of old votes
+   * @param mainCategories the list of main categories
+   *
+   * Called only by showVoteTable
+   *
+   * Reference: https://unicode.org/cldr/trac/ticket/11517
+   */
+  function addImportVotesFooter(voteTableDiv, voteList, mainCategories) {
+    "use strict";
+    voteTableDiv.appendChild(
+      createLinkToFn(
+        "v_oldvotes_all",
+        function () {
+          for (var k in voteList) {
+            voteList[k].box.checked = true;
+          }
+          for (var cat in mainCategories) {
+            $("#cat" + cat).prop("checked", true);
+          }
+        },
+        "button"
+      )
+    );
+
+    voteTableDiv.appendChild(
+      createLinkToFn(
+        "v_oldvotes_none",
+        function () {
+          for (var k in voteList) {
+            voteList[k].box.checked = false;
+          }
+          for (var cat in mainCategories) {
+            $("#cat" + cat).prop("checked", false);
+          }
+        },
+        "button"
+      )
+    );
+
+    if (mainCategories.length > 1) {
+      voteTableDiv.appendChild(
+        document.createTextNode(cldrText.get("v_oldvotes_all_section"))
+      );
+      for (var cat in mainCategories) {
+        let mainCat = mainCategories[cat];
+        var checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.id = "cat" + cat;
+        voteTableDiv.appendChild(checkbox);
+        voteTableDiv.appendChild(document.createTextNode(mainCat + " "));
+        listenFor(checkbox, "click", function (e) {
+          for (var k in voteList) {
+            var row = voteList[k];
+            if (row.pathHeader.startsWith(mainCat)) {
+              row.box.checked = this.checked;
+            }
+          }
+          stStopPropagation(e);
+          return false;
+        });
+      }
+    }
+  }
+
+  /**
+   * Reload a specific row
+   *
+   * Called by loadHandler in handleWiredClick
+   */
+  function refreshSingleRow(tr, theRow, onSuccess, onFailure) {
+    showLoader(tr.theTable.theDiv.loader, cldrText.get("loadingOneRow"));
+
+    var ourUrl =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=getrow" +
+      "&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&xpath=" +
+      theRow.xpathId +
+      "&fhash=" +
+      tr.rowHash +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      "&automatic=t";
+
+    if (isDashboard()) {
+      ourUrl += "&dashboard=true";
+    }
+
+    var loadHandler = function (json) {
+      try {
+        if (json.section.rows[tr.rowHash]) {
+          theRow = json.section.rows[tr.rowHash];
+          tr.theTable.json.section.rows[tr.rowHash] = theRow;
+          cldrTable.updateRow(tr, theRow);
+
+          hideLoader(tr.theTable.theDiv.loader);
+          onSuccess(theRow);
+          if (isDashboard()) {
+            refreshFixPanel(json);
+          } else {
+            window.showInPop(
+              "",
+              tr,
+              tr.proposedcell,
+              tr.proposedcell.showFn,
+              true /* immediate */
+            );
+            refreshCounterVetting();
+          }
+        } else {
+          tr.className = "ferrbox";
+          console.log("could not find " + tr.rowHash + " in " + json);
+          onFailure(
+            "refreshSingleRow: Could not refresh this single row: Server failed to return xpath #" +
+              theRow.xpathId +
+              " for locale " +
+              cldrStatus.getCurrentLocale()
+          );
+        }
+      } catch (e) {
+        console.log("Error in ajax post [refreshSingleRow] ", e.message);
+      }
+    };
+    var errorHandler = function (err) {
+      console.log("Error: " + err);
+      tr.className = "ferrbox";
+      tr.innerHTML =
+        "Error while  loading: <div style='border: 1px solid red;'>" +
+        err +
+        "</div>";
+      onFailure("err", err);
+    };
+    var xhrArgs = {
+      url: ourUrl + cacheKill(),
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.queueXhr(xhrArgs);
+  }
+
+  /**
+   * Bottleneck for voting buttons
+   */
+  function handleWiredClick(tr, theRow, vHash, box, button, what) {
+    var value = "";
+    var valToShow;
+    if (tr.wait) {
+      return;
+    }
+    if (box) {
+      valToShow = box.value;
+      value = box.value;
+      if (value.length == 0) {
+        if (box.focus) {
+          box.focus();
+          myUnDefer();
+        }
+        return; // nothing entered.
+      }
+    } else {
+      valToShow = button.value;
+    }
+    if (!what) {
+      what = "submit";
+    }
+    if (what == "submit") {
+      button.className = "ichoice-x-ok"; // TODO: ichoice-inprogress? spinner?
+      showLoader(tr.theTable.theDiv.loader, cldrText.get("voting"));
+    } else {
+      showLoader(tr.theTable.theDiv.loader, cldrText.get("checking"));
+    }
+
+    // select
+    updateCurrentId(theRow.xpstrid);
+
+    // and scroll
+    showCurrentId();
+
+    if (tr.myProposal) {
+      const otherCell = tr.querySelector(".othercell");
+      if (otherCell) {
+        otherCell.removeChild(tr.myProposal);
+      }
+      tr.myProposal = null; // mark any pending proposal as invalid.
+    }
+
+    var myUnDefer = function () {
+      tr.wait = false;
+    };
+    tr.wait = true;
+    resetPop(tr);
+    theRow.proposedResults = null;
+
+    console.log(
+      "Vote for " + tr.rowHash + " v='" + vHash + "', value='" + value + "'"
+    );
+    var ourContent = {
+      what: what,
+      xpath: tr.xpathId,
+      _: cldrStatus.getCurrentLocale(),
+      fhash: tr.rowHash,
+      vhash: vHash,
+      s: tr.theTable.session,
+    };
+
+    var ourUrl = cldrStatus.getContextPath() + "/SurveyAjax";
+
+    var voteLevelChanged = document.getElementById("voteLevelChanged");
+    if (voteLevelChanged) {
+      ourContent.voteLevelChanged = voteLevelChanged.value;
+    }
+
+    var originalTrClassName = tr.className;
+    tr.className = "tr_checking1";
+
+    var loadHandler = function (json) {
+      /*
+       * Restore tr.className, so it stops being 'tr_checking1' immediately on receiving
+       * any response. It may change again below, such as to 'tr_err' or 'tr_checking2'.
+       */
+      tr.className = originalTrClassName;
+      try {
+        if (json.err && json.err.length > 0) {
+          tr.className = "tr_err";
+          handleDisconnect("Error submitting a vote", json);
+          tr.innerHTML =
+            "<td colspan='4'>" +
+            cldrStatus.stopIcon() +
+            " Could not check value. Try reloading the page.<br>" +
+            json.err +
+            "</td>";
+          myUnDefer();
+          handleDisconnect("Error submitting a vote", json);
+        } else {
+          if (json.submitResultRaw) {
+            // if submitted..
+            tr.className = "tr_checking2";
+            refreshSingleRow(
+              tr,
+              theRow,
+              function (theRow) {
+                // submit went through. Now show the pop.
+                button.className = "ichoice-o";
+                button.checked = false;
+                hideLoader(tr.theTable.theDiv.loader);
+                if (
+                  json.testResults &&
+                  (json.testWarnings || json.testErrors)
+                ) {
+                  // tried to submit, have errs or warnings.
+                  showProposedItem(
+                    tr.inputTd,
+                    tr,
+                    theRow,
+                    valToShow,
+                    json.testResults
+                  );
+                }
+                if (box) {
+                  box.value = ""; // submitted - dont show.
+                }
+                myUnDefer();
+              },
+              function (err) {
+                myUnDefer();
+                handleDisconnect(err, json);
+              }
+            ); // end refresh-loaded-fcn
+            // end: async
+          } else {
+            // Did not submit. Show errors, etc
+            if (
+              (json.statusAction && json.statusAction != "ALLOW") ||
+              (json.testResults && (json.testWarnings || json.testErrors))
+            ) {
+              showProposedItem(
+                tr.inputTd,
+                tr,
+                theRow,
+                valToShow,
+                json.testResults,
+                json
+              );
+            } // else no errors, not submitted.  Nothing to do.
+            if (box) {
+              box.value = ""; // submitted - dont show.
+            }
+            button.className = "ichoice-o";
+            button.checked = false;
+            hideLoader(tr.theTable.theDiv.loader);
+            myUnDefer();
+          }
+        }
+      } catch (e) {
+        tr.className = "tr_err";
+        tr.innerHTML =
+          cldrStatus.stopIcon() +
+          " Could not check value. Try reloading the page.<br>" +
+          e.message;
+        console.log("Error in ajax post [handleWiredClick] ", e.message);
+        myUnDefer();
+        handleDisconnect("handleWiredClick:" + e.message, json);
+      }
+    };
+    var errorHandler = function (err) {
+      /*
+       * Restore tr.className, so it stops being 'tr_checking1' immediately on receiving
+       * any response. It may change again below, such as to 'tr_err'.
+       */
+      tr.className = originalTrClassName;
+      console.log("Error: " + err);
+      handleDisconnect("Error: " + err, null);
+      theRow.className = "ferrbox";
+      theRow.innerHTML =
+        "Error while  loading: <div style='border: 1px solid red;'>" +
+        err +
+        "</div>";
+      myUnDefer();
+    };
+    if (box) {
+      stdebug("this is a post: " + value);
+      ourContent.value = value;
+    }
+    var xhrArgs = {
+      url: ourUrl,
+      handleAs: "json",
+      content: ourContent,
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.queueXhr(xhrArgs);
+  }
+
+  /**
+   * Load the Admin Panel
+   *
+   * TODO move admin panel code to separate module
+   */
+  function loadAdminPanel() {
+    if (!vap) {
+      return;
+    }
+    var adminStuff = document.getElementById("adminStuff");
+    if (!adminStuff) {
+      return;
+    }
+    {
+      var content = document.createDocumentFragment();
+
+      var list = document.createElement("ul");
+      list.className = "adminList";
+      content.appendChild(list);
+
+      function loadOrFail(urlAppend, theDiv, loadHandler, postData) {
+        var ourUrl =
+          cldrStatus.getContextPath() +
+          "/AdminAjax.jsp?vap=" +
+          vap +
+          "&" +
+          urlAppend;
+        var errorHandler = function (err) {
+          console.log("adminload " + urlAppend + " Error: " + err);
+          theDiv.className = "ferrbox";
+          theDiv.innerHTML =
+            "Error while loading: <div style='border: 1px solid red;'>" +
+            err +
+            "</div>";
+        };
+        var xhrArgs = {
+          url: ourUrl + cacheKill(),
+          handleAs: "json",
+          load: loadHandler,
+          error: errorHandler,
+          postData: postData,
+        };
+        if (!loadHandler) {
+          xhrArgs.handleAs = "text";
+          xhrArgs.load = function (text) {
+            theDiv.innerHTML = text;
+          };
+        }
+        if (xhrArgs.postData) {
+          /*
+           * Make a POST request
+           */
+          console.log("admin post: ourUrl: " + ourUrl + " data:" + postData);
+          xhrArgs.headers = {
+            "Content-Type": "text/plain",
+          };
+        } else {
+          /*
+           * Make a GET request
+           */
+          console.log("admin get: ourUrl: " + ourUrl);
+        }
+        cldrAjax.sendXhr(xhrArgs);
+      }
+      var panelLast = null;
+      var panels = {};
+      var panelFirst = null;
+
+      function panelSwitch(name) {
+        if (panelLast) {
+          panelLast.div.style.display = "none";
+          panelLast.listItem.className = "notselected";
+          panelLast = null;
+        }
+        if (name && panels[name]) {
+          panelLast = panels[name];
+          panelLast.listItem.className = "selected";
+          panelLast.fn(panelLast.udiv);
+          panelLast.div.style.display = "block";
+          window.location.hash = "#!" + name;
+        }
+      }
+
+      function addAdminPanel(type, fn) {
+        var panel = (panels[type] = {
+          type: type,
+          name: cldrText.get(type) || type,
+          desc:
+            cldrText.get(type + "_desc") ||
+            "(no description - missing from cldrText)",
+          fn: fn,
+        });
+        panel.div = document.createElement("div");
+        panel.div.style.display = "none";
+        panel.div.className = "adminPanel";
+
+        var h = document.createElement("h3");
+        h.className = "adminTitle";
+        h.appendChild(document.createTextNode(panel.desc || type));
+        panel.div.appendChild(h);
+
+        panel.udiv = document.createElement("div");
+        panel.div.appendChild(panel.udiv);
+
+        panel.listItem = document.createElement("li");
+        panel.listItem.appendChild(document.createTextNode(panel.name || type));
+        panel.listItem.title = panel.desc || type;
+        panel.listItem.className = "notselected";
+        panel.listItem.onclick = function (e) {
+          panelSwitch(panel.type);
+          return false;
+        };
+        list.appendChild(panel.listItem);
+
+        content.appendChild(panel.div);
+
+        if (!panelFirst) {
+          panelFirst = panel;
+        }
+      }
+
+      addAdminPanel("admin_users", function (div) {
+        var frag = document.createDocumentFragment();
+
+        var u = document.createElement("div");
+        u.appendChild(document.createTextNode("Loading..."));
+        frag.appendChild(u);
+
+        removeAllChildNodes(div);
+        div.appendChild(frag);
+        loadOrFail("do=users", u, function (json) {
+          var frag2 = document.createDocumentFragment();
+
+          if (!json || !json.users || Object.keys(json.users) == 0) {
+            frag2.appendChild(
+              document.createTextNode(cldrText.get("No users."))
+            );
+          } else {
+            for (sess in json.users) {
+              var cs = json.users[sess];
+              var user = createChunk(null, "div", "adminUser");
+              user.appendChild(
+                createChunk("Session: " + sess, "span", "adminUserSession")
+              );
+              if (cs.user) {
+                user.appendChild(createUser(cs.user));
+              } else {
+                user.appendChild(
+                  createChunk("(anonymous)", "div", "adminUserUser")
+                );
+              }
+              /*
+               * cs.lastBrowserCallMillisSinceEpoch = time elapsed in millis since server heard from client
+               * cs.lastActionMillisSinceEpoch = time elapsed in millis since user did active action
+               * cs.millisTillKick = how many millis before user will be kicked if inactive
+               */
+              user.appendChild(
+                createChunk(
+                  "LastCall: " +
+                    cs.lastBrowserCallMillisSinceEpoch +
+                    ", LastAction: " +
+                    cs.lastActionMillisSinceEpoch +
+                    ", IP: " +
+                    cs.ip +
+                    ", ttk:" +
+                    (parseInt(cs.millisTillKick) / 1000).toFixed(1) +
+                    "s",
+                  "span",
+                  "adminUserInfo"
+                )
+              );
+
+              var unlinkButton = createChunk(
+                cldrText.get("admin_users_action_kick"),
+                "button",
+                "admin_users_action_kick"
+              );
+              user.appendChild(unlinkButton);
+              unlinkButton.onclick = function (e) {
+                unlinkButton.className = "deactivated";
+                unlinkButton.onclick = null;
+                loadOrFail(
+                  "do=unlink&s=" + cs.id,
+                  unlinkButton,
+                  function (json) {
+                    removeAllChildNodes(unlinkButton);
+                    if (json.removing == null) {
+                      unlinkButton.appendChild(
+                        document.createTextNode("Already Removed")
+                      );
+                    } else {
+                      unlinkButton.appendChild(
+                        document.createTextNode("Removed.")
+                      );
+                    }
+                  }
+                );
+                return stStopPropagation(e);
+              };
+              frag2.appendChild(user);
+              frag2.appendChild(document.createElement("hr"));
+            }
+          }
+          removeAllChildNodes(u);
+          u.appendChild(frag2);
+        });
+      });
+
+      addAdminPanel("admin_threads", function (div) {
+        var frag = document.createDocumentFragment();
+
+        div.className = "adminThreads";
+        var u = createChunk("Loading...", "div", "adminThreadList");
+        var stack = createChunk(null, "div", "adminThreadStack");
+        frag.appendChild(u);
+        frag.appendChild(stack);
+        var c2s = createChunk(
+          cldrText.get("clickToSelect"),
+          "button",
+          "clickToSelect"
+        );
+        clickToSelect(c2s, stack);
+
+        removeAllChildNodes(div);
+        div.appendChild(c2s);
+        var clicked = null;
+
+        div.appendChild(frag);
+        loadOrFail("do=threads", u, function (json) {
+          if (!json || !json.threads || Object.keys(json.threads.all) == 0) {
+            removeAllChildNodes(u);
+            u.appendChild(document.createTextNode(cldrText.get("No threads.")));
+          } else {
+            var frag2 = document.createDocumentFragment();
+            removeAllChildNodes(stack);
+            stack.innerHTML = cldrText.get("adminClickToViewThreads");
+            deadThreads = {};
+            if (json.threads.dead) {
+              var header = createChunk(
+                cldrText.get("adminDeadThreadsHeader"),
+                "div",
+                "adminDeadThreadsHeader"
+              );
+              var deadul = createChunk("", "ul", "adminDeadThreads");
+              for (var jj = 0; jj < json.threads.dead.length; jj++) {
+                var theThread = json.threads.dead[jj];
+                var deadLi = createChunk("#" + theThread.id, "li");
+                //deadLi.appendChild(createChunk(theThread.text,"pre"));
+                deadThreads[theThread.id] = theThread.text;
+                deadul.appendChild(deadLi);
+              }
+              header.appendChild(deadul);
+              stack.appendChild(header);
+            }
+            for (id in json.threads.all) {
+              var t = json.threads.all[id];
+              var thread = createChunk(null, "div", "adminThread");
+              var tid;
+              thread.appendChild(
+                (tid = createChunk(id, "span", "adminThreadId"))
+              );
+              if (deadThreads[id]) {
+                tid.className = tid.className + " deadThread";
+              }
+              thread.appendChild(
+                createChunk(t.name, "span", "adminThreadName")
+              );
+              thread.appendChild(
+                createChunk(
+                  cldrText.get(t.state),
+                  "span",
+                  "adminThreadState_" + t.state
+                )
+              );
+              thread.onclick = (function (t, id) {
+                return function () {
+                  stack.innerHTML = "<b>" + id + ":" + t.name + "</b>\n";
+                  if (deadThreads[id]) {
+                    stack.appendChild(
+                      createChunk(deadThreads[id], "pre", "deadThreadInfo")
+                    );
+                  }
+                  stack.appendChild(
+                    createChunk("\n\n```\n", "pre", "textForTrac")
+                  );
+                  for (var q in t.stack) {
+                    stack.innerHTML = stack.innerHTML + t.stack[q] + "\n";
+                  }
+                  stack.appendChild(
+                    createChunk("```\n\n", "pre", "textForTrac")
+                  );
+                };
+              })(t, id);
+              frag2.appendChild(thread);
+            }
+
+            removeAllChildNodes(u);
+            u.appendChild(frag2);
+          }
+        });
+      });
+
+      addAdminPanel("admin_exceptions", function (div) {
+        var frag = document.createDocumentFragment();
+
+        div.className = "adminThreads";
+        var v = createChunk(null, "div", "adminExceptionList");
+        var stack = createChunk(null, "div", "adminThreadStack");
+        frag.appendChild(v);
+        var u = createChunk(null, "div");
+        v.appendChild(u);
+        frag.appendChild(stack);
+
+        var c2s = createChunk(
+          cldrText.get("clickToSelect"),
+          "button",
+          "clickToSelect"
+        );
+        clickToSelect(c2s, stack);
+
+        removeAllChildNodes(div);
+        div.appendChild(c2s);
+        var clicked = null;
+
+        var last = -1;
+
+        var exceptions = [];
+
+        var exceptionNames = {};
+
+        div.appendChild(frag);
+        var more = createChunk(
+          cldrText.get("more_exceptions"),
+          "p",
+          "adminExceptionMore adminExceptionFooter"
+        );
+        var loading = createChunk(
+          cldrText.get("loading"),
+          "p",
+          "adminExceptionFooter"
+        );
+
+        v.appendChild(loading);
+        var loadNext = function (from) {
+          var append = "do=exceptions";
+          if (from) {
+            append = append + "&before=" + from;
+          }
+          console.log("Loading: " + append);
+          loadOrFail(append, u, function (json) {
+            if (!json || !json.exceptions || !json.exceptions.entry) {
+              if (!from) {
+                v.appendChild(
+                  createChunk(
+                    cldrText.get("no_exceptions"),
+                    "p",
+                    "adminExceptionFooter"
+                  )
+                );
+              } else {
+                v.removeChild(loading);
+                v.appendChild(
+                  createChunk(
+                    cldrText.get("last_exception"),
+                    "p",
+                    "adminExceptionFooter"
+                  )
+                );
+                // just the last one.
+              }
+            } else {
+              if (json.exceptions.entry.time == from) {
+                console.log("Asked for <" + from + " but got =" + from);
+                v.removeChild(loading);
+                return; //
+              }
+              var frag2 = document.createDocumentFragment();
+              if (!from) {
+                removeAllChildNodes(stack);
+                stack.innerHTML = cldrText.get("adminClickToViewExceptions");
+              }
+              // TODO: if(json.threads.dead) frag2.appendChunk(json.threads.dead.toString(),"span","adminDeadThreads");
+              last = json.exceptions.lastTime;
+              if (json.exceptions.entry) {
+                var e = json.exceptions.entry;
+                exceptions.push(json.exceptions.entry);
+                var exception = createChunk(null, "div", "adminException");
+                if (e.header && e.header.length < 80) {
+                  exception.appendChild(
+                    createChunk(e.header, "span", "adminExceptionHeader")
+                  );
+                } else {
+                  var t;
+                  exception.appendChild(
+                    (t = createChunk(
+                      e.header.substring(0, 80) + "...",
+                      "span",
+                      "adminExceptionHeader"
+                    ))
+                  );
+                  t.title = e.header;
+                }
+                exception.appendChild(
+                  createChunk(e.DATE, "span", "adminExceptionDate")
+                );
+                var clicky = (function (e) {
+                  return function (ee) {
+                    var frag3 = document.createDocumentFragment();
+                    frag3.appendChild(
+                      createChunk(e.header, "span", "adminExceptionHeader")
+                    );
+                    frag3.appendChild(
+                      createChunk(e.DATE, "span", "adminExceptionDate")
+                    );
+
+                    if (e.UPTIME) {
+                      frag3.appendChild(
+                        createChunk(e.UPTIME, "span", "adminExceptionUptime")
+                      );
+                    }
+                    if (e.CTX) {
+                      frag3.appendChild(
+                        createChunk(e.CTX, "span", "adminExceptionUptime")
+                      );
+                    }
+                    for (var q in e.fields) {
+                      var f = e.fields[q];
+                      var k = Object.keys(f);
+                      frag3.appendChild(createChunk(k[0], "h4", "textForTrac"));
+                      frag3.appendChild(
+                        createChunk("\n```", "pre", "textForTrac")
+                      );
+                      frag3.appendChild(
+                        createChunk(f[k[0]], "pre", "adminException" + k[0])
+                      );
+                      frag3.appendChild(
+                        createChunk("```\n", "pre", "textForTrac")
+                      );
+                    }
+
+                    if (e.LOGSITE) {
+                      frag3.appendChild(
+                        createChunk("LOGSITE\n", "h4", "textForTrac")
+                      );
+                      frag3.appendChild(
+                        createChunk("\n```", "pre", "textForTrac")
+                      );
+                      frag3.appendChild(
+                        createChunk(e.LOGSITE, "pre", "adminExceptionLogsite")
+                      );
+                      frag3.appendChild(
+                        createChunk("```\n", "pre", "textForTrac")
+                      );
+                    }
+                    removeAllChildNodes(stack);
+                    stack.appendChild(frag3);
+                    stStopPropagation(ee);
+                    return false;
+                  };
+                })(e);
+                listenFor(exception, "click", clicky);
+                var head = exceptionNames[e.header];
+                if (head) {
+                  if (!head.others) {
+                    head.others = [];
+                    head.count = document.createTextNode("");
+                    var countSpan = document.createElement("span");
+                    countSpan.appendChild(head.count);
+                    countSpan.className = "adminExceptionCount";
+                    listenFor(countSpan, "click", function (e) {
+                      // prepare div
+                      if (!head.otherdiv) {
+                        head.otherdiv = createChunk(
+                          null,
+                          "div",
+                          "adminExceptionOtherList"
+                        );
+                        head.otherdiv.appendChild(
+                          createChunk(
+                            cldrText.get("adminExceptionDupList"),
+                            "h4"
+                          )
+                        );
+                        for (k in head.others) {
+                          head.otherdiv.appendChild(head.others[k]);
+                        }
+                      }
+                      removeAllChildNodes(stack);
+                      stack.appendChild(head.otherdiv);
+                      stStopPropagation(e);
+                      return false;
+                    });
+                    head.appendChild(countSpan);
+                  }
+                  head.others.push(exception);
+                  head.count.nodeValue = cldrText.sub("adminExceptionDup", [
+                    head.others.length,
+                  ]);
+                  head.otherdiv = null; // reset
+                } else {
+                  frag2.appendChild(exception);
+                  exceptionNames[e.header] = exception;
+                }
+              }
+              u.appendChild(frag2);
+
+              if (json.exceptions.entry && json.exceptions.entry.time) {
+                if (exceptions.length > 0 && exceptions.length % 8 == 0) {
+                  v.removeChild(loading);
+                  v.appendChild(more);
+                  more.onclick = more.onmouseover = function () {
+                    v.removeChild(more);
+                    v.appendChild(loading);
+                    loadNext(json.exceptions.entry.time);
+                    return false;
+                  };
+                } else {
+                  setTimeout(function () {
+                    loadNext(json.exceptions.entry.time);
+                  }, 500);
+                }
+              }
+            }
+          });
+        };
+        loadNext(); // load the first exception
+      });
+
+      addAdminPanel("admin_settings", function (div) {
+        var frag = document.createDocumentFragment();
+
+        div.className = "adminSettings";
+        var u = createChunk("Loading...", "div", "adminSettingsList");
+        frag.appendChild(u);
+        loadOrFail("do=settings", u, function (json) {
+          if (!json || !json.settings || Object.keys(json.settings.all) == 0) {
+            removeAllChildNodes(u);
+            u.appendChild(document.createTextNode(cldrText.get("nosettings")));
+          } else {
+            var frag2 = document.createDocumentFragment();
+            for (id in json.settings.all) {
+              var t = json.settings.all[id];
+
+              var thread = createChunk(null, "div", "adminSetting");
+
+              thread.appendChild(createChunk(id, "span", "adminSettingId"));
+              if (id == "CLDR_HEADER") {
+                (function (theHeader, theValue) {
+                  var setHeader = null;
+                  setHeader = appendInputBox(thread, "adminSettingsChangeTemp");
+                  setHeader.value = theValue;
+                  setHeader.stChange = function (onOk, onErr) {
+                    loadOrFail(
+                      "do=settings_set&setting=" + theHeader,
+                      u,
+                      function (json) {
+                        if (
+                          !json ||
+                          !json.settings_set ||
+                          !json.settings_set.ok
+                        ) {
+                          onErr(cldrText.get("failed"));
+                          onErr(json.settings_set.err);
+                        } else {
+                          if (json.settings_set[theHeader]) {
+                            setHeader.value = json.settings_set[theHeader];
+                            if (theHeader == "CLDR_HEADER") {
+                              updateSpecialHeader(setHeader.value);
+                            }
+                          } else {
+                            setHeader.value = "";
+                            if (theHeader == "CLDR_HEADER") {
+                              updateSpecialHeader(null);
+                            }
+                          }
+                          onOk(cldrText.get("changed"));
+                        }
+                      },
+                      setHeader.value
+                    );
+                    return false;
+                  };
+                })(id, t); // call it
+
+                if (id == "CLDR_HEADER") {
+                  updateSpecialHeader(t);
+                }
+              } else {
+                thread.appendChild(createChunk(t, "span", "adminSettingValue"));
+              }
+              frag2.appendChild(thread);
+            }
+            removeAllChildNodes(u);
+            u.appendChild(frag2);
+          }
+        });
+
+        removeAllChildNodes(div);
+        div.appendChild(frag);
+      });
+
+      addAdminPanel("admin_ops", function (div) {
+        var frag = document.createDocumentFragment();
+
+        div.className = "adminThreads";
+
+        var baseUrl =
+          cldrStatus.getContextPath() + "/AdminPanel.jsp?vap=" + vap + "&do=";
+        var hashSuff = ""; //  "#" + window.location.hash;
+
+        var actions = ["rawload"];
+        for (var k in actions) {
+          var action = actions[k];
+          var newUrl = baseUrl + action + hashSuff;
+          var b = createChunk(cldrText.get(action), "button");
+          b.onclick = function () {
+            window.location = newUrl;
+            return false;
+          };
+          frag.appendChild(b);
+        }
+        removeAllChildNodes(div);
+        div.appendChild(frag);
+      });
+
+      // last panel loaded.
+      // If it's in the hashtag, use it, otherwise first.
+      if (window.location.hash && window.location.hash.indexOf("#!") == 0) {
+        panelSwitch(window.location.hash.substring(2));
+      }
+      if (!panelLast) {
+        // not able to load anything.
+        panelSwitch(panelFirst.type);
+      }
+      adminStuff.appendChild(content);
+    }
+  }
+
+  /**
+   * Update the counter on top of the vetting page
+   */
+  function refreshCounterVetting() {
+    if (cldrStatus.isVisitor() || isDashboard()) {
+      // if the user is a visitor, or this is the Dashboard, don't display the counter information
+      $("#nav-page .counter-infos, #nav-page .nav-progress").hide();
+      return;
+    }
+
+    var inputs = $(".vetting-page input:visible:checked");
+    var total = inputs.length;
+    var abstain = inputs.filter(function () {
+      return this.id.substr(0, 2) === "NO";
+    }).length;
+    var voted = total - abstain;
+
+    document.getElementById("count-total").innerHTML = total;
+    document.getElementById("count-abstain").innerHTML = abstain;
+    document.getElementById("count-voted").innerHTML = voted;
+    if (total === 0) {
+      total = 1;
+    }
+    document.getElementById("progress-voted").style.width =
+      (voted * 100) / total + "%";
+    document.getElementById("progress-abstain").style.width =
+      (abstain * 100) / total + "%";
+
+    if (cldrForum && cldrStatus.getCurrentLocale()) {
+      const surveyUser = cldrStatus.getSurveyUser();
+      if (surveyUser && surveyUser.id) {
+        const forumSummary = cldrForum.getForumSummaryHtml(
+          cldrStatus.getCurrentLocale(),
+          surveyUser.id,
+          false
+        );
+        document.getElementById("vForum").innerHTML = forumSummary;
+      }
+    }
+  }
+
+  /**
+   * Go to the next (1) or the previous page (1) during the vetting
+   *
+   * @param {Integer} shift next page (1) or previous (-1)
+   */
+  function chgPage(shift) {
+    // no page, or wrong shift
+    if (!_thePages || (shift !== -1 && shift !== 1)) {
+      return;
+    }
+
+    var menus = getMenusFilteredByCov();
+    var parentIndex = 0;
+    var index = 0;
+    var parent = _thePages.pageToSection[cldrStatus.getCurrentPage()].id;
+
+    // get the parent index
+    for (var m in menus) {
+      var menu = menus[m];
+      if (menu.id === parent) {
+        parentIndex = parseInt(m);
+        break;
+      }
+    }
+
+    for (var m in menus[parentIndex].pagesFiltered) {
+      var menu = menus[parentIndex].pagesFiltered[m];
+      if (menu.id === cldrStatus.getCurrentPage()) {
+        index = parseInt(m);
+        break;
+      }
+    }
+    // go to the next one
+    index += parseInt(shift);
+
+    if (index >= menus[parentIndex].pagesFiltered.length) {
+      parentIndex++;
+      index = 0;
+      if (parentIndex >= menus.length) {
+        parentIndex = 0;
+      }
+    }
+
+    if (index < 0) {
+      parentIndex--;
+      if (parentIndex < 0) {
+        parentIndex = menus.length - 1;
+      }
+      index = menus[parentIndex].pagesFiltered.length - 1;
+    }
+    cldrStatus.setCurrentSection(menus[parentIndex].id);
+    cldrStatus.setCurrentPage(menus[parentIndex].pagesFiltered[index].id);
+
+    reloadV();
+
+    var sidebar = $("#locale-menu #" + cldrStatus.getCurrentPage());
+    sidebar.closest(".open-menu").click();
+  }
+
+  /**
+   * Get all the menus under this coverage
+   *
+   * @return {Array} list of all the menus under this coverage
+   */
+  function getMenusFilteredByCov() {
+    if (!_thePages) {
+      return;
+    }
+    // get name of current coverage
+    var cov = surveyUserCov;
+    if (!cov) {
+      cov = surveyOrgCov;
+    }
+
+    // get the value
+    var val = covValue(cov);
+    var sections = _thePages.sections;
+    var menus = [];
+    // add filtered pages
+    for (var s in sections) {
+      var section = sections[s];
+      var pages = section.pages;
+      var sectionContent = [];
+      for (var p in pages) {
+        var page = pages[p];
+        var key = Object.keys(page.levs).pop();
+        if (parseInt(page.levs[key]) <= val) sectionContent.push(page);
+      }
+      if (sectionContent.length) {
+        section.pagesFiltered = sectionContent;
+        menus.push(section);
+      }
+    }
+    return menus;
+  }
+
+  ///////////////////
+
+  /**
+   * For vetting
+   *
+   * @param hideRegex
+   */
+  function changeStyle(hideRegex) {
+    for (m in document.styleSheets) {
+      var theRules;
+      if (document.styleSheets[m].cssRules) {
+        theRules = document.styleSheets[m].cssRules;
+      } else if (document.styleSheets[m].rules) {
+        theRules = document.styleSheets[m].rules;
+      }
+      for (n in theRules) {
+        var rule = theRules[n];
+        var sel = rule.selectorText;
+        if (sel != undefined && sel.match(/vv/)) {
+          var theStyle = rule.style;
+          if (sel.match(hideRegex)) {
+            if (theStyle.display == "table-row") {
+              theStyle.display = null;
+            }
+          } else {
+            if (theStyle.display != "table-row") {
+              theStyle.display = "table-row";
+            }
+          }
+        }
+      }
+    }
+  }
+
+  function setStyles() {
+    var hideRegexString = "X1234X";
+    for (var i = 0; i < document.checkboxes.elements.length; i++) {
+      var item = document.checkboxes.elements[i];
+      if (!item.checked) {
+        hideRegexString += "|";
+        hideRegexString += item.name;
+      }
+    }
+    var hideRegex = new RegExp(hideRegexString);
+    changeStyle(hideRegex);
+  }
+
+  function createLocLink(loc, locName, className) {
+    var cl = createChunk(locName, "a", "localeChunk " + className);
+    cl.title = loc;
+    cl.href = "survey?_=" + loc;
+    return cl;
+  }
+
+  function showAllItems(divName, user) {
+    var div = document.getElementById(divName);
+    div.className = "recentList";
+    div.update = function () {
+      var ourUrl =
+        cldrStatus.getContextPath() + "/SurveyAjax?what=mylocales&user=" + user;
+      var errorHandler = function (err) {
+        handleDisconnect("Error in showrecent: " + err);
+      };
+      showLoader(null, "Loading recent items");
+      var loadHandler = function (json) {
+        try {
+          if (json && json.mine) {
+            var frag = document.createDocumentFragment();
+            var header = json.mine.header;
+            var data = json.mine.data;
+            if (data.length == 0) {
+              frag.appendChild(createChunk(cldrText.get("recentNone"), "i"));
+            } else {
+              var rowDiv = document.createElement("div");
+              frag.appendChild(rowDiv);
+
+              rowDiv.appendChild(createChunk(cldrText.get("recentLoc"), "b"));
+              rowDiv.appendChild(createChunk(cldrText.get("recentCount"), "b"));
+
+              for (var q in data) {
+                var row = data[q];
+
+                var count = row[header.COUNT];
+
+                var rowDiv = document.createElement("div");
+                frag.appendChild(rowDiv);
+
+                var loc = row[header.LOCALE];
+                var locname = row[header.LOCALE_NAME];
+                rowDiv.appendChild(createLocLink(loc, locname, "recentLoc"));
+                rowDiv.appendChild(
+                  createChunk(count, "span", "value recentCount")
+                );
+
+                const sessionId = cldrStatus.getSessionId();
+                if (sessionId) {
+                  var dlLink = createChunk(
+                    cldrText.get("downloadXmlLink"),
+                    "a",
+                    "notselected"
+                  );
+                  dlLink.href =
+                    "DataExport.jsp?do=myxml&_=" +
+                    loc +
+                    "&user=" +
+                    user +
+                    "&s=" +
+                    sessionId;
+                  dlLink.target = "STDownload";
+                  rowDiv.appendChild(dlLink);
+                }
+              }
+            }
+
+            removeAllChildNodes(div);
+            div.appendChild(frag);
+            hideLoader(null);
+          } else {
+            handleDisconnect("Failed to load JSON recent items", json);
+          }
+        } catch (e) {
+          console.log("Error in ajax get ", e.message);
+          console.log(" response: " + text);
+          handleDisconnect(" exception in getrecent: " + e.message, null);
+        }
+      };
+      var xhrArgs = {
+        url: ourUrl,
+        handleAs: "json",
+        load: loadHandler,
+        error: errorHandler,
+      };
+      cldrAjax.queueXhr(xhrArgs);
+    };
+    div.update();
+  }
+
+  function showRecent(divName, locale, user) {
+    if (!locale) {
+      locale = "";
+    }
+    if (!user) {
+      user = "";
+    }
+    var div;
+    if (divName.nodeType > 0) {
+      div = divName;
+    } else {
+      div = document.getElementById(divName);
+    }
+    div.className = "recentList";
+    div.update = function () {
+      var ourUrl =
+        cldrStatus.getContextPath() +
+        "/SurveyAjax?what=recent_items&_=" +
+        locale +
+        "&user=" +
+        user +
+        "&limit=" +
+        15;
+      var errorHandler = function (err) {
+        handleDisconnect("Error in showrecent: " + err);
+      };
+      showLoader(null, "Loading recent items");
+      var loadHandler = function (json) {
+        try {
+          if (json && json.recent) {
+            var frag = document.createDocumentFragment();
+            var header = json.recent.header;
+            var data = json.recent.data;
+
+            if (data.length == 0) {
+              frag.appendChild(createChunk(cldrText.get("recentNone"), "i"));
+            } else {
+              var rowDiv = document.createElement("div");
+              frag.appendChild(rowDiv);
+
+              rowDiv.appendChild(createChunk(cldrText.get("recentLoc"), "b"));
+              rowDiv.appendChild(
+                createChunk(cldrText.get("recentXpathCode"), "b")
+              );
+              rowDiv.appendChild(createChunk(cldrText.get("recentValue"), "b"));
+              rowDiv.appendChild(createChunk(cldrText.get("recentWhen"), "b"));
+
+              for (var q in data) {
+                var row = data[q];
+
+                var loc = row[header.LOCALE];
+                var locname = row[header.LOCALE_NAME];
+                var org = row[header.ORG];
+                var last_mod = row[header.LAST_MOD];
+                var xpath = row[header.XPATH];
+                var xpath_code = row[header.XPATH_CODE];
+                var xpath_hash = row[header.XPATH_STRHASH];
+                var value = row[header.VALUE];
+
+                var rowDiv = document.createElement("div");
+                frag.appendChild(rowDiv);
+                rowDiv.appendChild(createLocLink(loc, locname, "recentLoc"));
+                var xpathItem;
+                xpath_code = xpath_code.replace(/\t/g, " / ");
+                rowDiv.appendChild(
+                  (xpathItem = createChunk(xpath_code, "a", "recentXpath"))
+                );
+                xpathItem.href = "survey?_=" + loc + "&strid=" + xpath_hash;
+                rowDiv.appendChild(
+                  createChunk(value, "span", "value recentValue")
+                );
+                rowDiv.appendChild(
+                  createChunk(
+                    new Date(last_mod).toLocaleString(),
+                    "span",
+                    "recentWhen"
+                  )
+                );
+              }
+            }
+            removeAllChildNodes(div);
+            div.appendChild(frag);
+            hideLoader(null);
+          } else {
+            handleDisconnect("Failed to load JSON recent items", json);
+          }
+        } catch (e) {
+          console.log("Error in ajax get ", e.message);
+          console.log(" response: " + text);
+          handleDisconnect(" exception in getrecent: " + e.message, null);
+        }
+      };
+      var xhrArgs = {
+        url: ourUrl,
+        handleAs: "json",
+        load: loadHandler,
+        error: errorHandler,
+      };
+      cldrAjax.queueXhr(xhrArgs);
+    };
+    div.update();
+  }
+
+  /**
+   * For the admin page
+   *
+   * @param list
+   * @param tableRef
+   * @returns
+   */
+
+  const dom = null;
+  const dojoNumber = null;
+
+  function showUserActivity(list, tableRef) {
+    window._userlist = list; // DEBUG
+    var table = dom.byId(tableRef);
+
+    var rows = [];
+    var theadChildren = getTagChildren(
+      table.getElementsByTagName("thead")[0].getElementsByTagName("tr")[0]
+    );
+
+    cldrSurvey.setDisplayed(theadChildren[1], false);
+    var rowById = [];
+
+    for (var k in list) {
+      var user = list[k];
+      var tr = dom.byId("u@" + user.id);
+
+      rowById[user.id] = parseInt(k); // ?!
+
+      var rowChildren = getTagChildren(tr);
+
+      removeAllChildNodes(rowChildren[1]); // org
+      removeAllChildNodes(rowChildren[2]); // name
+
+      var theUser;
+      cldrSurvey.setDisplayed(rowChildren[1], false);
+      rowChildren[2].appendChild((theUser = createUser(user)));
+
+      rows.push({
+        user: user,
+        tr: tr,
+        userDiv: theUser,
+        seen: rowChildren[5],
+        stats: [],
+        total: 0,
+      });
+    }
+
+    window._rrowById = rowById;
+
+    var loc2name = {};
+    request
+      .get(
+        cldrStatus.getContextPath() + "/SurveyAjax?what=stats_bydayuserloc",
+        {
+          handleAs: "json",
+        }
+      )
+      .then(function (json) {
+        /* COUNT: 1120,  DAY: 2013-04-30, LOCALE: km, LOCALE_NAME: khmer, SUBMITTER: 2 */
+        var stats = json.stats_bydayuserloc;
+        var header = stats.header;
+        for (var k in stats.data) {
+          var row = stats.data[k];
+          var submitter = row[header.SUBMITTER];
+          var submitterRow = rowById[submitter];
+          if (submitterRow !== undefined) {
+            var userRow = rows[submitterRow];
+            userRow.stats.push({
+              day: row[header.DAY],
+              count: row[header.COUNT],
+              locale: row[header.LOCALE],
+            });
+            userRow.total = userRow.total + row[header.COUNT];
+            loc2name[row[header.LOCALE]] = row[header.LOCALE_NAME];
+          }
+        }
+
+        function appendMiniChart(userRow, count) {
+          if (count > userRow.stats.length) {
+            count = userRow.stats.length;
+          }
+          removeAllChildNodes(userRow.seenSub);
+          for (var k = 0; k < count; k++) {
+            var theStat = userRow.stats[k];
+            var chartRow = createChunk("", "div", "chartRow");
+
+            var chartDay = createChunk(theStat.day, "span", "chartDay");
+            var chartLoc = createChunk(theStat.locale, "span", "chartLoc");
+            chartLoc.title = loc2name[theStat.locale];
+            var chartCount = createChunk(
+              dojoNumber.format(theStat.count),
+              "span",
+              "chartCount"
+            );
+
+            chartRow.appendChild(chartDay);
+            chartRow.appendChild(chartLoc);
+            chartRow.appendChild(chartCount);
+
+            userRow.seenSub.appendChild(chartRow);
+          }
+          if (count < userRow.stats.length) {
+            chartRow.appendChild(document.createTextNode("..."));
+          }
+        }
+
+        for (var k in rows) {
+          var userRow = rows[k];
+          if (userRow.total > 0) {
+            addClass(userRow.tr, "hadActivity");
+            userRow.tr
+              .getElementsByClassName("recentActivity")[0]
+              .appendChild(
+                document.createTextNode(
+                  " (" + dojoNumber.format(userRow.total) + ")"
+                )
+              );
+
+            userRow.seenSub = document.createElement("div");
+            userRow.seenSub.className = "seenSub";
+            userRow.seen.appendChild(userRow.seenSub);
+
+            appendMiniChart(userRow, 3);
+            if (userRow.stats.length > 3) {
+              var chartMore, chartLess;
+              chartMore = createChunk("+", "span", "chartMore");
+              chartLess = createChunk("-", "span", "chartMore");
+              chartMore.onclick = (function (chartMore, chartLess, userRow) {
+                return function () {
+                  cldrSurvey.setDisplayed(chartMore, false);
+                  cldrSurvey.setDisplayed(chartLess, true);
+                  appendMiniChart(userRow, userRow.stats.length);
+                  return false;
+                };
+              })(chartMore, chartLess, userRow);
+              chartLess.onclick = (function (chartMore, chartLess, userRow) {
+                return function () {
+                  cldrSurvey.setDisplayed(chartMore, true);
+                  cldrSurvey.setDisplayed(chartLess, false);
+                  appendMiniChart(userRow, 3);
+                  return false;
+                };
+              })(chartMore, chartLess, userRow);
+              userRow.seen.appendChild(chartMore);
+              cldrSurvey.setDisplayed(chartLess, false);
+              userRow.seen.appendChild(chartLess);
+            }
+          } else {
+            addClass(userRow.tr, "noActivity");
+          }
+        }
+      });
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    updateIf: updateIf,
+    isReport: isReport,
+    addClass: addClass,
+    removeClass: removeClass,
+    removeAllChildNodes: removeAllChildNodes,
+    setDisplayed: setDisplayed,
+    isInputBusy: isInputBusy,
+    createChunk: createChunk,
+    clickToSelect: clickToSelect,
+    createLinkToFn: createLinkToFn,
+    createGravitar: createGravitar,
+    stStopPropagation: stStopPropagation,
+    showInPop: showInPop,
+    showInPop2: showInPop2,
+    showLoader: showLoader,
+    hideLoader: hideLoader,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    // test: {
+    // getBodyHtml: getBodyHtml,
+    // },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrTable.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrTable.js
@@ -1,21 +1,23 @@
-/*
- * CldrSurveyVettingTable.js - split off from survey.js, for CLDR Survey Tool.
- *
- * Functions for populating the main table in the vetting page:
- * 		cldrSurveyTable.insertRows
- * 		cldrSurveyTable.updateRow
- *
- * cldrSurveyTable.updateRow is also used for the Dashboard (see review.js).
- *
- * TODO: identify and reduce dependencies; add unit tests that don't depend on server or browser.
- */
 "use strict";
 
-/*
- * Use an IIFE module pattern to create a namespace for the public functions,
+/**
+ * cldrText: encapsulate code related to the main Survey Tool html table,
+ * whose rows describe xpaths.
+ * This is the non-dojo version. For dojo, see CldrDojoTable.js
+ *
+ * Functions for populating the main table in the vetting page:
+ * 		cldrTable.insertRows
+ * 		cldrTable.updateRow
+ *
+ * cldrTable.updateRow is also used for the Dashboard.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
  */
-const cldrSurveyTable = (function () {
+const cldrTable = (function () {
   /*
    * ALWAYS_REMOVE_ALL_CHILD_NODES and NEVER_REUSE_TABLE should both be false for efficiency,
    * but if necessary they can be made true to revert to old less efficient behavior.

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrText.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrText.js
@@ -1,8 +1,9 @@
 "use strict";
-// this file, unlike most of our js files, has been formatted using "npx prettier" with default settings
 
 /**
  * cldrText: encapsulate text messages for the user interface.
+ * This works with or without dojo; no dependency on dojo.
+ *
  * Use an IIFE pattern to create a namespace for the public functions,
  * and to hide everything else, minimizing global scope pollution.
  * Ideally this should be a module (in the sense of using import/export),

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrXpathMap.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrXpathMap.js
@@ -1,0 +1,151 @@
+"use strict";
+
+/**
+ * @class XpathMap
+ * This manages xpathId / strid / PathHeader etc mappings.
+ * It is a cache, and gets populated with data 'volunteered' by page loads, so that
+ * hopefully it doesn't need to do any network operations on its own.
+ * However, it MAY BE capable of filling in any missing data via AJAX. This is why its operations are async.
+ */
+function XpathMap() {
+  /**
+   * Maps strid (hash) to info struct.
+   * The info struct is the basic unit here, it looks like the following:
+   *   {
+   *	   hex: '20fca8231d41',
+   *	   path: '//ldml/shoeSize',
+   *	   id:  1337,
+   *	   ph: ['foo','bar','baz']  **TBD**
+   *   }
+   *
+   *  All other hashes here are just alternate indices into this data.
+   *
+   * @property XpathMap.stridToInfo
+   */
+  this.stridToInfo = {};
+  /**
+   * Map xpathId (such as 1337) to info
+   * @property XpathMap.xpidToInfo
+   */
+  this.xpidToInfo = {};
+  /**
+   * Map xpath (//ldml/...) to info.
+   * @property XpathMap.xpathToInfo
+   */
+  this.xpathToInfo = {};
+}
+
+/**
+ * This function will do a search and then call the onResult function.
+ * Priority order for search: hex, id, then path.
+ * @function get
+ * @param search {Object} the object to search for
+ * @param search.hex {String} optional - search by hex id
+ * @param search.path {String} optional - search by xpath
+ * @param search.id {Number} optional - search by number (String will be converted to Number)
+ * @param onResult - will be called with one parameter that looks like this:
+ *  { search, err, result } -  'search' is the input param,
+ * 'err' if non-null is any error, and 'result' if non-null is the result info struct.
+ * If there is an error, 'result' will be null. Please do not modify 'result'!
+ */
+XpathMap.prototype.get = function get(search, onResult) {
+  // see if we have anything immediately
+  result = null;
+  if (!result && search.hex) {
+    result = this.stridToInfo[search.hex];
+  }
+  if (!result && search.id) {
+    if (typeof search.id !== Number) {
+      search.id = new Number(search.id);
+    }
+    result = this.xpidToInfo[search.id];
+  }
+  if (!result && search.path) {
+    result = this.xpathToInfo[search.path];
+  }
+  if (result) {
+    onResult({
+      search: search,
+      result: result,
+    });
+  } else {
+    stdebug(
+      "XpathMap search failed for " + JSON.stringify(search) + " - doing rpc"
+    );
+    var querystr = null;
+    if (search.hex) {
+      querystr = search.hex;
+    } else if (search.path) {
+      querystr = search.path;
+    } else if (search.id) {
+      querystr = "#" + search.id;
+    } else {
+      querystr = ""; // error
+    }
+    const loadHandler = function (json) {
+      if (json.getxpath) {
+        xpathMap.put(json.getxpath); // store back first, then
+        onResult({
+          search: search,
+          result: json.getxpath,
+        }); // call
+      } else {
+        onResult({
+          search: search,
+          err: "no results from server",
+        });
+      }
+    };
+
+    const errorHandler = function (err) {
+      onResult({
+        search: search,
+        err: err,
+      });
+    };
+
+    const xhrArgs = {
+      url: "SurveyAjax?what=getxpath&xpath=" + querystr,
+      handleAs: "json",
+      load: loadHandler,
+      err: errorHandler,
+    };
+    cldrAjax.queueXhr(xhrArgs);
+  }
+};
+
+/**
+ * Contribute some data to the map.
+ * @function contribute
+ */
+XpathMap.prototype.put = function put(info) {
+  if (!info || !info.id || !info.path || !info.hex || !info.ph) {
+    stdebug(
+      "XpathMap: rejecting incomplete contribution " + JSON.stringify(info)
+    );
+  } else if (this.stridToInfo[info.hex]) {
+    stdebug(
+      "XpathMap: rejecting duplicate contribution " + JSON.stringify(info)
+    );
+  } else {
+    this.stridToInfo[info.hex] = this.xpidToInfo[info.id] = this.xpathToInfo[
+      info.path
+    ] = info;
+    stdebug("XpathMap: adding contribution " + JSON.stringify(info));
+  }
+};
+
+/**
+ * Format a pathheader array.
+ * @function formatPathHeader
+ * @param ph {Object} pathheaer struct (Section/Page/Header/Code)
+ * @return {String}
+ */
+XpathMap.prototype.formatPathHeader = function formatPathHeader(ph) {
+  if (!ph) {
+    return "";
+  } else {
+    var phArray = [ph.section, ph.page, ph.header, ph.code];
+    return phArray.join(" | "); // type error - valid?
+  }
+};

--- a/tools/cldr-apps/src/main/webapp/js/redesign.js
+++ b/tools/cldr-apps/src/main/webapp/js/redesign.js
@@ -1,3 +1,5 @@
+// This is the dojo version. A non-dojo version doesn't exist yet.
+
 /*
  * TODO: rename this file to reflect its current role rather than its history.
  * Its history presumably involved redesigning some aspect(s) of Survey Tool.
@@ -436,8 +438,8 @@ function unpackMenuSideBar(json) {
 
   // forum link
   $("#forum-link").click(function () {
-    if (cldrStForum) {
-      cldrStForum.reload();
+    if (cldrForum) {
+      cldrForum.reload();
     }
   });
 

--- a/tools/cldr-apps/src/main/webapp/js/review.js
+++ b/tools/cldr-apps/src/main/webapp/js/review.js
@@ -1,3 +1,5 @@
+// This is the dojo version. A non-dojo version doesn't exist yet.
+
 /*
  * Show the "Review" page, a.k.a. the "Dashboard"
  */
@@ -102,16 +104,16 @@ function showReviewPage(json, showFn) {
       '"></span></div></a></li>';
   });
 
-  if (cldrStForum && cldrStatus.getCurrentLocale()) {
+  if (cldrForum && cldrStatus.getCurrentLocale()) {
     const surveyUser = cldrStatus.getSurveyUser();
     if (surveyUser && surveyUser.id) {
-      const forumSummary = cldrStForum.getForumSummaryHtml(
+      const forumSummary = cldrForum.getForumSummaryHtml(
         cldrStatus.getCurrentLocale(),
         surveyUser.id,
         true /* table */
       );
       sidebarHtml +=
-        "<li><a id='dashToForum' onclick='cldrStForum.reload();'>Forum</a></li>\n";
+        "<li><a id='dashToForum' onclick='cldrForum.reload();'>Forum</a></li>\n";
       sidebarHtml += "<li>" + forumSummary + "</li>\n";
     }
   }
@@ -803,7 +805,7 @@ function insertFixInfo(theDiv, xpath, session, json) {
   tr.rowHash = k;
   tr.theTable = theTable;
 
-  cldrSurveyTable.updateRow(tr, theRow);
+  cldrTable.updateRow(tr, theRow);
 
   if (!tr.forumDiv) {
     tr.forumDiv = document.createElement("div");

--- a/tools/cldr-apps/src/main/webapp/js/special/bulk_close_posts.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/bulk_close_posts.js
@@ -19,7 +19,7 @@ define("js/special/bulk_close_posts.js", [
   _super = Page.prototype = new SpecialPage();
 
   Page.prototype.show = function show(params) {
-    cldrStBulkClosePosts.load(params);
+    cldrBulkClosePosts.load(params);
   };
 
   return Page;

--- a/tools/cldr-apps/src/main/webapp/js/special/forum.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/forum.js
@@ -83,7 +83,7 @@ define("js/special/forum.js", [
       });
       const surveyUser = cldrStatus.getSurveyUser();
       const userId = surveyUser && surveyUser.id ? surveyUser.id : 0;
-      cldrStForum.loadForum(curLocale, userId, forumMessage, params);
+      cldrForum.loadForum(curLocale, userId, forumMessage, params);
     }
   };
 

--- a/tools/cldr-apps/src/main/webapp/js/special/forum_participation.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/forum_participation.js
@@ -20,7 +20,7 @@ define("js/special/forum_participation.js", [
   _super = Page.prototype = new SpecialPage();
 
   Page.prototype.show = function show(params) {
-    cldrStForumParticipation.load(params);
+    cldrForumParticipation.load(params);
   };
 
   return Page;

--- a/tools/cldr-apps/src/main/webapp/js/special/search.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/search.js
@@ -147,7 +147,7 @@ define("js/special/search.js", ["js/special/SpecialPage.js"], function (
           if (newLocale != null && newLocale != "") {
             xurl = xurl + "&_=" + newLocale;
           }
-          cldrStAjax.queueXhr({
+          cldrAjax.queueXhr({
             url: xurl, // allow cache
             handleAs: "json",
             load: function (h) {

--- a/tools/cldr-apps/src/main/webapp/js/special/statistics.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/statistics.js
@@ -326,7 +326,7 @@ define("js/special/statistics.js", [
             );
 
             subDiv.appendChild(loading);
-            cldrStAjax.queueXhr({
+            cldrAjax.queueXhr({
               url: theSection.url,
               handleAs: "json",
               load: function (json) {

--- a/tools/cldr-apps/src/main/webapp/js/special/tc-emaillist.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/tc-emaillist.js
@@ -51,7 +51,7 @@ define("js/special/tc-emaillist.js", ["js/special/SpecialPage.js"], function (
       "/SurveyAjax?&s=" +
       cldrStatus.getSessionId() +
       "&what=participating_users"; // allow cache
-    cldrStAjax.queueXhr({
+    cldrAjax.queueXhr({
       url: xurl, // allow cache
       handleAs: "json",
       load: function (h) {

--- a/tools/cldr-apps/src/main/webapp/js/special/vetting_participation.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/vetting_participation.js
@@ -249,7 +249,7 @@ define("js/special/vetting_participation.js", [
       load: loadHandler,
       error: errorHandler,
     };
-    cldrStAjax.sendXhr(xhrArgs);
+    cldrAjax.sendXhr(xhrArgs);
   }
 
   /**

--- a/tools/cldr-apps/src/main/webapp/js/special/vsummary.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/vsummary.js
@@ -232,7 +232,7 @@ define("js/special/vsummary.js", ["js/special/SpecialPage.js"], function (
       stopRefresh();
       vsReload.disabled = true;
 
-      cldrStAjax.sendXhr({
+      cldrAjax.sendXhr({
         url: xurl + "&loadingpolicy=" + policy,
         handleAs: "json",
         load: function (json) {

--- a/tools/cldr-apps/src/main/webapp/js/survey.js
+++ b/tools/cldr-apps/src/main/webapp/js/survey.js
@@ -1,6 +1,8 @@
 /*
  * survey.js - Copyright (C) 2012,2016 IBM Corporation and Others. All Rights Reserved.
  * SurveyTool main JavaScript stuff
+ * 
+ * This is the dojo version. For non-dojo, see new/cldrSurvey.js and other new/*.js
  */
 
 /*
@@ -789,7 +791,7 @@ function unbust() {
   saidDisconnect = false;
   removeClass(document.getElementsByTagName("body")[0], "disconnected");
   wasBusted = false;
-  cldrStAjax.clearXhr();
+  cldrAjax.clearXhr();
   hideLoader();
   saidDisconnect = false;
   updateStatus(); // will restart regular status updates
@@ -817,7 +819,7 @@ function handleChangedLocaleStamp(stamp, name) {
    * For performance, postpone the all-row WHAT_GETROW update if multiple
    * requests (e.g., vote or single-row WHAT_GETROW requests) are pending.
    */
-  if (cldrStAjax.queueCount() > 1) {
+  if (cldrAjax.queueCount() > 1) {
     return;
   }
   if (Object.keys(showers).length == 0) {
@@ -1034,7 +1036,7 @@ function trySurveyLoad() {
   try {
     var url = cldrStatus.getContextPath() + "/survey?" + cacheKill();
     console.log("Attempting to restart ST at " + url);
-    cldrStAjax.sendXhr({
+    cldrAjax.sendXhr({
       url: url,
     });
   } catch (e) {}
@@ -1247,7 +1249,7 @@ function updateStatus() {
     surveySessionUrl = "&s=" + sessionId;
   }
 
-  cldrStAjax.sendXhr({
+  cldrAjax.sendXhr({
     url:
       cldrStatus.getContextPath() +
       "/SurveyAjax?what=status" +
@@ -1907,7 +1909,7 @@ function showForumStuff(frag, forumDivClone, tr) {
       theRow.voteVhash !== "" &&
       !theRow.rowFlagged;
     const myValue = theRow.hasVoted ? getUsersValue(theRow) : null;
-    cldrStForum.addNewPostButtons(
+    cldrForum.addNewPostButtons(
       frag,
       cldrStatus.getCurrentLocale(),
       couldFlag,
@@ -1964,7 +1966,7 @@ function showForumStuff(frag, forumDivClone, tr) {
         }
       },
     };
-    cldrStAjax.queueXhr(xhrArgs);
+    cldrAjax.queueXhr(xhrArgs);
   }, 1900);
 
   function getUsersValue(theRow) {
@@ -2034,7 +2036,7 @@ function updateInfoPanelForumPosts(tr) {
     try {
       if (json && json.ret) {
         const posts = json.ret;
-        const content = cldrStForum.parseContent(posts, "info");
+        const content = cldrForum.parseContent(posts, "info");
         /*
          * Reality check: the json should refer to the same path as tr, which in practice
          * always matches cldrStatus.getCurrentId(). If not, log a warning and substitute "Please reload"
@@ -2080,7 +2082,7 @@ function updateInfoPanelForumPosts(tr) {
     load: loadHandler,
     error: errorHandler,
   };
-  cldrStAjax.queueXhr(xhrArgs);
+  cldrAjax.queueXhr(xhrArgs);
 }
 
 /**
@@ -2091,7 +2093,7 @@ function updateInfoPanelForumPosts(tr) {
  * @param {Node} forumDiv
  */
 function appendForumStuff(tr, theRow, forumDiv) {
-  cldrStForum.setUserCanPost(tr.theTable.json.canModify);
+  cldrForum.setUserCanPost(tr.theTable.json.canModify);
 
   removeAllChildNodes(forumDiv); // we may be updating.
   var theForum = locmap.getLanguage(cldrStatus.getCurrentLocale());
@@ -2552,7 +2554,7 @@ function showProposedItem(inTd, tr, theRow, value, tests, json) {
       alert(str2);
 
       // show this message in a sidebar also
-      showInPop(stopIcon + str, tr, null, null, true);
+      showInPop(cldrStatus.stopIcon() + str, tr, null, null, true);
     }
     return;
   } else if (json && json.didNotSubmit) {
@@ -3310,7 +3312,7 @@ function refreshSingleRow(tr, theRow, onSuccess, onFailure) {
       if (json.section.rows[tr.rowHash]) {
         theRow = json.section.rows[tr.rowHash];
         tr.theTable.json.section.rows[tr.rowHash] = theRow;
-        cldrSurveyTable.updateRow(tr, theRow);
+        cldrTable.updateRow(tr, theRow);
 
         hideLoader(tr.theTable.theDiv.loader);
         onSuccess(theRow);
@@ -3355,7 +3357,7 @@ function refreshSingleRow(tr, theRow, onSuccess, onFailure) {
     load: loadHandler,
     error: errorHandler,
   };
-  cldrStAjax.queueXhr(xhrArgs);
+  cldrAjax.queueXhr(xhrArgs);
 }
 
 /**
@@ -3545,7 +3547,7 @@ function handleWiredClick(tr, theRow, vHash, box, button, what) {
     load: loadHandler,
     error: errorHandler,
   };
-  cldrStAjax.queueXhr(xhrArgs);
+  cldrAjax.queueXhr(xhrArgs);
 }
 
 /**
@@ -3610,7 +3612,7 @@ function loadAdminPanel() {
          */
         console.log("admin get: ourUrl: " + ourUrl);
       }
-      cldrStAjax.sendXhr(xhrArgs);
+      cldrAjax.sendXhr(xhrArgs);
     }
     var panelLast = null;
     var panels = {};
@@ -4199,10 +4201,10 @@ function refreshCounterVetting() {
   document.getElementById("progress-abstain").style.width =
     (abstain * 100) / total + "%";
 
-  if (cldrStForum && cldrStatus.getCurrentLocale()) {
+  if (cldrForum && cldrStatus.getCurrentLocale()) {
     const surveyUser = cldrStatus.getSurveyUser();
     if (surveyUser && surveyUser.id) {
-      const forumSummary = cldrStForum.getForumSummaryHtml(
+      const forumSummary = cldrForum.getForumSummaryHtml(
         cldrStatus.getCurrentLocale(),
         surveyUser.id,
         false
@@ -4446,7 +4448,7 @@ function showAllItems(divName, user) {
           load: loadHandler,
           error: errorHandler,
         };
-        cldrStAjax.queueXhr(xhrArgs);
+        cldrAjax.queueXhr(xhrArgs);
       };
       div.update();
     });
@@ -4557,7 +4559,7 @@ function showRecent(divName, locale, user) {
           load: loadHandler,
           error: errorHandler,
         };
-        cldrStAjax.queueXhr(xhrArgs);
+        cldrAjax.queueXhr(xhrArgs);
       };
       div.update();
     });
@@ -4578,8 +4580,8 @@ function showUserActivity(list, tableRef) {
     "dojo/request",
     "dojo/number",
     "dojo/domReady!",
-  ], // HANDLES
-  function (ready, dom, request, dojoNumber) {
+  ], function (ready, dom, request, dojoNumber) {
+    // HANDLES
     ready(function () {
       window._userlist = list; // DEBUG
       var table = dom.byId(tableRef);


### PR DESCRIPTION
-New boolean SurveyTool.USE_DOJO determines usage of the dojo or non-dojo front end

-Works as before if USE_DOJO is true; does not work yet if USE_DOJO is false

-New folder js/new has js files that do not depend on dojo (directly or indirectly)

-Changed file/object naming conventions; shorter; e.g., cldrAjax instead of cldrStAjax

-Rename some dojo-dependent files to start with CldrDojo; e.g., CldrDojoForum.js

-Fix bug in PR 893: cldrGui.makeVoteCountMenu was incomplete

-Fix bug in PR 893: stopIcon should be cldrStatus.stopIcon() in survey.js

-Fix bug in PR 893: bad js syntax in SurveyTool.serveWaitingPage window.setTimeout

-Remove dead code; clean up

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14251
- [x] Updated PR title and link in previous line to include Issue number

