### PR TITLE
CLDR-14251 Modernize: continue implementing front end without dojo

### DIFF
--- a/tools/cldr-apps/js-unittest/Test.html
+++ b/tools/cldr-apps/js-unittest/Test.html
@@ -19,27 +19,36 @@
       mocha.setup('bdd');
       mocha.checkLeaks();
     </script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="../src/main/webapp/js/new/cldrXpathMap.js"></script>
+    <script src="../src/main/webapp/js/new/cldrAbout.js"></script>
     <script src="../src/main/webapp/js/new/cldrBulkClosePosts.js"></script>
-    <script src="../src/main/webapp/js/new/cldrTable.js"></script>
-    <script src="../src/main/webapp/js/new/cldrForumParticipation.js"></script>
-    <script src="../src/main/webapp/js/new/cldrForumFilter.js"></script>
     <script src="../src/main/webapp/js/new/cldrForum.js"></script>
+    <script src="../src/main/webapp/js/new/cldrForumFilter.js"></script>
+    <script src="../src/main/webapp/js/new/cldrForumParticipation.js"></script>
+    <script src="../src/main/webapp/js/new/cldrCreateLogin.js"></script>
     <script src="../src/main/webapp/js/new/cldrCsvFromTable.js"></script>
+    <script src="../src/main/webapp/js/new/cldrDom.js"></script>
+    <script src="../src/main/webapp/js/new/cldrInfo.js"></script>
     <script src="../src/main/webapp/js/new/cldrStatus.js"></script>
     <script src="../src/main/webapp/js/new/cldrGui.js"></script>
+    <script src="../src/main/webapp/js/new/cldrSurvey.js"></script>
+    <script src="../src/main/webapp/js/new/cldrTable.js"></script>
     <script src="../src/main/webapp/js/new/cldrText.js"></script>
     <script src="data/forum_fr.js"></script>
     <script src="data/forum_participation_json.js"></script>
     <script src="data/bulk_close_posts_json.js"></script>
     <script src="TestCldrTest.js"></script>
+    <script src="TestCldrAbout.js"></script>
+    <script src="TestCldrBulkClosePosts.js"></script>
+    <script src="TestCldrChecksum.js"></script>
+    <script src="TestCldrCreateLogin.js"></script>
+    <script src="TestCldrCsvFromTable.js"></script>
     <script src="TestCldrForum.js"></script>
     <script src="TestCldrForumFilter.js"></script>
     <script src="TestCldrForumParticipation.js"></script>
-    <script src="TestCldrChecksum.js"></script>
-    <script src="TestCldrCsvFromTable.js"></script>
-    <script src="TestCldrBulkClosePosts.js"></script>
-    <script src="TestCldrStatus.js"></script>
     <script src="TestCldrGui.js"></script>
+    <script src="TestCldrStatus.js"></script>
     <script src="TestCldrText.js"></script>
     <script class="mocha-exec">
       mocha.run();

--- a/tools/cldr-apps/js-unittest/TestCldrAbout.js
+++ b/tools/cldr-apps/js-unittest/TestCldrAbout.js
@@ -1,0 +1,41 @@
+"use strict";
+
+{
+  const assert = chai.assert;
+
+  describe("cldrAbout.test.getHtml", function () {
+    const json = {
+      ICU_VERSION: "68.1.0.0",
+    };
+    const html = cldrAbout.test.getHtml(json);
+
+    it("should not return null or empty", function () {
+      assert(html != null && html !== "", "html is neither null nor empty");
+    });
+
+    const xml = "<div>" + html + "</div>";
+    const xmlStr = cldrTest.parseAsMimeType(xml, "application/xml");
+    it("should return valid xml when in div element", function () {
+      assert(xmlStr || false, "parses OK as xml when in div element");
+    });
+
+    const htmlStr = cldrTest.parseAsMimeType(html, "text/html");
+    it("should return good html", function () {
+      assert(htmlStr || false, "parses OK as html");
+    });
+
+    it("should contain angle brackets", function () {
+      assert(
+        htmlStr.indexOf("<") !== -1 && htmlStr.indexOf(">") !== -1,
+        "does contain angle brackets"
+      );
+    });
+
+    const label = "ICU";
+    const value = json.ICU_VERSION;
+    it("should contain " + label + " and " + value, function () {
+      assert(html.indexOf(label) !== -1, label + " does occur in " + html);
+      assert(html.indexOf(value) !== -1, value + " does occur in " + html);
+    });
+  });
+}

--- a/tools/cldr-apps/js-unittest/TestCldrCreateLogin.js
+++ b/tools/cldr-apps/js-unittest/TestCldrCreateLogin.js
@@ -1,0 +1,31 @@
+"use strict";
+
+{
+  const assert = chai.assert;
+
+  describe("cldrCreateLogin.test.getHtml", function () {
+    const html = cldrCreateLogin.test.getHtml();
+
+    it("should not return null or empty", function () {
+      assert(html != null && html !== "", "html is neither null nor empty");
+    });
+
+    const xml = "<div>" + html + "</div>";
+    const xmlStr = cldrTest.parseAsMimeType(xml, "application/xml");
+    it("should return valid xml when in div element", function () {
+      assert(xmlStr || false, "parses OK as xml when in div element");
+    });
+
+    const htmlStr = cldrTest.parseAsMimeType(html, "text/html");
+    it("should return good html", function () {
+      assert(htmlStr || false, "parses OK as html");
+    });
+
+    it("should contain angle brackets", function () {
+      assert(
+        htmlStr.indexOf("<") !== -1 && htmlStr.indexOf(">") !== -1,
+        "does contain angle brackets"
+      );
+    });
+  });
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AboutST.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AboutST.java
@@ -1,0 +1,42 @@
+package org.unicode.cldr.web;
+
+import javax.servlet.ServletContext;
+
+import org.unicode.cldr.util.CLDRConfigImpl;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRURLS;
+import org.unicode.cldr.web.SurveyAjax.JSONWriter;
+
+import com.ibm.icu.util.VersionInfo;
+
+public class AboutST {
+    public void getJson(JSONWriter r, SurveyMain sm) {
+        String props[] = {
+            "java.version", "java.vendor", "java.vm.version", "java.vm.vendor",
+            "java.vm.name", "os.name", "os.arch", "os.version"};
+        for (int i = 0; i < props.length; i++) {
+            r.put(props[i].replace('.', '_'), java.lang.System.getProperty(props[i]));
+        }
+        r.put("GEN_VERSION", CLDRFile.GEN_VERSION);
+        r.put("ICU_VERSION", VersionInfo.ICU_VERSION);
+        ServletContext sc = sm.getServletContext();
+        r.put("serverInfo", sc.getServerInfo());
+        r.put("servletMajorVersion", sc.getMajorVersion());
+        r.put("servletMinorVersion", sc.getMinorVersion());
+        r.put("TRANS_HINT_LOCALE", SurveyMain.TRANS_HINT_LOCALE.toLanguageTag());
+        r.put("TRANS_HINT_LANGUAGE_NAME", SurveyMain.TRANS_HINT_LANGUAGE_NAME);
+        if (SurveyMain.isConfigSetup) {
+            for (String k : org.unicode.cldr.util.CLDRConfigImpl.ALL_GIT_HASHES) {
+                r.put(k, CLDRURLS.gitHashToLink(CLDRConfigImpl.getInstance().getProperty(k)));
+            }
+        }
+        if (SurveyMain.isDbSetup) {
+            org.unicode.cldr.web.DBUtils d = org.unicode.cldr.web.DBUtils.getInstance();
+            if (d != null) {
+                r.put("hasDataSource", d.hasDataSource());
+                r.put("dbKind", DBUtils.getDBKind());
+                r.put("dbInfo", d.getDBInfo());
+            }
+        }
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AdminPanel.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AdminPanel.java
@@ -1,0 +1,253 @@
+package org.unicode.cldr.web;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Random;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRConfigImpl;
+import org.unicode.cldr.web.SurveyAjax.JSONWriter;
+
+public class AdminPanel {
+    public void getJson(JSONWriter r, HttpServletRequest request, HttpServletResponse response, SurveyMain sm) throws JSONException, IOException {
+        /*
+         * Assume caller has already confirmed UserRegistry.userIsAdmin
+         */
+        String action = request.getParameter("do");
+        if (action == null || action.isEmpty()) {
+            System.out.println("Warning: AdminPanel.getJson called without do parameter!");
+            return;
+        }
+        if (action.equals("users")) {
+            listUsers(r);
+        } else if (action.equals("unlink")) {
+            unlinkUser(r, request);
+        } else if (action.equals("threads")) {
+            showThreads(r);
+        } else if (action.equals("exceptions")) {
+            showExceptions(r, request);
+        } else if (action.equals("settings")) {
+            showSettings(r);
+        } else if (action.equals("settings_set")) {
+            setSettings(r, request);
+        } else if (action.equals("rawload")) {
+            doRawLoad(r, request);
+        } else if (action.equals("create_login")) {
+            createAndLogin(r, request, response, sm);
+        } else {
+            r.put("err", "Unknown action: " + action);
+        }
+    }
+
+    private void listUsers(JSONWriter r) throws JSONException {
+        JSONObject users = new JSONObject();
+        for (CookieSession cs : CookieSession.getAllSet()) {
+            JSONObject sess = new JSONObject();
+            if (cs.user != null) {
+                sess.put("user", SurveyAjax.JSONWriter.wrap(cs.user));
+            }
+            sess.put("id", cs.id);
+            sess.put("ip", cs.ip);
+            sess.put("lastBrowserCallMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastBrowserCallMillisSinceEpoch()));
+            sess.put("lastActionMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastActionMillisSinceEpoch()));
+            sess.put("millisTillKick", cs.millisTillKick());
+            users.put(cs.id, sess);
+        }
+        r.put("users", users);
+    }
+
+    private void unlinkUser(JSONWriter r, HttpServletRequest request) throws JSONException {
+        String s = request.getParameter("s");
+        CookieSession cs = CookieSession.retrieveWithoutTouch(s);
+        if (cs != null) {
+            JSONObject sess = new JSONObject();
+            if (cs.user != null) {
+                sess.put("user", SurveyAjax.JSONWriter.wrap(cs.user));
+            }
+            sess.put("id", cs.id);
+            sess.put("ip", cs.ip);
+            sess.put("lastBrowserCallMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastBrowserCallMillisSinceEpoch()));
+            sess.put("lastActionMillisSinceEpoch", SurveyMain.timeDiff(cs.getLastActionMillisSinceEpoch()));
+            sess.put("millisTillKick", cs.millisTillKick());
+            r.put("kick", s);
+            r.put("removing", sess);
+            cs.remove();
+        } else {
+            r.put("kick", s);
+            r.put("removing", null);
+        }
+    }
+
+    private void showThreads(JSONWriter r) throws JSONException {
+        JSONObject threads = new JSONObject();
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        long deadlockedThreads[] = threadBean.findDeadlockedThreads();
+        if (deadlockedThreads != null) {
+            JSONArray dead = new JSONArray();
+            ThreadInfo deadThreadInfo[] = threadBean.getThreadInfo(
+                deadlockedThreads, true, true);
+            for (ThreadInfo deadThread : deadThreadInfo) {
+                dead.put(new JSONObject()
+                    .put("name", deadThread.getThreadName())
+                    .put("id", deadThread.getThreadId())
+                    .put("text", deadThread.toString()));
+            }
+            threads.put("dead", dead);
+        }
+        Map<Thread, StackTraceElement[]> s = Thread.getAllStackTraces();
+        JSONObject threadList = new JSONObject();
+        for (Map.Entry<Thread, StackTraceElement[]> e : s.entrySet()) {
+            Thread t = e.getKey();
+            JSONObject thread = new JSONObject()
+                .put("state", t.getState())
+                .put("name", t.getName())
+                .put("stack", new JSONArray(e.getValue()));
+            threadList.put(Long.toString(t.getId()), thread);
+        }
+        threads.put("all", threadList);
+        r.put("threads", threads);
+    }
+
+    private void showExceptions(JSONWriter r, HttpServletRequest request) throws JSONException, IOException {
+        JSONObject exceptions = new JSONObject();
+        ChunkyReader cr = SurveyLog.getChunkyReader();
+        exceptions.put("lastTime", cr.getLastTime());
+        ChunkyReader.Entry e = null;
+        if (request.getParameter("before") != null) {
+            Long before = Long.parseLong(request.getParameter("before"));
+            e = cr.getEntryBelow(before);
+        } else {
+            e = cr.getLastEntry();
+        }
+        if (e != null) {
+            exceptions.put("entry", e);
+        }
+        r.put("exceptions", exceptions);
+    }
+
+    private void showSettings(JSONWriter r) throws JSONException {
+        CLDRConfigImpl cci = (CLDRConfigImpl) (CLDRConfig.getInstance());
+        JSONObject all = new JSONObject().put("all", cci.toJSONObject());
+        r.put("settings", all);
+    }
+
+    private void setSettings(JSONWriter r, HttpServletRequest request) throws JSONException {
+        JSONObject settings = new JSONObject();
+        try {
+            String setting = request.getParameter("setting");
+            StringBuilder sb = new StringBuilder();
+            java.io.Reader reader = request.getReader();
+            int ch;
+            while ((ch = reader.read()) > -1) {
+                sb.append((char) ch);
+            }
+            CLDRConfig cci = (CLDRConfig.getInstance());
+            cci.setProperty(setting, sb.toString());
+            settings.put("ok", true);
+            settings.put(setting, cci.getProperty(setting));
+        } catch (Throwable t) {
+            SurveyLog.logException(t, "Tring to set setting ");
+            settings.put("err", t.toString());
+        }
+        r.put("settings_set", settings);
+    }
+
+    private void doRawLoad(JSONWriter r, HttpServletRequest request) {
+        if (CLDRConfig.getInstance().getEnvironment() != CLDRConfig.Environment.SMOKETEST) {
+            r.put("err", "Only available in SMOKETEST context.");
+        } else {
+            String users = request.getParameter("users");
+            String pxml = request.getParameter("pxml");
+            if (users != null && pxml != null && !users.isEmpty() && !pxml.isEmpty()) {
+                // TODO: see AdminPanel.jsp
+                // <h3>Starting import org.unicode.cldr.web.SurveyAjax.JSONWriter;
+                // import from <%= users %></h3>
+                // int usersRead = CookieSession.sm.reg.readUserFile(CookieSession.sm, new java.io.File(users));
+                // ...
+            }
+            r.put("err", "rawload not yet implemented without jsp");
+        }
+    }
+
+    /**
+     * Create a new temporary user, and login as that user
+     *
+     * @param r
+     * @param request
+     * @param response
+     * @param sm
+     *
+     * Earlier version was in createAndLogin.jsp
+     */
+    private void createAndLogin(JSONWriter r, HttpServletRequest request, HttpServletResponse response, SurveyMain sm) {
+        if (SurveyMain.isSetup == false) {
+            r.put("isSetup", false);
+            return;
+        }
+        // zap any current login
+        Cookie c0 = WebContext.getCookie(request, SurveyMain.QUERY_EMAIL);
+        if (c0 != null) {
+            c0.setValue("");
+            c0.setMaxAge(0);
+            response.addCookie(c0);
+        }
+        Cookie c1 = WebContext.getCookie(request, SurveyMain.QUERY_PASSWORD);
+        if (c1 != null) {
+            c1.setValue("");
+            c1.setMaxAge(0);
+            response.addCookie(c1);
+        }
+        sm.reg.setOrgList();
+        String orgs[] = UserRegistry.getOrgList();
+        String myorg = orgs[(int) Math.rint(Math.random() * (orgs.length - 1))];
+        String defaultLevel = "";
+        ArrayList<String> levelStr = new ArrayList<>();
+        for (int lev : UserRegistry.ALL_LEVELS) {
+            if (lev != UserRegistry.ADMIN) {
+                String s = String.valueOf(lev) + " (" + UserRegistry.levelAsStr(lev) + ")";
+                levelStr.add(s);
+                if (lev == UserRegistry.TC) {
+                    defaultLevel = s;
+                }
+            }
+        }
+        r.put("name", randomName());
+        r.put("orgs", orgs);
+        r.put("defaultOrg", myorg);
+        r.put("levels", levelStr.toArray());
+        r.put("defaultLevel", defaultLevel);
+    }
+
+    private String randomName() {
+        // generate random name
+        StringBuilder genname = new StringBuilder();
+
+        // http://en.wikipedia.org/wiki/List_of_most_popular_given_names#Oceania
+        genname.append(choose("Tarita", "Hiro", "Teiki", "Moana", "Manua", "Marama",
+            "Teiva", "Teva", "Maui", "Tehei", "Tamatoa", "Ioane", "Tapuarii",
+            "Tiare", "Hinano", "Poema", "Maeva", "Hina", "Vaea", "Titaua", "Moea",
+            "Moeata", "Tarita", "Titaina", "Teura", "Heikapu", "Mareva"));
+        genname.append(' ');
+        genname.append((char) ('A' + new Random().nextInt(26)));
+        genname.append('.');
+        genname.append(' ');
+        genname.append(choose("Vetter", "Linguist", "User", "Typer", "Tester", "Specialist",
+            "Person", "Account", "Login", "CLDR"));
+        return genname.toString();
+    }
+
+    private String choose(String... option) {
+        return option[new Random().nextInt(option.length)];
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -285,10 +285,11 @@ public class SurveyAjax extends HttpServlet {
     public static final String WHAT_USER_LIST = "user_list"; // users.js
     public static final String WHAT_USER_OLDVOTES = "user_oldvotes"; // users.js
     public static final String WHAT_USER_XFEROLDVOTES = "user_xferoldvotes"; // users.js
-    public static final String WHAT_OLDVOTES = "oldvotes"; // CldrSurveyVettingLoader.js
-    public static final String WHAT_FLAGGED = "flagged"; // CldrSurveyVettingLoader.js
-    public static final String WHAT_AUTO_IMPORT = "auto_import"; // CldrSurveyVettingLoader.js
-    public static final String WHAT_ADMIN_PANEL = "admin_panel"; // CldrSurveyVettingLoader.js
+    public static final String WHAT_OLDVOTES = "oldvotes"; // cldrLoad.js
+    public static final String WHAT_FLAGGED = "flagged"; // cldrLoad.js
+    public static final String WHAT_AUTO_IMPORT = "auto_import"; // cldrLoad.js
+    public static final String WHAT_ADMIN_PANEL = "admin_panel"; // cldrAdmin.js
+    public static final String WHAT_ABOUT = "about"; // cldrLoad.js, cldrAbout.js
 
     public static final int oldestVersionForImportingVotes = 25; // Oldest table is cldr_vote_value_25, as of 2018-05-23.
 
@@ -379,6 +380,10 @@ public class SurveyAjax extends HttpServlet {
                 getRow(request, response, out, sm, sess, l, xpath);
             } else if (what.equals(WHAT_REPORT)) {
                 generateReport(request, response, out, sm, sess, l);
+            } else if (what.equals(WHAT_ABOUT)) {
+                JSONWriter r = newJSONStatus(request, sm);
+                new AboutST().getJson(r, sm);
+                send(r, out);
             } else if (what.equals(WHAT_STATS_BYLOC)) {
                 JSONWriter r = newJSONStatusQuick(sm);
                 JSONObject query = DBUtils.queryToCachedJSON(what, 5 * 60 * 1000, StatisticsUtils.QUERY_ALL_VOTES);
@@ -554,7 +559,15 @@ public class SurveyAjax extends HttpServlet {
                     if (what.equals(WHAT_ADMIN_PANEL)) {
                         mySession.userDidAction();
                         if (UserRegistry.userIsAdmin(mySession.user)) {
-                            response.sendRedirect(request.getContextPath() + "/AdminPanel.jsp" + "?vap=" + SurveyMain.vap);
+                            if (SurveyTool.USE_DOJO) {
+                                response.sendRedirect(request.getContextPath() + "/AdminPanel.jsp" + "?vap=" + SurveyMain.vap);
+                            } else {
+                                mySession.userDidAction();
+                                JSONWriter r = newJSONStatus(request, sm);
+                                r.put("what", what);
+                                new AdminPanel().getJson(r, request, response, sm);
+                                send(r, out);
+                            }
                         } else {
                             sendError(out, "Only Admin can access Admin Panel", ErrorCode.E_NO_PERMISSION);
                         }
@@ -2686,7 +2699,6 @@ public class SurveyAjax extends HttpServlet {
         CLDRConfigImpl.setUrls(request);
         WebContext ctx = new WebContext(request, response);
         ElapsedTimer et = new ElapsedTimer();
-
         String loc = locale.toString();
         ctx.setLocale(locale);
         xpath = WebContext.decodeFieldString(xpath); // TODO: why doesn't processRequest do decodeFieldString? Not needed, all ASCII?
@@ -3140,7 +3152,8 @@ public class SurveyAjax extends HttpServlet {
                 out.write("<td title='vote:' style='" + resultStyle + "'>\n");
                 if (!checkResult.isEmpty()) {
                     out.write("<script>\n");
-                    out.write("document.write(testsToHtml(" + SurveyAjax.JSONWriter.wrap(checkResult) + ")");
+                    String testsToHtml = SurveyTool.USE_DOJO ? "cldrSurvey.testsToHtml" : "testsToHtml";
+                    out.write("document.write(" + testsToHtml + "(" + SurveyAjax.JSONWriter.wrap(checkResult) + ")");
                     out.write("</script>\n");
                 }
                 out.write(WebContext.iconHtml(request, resultIcon, result) + result);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -592,8 +592,9 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                 }
             }
 
-            if (isUnofficial() && (ctx.hasTestPassword() || ctx.hasAdminPassword())
-                && ctx.field("action").equals("new_and_login")) { // accessed from createAndLogin.jsp
+            if (isUnofficial() && ctx.field("action").equals("new_and_login") &&
+                    (ctx.hasTestPassword() || ctx.hasAdminPassword() || requestIsByAdmin(request))) {
+                // accessed from createAndLogin.jsp or cldrCreateLogin.js
                 ctx.println("<hr>");
                 String real = ctx.field("real").trim();
                 if (real.isEmpty() || real.equals("REALNAME")) {
@@ -673,6 +674,18 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             Thread.currentThread().setName(baseThreadName);
             ctx.close();
         }
+    }
+
+    private boolean requestIsByAdmin(HttpServletRequest request) {
+        String sess = request.getParameter(SurveyMain.QUERY_SESSION);
+        if (sess != null) {
+            CookieSession.checkForExpiredSessions();
+            CookieSession mySession = CookieSession.retrieve(sess);
+            if (mySession != null && UserRegistry.userIsAdmin(mySession.user)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -1743,6 +1756,9 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * @param ctx
      *
      * TODO: this function is over 666 lines long. Shorten it with subroutines.
+     * Move it to a new class, maybe "UserList.java". Separate the model (data)
+     * from the presentation (html). Generate the presentation on the front end.
+     * Generate only the data on the back end, and deliver it as json.
      */
     private void doList(WebContext ctx) {
         int n = 0;
@@ -2256,7 +2272,13 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                 ctx.println("</tbody></table>");
 
                 // now, serialize the list..
-                ctx.println("<script>var shownUsers = " + shownUsers.toString() + ";\r\nshowUserActivity(shownUsers, 'userListTable');\r\n</script>\n");
+                /*
+                 * TODO: implement this with strict js, without using java to write js!
+                 * ...this function SurveyMain.doList() is over 666 lines long...
+                 * showUserActivity doesn't work if called this way, if !SurveyTool.USE_DOJO
+                 */
+                ctx.println("<script>var shownUsers = " + shownUsers.toString() + ";\n" +
+                		"showUserActivity(shownUsers, 'userListTable');\n</script>\n");
 
                 if (hideUserList) {
                     ctx.println("</div>");
@@ -3026,7 +3048,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             whySent = "You are being notified of the CLDR vetting account for you.\n";
         } else {
             fromId = null;
-            whySent = "Your CLDR vetting account information is being sent to you\r\n\r\n";
+            whySent = "Your CLDR vetting account information is being sent to you\n\n";
         }
         String body = whySent + "To access it, visit: \n<"
             + defaultBase + "?" + QUERY_PASSWORD + "=" + pass + "&"

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -3,6 +3,8 @@ package org.unicode.cldr.web;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collections;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -18,7 +20,7 @@ import org.unicode.cldr.util.VettingViewer;
 
 public class SurveyTool extends HttpServlet {
     private static final long serialVersionUID = 1L;
-    private static final boolean USE_DOJO = true;
+    public static final boolean USE_DOJO = true;
 
     @Override
     public final void init(final ServletConfig config) throws ServletException {
@@ -88,7 +90,7 @@ public class SurveyTool extends HttpServlet {
     }
 
     private void serveWaitingPage(HttpServletRequest request, PrintWriter out, SurveyMain sm)
-            throws IOException {
+        throws IOException {
         /*
          * TODO: simplify serveWaitingPage and/or move it to the front end.
          * This is a crude port from old v.jsp, with js inside html inside java.
@@ -183,7 +185,7 @@ public class SurveyTool extends HttpServlet {
         out.write("  window.setTimeout(function() {\n");
         out.write("    window.location.reload(true);\n");
         out.write("    //document.location='" + url
-                    + "' + document.location.search + document.location.hash;\n");
+            + "' + document.location.search + document.location.hash;\n");
         out.write("  },10000 /* ten seconds */);\n");
         out.write("</script>\n");
     }
@@ -248,7 +250,7 @@ public class SurveyTool extends HttpServlet {
     }
 
     private void serveRunnningNormallyPage(HttpServletRequest request, PrintWriter out, SurveyMain sm)
-            throws IOException {
+        throws IOException {
         String lang = SurveyMain.TRANS_HINT_LOCALE.toLanguageTag();
         out.write("<html lang='" + lang + "' class='claro'>\n");
         out.write("<head>\n");
@@ -311,6 +313,34 @@ public class SurveyTool extends HttpServlet {
         out.write("<script src='//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js'></script>\n");
     }
 
+    private static final String[] newJsFiles = {
+        "cldrText.js",
+        "cldrStatus.js",
+        "cldrAjax.js",
+        "cldrAbout.js",
+        "cldrBulkClosePosts.js",
+        "cldrCreateLogin.js",
+        "cldrDom.js",
+        "cldrForumParticipation.js",
+        "cldrForumFilter.js",
+        "cldrCsvFromTable.js",
+        "cldrDeferHelp.js",
+        "cldrForum.js",
+        "cldrForumPanel.js",
+        "cldrOtherSpecial.js",
+        "cldrFlip.js",
+        "cldrLocaleMap.js",
+        "cldrXpathMap.js",
+        "cldrSurvey.js",
+        "cldrInfo.js",
+        "cldrAdmin.js",
+        "cldrLoad.js",
+        "cldrOldVotes.js",
+        "cldrTable.js",
+        "cldrEvent.js",
+        "cldrGui.js",
+    };
+
     private static void includeCldrJavaScript(HttpServletRequest request, Writer out) throws IOException {
         final String prefix = "<script src='" + request.getContextPath() + "/js/";
         final String tail = "'></script>\n";
@@ -318,11 +348,10 @@ public class SurveyTool extends HttpServlet {
 
         out.write(prefix + "jquery.autosize.min.js" + tail); // exceptional
 
-        out.write(prefix + "new/cldrText" + js); // new/cldrText.js -- same file for dojo and non-dojo
-        out.write(prefix + "new/cldrStatus" + js); // new/cldrStatus.js -- same file for dojo and non-dojo
-        out.write(prefix + "new/cldrAjax" + js); // new/cldrAjax.js -- same file for dojo and non-dojo
-
         if (USE_DOJO) {
+            out.write(prefix + "new/cldrText" + js); // new/cldrText.js
+            out.write(prefix + "new/cldrStatus" + js); // new/cldrStatus.js
+            out.write(prefix + "new/cldrAjax" + js); // new/cldrAjax.js
             out.write(prefix + "CldrDojoBulkClosePosts" + js); // CldrDojoBulkClosePosts.js
             out.write(prefix + "CldrDojoForumParticipation" + js); // CldrDojoForumParticipation.js
             out.write(prefix + "new/cldrForumFilter" + js); // new/cldrForumFilter.js
@@ -337,19 +366,13 @@ public class SurveyTool extends HttpServlet {
             out.write(prefix + "review" + js); // review.js
             out.write(prefix + "CldrDojoGui" + js); // CldrGuiDojo.js
         } else {
-            out.write(prefix + "new/cldrBulkClosePosts" + js); // new/cldrBulkClosePosts.js
-            out.write(prefix + "new/cldrForumParticipation" + js); // new/cldrForumParticipation.js
-            out.write(prefix + "new/cldrForumFilter" + js); // new/cldrForumFilter.js
-            out.write(prefix + "new/cldrCsvFromTable" + js); // new/cldrCsvFromTable.js
-            out.write(prefix + "new/cldrDeferHelp" + js); // new/cldrDeferHelp.js
-            out.write(prefix + "new/cldrForum" + js); // new/cldrForum.js
-            out.write(prefix + "new/cldrFlip" + js); // new/cldrFlip.js
-            out.write(prefix + "new/cldrLocaleMap" + js); // new/cldrLocaleMap.js
-            out.write(prefix + "new/cldrXpathMap" + js); // new/cldrXpathMap.js
-            out.write(prefix + "new/cldrLoad" + js); // new/cldrLoad.js
-            out.write(prefix + "new/cldrTable" + js); // new/cldrTable.js
-            out.write(prefix + "bootstrap.min.js" + tail); // exceptional
-            out.write(prefix + "new/cldrGui" + js); // new/cldrGui.js
+            out.write(prefix + "bootstrap.min.js" + tail);
+            Arrays.sort(newJsFiles);
+            Arrays.sort(newJsFiles, Collections.reverseOrder());
+            for (String s: newJsFiles) {
+                String ss = s.replace(".js", "");
+                out.write(prefix + "new/" + ss + js);
+            }
         }
     }
 

--- a/tools/cldr-apps/src/main/webapp/AdminPanel.jsp
+++ b/tools/cldr-apps/src/main/webapp/AdminPanel.jsp
@@ -132,11 +132,14 @@ String sql = request.getContextPath()+"/survey?sql="+vap+"";
 </div>
 <script>
 var vap='<%= vap %>';
+<% if (SurveyTool.USE_DOJO) { %>
 require(["dojo/ready"], function(ready) {
 	ready(loadAdminPanel);
 });
-
+<% } else { %>
+$(cldrSurvey.loadAdminPanel());
 </script>
+<% } %>
 
 <div id='adminStuff'></div>
 

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrAbout.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrAbout.js
@@ -1,0 +1,184 @@
+"use strict";
+
+/**
+ * cldrAbout: encapsulate functions for the "About" page of Survey Tool
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+
+const cldrAbout = (function () {
+  const moreInfo =
+    "<p class='hang'>For more information about the Survey Tool, " +
+    "see <a href='http://www.unicode.org/cldr'>unicode.org/cldr</a>.</p>\n";
+
+  const javaOsVersionKeys = [
+    "java.version",
+    "java.vendor",
+    "java.vm.version",
+    "java.vm.vendor",
+    "java.vm.name",
+    "os.name",
+    "os.arch",
+    "os.version",
+  ];
+
+  function load() {
+    const xhrArgs = {
+      url: cldrStatus.getContextPath() + "/SurveyAjax?what=about",
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  function loadHandler(json) {
+    // Clear the 'right sidebar'
+    cldrInfo.showNothing();
+
+    const ourDiv = document.createElement("div");
+    ourDiv.innerHTML = getHtml(json);
+    cldrSurvey.hideLoader();
+    cldrLoad.flipToOtherDiv(ourDiv);
+  }
+
+  function errorHandler(err) {
+    const ourDiv = document.createElement("div");
+    ourDiv.innerHTML = err;
+  }
+
+  function getHtml(json) {
+    let html = cldrStatus.logoIcon();
+    html += javaVersions(json) + otherVersions(json) + stInfo(json);
+    if (json["hasDataSource"]) {
+      html += dbInfo(json);
+    }
+    html += moreInfo;
+    return html;
+  }
+
+  function javaVersions(json) {
+    let html = "<h4 class='selected'>Java Versions</h4>\n";
+    html += "<table class='userlist' border='2'>\n";
+    for (let i in javaOsVersionKeys) {
+      const label = javaOsVersionKeys[i];
+      const key = label.replaceAll(".", "_");
+      const val = json[key];
+      // Style of rows alternates between classes 'row0' and 'row1', hence i % 2
+      const rowClass = "row" + (i % 2);
+      html +=
+        "<tr class='" +
+        rowClass +
+        "'><th><tt>" +
+        label +
+        "</tt></th><td>" +
+        val +
+        "</td></tr>\n";
+    }
+    html += "</table>\n";
+    return html;
+  }
+
+  function otherVersions(json) {
+    const majorMinor =
+      json["servletMajorVersion"] + "." + json["servletMinorVersion"];
+
+    let i = 0;
+    let html = "<h4 class='selected'>Other Versions</h4>\n";
+    html += "<table class='userlist' border='2'>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>CLDRFile.GEN_VERSION</th>";
+    html += "<td>" + json["GEN_VERSION"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>ICU</th>";
+    html += "<td>" + json["ICU_VERSION"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>Server</th>";
+    html += "<td>" + json["serverInfo"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>Java Servlet API</th>";
+    html += "<td>" + majorMinor + "</td>\n";
+    html += "</tr>\n";
+
+    html += "</table>\n";
+    return html;
+  }
+
+  function stInfo(json) {
+    let i = 0;
+    let html = "<h4 class='selected'>Survey Tool information</h4>\n";
+    html += "<table class='userlist' border='2'>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>SurveyMain.TRANS_HINT_LOCALE</th>";
+    html += "<td>" + json["TRANS_HINT_LOCALE"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>SurveyMain.TRANS_HINT_LANGUAGE_NAME</th>";
+    html += "<td>" + json["TRANS_HINT_LANGUAGE_NAME"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>CLDR_UTILITIES_HASH</th>";
+    html += "<td>" + json["CLDR_UTILITIES_HASH"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>CLDR_SURVEYTOOL_HASH</th>";
+    html += "<td>" + json["CLDR_SURVEYTOOL_HASH"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>CLDR_DATA_HASH</th>";
+    html += "<td>" + json["CLDR_DATA_HASH"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "</table>\n";
+    return html;
+  }
+
+  function dbInfo(json) {
+    let i = 0;
+    let html = "<h4 class='selected'>Database information</h4>\n";
+    html += "<table class='userlist' border='2'>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>Have Datasource?</th>";
+    html += "<td>" + json["hasDataSource"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "<tr class='row" + (i++ % 2) + "'>\n";
+    html += "<th>DB Kind / Info</th>";
+    html += "<td>" + json["dbKind"] + "<br />" + json["dbInfo"] + "</td>\n";
+    html += "</tr>\n";
+
+    html += "</table>\n";
+    return html;
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    load: load,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      getHtml: getHtml,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrAdmin.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrAdmin.js
@@ -1,0 +1,780 @@
+"use strict";
+
+/**
+ * cldrAdmin: encapsulate the Admin Panel.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+const cldrAdmin = (function () {
+  const ADMIN_DEBUG = true;
+
+  let panelLast = null;
+  let panels = {};
+  let panelFirst = null;
+
+  let exceptions = [];
+  let exceptionNames = {};
+
+  function load() {
+    cldrInfo.showNothing();
+
+    const ourDiv = document.createElement("div");
+    const surveyUser = cldrStatus.getSurveyUser();
+    const hasPermission = surveyUser && surveyUser.userlevelName === "ADMIN";
+    if (!hasPermission) {
+      ourDiv.innerHTML = cldrText.get("E_NO_PERMISSION");
+    } else {
+      ourDiv.innerHTML = getHtml();
+    }
+    // caution: ourDiv isn't added to DOM until we call flipToOtherDiv
+    cldrSurvey.hideLoader();
+    cldrLoad.flipToOtherDiv(ourDiv);
+    if (hasPermission) {
+      loadAdminPanel();
+    }
+  }
+
+  function getHtml() {
+    let html =
+      cldrStatus.logoIcon() +
+      "<h2>Survey Tool Administration | " +
+      window.location.hostname +
+      "</h2>\n" +
+      // TODO: "raw SQL"
+      "<a href='#createAndLogin'>CreateAndLogin</a>\n" +
+      "<div style='float: right; font-size: x-small;'>" +
+      "<span id='visitors'></span></div>\n" +
+      "<hr />\n" +
+      "<div class='fnotebox'>" +
+      "For instructions, see <a href='http://cldr.unicode.org/index/survey-tool/admin'>Admin Docs</a>.<br />" +
+      "Tabs do not (currently) auto update. Click a tab again to update.</div>\n" +
+      "<div id='adminStuff'></div>\n";
+    return html;
+  }
+
+  function loadAdminPanel() {
+    const adminStuff = document.getElementById("adminStuff");
+    if (!adminStuff) {
+      return;
+    }
+    const content = document.createDocumentFragment();
+    const list = document.createElement("ul");
+    list.className = "adminList";
+    content.appendChild(list);
+
+    addAdminPanel("admin_users", adminUsers, list, content);
+    addAdminPanel("admin_threads", adminThreads, list, content);
+    addAdminPanel("admin_exceptions", adminExceptions, list, content);
+    addAdminPanel("admin_settings", adminSettings, list, content);
+    addAdminPanel("admin_ops", adminOps, list, content);
+
+    // last panel loaded.
+    // If it's in the hashtag, use it, otherwise first.
+    // TODO: this doesn't work since we no longer have "#!"; if needed, revise the mechanism
+    if (window.location.hash && window.location.hash.indexOf("#!") == 0) {
+      panelSwitch(window.location.hash.substring(2));
+    }
+    if (!panelLast) {
+      // not able to load anything.
+      panelSwitch(panelFirst.type);
+    }
+    adminStuff.appendChild(content);
+  }
+
+  function addAdminPanel(type, fn, list, content) {
+    const panel = (panels[type] = {
+      type: type,
+      name: cldrText.get(type) || type,
+      desc:
+        cldrText.get(type + "_desc") ||
+        "(no description - missing from cldrText)",
+      fn: fn,
+    });
+    panel.div = document.createElement("div");
+    panel.div.style.display = "none";
+    panel.div.className = "adminPanel";
+
+    const h = document.createElement("h3");
+    h.className = "adminTitle";
+    h.appendChild(document.createTextNode(panel.desc || type));
+    panel.div.appendChild(h);
+
+    panel.udiv = document.createElement("div");
+    panel.div.appendChild(panel.udiv);
+
+    panel.listItem = document.createElement("li");
+    panel.listItem.appendChild(document.createTextNode(panel.name || type));
+    panel.listItem.title = panel.desc || type;
+    panel.listItem.className = "notselected";
+    panel.listItem.onclick = function (e) {
+      panelSwitch(panel.type);
+      return false;
+    };
+    list.appendChild(panel.listItem);
+
+    content.appendChild(panel.div);
+
+    if (!panelFirst) {
+      panelFirst = panel;
+    }
+  }
+
+  function adminUsers(div) {
+    const frag = document.createDocumentFragment();
+    const u = document.createElement("div");
+    u.appendChild(document.createTextNode("Loading..."));
+    frag.appendChild(u);
+    cldrDom.removeAllChildNodes(div);
+    div.appendChild(frag);
+    loadOrFail("do=users", u, function (json) {
+      loadAdminUsers(json, u);
+    });
+  }
+
+  function adminThreads(div) {
+    const frag = document.createDocumentFragment();
+    div.className = "adminThreads";
+    const u = cldrDom.createChunk("Loading...", "div", "adminThreadList");
+    const stack = cldrDom.createChunk(null, "div", "adminThreadStack");
+    frag.appendChild(u);
+    frag.appendChild(stack);
+    const c2s = cldrDom.createChunk(
+      cldrText.get("clickToSelect"),
+      "button",
+      "clickToSelect"
+    );
+    cldrDom.clickToSelect(c2s, stack);
+
+    cldrDom.removeAllChildNodes(div);
+    div.appendChild(c2s);
+    div.appendChild(frag);
+    loadOrFail("do=threads", u, function (json) {
+      loadAdminThreads(json, u, stack);
+    });
+  }
+
+  function adminSettings(div) {
+    const frag = document.createDocumentFragment();
+    div.className = "adminSettings";
+    const u = cldrDom.createChunk("Loading...", "div", "adminSettingsList");
+    frag.appendChild(u);
+    loadOrFail("do=settings", u, function (json) {
+      loadAdminSettings(json, u);
+    });
+    cldrDom.removeAllChildNodes(div);
+    div.appendChild(frag);
+  }
+
+  function loadAdminUsers(json, u) {
+    const frag2 = document.createDocumentFragment();
+
+    if (!json || !json.users || Object.keys(json.users) == 0) {
+      frag2.appendChild(document.createTextNode(cldrText.get("No users.")));
+    } else {
+      for (let sess in json.users) {
+        const cs = json.users[sess];
+        const user = cldrDom.createChunk(null, "div", "adminUser");
+        user.appendChild(
+          cldrDom.createChunk("Session: " + sess, "span", "adminUserSession")
+        );
+        if (cs.user) {
+          user.appendChild(cldrSurvey.createUser(cs.user));
+        } else {
+          user.appendChild(
+            cldrDom.createChunk("(anonymous)", "div", "adminUserUser")
+          );
+        }
+        /*
+         * cs.lastBrowserCallMillisSinceEpoch = time elapsed in millis since server heard from client
+         * cs.lastActionMillisSinceEpoch = time elapsed in millis since user did active action
+         * cs.millisTillKick = how many millis before user will be kicked if inactive
+         */
+        user.appendChild(
+          cldrDom.createChunk(
+            "LastCall: " +
+              cs.lastBrowserCallMillisSinceEpoch +
+              ", LastAction: " +
+              cs.lastActionMillisSinceEpoch +
+              ", IP: " +
+              cs.ip +
+              ", ttk:" +
+              (parseInt(cs.millisTillKick) / 1000).toFixed(1) +
+              "s",
+            "span",
+            "adminUserInfo"
+          )
+        );
+
+        const unlinkButton = cldrDom.createChunk(
+          cldrText.get("admin_users_action_kick"),
+          "button",
+          "admin_users_action_kick"
+        );
+        user.appendChild(unlinkButton);
+        unlinkButton.onclick = function (e) {
+          unlinkButton.className = "deactivated";
+          unlinkButton.onclick = null;
+          loadOrFail("do=unlink&s=" + cs.id, unlinkButton, function (json) {
+            cldrDom.removeAllChildNodes(unlinkButton);
+            if (json.removing == null) {
+              unlinkButton.appendChild(
+                document.createTextNode("Already Removed")
+              );
+            } else {
+              unlinkButton.appendChild(document.createTextNode("Removed."));
+            }
+          });
+          return cldrEvent.stopPropagation(e);
+        };
+        frag2.appendChild(user);
+        frag2.appendChild(document.createElement("hr"));
+      }
+    }
+    cldrDom.removeAllChildNodes(u);
+    u.appendChild(frag2);
+  }
+
+  function loadAdminThreads(json, u, stack) {
+    if (!json || !json.threads || Object.keys(json.threads.all) == 0) {
+      cldrDom.removeAllChildNodes(u);
+      u.appendChild(document.createTextNode(cldrText.get("No threads.")));
+    } else {
+      const frag2 = document.createDocumentFragment();
+      cldrDom.removeAllChildNodes(stack);
+      stack.innerHTML = cldrText.get("adminClickToViewThreads");
+      let deadThreads = {};
+      if (json.threads.dead) {
+        const header = cldrDom.createChunk(
+          cldrText.get("adminDeadThreadsHeader"),
+          "div",
+          "adminDeadThreadsHeader"
+        );
+        const deadul = cldrDom.createChunk("", "ul", "adminDeadThreads");
+        for (let jj = 0; jj < json.threads.dead.length; jj++) {
+          const theThread = json.threads.dead[jj];
+          const deadLi = cldrDom.createChunk("#" + theThread.id, "li");
+          deadThreads[theThread.id] = theThread.text;
+          deadul.appendChild(deadLi);
+        }
+        header.appendChild(deadul);
+        stack.appendChild(header);
+      }
+      for (let id in json.threads.all) {
+        const t = json.threads.all[id];
+        const thread = cldrDom.createChunk(null, "div", "adminThread");
+        const tid = cldrDom.createChunk(id, "span", "adminThreadId");
+        thread.appendChild(tid);
+        if (deadThreads[id]) {
+          tid.className = tid.className + " deadThread";
+        }
+        thread.appendChild(
+          cldrDom.createChunk(t.name, "span", "adminThreadName")
+        );
+        thread.appendChild(
+          cldrDom.createChunk(
+            cldrText.get(t.state),
+            "span",
+            "adminThreadState_" + t.state
+          )
+        );
+        thread.onclick = (function (t, id) {
+          return function () {
+            stack.innerHTML = "<b>" + id + ":" + t.name + "</b>\n";
+            if (deadThreads[id]) {
+              stack.appendChild(
+                cldrDom.createChunk(deadThreads[id], "pre", "deadThreadInfo")
+              );
+            }
+            stack.appendChild(
+              cldrDom.createChunk("\n\n```\n", "pre", "textForTrac")
+            );
+            for (let q in t.stack) {
+              stack.innerHTML = stack.innerHTML + t.stack[q] + "\n";
+            }
+            stack.appendChild(
+              cldrDom.createChunk("```\n\n", "pre", "textForTrac")
+            );
+          };
+        })(t, id);
+        frag2.appendChild(thread);
+      }
+      cldrDom.removeAllChildNodes(u);
+      u.appendChild(frag2);
+    }
+  }
+
+  function adminExceptions(div) {
+    const frag = document.createDocumentFragment();
+
+    div.className = "adminThreads";
+    const v = cldrDom.createChunk(null, "div", "adminExceptionList");
+    v.setAttribute("id", "admin_v");
+    const stack = cldrDom.createChunk(null, "div", "adminThreadStack");
+    stack.setAttribute("id", "admin_stack");
+
+    frag.appendChild(v);
+    const u = cldrDom.createChunk(null, "div");
+    u.setAttribute("id", "admin_u");
+    v.appendChild(u);
+    frag.appendChild(stack);
+
+    const c2s = cldrDom.createChunk(
+      cldrText.get("clickToSelect"),
+      "button",
+      "clickToSelect"
+    );
+    cldrDom.clickToSelect(c2s, stack);
+
+    cldrDom.removeAllChildNodes(div);
+    div.appendChild(c2s);
+
+    exceptions = [];
+    exceptionNames = {};
+
+    div.appendChild(frag);
+    const loading = cldrDom.createChunk(
+      cldrText.get("loading"),
+      "p",
+      "adminExceptionFooter"
+    );
+    loading.setAttribute("id", "admin_loading");
+    v.appendChild(loading);
+    loadNext(null); // load the first exception
+  }
+
+  function loadNext(from) {
+    let append = "do=exceptions";
+    if (from) {
+      append = append + "&before=" + from;
+    }
+    console.log("Loading: " + append);
+    const u = document.getElementById("admin_u");
+    loadOrFail(append, u, function (json) {
+      loadAdminExceptions(json, u, from);
+    });
+  }
+
+  function loadAdminExceptions(json, u, from) {
+    const v = document.getElementById("admin_v");
+    const loading = document.getElementById("admin_loading");
+    const stack = document.getElementById("admin_stack");
+
+    if (!json || !json.exceptions || !json.exceptions.entry) {
+      if (!from) {
+        v.appendChild(
+          cldrDom.createChunk(
+            cldrText.get("no_exceptions"),
+            "p",
+            "adminExceptionFooter"
+          )
+        );
+      } else {
+        // just the last one
+        v.removeChild(loading);
+        v.appendChild(
+          cldrDom.createChunk(
+            cldrText.get("last_exception"),
+            "p",
+            "adminExceptionFooter"
+          )
+        );
+      }
+    } else {
+      if (json.exceptions.entry.time == from) {
+        console.log("Asked for <" + from + " but got =" + from);
+        v.removeChild(loading);
+        return;
+      }
+      const frag2 = document.createDocumentFragment();
+      if (!from) {
+        cldrDom.removeAllChildNodes(stack);
+        stack.innerHTML = cldrText.get("adminClickToViewExceptions");
+      }
+      // TODO: if(json.threads.dead) frag2.appendChunk(json.threads.dead.toString(),"span","adminDeadThreads");
+      if (json.exceptions.entry) {
+        /*
+         * TODO: clarify usage of "var e" here! "e" is used for json.exceptions.entry,
+         * and also in "clicky" below, where it might or might not represent the click "event"???
+         */
+        var e = json.exceptions.entry;
+        exceptions.push(json.exceptions.entry);
+        var exception = cldrDom.createChunk(null, "div", "adminException");
+        if (e.header && e.header.length < 80) {
+          exception.appendChild(
+            cldrDom.createChunk(e.header, "span", "adminExceptionHeader")
+          );
+        } else {
+          var t;
+          exception.appendChild(
+            (t = cldrDom.createChunk(
+              e.header.substring(0, 80) + "...",
+              "span",
+              "adminExceptionHeader"
+            ))
+          );
+          t.title = e.header;
+        }
+        exception.appendChild(
+          cldrDom.createChunk(e.DATE, "span", "adminExceptionDate")
+        );
+        var clicky = (function (e) {
+          // TODO: what is "e" here? entry, or event??
+          return function (ee) {
+            // TODO: "ee"? This is a mess!
+            var frag3 = document.createDocumentFragment();
+            frag3.appendChild(
+              cldrDom.createChunk(e.header, "span", "adminExceptionHeader")
+            );
+            frag3.appendChild(
+              cldrDom.createChunk(e.DATE, "span", "adminExceptionDate")
+            );
+
+            if (e.UPTIME) {
+              frag3.appendChild(
+                cldrDom.createChunk(e.UPTIME, "span", "adminExceptionUptime")
+              );
+            }
+            if (e.CTX) {
+              frag3.appendChild(
+                cldrDom.createChunk(e.CTX, "span", "adminExceptionUptime")
+              );
+            }
+            for (let q in e.fields) {
+              var f = e.fields[q];
+              var k = Object.keys(f);
+              frag3.appendChild(cldrDom.createChunk(k[0], "h4", "textForTrac"));
+              frag3.appendChild(
+                cldrDom.createChunk("\n```", "pre", "textForTrac")
+              );
+              frag3.appendChild(
+                cldrDom.createChunk(f[k[0]], "pre", "adminException" + k[0])
+              );
+              frag3.appendChild(
+                cldrDom.createChunk("```\n", "pre", "textForTrac")
+              );
+            }
+
+            if (e.LOGSITE) {
+              frag3.appendChild(
+                cldrDom.createChunk("LOGSITE\n", "h4", "textForTrac")
+              );
+              frag3.appendChild(
+                cldrDom.createChunk("\n```", "pre", "textForTrac")
+              );
+              frag3.appendChild(
+                cldrDom.createChunk(e.LOGSITE, "pre", "adminExceptionLogsite")
+              );
+              frag3.appendChild(
+                cldrDom.createChunk("```\n", "pre", "textForTrac")
+              );
+            }
+            cldrDom.removeAllChildNodes(stack);
+            stack.appendChild(frag3);
+            cldrEvent.stopPropagation(ee);
+            return false;
+          };
+        })(e);
+        cldrDom.listenFor(exception, "click", clicky);
+        var head = exceptionNames[e.header];
+        if (head) {
+          if (!head.others) {
+            head.others = [];
+            head.count = document.createTextNode("");
+            var countSpan = document.createElement("span");
+            countSpan.appendChild(head.count);
+            countSpan.className = "adminExceptionCount";
+            cldrDom.listenFor(countSpan, "click", function (e) {
+              // prepare div
+              if (!head.otherdiv) {
+                head.otherdiv = cldrDom.createChunk(
+                  null,
+                  "div",
+                  "adminExceptionOtherList"
+                );
+                head.otherdiv.appendChild(
+                  cldrDom.createChunk(
+                    cldrText.get("adminExceptionDupList"),
+                    "h4"
+                  )
+                );
+                for (let k in head.others) {
+                  head.otherdiv.appendChild(head.others[k]);
+                }
+              }
+              cldrDom.removeAllChildNodes(stack);
+              stack.appendChild(head.otherdiv);
+              cldrEvent.stopPropagation(e);
+              return false;
+            });
+            head.appendChild(countSpan);
+          }
+          head.others.push(exception);
+          head.count.nodeValue = cldrText.sub("adminExceptionDup", [
+            head.others.length,
+          ]);
+          head.otherdiv = null; // reset
+        } else {
+          frag2.appendChild(exception);
+          exceptionNames[e.header] = exception;
+        }
+      }
+      u.appendChild(frag2);
+
+      if (json.exceptions.entry && json.exceptions.entry.time) {
+        if (exceptions.length > 0 && exceptions.length % 8 == 0) {
+          v.removeChild(loading);
+          const more = cldrDom.createChunk(
+            cldrText.get("more_exceptions"),
+            "p",
+            "adminExceptionMore adminExceptionFooter"
+          );
+          more.setAttribute("id", "admin_more");
+          more.onclick = more.onmouseover = function () {
+            v.removeChild(more);
+            v.appendChild(loading);
+            loadNext(json.exceptions.entry.time);
+            return false;
+          };
+          v.appendChild(more);
+        } else {
+          setTimeout(function () {
+            loadNext(json.exceptions.entry.time);
+          }, 500);
+        }
+      }
+    }
+  }
+
+  function loadAdminSettings(json, u) {
+    if (!json || !json.settings || Object.keys(json.settings.all) == 0) {
+      cldrDom.removeAllChildNodes(u);
+      u.appendChild(document.createTextNode(cldrText.get("nosettings")));
+    } else {
+      const frag2 = document.createDocumentFragment();
+      for (let id in json.settings.all) {
+        const t = json.settings.all[id];
+        const thread = cldrDom.createChunk(null, "div", "adminSetting");
+        thread.appendChild(cldrDom.createChunk(id, "span", "adminSettingId"));
+        if (id === "CLDR_HEADER") {
+          (function (theHeader, theValue) {
+            let setHeader = appendInputBox(thread, "adminSettingsChangeTemp");
+            setHeader.value = theValue;
+            setHeader.stChange = function (onOk, onErr) {
+              loadOrFail(
+                "do=settings_set&setting=" + theHeader,
+                u,
+                function (json) {
+                  if (!json || !json.settings_set || !json.settings_set.ok) {
+                    onErr(cldrText.get("failed"));
+                    onErr(json.settings_set.err);
+                  } else {
+                    if (json.settings_set[theHeader]) {
+                      setHeader.value = json.settings_set[theHeader];
+                      if (theHeader == "CLDR_HEADER") {
+                        cldrSurvey.updateSpecialHeader(setHeader.value);
+                      }
+                    } else {
+                      setHeader.value = "";
+                      if (theHeader == "CLDR_HEADER") {
+                        cldrSurvey.updateSpecialHeader(null);
+                      }
+                    }
+                    onOk(cldrText.get("changed"));
+                  }
+                },
+                setHeader.value
+              );
+              return false;
+            };
+          })(id, t); // call it
+
+          if (id === "CLDR_HEADER") {
+            cldrSurvey.updateSpecialHeader(t);
+          }
+        } else {
+          thread.appendChild(
+            cldrDom.createChunk(t, "span", "adminSettingValue")
+          );
+        }
+        frag2.appendChild(thread);
+      }
+      cldrDom.removeAllChildNodes(u);
+      u.appendChild(frag2);
+    }
+  }
+
+  function adminOps(div) {
+    const frag = document.createDocumentFragment();
+    div.className = "adminThreads";
+    const sessionId = cldrStatus.getSessionId();
+
+    const baseUrl =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=admin_panel&s=" +
+      sessionId +
+      "&do=";
+
+    const actions = ["rawload"];
+    for (let k in actions) {
+      const action = actions[k];
+      const newUrl = baseUrl + action;
+      const b = cldrDom.createChunk(cldrText.get(action), "button");
+      b.onclick = function () {
+        window.location = newUrl;
+        return false;
+      };
+      frag.appendChild(b);
+    }
+    cldrDom.removeAllChildNodes(div);
+    div.appendChild(frag);
+  }
+
+  function loadOrFail(urlAppend, theDiv, loadHandler, postData) {
+    const ourUrl =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=admin_panel&" +
+      urlAppend +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      cldrSurvey.cacheKill();
+    const errorHandler = function (err) {
+      console.log("adminload " + urlAppend + " Error: " + err);
+      theDiv.className = "ferrbox";
+      theDiv.innerHTML =
+        "Error while loading: <div style='border: 1px solid red;'>" +
+        err +
+        "</div>";
+    };
+    const xhrArgs = {
+      url: ourUrl,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+      postData: postData,
+    };
+    if (!loadHandler) {
+      xhrArgs.handleAs = "text";
+      xhrArgs.load = function (text) {
+        theDiv.innerHTML = text;
+      };
+    }
+    if (xhrArgs.postData) {
+      /*
+       * Make a POST request
+       */
+      console.log("admin post: ourUrl: " + ourUrl + " data:" + postData);
+      xhrArgs.headers = {
+        "Content-Type": "text/plain",
+      };
+    } else {
+      /*
+       * Make a GET request
+       */
+      console.log("admin get: ourUrl: " + ourUrl);
+    }
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  function panelSwitch(name) {
+    if (panelLast) {
+      panelLast.div.style.display = "none";
+      panelLast.listItem.className = "notselected";
+      panelLast = null;
+    }
+    if (name && panels[name]) {
+      panelLast = panels[name];
+      panelLast.listItem.className = "selected";
+      panelLast.fn(panelLast.udiv);
+      panelLast.div.style.display = "block";
+      //// window.location.hash = "#!" + name;
+    }
+  }
+
+  function appendInputBox(parent, which) {
+    const label = cldrDom.createChunk(cldrText.get(which), "div", which);
+    const input = document.createElement("input");
+    input.stChange = function (onOk, onErr) {};
+    const change = cldrDom.createChunk(
+      cldrText.get("appendInputBoxChange"),
+      "button",
+      "appendInputBoxChange"
+    );
+    const cancel = cldrDom.createChunk(
+      cldrText.get("appendInputBoxCancel"),
+      "button",
+      "appendInputBoxCancel"
+    );
+    const notify = document.createElement("div");
+    notify.className = "appendInputBoxNotify";
+    input.className = "appendInputBox";
+    label.appendChild(change);
+    label.appendChild(cancel);
+    label.appendChild(notify);
+    label.appendChild(input);
+    parent.appendChild(label);
+    input.label = label;
+
+    const doChange = function () {
+      cldrDom.addClass(label, "d-item-selected");
+      cldrDom.removeAllChildNodes(notify);
+      notify.appendChild(cldrDom.createChunk(cldrText.get("loading"), "i"));
+      const onOk = function (msg) {
+        cldrDom.removeClass(label, "d-item-selected");
+        cldrDom.removeAllChildNodes(notify);
+        notify.appendChild(
+          hideAfter(cldrDom.createChunk(msg, "span", "okayText"))
+        );
+      };
+      const onErr = function (msg) {
+        cldrDom.removeClass(label, "d-item-selected");
+        cldrDom.removeAllChildNodes(notify);
+        notify.appendChild(cldrDom.createChunk(msg, "span", "stopText"));
+      };
+      input.stChange(onOk, onErr);
+    };
+
+    const changeFn = function (e) {
+      doChange();
+      cldrEvent.stopPropagation(e);
+      return false;
+    };
+    const cancelFn = function (e) {
+      input.value = "";
+      doChange();
+      cldrEvent.stopPropagation(e);
+      return false;
+    };
+    const keypressFn = function (e) {
+      if (!e || !e.keyCode) {
+        return true; // not getting the point here.
+      } else if (e.keyCode == 13) {
+        doChange();
+        return false;
+      } else {
+        return true;
+      }
+    };
+    cldrDom.listenFor(change, "click", changeFn);
+    cldrDom.listenFor(cancel, "click", cancelFn);
+    cldrDom.listenFor(input, "keypress", keypressFn);
+    return input;
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    load: load,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      getHtml: getHtml,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrAjax.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrAjax.js
@@ -228,11 +228,25 @@ const cldrAjax = (function () {
   function makeErrorMessage(request, url) {
     let msg =
       "Status " + request.status + " " + request.statusText + "; URL: " + url;
-    if (request.responseText) {
-      msg += " Response: " + request.responseText;
+    if (request.responseType === "text" || request.responseType === "") {
+      if (request.responseText) {
+        msg += " Response: " + request.responseText;
+      }
+    } else if (request.responseType === "json") {
+      if (request.response) {
+        msg += JSON.stringify(request.response);
+      }
+    } else {
+      msg += " Response type: " + request.responseType;
+      if (ST_AJAX_DEBUG) {
+        console.log(
+          "cldrAjax.makeErrorMessage got responseType=" + request.responseType
+        );
+      }
     }
     return msg;
   }
+
   /**
    * How many requests are in the queue?
    *

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrBulkClosePosts.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrBulkClosePosts.js
@@ -25,13 +25,8 @@ const cldrBulkClosePosts = (function () {
     /*
      * Set up the 'right sidebar'; cf. bulk_close_postsGuidance
      */
-    cldrSurvey.showInPop2(
-      cldrText.get(params.name + "Guidance"),
-      null,
-      null,
-      null,
-      true
-    );
+    const message = cldrText.get(params.name + "Guidance");
+    cldrInfo.showMessage(message);
 
     const url = getBulkClosePostsUrl();
     const errorHandler = function (err) {
@@ -54,7 +49,7 @@ const cldrBulkClosePosts = (function () {
       contentDiv.innerHTML = html;
 
       // No longer loading
-      cldrSurvey.hideLoader(null);
+      cldrSurvey.hideLoader();
       params.flipper.flipTo(params.pages.other, contentDiv);
     };
     const xhrArgs = {

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrCreateLogin.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrCreateLogin.js
@@ -1,0 +1,201 @@
+"use strict";
+
+/**
+ * cldrCreateLogin: encapsulate the "Create and Login" part of the Admin Panel.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+const cldrCreateLogin = (function () {
+  function load() {
+    cldrInfo.showNothing();
+
+    const ourDiv = document.createElement("div");
+    ourDiv.setAttribute("id", "createLoginDiv");
+    ourDiv.innerHTML = getHtml();
+    // caution: ourDiv isn't added to DOM until we call flipToOtherDiv
+    cldrSurvey.hideLoader();
+    cldrLoad.flipToOtherDiv(ourDiv);
+    fetchData();
+  }
+
+  const createLoginNote =
+    "<p><i>Note: the organization chosen will be random, unless you change it at the bottom of this page.</i><br/>\n" +
+    "<i>This account is for testing purposes and may be deleted without notice!</i></p>\n";
+
+  const formHtml =
+    "<form id='createLoginForm' class='adduser' action='' method='POST'>" +
+    "  <input type='hidden' name='action' value='new_and_login' />\n" +
+    "  <table>\n" +
+    "    <tr>\n" +
+    "      <th><label for='real'>User Name:</label></th>\n" +
+    "      <td><input id='real' name='real' size='40' value='' /></td>\n" +
+    "    </tr>\n" +
+    "    <tr class='submit'>\n" +
+    "      <td colspan='2'><button style='font-size: xx-large' type='submit'>Login</button></td>\n" +
+    "    </tr>\n" +
+    "  </table>\n" +
+    "  <h3>More Options...</h3>\n" +
+    "  <table>\n" +
+    "    <tr>\n" +
+    "      <th><label for='new_org'>Specific Organization:</label></th>\n" +
+    "      <td><select id='choose_org' onchange=''></select></td>\n" +
+    "      <td><input id='new_org' name='new_org' value='' /></td>\n" +
+    "    </tr>\n" +
+    "    <tr>\n" +
+    "      <th><label for='new_userlevel'>Userlevel:</label></th>\n" +
+    "      <td><select id='new_userlevel' name='new_userlevel'></select></td>\n" +
+    "    </tr>\n" +
+    "    <tr>\n" +
+    "      <th><label for='new_locales'>Languages responsible:</label></th>\n" +
+    "      <td><input name='new_locales' value='' /><br/>\n" +
+    "        (Space separated. Examples: 'en de fr')</td>\n" +
+    "    </tr>\n" +
+    "    <tr>\n" +
+    "      <th>Login Options</th>\n" +
+    "      <td>\n" +
+    "        <label for='new_and_login_autoProceed'><input name='new_and_login_autoProceed' type='checkbox' checked='true' />" +
+    "          Log me in immediately after creating the account?</label>\n" +
+    "        <label for='new_and_login_stayLoggedIn'><input name='new_and_login_stayLoggedIn' type='checkbox' checked='true' />" +
+    "          Remember me the next time I login? (cookie)</label>\n" +
+    "      </td>\n" +
+    "    </tr>\n" +
+    "  </table>\n" +
+    "</form>\n";
+
+  function getHtml() {
+    let html = "<h2>Add a Test Survey Tool user</h2>\n";
+    html += createLoginNote;
+    html += "<hr />\n";
+    html += formHtml;
+    return html;
+  }
+
+  function fetchData() {
+    const ourUrl =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=admin_panel&do=create_login" +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      cldrSurvey.cacheKill();
+
+    const xhrArgs = {
+      url: ourUrl,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  function loadHandler(json) {
+    if (json.err) {
+      const div = document.getElementById("createLoginDiv");
+      div.innerHTML = err;
+      return;
+    }
+    setupFormActionUrl();
+    setupChooseOrg(json);
+    setupChooseLevel(json);
+    setupUserName(json);
+  }
+
+  function setupFormActionUrl() {
+    const id = "createLoginForm";
+    const el = document.getElementById(id);
+    if (!el) {
+      console.log(id + " not found in setupFormActionUrl");
+      return;
+    }
+    el.setAttribute("action", "survey?s=" + cldrStatus.getSessionId());
+  }
+
+  function setupUserName(json) {
+    const id = "real";
+    const el = document.getElementById(id);
+    if (!el) {
+      console.log(id + " not found in setupUserName");
+      return;
+    }
+    el.setAttribute("value", json.name);
+    el.focus();
+  }
+
+  function setupChooseOrg(json) {
+    const id = "choose_org";
+    const id2 = "new_org";
+    const el = document.getElementById(id);
+    if (!el) {
+      console.log(id + " not found in setupChooseOrg");
+      return;
+    }
+    el.setAttribute(
+      "onchange",
+      "document.getElementById('" + id2 + "').value=this.value"
+    );
+    const el2 = document.getElementById(id2);
+    if (!el2) {
+      console.log(id2 + " not found in setupChooseOrg");
+      return;
+    }
+    el2.setAttribute("value", json.defaultOrg);
+
+    let html = "<option value='' selected='selected'>Choose...</option>\n";
+    for (let i in json.orgs) {
+      const org = json.orgs[i];
+      const selected = org === json.defaultOrg ? " selected='true'" : "";
+      html +=
+        "<option value='" + org + "'" + selected + ">" + org + "</option>\n";
+    }
+    el.innerHTML = html;
+  }
+
+  function setupChooseLevel(json) {
+    const id = "new_userlevel";
+    const el = document.getElementById(id);
+    if (!el) {
+      console.log(id + " not found in setupChooseLevel");
+      return;
+    }
+    let html = "<option value='' selected='selected'>Choose...</option>\n";
+    for (let i in json.levels) {
+      const level = json.levels[i];
+      const selected = level === json.defaultLevel ? " selected='true'" : "";
+      html +=
+        "<option value='" +
+        level +
+        "'" +
+        selected +
+        ">" +
+        level +
+        "</option>\n";
+    }
+    el.innerHTML = html;
+  }
+
+  function errorHandler(err) {
+    theDiv.className = "ferrbox";
+    theDiv.innerHTML =
+      "Error while loading: <div style='border: 1px solid red;'>" +
+      err +
+      "</div>";
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    load: load,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      getHtml: getHtml,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrDom.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrDom.js
@@ -1,0 +1,239 @@
+"use strict";
+
+/**
+ * cldrDom: encapsulate DOM (Document Object Model) utilities for CLDR Survey Tool
+ * This is for non-dojo use. For dojo, see survey.js
+ */
+
+const cldrDom = (function () {
+  /**
+   * Remove a CSS class from a node
+   *
+   * @param {Node} obj
+   * @param {String} className
+   */
+  function removeClass(obj, className) {
+    if (!obj) {
+      return obj;
+    }
+    if (obj.className.indexOf(className) > -1) {
+      obj.className = obj.className.substring(className.length + 1);
+    }
+    return obj;
+  }
+
+  /**
+   * Add a CSS class from a node
+   *
+   * @param {Node} obj
+   * @param {String} className
+   */
+  function addClass(obj, className) {
+    if (!obj) {
+      return obj;
+    }
+    if (obj.className.indexOf(className) == -1) {
+      obj.className = className + " " + obj.className;
+    }
+    return obj;
+  }
+
+  /**
+   * Remove all subnodes
+   *
+   * @param {Node} td
+   */
+  function removeAllChildNodes(td) {
+    if (td == null) {
+      return;
+    }
+    while (td.firstChild) {
+      td.removeChild(td.firstChild);
+    }
+  }
+
+  /**
+   * Set/remove style.display
+   */
+  function setDisplayed(div, visible) {
+    if (div === null) {
+      console.log("cldrDom.setDisplayed: called on null");
+      return;
+    } else if (div.domNode) {
+      cldrDom.setDisplayed(div.domNode, visible); // recurse, it's a dijit
+    } else if (!div.style) {
+      console.log(
+        "cldrDom.setDisplayed: called on malformed node " +
+          div +
+          " - no style! " +
+          Object.keys(div)
+      );
+    } else {
+      if (visible) {
+        div.style.display = "";
+      } else {
+        div.style.display = "none";
+      }
+    }
+  }
+
+  /**
+   * Create a DOM object with the specified text, tag, and HTML class.
+   *
+   * @param {String} text textual content of the new object, or null for none
+   * @param {String} tag which element type to create, or null for "span"
+   * @param {String} className CSS className, or null for none.
+   * @return {Object} new DOM object
+   */
+  function createChunk(text, tag, className) {
+    if (!tag) {
+      tag = "span";
+    }
+    var chunk = document.createElement(tag);
+    if (className) {
+      chunk.className = className;
+    }
+    if (text) {
+      chunk.appendChild(document.createTextNode(text));
+    }
+    return chunk;
+  }
+
+  /**
+   * Create a 'link' that goes to a function. By default it's an 'a', but could be a button, etc.
+   * @param strid  {String} string to be used with cldrText.get
+   * @param fn {function} function, given the DOM obj as param
+   * @param tag {String}  tag of new obj.  'a' by default.
+   * @return {Element} newobj
+   */
+  function createLinkToFn(strid, fn, tag) {
+    if (!tag) {
+      tag = "a";
+    }
+    var msg = cldrText.get(strid);
+    var obj = document.createElement(tag);
+    obj.appendChild(document.createTextNode(msg));
+    if (tag == "a") {
+      obj.href = "";
+    }
+    listenFor(obj, "click", function (e) {
+      fn(obj);
+      cldrEvent.stopPropagation(e);
+      return false;
+    });
+    return obj;
+  }
+
+  /**
+   * Update the item, if it exists
+   *
+   * @param id ID of DOM node, or a Node itself
+   * @param txt text to replace with - should just be plaintext, but currently can be HTML
+   */
+  function updateIf(id, txt) {
+    var something;
+    if (id instanceof Node) {
+      something = id;
+    } else {
+      something = document.getElementById(id);
+    }
+    if (something != null) {
+      something.innerHTML = txt; // TODO shold only use for plain text
+    }
+  }
+
+  /**
+   * Add an event listener function to the object.
+   *
+   * @param {DOM} what object to listen to (or array of them)
+   * @param {String} what event, bare name such as 'click'
+   * @param {Function} fn function, of the form:
+   *        function(e) {
+   *          doSomething();
+   *          cldrEvent.stopPropagation(e);
+   *          return false;
+   *        }
+   * @param {String} ievent IE name of an event, if not 'on'+what
+   * @return {DOM} returns the object what (or the array)
+   */
+  function listenFor(whatArray, event, fn, ievent) {
+    function listenForOne(what, event, fn, ievent) {
+      if (!what._stlisteners) {
+        what._stlisteners = {};
+      }
+
+      if (what.addEventListener) {
+        if (what._stlisteners[event]) {
+          if (what.removeEventListener) {
+            what.removeEventListener(event, what._stlisteners[event], false);
+          } else {
+            console.log("Err: no removeEventListener on " + what);
+          }
+        }
+        what.addEventListener(event, fn, false);
+      } else {
+        if (!ievent) {
+          ievent = "on" + event;
+        }
+        if (what._stlisteners[event]) {
+          what.detachEvent(ievent, what._stlisteners[event]);
+        }
+        what.attachEvent(ievent, fn);
+      }
+      what._stlisteners[event] = fn;
+
+      return what;
+    }
+
+    if (Array.isArray(whatArray)) {
+      for (var k in whatArray) {
+        listenForOne(whatArray[k], event, fn, ievent);
+      }
+      return whatArray;
+    } else {
+      return listenForOne(whatArray, event, fn, ievent);
+    }
+  }
+
+  /**
+   * On click, select all
+   *
+   * @param {Node} obj to listen to
+   * @param {Node} targ to select
+   */
+  function clickToSelect(obj, targ) {
+    if (!targ) {
+      targ = obj;
+    }
+    listenFor(obj, "click", function (e) {
+      if (window.getSelection) {
+        window.getSelection().selectAllChildren(targ);
+      }
+      cldrEvent.stopPropagation(e);
+      return false;
+    });
+    return obj;
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    addClass: addClass,
+    clickToSelect: clickToSelect,
+    createChunk: createChunk,
+    createLinkToFn: createLinkToFn,
+    listenFor: listenFor,
+    removeAllChildNodes: removeAllChildNodes,
+    removeClass: removeClass,
+    setDisplayed: setDisplayed,
+    updateIf: updateIf,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    // test: {
+    //   f: f,
+    // },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrEvent.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrEvent.js
@@ -1,0 +1,715 @@
+"use strict";
+
+/**
+ * cldrEvent: encapsulate handling of events like mouse clicks, etc.
+ * This file is for use without dojo. For dojo, see redesign.js.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+const cldrEvent = (function () {
+  let sentenceFilter;
+
+  let cachedJson; // use a cache because the coverage can change, so we might need to update the menu
+
+  let toToggleOverlay;
+
+  let oldTypePopup = "";
+
+  function startup() {
+    // for locale search
+    $("body").on("click", "#show-locked", { type: "lock" }, toggleLockedRead);
+    $("body").on("click", "#show-read", { type: "read" }, toggleLockedRead);
+    $("#locale-info .local-search").keyup(filterAllLocale);
+    $(".pull-menu > a").click(interceptPulldownLink);
+
+    // locale chooser intercept
+    $("body").on("click", ".locName", interceptLocale);
+
+    // handle the left sidebar
+    $("#left-sidebar").hover(
+      function () {
+        if (!$("body").hasClass("disconnected") && !cldrLoad.dialogIsOpen()) {
+          // don't hover if another dialog is open.
+          $(this).addClass("active");
+          toggleOverlay();
+        }
+      },
+      function () {
+        if (
+          cldrStatus.getCurrentLocale() ||
+          cldrStatus.getCurrentSpecial() != "locales"
+        ) {
+          // don't stick the sidebar open if we're not in the locale chooser.
+          $(this).removeClass("active");
+          toggleOverlay();
+        }
+      }
+    );
+    $(".refresh-search").click(searchRefresh);
+
+    // help bootstrap -> close popup when click outside
+    $("body").on("click", function (e) {
+      $('[data-toggle="popover"]').each(function () {
+        //the 'is' for buttons that trigger popups
+        //the 'has' for icons within a button that triggers a popup
+        if (
+          !$(this).is(e.target) &&
+          $(this).has(e.target).length === 0 &&
+          $(".popover").has(e.target).length === 0
+        ) {
+          $(this).popover("hide");
+        }
+      });
+    });
+
+    // example on hover
+    $("body").on(
+      "mouseenter",
+      ".vetting-page .infos-code, .vetting-page .subSpan",
+      function () {
+        var example = $(this)
+          .closest(".d-disp,.d-item,.d-item-err,.d-item-warn")
+          .find(".d-example");
+        if (example) {
+          $(this)
+            .popover({
+              html: true,
+              placement: "top",
+              content: example.html(),
+            })
+            .popover("show");
+        }
+      }
+    );
+
+    $("body").on(
+      "mouseleave",
+      ".vetting-page .infos-code, .vetting-page .subSpan",
+      function () {
+        $(this).popover("hide");
+      }
+    );
+    resizeSidebar();
+
+    $("body").on("click", ".toggle-right", toggleRightPanel);
+    $(".tip-log").tooltip({
+      placement: "bottom",
+    });
+    $("body").keydown(function (event) {
+      /*
+       * Some browsers (e.g., Firefox) treat Backspace (or Delete on macOS) as a shortcut for
+       * going to the previous page in the browser's history. That's a problem when we have an
+       * input window open for the user to type a new candidate item, especially if the window
+       * is still visible but has lost focus. Prevent that behavior for backspace when the input
+       * window has lost focus. Formerly, key codes 37 (left arrow) and 39 (right arrow) were used
+       * here as shortcuts for chgPage(-1) and chgPage(1), respectively. However, that caused
+       * problems similar to the problem with Backspace. Reference: https://unicode.org/cldr/trac/ticket/11218
+       */
+      if ($(":focus").length === 0) {
+        if (event.keyCode === 8) {
+          // backspace
+          event.preventDefault();
+        }
+      }
+    });
+  }
+
+  /**
+   * Size the sidebar relative to the header
+   */
+  function resizeSidebar() {
+    var sidebar = $("#left-sidebar");
+    var header = $(".navbar-fixed-top");
+
+    sidebar.css("height", $(window).height() - header.height());
+    sidebar.css("top", header.height());
+  }
+
+  /**
+   * Filter all the locales (first child, then parent so we can build the tree,
+   * and let the parent displayed if a child is matched)
+   *
+   * @param event
+   * @returns false (return value is ignored by all callers)
+   *
+   * This function is called from elsewhere in this file, and from CldrSurveyVettingLoader.js.
+   */
+  function filterAllLocale(event) {
+    if ($(this).hasClass("local-search")) {
+      $("a.locName").removeClass("active");
+      $("#locale-list,#locale-menu").removeClass("active");
+    }
+    sentenceFilter = $("input.local-search").val().toLowerCase();
+    $(".subLocaleList .locName").each(filterLocale); // filtersublocale
+    $(".topLocale .locName").each(filterLocale); // filtertolocale
+
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    return false;
+  }
+
+  /**
+   * Filter (locked and read-only) with locale
+   *
+   * @param event
+   */
+  function toggleLockedRead(event) {
+    var type = event.data.type;
+    if ($(this).is(":checked")) {
+      if (type == "read") {
+        $(".locName:not(.canmodify):not(.locked)").parent().removeClass("hide");
+      } else {
+        $(".locName.locked").parent().removeClass("hide");
+      }
+    } else {
+      if (type == "read") {
+        $(".locName:not(.canmodify):not(.locked)").parent().addClass("hide");
+      } else {
+        $(".locName.locked").parent().addClass("hide");
+      }
+    }
+    filterAllLocale();
+  }
+
+  /**
+   * Hide/show the locale matching the pattern and the checkbox
+   */
+  function filterLocale() {
+    var text = $(this).text().toLowerCase();
+    var parent = $(this).parent();
+    if (
+      text.indexOf(sentenceFilter) == 0 &&
+      (checkLocaleShow($(this), sentenceFilter.length) ||
+        sentenceFilter === text)
+    ) {
+      parent.removeClass("hide");
+      if (parent.hasClass("topLocale")) {
+        parent.parent().removeClass("hide");
+        parent.next().children("div").removeClass("hide");
+      }
+    } else {
+      if (parent.hasClass("topLocale")) {
+        if (parent.next().children("div").not(".hide").length == 0) {
+          parent.addClass("hide");
+          parent.parent().addClass("hide");
+        } else {
+          parent.removeClass("hide");
+          parent.parent().removeClass("hide");
+        }
+      } else {
+        parent.addClass("hide");
+      }
+    }
+  }
+
+  /**
+   * Should we show this locale considering the checkbox?
+   *
+   * @param element
+   * @param size
+   * @return true or false
+   */
+  function checkLocaleShow(element, size) {
+    if (size > 0) {
+      return true;
+    }
+    if (element.hasClass("locked") && $("#show-locked").is(":checked")) {
+      return true;
+    }
+    if (
+      (!element.hasClass("canmodify") &&
+        $("#show-read").is(":checked") &&
+        !element.hasClass("locked")) ||
+      element.hasClass("canmodify")
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Intercept the click of the locale name
+   */
+  function interceptLocale() {
+    var name = $(this).text();
+    var source = $(this).attr("title");
+
+    $("input.local-search").val(name);
+    $("a.locName").removeClass("active");
+    $(this).addClass("active");
+    filterAllLocale();
+    $("#locale-list").addClass("active");
+    $("#locale-menu").addClass("active");
+  }
+
+  /**
+   * Sidebar constructor
+   *
+   * @param json
+   */
+  function unpackMenuSideBar(json) {
+    if (json.menus) {
+      cachedJson = json;
+    } else {
+      var lName = json["_v"];
+      if (!cachedJson) {
+        return;
+      }
+      json = cachedJson;
+      json.covlev_user = lName;
+    }
+    var menus = json.menus.sections;
+    var levelName = json.covlev_user;
+
+    if (!levelName || levelName === "default") {
+      levelName = json.covlev_org;
+    }
+    var menuRoot = $("#locale-menu");
+    var level = 0;
+    var levels = json.menus.levels;
+    var reports = json.reports;
+
+    // get the level number
+    $.each(levels, function (index, element) {
+      if (element.name == levelName) {
+        level = parseInt(element.level);
+      }
+    });
+
+    if (level === 0) {
+      // We couldn't find the level name. Try again as if 'auto'.
+      levelName = json.covlev_org;
+
+      //get the level number
+      $.each(levels, function (index, element) {
+        if (element.name == levelName) {
+          level = parseInt(element.level);
+        }
+      });
+
+      if (level === 0) {
+        // Still couldn't.
+        level = 10; // fall back to CORE.
+      }
+    }
+
+    var html = "<ul>";
+    if (!cldrStatus.isVisitor()) {
+      // put the dashboard out
+      var tmp = null;
+      var reportHtml = "";
+      $.each(reports, function (index, element) {
+        if (element.url != "r_vetting_json") {
+          reportHtml +=
+            '<li class="list-unstyled review-link" data-query="' +
+            element.hasQuery +
+            '" data-url="' +
+            element.url +
+            '"><div>' +
+            element.display +
+            "</div></li>";
+        } else {
+          tmp = element;
+        }
+      });
+
+      if (tmp) {
+        html +=
+          '<li class="list-unstyled review-link" data-query="' +
+          tmp.hasQuery +
+          '" data-url="' +
+          tmp.url +
+          '"><div>' +
+          tmp.display +
+          '<span class="pull-right glyphicon glyphicon-home" style="position:relative;top:2px;right:1px;"></span></div></li>';
+      }
+
+      html +=
+        '<li class="list-unstyled open-menu"><div>Reports<span class="pull-right glyphicon glyphicon-chevron-right"></span></div>';
+      html += '<ul class="second-level">';
+      html += reportHtml;
+      html += "</ul></li>";
+    }
+    html +=
+      '<li class="list-unstyled" id="forum-link"><div>Forum<span class="pull-right glyphicon glyphicon-comment"></span></div></li>';
+    html += "</ul>";
+
+    html += "<ul>";
+    $.each(menus, function (index, element) {
+      var menuName = element.name;
+      let childCount = 0;
+      html +=
+        '<li class="list-unstyled open-menu"><div>' +
+        menuName +
+        '<span class="pull-right glyphicon glyphicon-chevron-right"></span></div><ul class="second-level">';
+      $.each(element.pages, function (index, element) {
+        var pageName = element.name;
+        var pageId = element.id;
+        $.each(element.levs, function (index, element) {
+          if (parseInt(element) <= level) {
+            html +=
+              '<li class="sidebar-chooser list-unstyled" id="' +
+              pageId +
+              '"><div>' +
+              pageName +
+              "</div></li>";
+            childCount++;
+          }
+        });
+      });
+      if (childCount === 0) {
+        html += "<i>" + cldrText.get("coverage_no_items") + "</i>";
+      }
+      html += "</ul></li>";
+    });
+
+    html += "</ul>";
+
+    menuRoot.html(html);
+    menuRoot.find(".second-level").hide();
+
+    // don't slide up and down infinitely
+    $(".second-level").click(function (event) {
+      event.stopPropagation();
+      event.preventDefault();
+    });
+
+    // slide down the menu
+    $(".open-menu").click(function () {
+      $("#locale-menu .second-level").slideUp();
+      $(".open-menu .glyphicon")
+        .removeClass("glyphicon-chevron-down")
+        .addClass("glyphicon-chevron-right");
+
+      $(this).children("ul").slideDown();
+      $(this)
+        .find(".glyphicon")
+        .removeClass("glyphicon-chevron-right")
+        .addClass("glyphicon-chevron-down");
+    });
+
+    // menu
+    $(".sidebar-chooser").click(function () {
+      cldrStatus.setCurrentPage($(this).attr("id"));
+      cldrStatus.setCurrentSpecial("");
+      cldrLoad.reloadV();
+      $("#left-sidebar").removeClass("active");
+      toggleOverlay();
+    });
+
+    // review link
+    $(".review-link").click(function () {
+      $("#left-sidebar").removeClass("active");
+      toggleOverlay();
+      $("#OtherSection").hide();
+      if ($(this).data("query")) {
+        window.location =
+          cldrStatus.getSurvUrl() +
+          "?" +
+          $(this).data("url") +
+          "&_=" +
+          cldrStatus.getCurrentLocale();
+      } else {
+        cldrStatus.setCurrentSpecial($(this).data("url"));
+        cldrStatus.setCurrentId("");
+        cldrStatus.setCurrentPage("");
+        cldrLoad.reloadV();
+      }
+    });
+
+    // forum link
+    $("#forum-link").click(function () {
+      if (cldrForum) {
+        cldrForum.reload();
+      }
+    });
+
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale) {
+      $('a[data-original-title="' + curLocale + '"]').click();
+      $("#title-coverage").show();
+    }
+
+    // reopen the menu to the current page
+    const curPage = cldrStatus.getCurrentPage();
+    if (curPage) {
+      var menu = $("#locale-menu #" + curPage);
+      menu.closest(".open-menu").click();
+    }
+  }
+
+  /**
+   * Force the left sidebar to open
+   */
+  function forceSidebar() {
+    searchRefresh();
+    $("#left-sidebar").mouseenter();
+  }
+
+  /**
+   * Refresh the search field
+   */
+  function searchRefresh() {
+    $(".local-search").val("");
+    $(".local-search").keyup();
+  }
+
+  /**
+   * Toggle the overlay of the menu
+   *
+   * Called from elsewhere in this file, and also by toggleFix in review.js
+   */
+  function toggleOverlay() {
+    var overlay = $("#overlay");
+    var sidebar = $("#left-sidebar");
+    if (!sidebar.hasClass("active")) {
+      overlay.removeClass("active");
+      toToggleOverlay = true;
+
+      setTimeout(function () {
+        if (toToggleOverlay) {
+          overlay.css("z-index", "-10");
+        }
+      }, 500 /* half a second */);
+    } else {
+      toToggleOverlay = false;
+      overlay.css("z-index", "1000");
+      overlay.addClass("active");
+    }
+  }
+
+  /**
+   * Hide both the overlay and left sidebar
+   */
+  function hideOverlayAndSidebar() {
+    var sidebar = $("#left-sidebar");
+    sidebar.removeClass("active");
+    toggleOverlay();
+  }
+
+  /**
+   * Show the help popup in the center of the screen
+   *
+   * @param type
+   * @param content
+   * @param head
+   * @param aj
+   * @param dur
+   */
+  function popupAlert(type, content, head, aj, dur) {
+    var ajax = typeof aj === "undefined" ? "" : aj;
+    var header = typeof aj === "undefined" ? "" : head;
+    var duration = typeof dur === "undefined" ? 4000 /* four seconds */ : dur;
+    var alert = $("#progress").closest(".alert");
+    alert
+      .removeClass("alert-warning")
+      .removeClass("alert-info")
+      .removeClass("alert-danger")
+      .removeClass("alert-success");
+    alert.addClass("alert-" + type);
+    $("#progress_oneword").html(content);
+    $("#progress_ajax").html(ajax);
+    $("#specialHeader").html(header);
+    if (header != "") {
+      $("#specialHeader").show();
+    } else {
+      $("#specialHeader").hide();
+    }
+
+    if (oldTypePopup != type) {
+      if (!alert.is(":visible")) {
+        alert.fadeIn();
+        if (duration > 0) {
+          setTimeout(function () {
+            alert.fadeOut();
+          }, duration);
+        }
+      }
+      oldTypePopup = type;
+    }
+  }
+
+  /**
+   * Create/update the pull-down menu popover
+   *
+   * @param event
+   */
+  function interceptPulldownLink(event) {
+    var menu = $(this).closest(".pull-menu");
+    menu
+      .popover("destroy")
+      .popover({
+        placement: "bottom",
+        html: true,
+        content: menu.children("ul").html(),
+        trigger: "manual",
+        delay: 1500,
+        template:
+          '<div class="popover" onmouseover="$(this).mouseleave(function() {$(this).fadeOut(); });">' +
+          '<div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3>' +
+          '<div class="popover-content"><p></p></div></div></div>',
+      })
+      .click(function (e) {
+        e.preventDefault();
+      })
+      .popover("show");
+
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Add some label with a tooltip to every icon
+   *
+   * Called only from review.js -- not yet used for !USE_DOJO
+   */
+  function labelizeIcon() {
+    var icons = [
+      {
+        selector: ".d-dr-approved",
+        type: "success",
+        text: "Approved",
+        title: 'The "Proposed" (winning) value will be in the release.',
+      },
+      {
+        selector: ".d-dr-contributed",
+        type: "success",
+        text: "Contributed",
+        title:
+          'The "Proposed" (winning) value will be in the release (with a slightly lower status).',
+      },
+      {
+        selector: ".d-dr-provisional",
+        type: "warning",
+        text: "Provisional",
+        title:
+          'There is a "Proposed" (winning) value, but it doesn\'t have enough votes.',
+      },
+      {
+        selector: ".d-dr-unconfirmed",
+        type: "warning",
+        text: "Unconfirmed",
+        title:
+          'There is a "Proposed" (winning) value, but it doesn\'t have enough votes.',
+      },
+      {
+        selector: ".d-dr-inherited-provisional",
+        type: "inherited-provisional",
+        text: "Inherited and Provisional",
+        title: 'The "Proposed" (winning) value is inherited and provisional.',
+      },
+      {
+        selector: ".d-dr-inherited-unconfirmed",
+        type: "inherited-unconfirmed",
+        text: "Inherited and Unconfirmed",
+        title: 'The "Proposed" (winning) value is inherited and unconfirmed.',
+      },
+      {
+        selector: ".d-dr-missing",
+        type: "warning",
+        text: "Missing",
+        title: "There is no winning value. The inherited value will be used.",
+      },
+      {
+        selector: ".i-star",
+        type: "primary",
+        text: "Baseline",
+        title:
+          "The baseline value, which was approved in the last release, plus latest XML fixes by the Technical Committee, if any.",
+      },
+    ];
+
+    $.each(icons, function (index, element) {
+      $(element.selector).each(function () {
+        if ($(this).next(".label").length !== 0) {
+          $(this).next().remove();
+        }
+        $(this).after(
+          '<div class="label label-' +
+            element.type +
+            ' label-icon">' +
+            element.text +
+            "</div>"
+        );
+        $(this).next().tooltip({ title: element.title });
+      });
+    });
+  }
+
+  /**
+   * Show or hide the right panel
+   */
+  function toggleRightPanel() {
+    var main = $("#main-row > .col-md-9");
+    if (!main.length) {
+      showRightPanel();
+    } else {
+      hideRightPanel();
+    }
+  }
+
+  /**
+   * Show the right panel
+   */
+  function showRightPanel() {
+    $("#main-row > .col-md-12, #nav-page > .col-md-12")
+      .addClass("col-md-9")
+      .removeClass("col-md-12");
+    $("#main-row #itemInfo").show();
+  }
+
+  /**
+   * Hide the right panel
+   *
+   * Called by toggleRightPanel, and also by the loadHandler() for isReport() true but isDashboard() false.
+   * Otherwise, for the Date/Time, Zones, Numbers reports (especially Zones), the panel may invisibly prevent
+   * clicking on the "view" buttons.
+   */
+  function hideRightPanel() {
+    $("#main-row > .col-md-9, #nav-page > .col-md-9")
+      .addClass("col-md-12")
+      .removeClass("col-md-9");
+    $("#main-row #itemInfo").hide();
+  }
+
+  /**
+   * Used from within event handlers. cross platform 'stop propagation'
+   *
+   * @param e event
+   * @returns true or false
+   */
+  function stopPropagation(e) {
+    if (!e) {
+      return false;
+    } else if (e.stopPropagation) {
+      return e.stopPropagation();
+    } else if (e.cancelBubble) {
+      return e.cancelBubble();
+    } else {
+      // hope for the best
+      return false;
+    }
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    filterAllLocale: filterAllLocale,
+    forceSidebar: forceSidebar,
+    hideOverlayAndSidebar: hideOverlayAndSidebar,
+    hideRightPanel: hideRightPanel,
+    popupAlert: popupAlert,
+    resizeSidebar: resizeSidebar,
+    searchRefresh: searchRefresh,
+    startup: startup,
+    stopPropagation: stopPropagation,
+    unpackMenuSideBar: unpackMenuSideBar,
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrFlip.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrFlip.js
@@ -1,5 +1,5 @@
-"use strict";
-
+// "use strict";
+// TODO: modernize, make strict, possibly a class
 /**
  * Section flipping class
  * @class Flipper
@@ -13,7 +13,9 @@ function Flipper(ids) {
     var node = document.getElementById(id);
     // TODO if node==null throw
     if (this._panes.length > 0) {
-      cldrSurvey.setDisplayed(node, false); // hide it
+      if (typeof cldrSurvey !== "undefined") {
+        cldrDom.setDisplayed(node, false); // hide it
+      }
     } else {
       this._visible = id;
     }
@@ -33,13 +35,15 @@ Flipper.prototype.flipTo = function (id, node) {
   if (this._visible == id && node === null) {
     return; // noop - unless adding s'thing
   }
-  cldrSurvey.setDisplayed(this._map[this._visible], false);
+  if (typeof cldrSurvey !== "undefined") {
+    cldrDom.setDisplayed(this._map[this._visible], false);
+  }
   for (var k in this._killfn) {
     this._killfn[k]();
   }
   this._killfn = []; // pop?
   if (node !== null && node !== undefined) {
-    removeAllChildNodes(this._map[id]);
+    cldrDom.removeAllChildNodes(this._map[id]);
     if (node.nodeType > 0) {
       this._map[id].appendChild(node);
     } else {
@@ -49,7 +53,9 @@ Flipper.prototype.flipTo = function (id, node) {
       }
     }
   }
-  cldrSurvey.setDisplayed(this._map[id], true);
+  if (typeof cldrSurvey !== "undefined") {
+    cldrDom.setDisplayed(this._map[id], true);
+  }
   this._visible = id;
   return this._map[id];
 };

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrForumPanel.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrForumPanel.js
@@ -1,0 +1,470 @@
+"use strict";
+
+/**
+ * cldrForumPanel: encapsulate Survey Tool Forum Info Panel code.
+ * This is the new non-dojo version. For dojo, see survey.js showForumStuff()
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ *
+ * Dependencies on external code: ...
+ */
+const cldrForumPanel = (function () {
+  /**
+   * Array storing all only-1 sublocale
+   */
+  let oneLocales = [];
+
+  /**
+   * Timeout for showing sideways view
+   */
+  let sidewaysShowTimeout = -1;
+
+  /**
+   * Called when showing the popup (i.e., the Info Panel) each time
+   *
+   * @param {Node} frag
+   * @param {Node} forumDivClone = tr.forumDiv.cloneNode(true)
+   * @param {Node} tr
+   *
+   * TODO: shorten this function (use subroutines)
+   *
+   * Formerly known as cldrSurvey.showForumStuff
+   */
+  function loadInfo(frag, forumDivClone, tr) {
+    let isOneLocale = false;
+    if (oneLocales[cldrStatus.getCurrentLocale()]) {
+      isOneLocale = true;
+    }
+    if (!isOneLocale) {
+      const sidewaysControl = cldrDom.createChunk(
+        cldrText.get("sideways_loading0"),
+        "div",
+        "sidewaysArea"
+      );
+      frag.appendChild(sidewaysControl);
+
+      function clearMyTimeout() {
+        if (sidewaysShowTimeout != -1) {
+          // https://www.w3schools.com/jsref/met_win_clearinterval.asp
+          window.clearInterval(sidewaysShowTimeout);
+          sidewaysShowTimeout = -1;
+        }
+      }
+      clearMyTimeout();
+      sidewaysShowTimeout = window.setTimeout(function () {
+        clearMyTimeout();
+        cldrDom.updateIf(sidewaysControl, cldrText.get("sideways_loading1"));
+
+        var url =
+          cldrStatus.getContextPath() +
+          "/SurveyAjax?what=getsideways&_=" +
+          cldrStatus.getCurrentLocale() +
+          "&s=" +
+          cldrStatus.getSessionId() +
+          "&xpath=" +
+          tr.theRow.xpstrid +
+          cldrSurvey.cacheKill();
+        cldrLoad.myLoad(url, "sidewaysView", function (json) {
+          /*
+           * Count the number of unique locales in json.others and json.novalue.
+           */
+          var relatedLocales = json.novalue.slice();
+          for (var s in json.others) {
+            for (var t in json.others[s]) {
+              relatedLocales[json.others[s][t]] = true;
+            }
+          }
+          // if there is 1 sublocale (+ 1 default), we do nothing
+          if (Object.keys(relatedLocales).length <= 2) {
+            oneLocales[cldrStatus.getCurrentLocale()] = true;
+            cldrDom.updateIf(sidewaysControl, "");
+          } else {
+            if (!json.others) {
+              cldrDom.updateIf(sidewaysControl, ""); // no sibling locales (or all null?)
+            } else {
+              cldrDom.updateIf(sidewaysControl, ""); // remove string
+
+              var topLocale = json.topLocale;
+              const locmap = cldrLoad.getTheLocaleMap();
+              var curLocale = locmap.getRegionAndOrVariantName(topLocale);
+              var readLocale = null;
+
+              // merge the read-only sublocale to base locale
+              var mergeReadBase = function mergeReadBase(list) {
+                var baseValue = null;
+                // find the base locale, remove it and store its value
+                for (var l = 0; l < list.length; l++) {
+                  var loc = list[l][0];
+                  if (loc === topLocale) {
+                    baseValue = list[l][1];
+                    list.splice(l, 1);
+                    break;
+                  }
+                }
+
+                // replace the default locale(read-only) with base locale, store its name for label
+                for (var l = 0; l < list.length; l++) {
+                  var loc = list[l][0];
+                  var bund = locmap.getLocaleInfo(loc);
+                  if (bund && bund.readonly) {
+                    readLocale = locmap.getRegionAndOrVariantName(loc);
+                    list[l][0] = topLocale;
+                    list[l][1] = baseValue;
+                    break;
+                  }
+                }
+              };
+
+              // compare all sublocale values
+              var appendLocaleList = function appendLocaleList(list, curValue) {
+                var group = document.createElement("optGroup");
+                var br = document.createElement("optGroup");
+                group.appendChild(br);
+
+                group.setAttribute(
+                  "label",
+                  "Regional Variants for " + curLocale
+                );
+                group.setAttribute(
+                  "title",
+                  "Regional Variants for " + curLocale
+                );
+
+                var escape = "\u00A0\u00A0\u00A0";
+                var unequalSign = "\u2260\u00A0";
+
+                for (var l = 0; l < list.length; l++) {
+                  var loc = list[l][0];
+                  var title = list[l][1];
+                  var item = document.createElement("option");
+                  item.setAttribute("value", loc);
+                  if (title == null) {
+                    item.setAttribute("title", "undefined");
+                  } else {
+                    item.setAttribute("title", title);
+                  }
+
+                  var str = locmap.getRegionAndOrVariantName(loc);
+                  if (loc === topLocale) {
+                    str = str + " (= " + readLocale + ")";
+                  }
+
+                  if (loc === cldrStatus.getCurrentLocale()) {
+                    str = escape + str;
+                    item.setAttribute("selected", "selected");
+                    item.setAttribute("disabled", "disabled");
+                  } else if (title != curValue) {
+                    str = unequalSign + str;
+                  } else {
+                    str = escape + str;
+                  }
+                  item.appendChild(document.createTextNode(str));
+                  group.appendChild(item);
+                }
+                popupSelect.appendChild(group);
+              };
+
+              var dataList = [];
+
+              var popupSelect = document.createElement("select");
+              for (var s in json.others) {
+                for (var t in json.others[s]) {
+                  dataList.push([json.others[s][t], s]);
+                }
+              }
+
+              /*
+               * Set curValue = the value for cldrStatus.getCurrentLocale()
+               */
+              var curValue = null;
+              for (let l = 0; l < dataList.length; l++) {
+                var loc = dataList[l][0];
+                if (loc === cldrStatus.getCurrentLocale()) {
+                  curValue = dataList[l][1];
+                  break;
+                }
+              }
+              /*
+               * Force the use of unequalSign in the regional comparison pop-up for locales in
+               * json.novalue, by assigning a value that's different from curValue.
+               */
+              if (json.novalue) {
+                const differentValue = curValue === "A" ? "B" : "A"; // anything different from curValue
+                for (s in json.novalue) {
+                  dataList.push([json.novalue[s], differentValue]);
+                }
+              }
+              mergeReadBase(dataList);
+
+              // then sort by sublocale name
+              dataList = dataList.sort(function (a, b) {
+                return (
+                  locmap.getRegionAndOrVariantName(a[0]) >
+                  locmap.getRegionAndOrVariantName(b[0])
+                );
+              });
+              appendLocaleList(dataList, curValue);
+
+              var group = document.createElement("optGroup");
+              popupSelect.appendChild(group);
+
+              cldrDom.listenFor(popupSelect, "change", function (e) {
+                var newLoc = popupSelect.value;
+                if (newLoc !== cldrStatus.getCurrentLocale()) {
+                  cldrStatus.setCurrentLocale(newLoc);
+                  cldrLoad.reloadV();
+                }
+                return cldrEvent.stopPropagation(e);
+              });
+
+              sidewaysControl.appendChild(popupSelect);
+            }
+          }
+        });
+      }, 2000); // wait 2 seconds before loading this.
+    }
+
+    // Still deep inside the very long function loadInfo...
+
+    if (tr.theRow) {
+      const theRow = tr.theRow;
+      const couldFlag =
+        theRow.canFlagOnLosing &&
+        theRow.voteVhash !== theRow.winningVhash &&
+        theRow.voteVhash !== "" &&
+        !theRow.rowFlagged;
+      const myValue = theRow.hasVoted ? getUsersValue(theRow) : null;
+      cldrForum.addNewPostButtons(
+        frag,
+        cldrStatus.getCurrentLocale(),
+        couldFlag,
+        theRow.xpstrid,
+        theRow.code,
+        myValue
+      );
+    }
+
+    let loader2 = cldrDom.createChunk(cldrText.get("loading"), "i");
+    frag.appendChild(loader2);
+
+    /**
+     * @param {Integer} nrPosts
+     */
+    function havePosts(nrPosts) {
+      cldrDom.setDisplayed(loader2, false); // not needed
+      tr.forumDiv.forumPosts = nrPosts;
+
+      if (nrPosts == 0) {
+        return; // nothing to do,
+      }
+
+      var showButton = cldrDom.createChunk(
+        "Show " + tr.forumDiv.forumPosts + " posts",
+        "button",
+        "forumShow"
+      );
+
+      forumDivClone.appendChild(showButton);
+
+      var theListen = function (e) {
+        cldrDom.setDisplayed(showButton, false);
+        updatePosts(tr);
+        cldrEvent.stopPropagation(e);
+        return false;
+      };
+      cldrDom.listenFor(showButton, "click", theListen);
+      cldrDom.listenFor(showButton, "mouseover", theListen);
+    }
+
+    // still in the very long function loadInfo...
+    // lazy load post count!
+    // load async
+    let ourUrl = tr.forumDiv.url + "&what=forum_count" + cldrSurvey.cacheKill();
+    window.setTimeout(function () {
+      var xhrArgs = {
+        url: ourUrl,
+        handleAs: "json",
+        load: function (json) {
+          if (json && json.forum_count !== undefined) {
+            havePosts(parseInt(json.forum_count));
+          } else {
+            console.log("Some error loading post count??");
+          }
+        },
+      };
+      cldrAjax.queueXhr(xhrArgs);
+    }, 1900);
+  } // end of the very long function loadInfo
+
+  function getUsersValue(theRow) {
+    const surveyUser = cldrStatus.getSurveyUser();
+    if (surveyUser && surveyUser.id) {
+      if (theRow.voteVhash && theRow.voteVhash !== "") {
+        const item = theRow.items[theRow.voteVhash];
+        if (item && item.votes && item.votes[surveyUser.id]) {
+          if (item.value === cldrSurvey.INHERITANCE_MARKER) {
+            return theRow.inheritedValue;
+          }
+          return item.value;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Update the forum posts in the Info Panel
+   *
+   * This includes the version of the Info Panel displayed in the Dashboard "Fix" window
+   *
+   * @param tr the table-row element with which the forum posts are associated,
+   *		and whose info is shown in the Info Panel; or null, to get the
+   *		tr from surveyCurrentId
+   */
+  function updatePosts(tr) {
+    if (!tr) {
+      if (cldrStatus.getCurrentId() !== "") {
+        /*
+         * TODO: encapsulate this usage of 'r@' somewhere
+         */
+        tr = document.getElementById("r@" + cldrStatus.getCurrentId());
+      } else {
+        /*
+         * This is normal when adding a post in the main forum interface, which has no Info Panel).
+         */
+        return;
+      }
+    }
+    if (!tr || !tr.forumDiv || !tr.forumDiv.url) {
+      /*
+       * This is normal for updatePosts(null) called by success handler
+       * for submitPost, from Dashboard, since Fix window is no longer open
+       */
+      return;
+    }
+    let ourUrl = tr.forumDiv.url + "&what=forum_fetch";
+
+    let errorHandler = function (err) {
+      console.log("Error in updatePosts: " + err);
+      const message =
+        cldrStatus.stopIcon() +
+        " Couldn't load forum post for this row- please refresh the page. <br>Error: " +
+        err +
+        "</td>";
+      cldrInfo.showWithRow(message, tr);
+      handleDisconnect("Could not load for updatePosts:" + err, null);
+    };
+
+    let loadHandler = function (json) {
+      try {
+        if (json && json.ret) {
+          const posts = json.ret;
+          const content = cldrForum.parseContent(posts, "info");
+          /*
+           * Reality check: the json should refer to the same path as tr, which in practice
+           * always matches cldrStatus.getCurrentId(). If not, log a warning and substitute "Please reload"
+           * for the content.
+           */
+          let xpstrid = posts[0].xpath;
+          if (xpstrid !== tr.xpstrid || xpstrid !== cldrStatus.getCurrentId()) {
+            console.log(
+              "Warning: xpath strid mismatch in updatePosts loadHandler:"
+            );
+            console.log("posts[0].xpath = " + posts[0].xpath);
+            console.log("tr.xpstrid = " + tr.xpstrid);
+            console.log("surveyCurrentId = " + cldrStatus.getCurrentId());
+
+            content = "Please reload";
+          }
+          /*
+           * Update the element whose class is 'forumDiv'.
+           * Note: When updatePosts is called by the mouseover event handler for
+           * the "Show n posts" button set up by havePosts, a clone of tr.forumDiv is created
+           * (for mysterious reasons) by that event handler, and we could pass forumDivClone
+           * as a parameter to updatePosts, then do forumDivClone.appendChild(content)
+           * here, which is essentially how it formerly worked. However, that wouldn't work when
+           * we're called by the success handler for submitPost. This works in all cases.
+           */
+          $(".forumDiv").first().html(content);
+        }
+      } catch (e) {
+        console.log("Error in ajax forum read ", e.message);
+        console.log(" response: " + json);
+        const message =
+          cldrStatus.stopIcon() + " exception in ajax forum read: " + e.message;
+        cldrInfo.showWithRow(message, tr);
+      }
+    };
+
+    const xhrArgs = {
+      url: ourUrl,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+    };
+    cldrAjax.queueXhr(xhrArgs);
+  }
+
+  /**
+   * Called when initially setting up the section.
+   *
+   * @param {Node} tr
+   * @param {Node} theRow
+   * @param {Node} forumDiv
+   */
+  function appendForumStuff(tr, theRow, forumDiv) {
+    cldrForum.setUserCanPost(tr.theTable.json.canModify);
+
+    cldrDom.removeAllChildNodes(forumDiv); // we may be updating.
+    const locmap = cldrLoad.getTheLocaleMap();
+    var theForum = locmap.getLanguage(cldrStatus.getCurrentLocale());
+    forumDiv.replyStub =
+      cldrStatus.getContextPath() +
+      "/survey?forum=" +
+      theForum +
+      "&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&replyto=";
+    forumDiv.postUrl = forumDiv.replyStub + "x" + theRow;
+    /*
+     * Note: SurveyAjax requires a "what" parameter for SurveyAjax.
+     * It is not supplied here, but may be added later with code such as:
+     *	let ourUrl = tr.forumDiv.url + "&what=forum_count" + cacheKill() ;
+     *	let ourUrl = tr.forumDiv.url + "&what=forum_fetch";
+     * Unfortunately that means "what" is not the first argument, as it would
+     * be ideally for human readability of request urls.
+     */
+    forumDiv.url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?xpath=" +
+      theRow.xpathId +
+      "&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&fhash=" +
+      theRow.rowHash +
+      "&vhash=" +
+      "&s=" +
+      tr.theTable.session +
+      "&voteinfo=t";
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    loadInfo: loadInfo,
+    appendForumStuff: appendForumStuff,
+    updatePosts: updatePosts,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      // f: f,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrForumParticipation.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrForumParticipation.js
@@ -35,13 +35,8 @@ const cldrForumParticipation = (function () {
     /*
      * Set up the 'right sidebar'; cf. forum_participationGuidance
      */
-    cldrSurvey.showInPop2(
-      cldrText.get(params.name + "Guidance"),
-      null,
-      null,
-      null,
-      true
-    );
+    const message = cldrText.get(params.name + "Guidance");
+    cldrInfo.showMessage(message);
 
     const url = getForumParticipationUrl();
     const errorHandler = function (err) {
@@ -64,7 +59,7 @@ const cldrForumParticipation = (function () {
       ourDiv.innerHTML = html;
 
       // No longer loading
-      cldrSurvey.hideLoader(null);
+      cldrSurvey.hideLoader();
       params.flipper.flipTo(params.pages.other, ourDiv);
     };
     const xhrArgs = {

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrInfo.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrInfo.js
@@ -1,0 +1,244 @@
+"use strict";
+
+/**
+ * cldrInfo: encapsulate Survey Tool "Info Panel" (right sidebar) functions
+ * This is for non-dojo use. For dojo, see survey.js
+ */
+
+const cldrInfo = (function () {
+  let unShow = null;
+  let lastShown = null;
+
+  /**
+   * Make the object "theObj" cause the info window to show when clicked.
+   *
+   * @param {String} str
+   * @param {Node} tr the TR element that is clicked
+   * @param {Node} theObj to listen to
+   * @param {Function} fn the draw function
+   */
+  function listen(str, tr, theObj, fn) {
+    cldrDom.listenFor(theObj, "click", function (e) {
+      show(str, tr, theObj /* hideIfLast */, fn);
+      cldrEvent.stopPropagation(e);
+      return false;
+    });
+  }
+
+  function showNothing() {
+    return show(null, null, null, null);
+  }
+
+  function showMessage(str) {
+    return show(str, null, null, null);
+  }
+
+  function showWithRow(str, tr) {
+    return show(str, tr, null, null);
+  }
+
+  function showRowObjFunc(tr, hideIfLast, fn) {
+    return show(null, tr, hideIfLast, fn);
+  }
+
+  /**
+   * Display the right-hand "info" panel.
+   *
+   * @param {String} str the string to show at the top
+   * @param {Node} tr the <TR> of the row
+   * @param {Object} hideIfLast
+   * @param {Function} fn
+   */
+  function show(str, tr, hideIfLast, fn) {
+    if (unShow) {
+      unShow();
+      unShow = null;
+    }
+
+    if (tr && tr.sethash) {
+      cldrLoad.updateCurrentId(tr.sethash);
+    }
+    setLastShown(hideIfLast);
+
+    /*
+     * This is the temporary fragment used for the
+     * "info panel" contents.
+     */
+    var fragment = document.createDocumentFragment();
+
+    if (tr && tr.theRow) {
+      const { theRow } = tr;
+      const { helpHtml, rdf } = theRow;
+      if (helpHtml || rdf) {
+        cldrDeferHelp.addDeferredHelpTo(fragment, helpHtml, rdf);
+      }
+      // extra attributes
+      if (
+        theRow.extraAttributes &&
+        Object.keys(theRow.extraAttributes).length > 0
+      ) {
+        var extraHeading = cldrDom.createChunk(
+          cldrText.get("extraAttribute_heading"),
+          "h3",
+          "extraAttribute_heading"
+        );
+        var extraContainer = cldrDom.createChunk("", "div", "extraAttributes");
+        appendExtraAttributes(extraContainer, theRow);
+        theHelp.appendChild(extraHeading);
+        theHelp.appendChild(extraContainer);
+      }
+    }
+
+    if (cldrStatus.isDashboard()) {
+      fixPopoverVotePos();
+    }
+
+    if (str) {
+      // If a simple string, clone the string
+      var div2 = document.createElement("div");
+      div2.innerHTML = str;
+      fragment.appendChild(div2);
+    }
+    // If a generator fn (common case), call it.
+    if (fn) {
+      unShow = fn(fragment);
+    }
+
+    var theVoteinfo = null;
+    if (tr && tr.voteDiv) {
+      theVoteinfo = tr.voteDiv;
+    }
+    if (theVoteinfo) {
+      fragment.appendChild(theVoteinfo.cloneNode(true));
+    }
+    if (tr && tr.ticketLink) {
+      fragment.appendChild(tr.ticketLink.cloneNode(true));
+    }
+
+    // forum stuff
+    if (tr && tr.forumDiv) {
+      /*
+       * The name forumDivClone is a reminder that forumDivClone !== tr.forumDiv.
+       * TODO: explain the reason for using cloneNode here, rather than using
+       * tr.forumDiv directly. Would it work as well to set tr.forumDiv = forumDivClone,
+       * after cloning?
+       */
+      var forumDivClone = tr.forumDiv.cloneNode(true);
+      cldrForumPanel.loadInfo(fragment, forumDivClone, tr); // give a chance to update anything else
+      fragment.appendChild(forumDivClone);
+    }
+
+    if (tr && tr.theRow && tr.theRow.xpath) {
+      fragment.appendChild(
+        cldrDom.clickToSelect(
+          cldrDom.createChunk(tr.theRow.xpath, "div", "xpath")
+        )
+      );
+    }
+    var pucontent = document.getElementById("itemInfo");
+    if (!pucontent) {
+      console.log("itemInfo not found in show!");
+      return;
+    }
+
+    // Now, copy or append the 'fragment' to the
+    // appropriate spot. This depends on how we were called.
+    if (tr) {
+      if (cldrStatus.isDashboard()) {
+        cldrSurvey.showHelpFixPanel(fragment);
+      } else {
+        cldrDom.removeAllChildNodes(pucontent);
+        pucontent.appendChild(fragment);
+      }
+    } else {
+      if (!cldrStatus.isDashboard()) {
+        // show, for example, dataPageInitialGuidance in Info Panel
+        var clone = fragment.cloneNode(true);
+        cldrDom.removeAllChildNodes(pucontent);
+        pucontent.appendChild(clone);
+      }
+    }
+    fragment = null;
+
+    // for the voter
+    $(".voteInfo_voterInfo").hover(
+      function () {
+        var email = $(this).data("email").replace(" (at) ", "@");
+        if (email !== "") {
+          $(this).html(
+            '<a href="mailto:' +
+              email +
+              '" title="' +
+              email +
+              '" style="color:black"><span class="glyphicon glyphicon-envelope"></span></a>'
+          );
+          $(this).closest("td").css("text-align", "center");
+          $(this).children("a").tooltip().tooltip("show");
+        } else {
+          $(this).html($(this).data("name"));
+          $(this).closest("td").css("text-align", "left");
+        }
+      },
+      function () {
+        $(this).html($(this).data("name"));
+        $(this).closest("td").css("text-align", "left");
+      }
+    );
+    if (!cldrStatus.isDashboard()) {
+      return pucontent;
+    } else {
+      return null;
+    }
+  }
+
+  function setLastShown(obj) {
+    if (lastShown && obj != lastShown) {
+      cldrDom.removeClass(lastShown, "pu-select");
+      const partr = parentOfType("TR", lastShown);
+      if (partr) {
+        cldrDom.removeClass(partr, "selectShow");
+      }
+    }
+    if (obj) {
+      cldrDom.addClass(obj, "pu-select");
+      const partr = parentOfType("TR", obj);
+      if (partr) {
+        cldrDom.addClass(partr, "selectShow");
+      }
+    }
+    lastShown = obj;
+  }
+
+  function reset() {
+    lastShown = null;
+  }
+
+  function parentOfType(tag, obj) {
+    if (!obj) {
+      return null;
+    }
+    if (obj.nodeName === tag) {
+      return obj;
+    }
+    return parentOfType(tag, obj.parentElement);
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    listen: listen,
+    reset: reset,
+    showMessage: showMessage,
+    showNothing: showNothing,
+    showRowObjFunc: showRowObjFunc,
+    showWithRow: showWithRow,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    // test: {
+    //   f: f,
+    // },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
@@ -12,8 +12,6 @@
  */
 
 const cldrLoad = (function () {
-  const CLDR_LOAD_DEBUG = true;
-
   /**
    * haveDialog: when true, it means a "dialog" of some kind is displayed.
    * Used for inhibiting $('#left-sidebar').hover in redesign.js.
@@ -21,306 +19,394 @@ const cldrLoad = (function () {
    */
   let haveDialog = false;
 
-  const dijitDropDownMenu = null;
-  const dijitDropDownButton = null;
+  /**
+   * copy of menu data
+   */
+  let _thePages = null;
+
+  let locmap = null;
+
+  let canmodify = {};
+
+  let isLoading = false;
+
+  /**
+   * list of pages to use with the flipper
+   */
+  const pages = {
+    loading: "LoadingMessageSection",
+    data: "DynamicDataSection",
+    other: "OtherSection",
+  };
+
+  /**
+   * List of buttons/titles to set.
+   */
+  const menubuttons = {
+    locale: "title-locale",
+    section: "title-section",
+    page: "title-page",
+    dcontent: "title-dcontent",
+
+    // menubuttons.set is called by updateLocaleMenu and updateHashAndMenus
+    set: function (x, y) {
+      var cnode = document.getElementById(x + "-container");
+      var wnode = pseudoDijitRegistryById(x);
+      var dnode = document.getElementById(x);
+      if (!cnode) {
+        cnode = dnode; // for Elements that do their own stunts
+      }
+      if (y && y !== "-") {
+        if (wnode) {
+          wnode.set("label", y);
+        } else {
+          cldrDom.updateIf(x, y); // non widget
+        }
+        cldrDom.setDisplayed(cnode, true);
+      } else {
+        cldrDom.setDisplayed(cnode, false);
+        if (wnode) {
+          wnode.set("label", "-");
+        } else {
+          cldrDom.updateIf(x, "-"); // non widget
+        }
+      }
+    },
+  };
+
+  let otherSpecial = null;
+
+  let flipper = null;
+
+  // TODO: implement things like these without using dojo/dijit
   const dijitMenuSeparator = null;
-  const dijitMenuItem = null;
   const dijitButton = null;
-  const dijitDialog = null;
-  const dijitRegistry = null;
-  const dojoxBusyButton = null;
-  const dojoHash = null;
-  const dojoTopic = null;
+
+  /**************************/
+
   /**
    * Call this once in the page. It expects to find a node #DynamicDataSection
    */
   function showV() {
-    var appendLocaleLink = function appendLocaleLink(
-      subLocDiv,
-      subLoc,
-      subInfo,
-      fullTitle
-    ) {
-      var name = locmap.getRegionAndOrVariantName(subLoc);
-      if (fullTitle) {
-        name = locmap.getLocaleName(subLoc);
-      }
-      var clickyLink = cldrSurvey.createChunk(name, "a", "locName");
-      clickyLink.href = linkToLocale(subLoc);
-      subLocDiv.appendChild(clickyLink);
-      if (subInfo == null) {
-        console.log("* internal: subInfo is null for " + name + " / " + subLoc);
-      }
-      if (subInfo.name_var) {
-        cldrSurvey.addClass(clickyLink, "name_var");
-      }
-      clickyLink.title = subLoc; // remove auto generated "locName.title"
+    locmap = new LocaleMap(null); // TODO: is it really a singleton?
+    // it may be modified below with locmap = new LocaleMap(json.locmap)
 
-      if (subInfo.readonly) {
-        cldrSurvey.addClass(clickyLink, "locked");
-        cldrSurvey.addClass(subLocDiv, "hide");
+    flipper = new Flipper([pages.loading, pages.data, pages.other]);
 
-        if (subInfo.special_comment) {
-          clickyLink.title = subInfo.special_comment;
-        } else if (subInfo.dcChild) {
-          clickyLink.title = cldrText.sub("defaultContentChild_msg", {
-            name: subInfo.name,
-            dcChild: subInfo.dcChild,
-            dcChildName: locmap.getLocaleName(subInfo.dcChild),
-          });
-        } else {
-          clickyLink.title = cldrText.get("readonlyGuidance");
-        }
-      } else if (subInfo.special_comment) {
-        // could be the sandbox locale, or some other comment.
-        clickyLink.title = subInfo.special_comment;
-      }
+    otherSpecial = new OtherSpecial();
 
-      if (window.canmodify && subLoc in window.canmodify) {
-        cldrSurvey.addClass(clickyLink, "canmodify");
-      } else {
-        cldrSurvey.addClass(subLocDiv, "hide"); // not modifiable
-      }
-      return clickyLink;
-    };
-
-    /**
-     * list of pages to use with the flipper
-     * @property pages
-     */
-    var pages = {
-      loading: "LoadingMessageSection",
-      data: "DynamicDataSection",
-      other: "OtherSection",
-    };
-    var flipper = new Flipper([pages.loading, pages.data, pages.other]);
-
-    var pucontent = document.getElementById("itemInfo");
-    var theDiv = flipper.get(pages.data);
+    const pucontent = document.getElementById("itemInfo");
+    const theDiv = flipper.get(pages.data);
     theDiv.pucontent = pucontent;
 
     pucontent.appendChild(
-      cldrSurvey.createChunk(cldrText.get("itemInfoBlank"), "i")
+      cldrDom.createChunk(cldrText.get("itemInfoBlank"), "i")
     );
 
-    /**
-     * List of buttons/titles to set.
-     * @property menubuttons
-     */
-    var menubuttons = {
-      locale: "title-locale",
-      section: "title-section",
-      page: "title-page",
-      dcontent: "title-dcontent",
+    // click on the title to copy (permalink)
+    cldrDom.clickToSelect(document.getElementById("ariScroller"));
+    cldrDom.updateIf(
+      "title-dcontent-link",
+      cldrText.get("defaultContent_titleLink")
+    );
 
-      // menubuttons.set is called by updateLocaleMenu and updateHashAndMenus
-      set: function (x, y) {
-        stdebug("menuset " + x + " = " + y);
-        var cnode = document.getElementById(x + "-container");
-        var wnode = dijitRegistry.byId(x);
-        var dnode = document.getElementById(x);
-        if (!cnode) {
-          cnode = dnode; // for Elements that do their own stunts
-        }
-        if (y && y !== "-" && y !== "") {
-          if (wnode != null) {
-            wnode.set("label", y);
-          } else {
-            cldrSurvey.updateIf(x, y); // non widget
-          }
-          setDisplayed(cnode, true);
-        } else {
-          setDisplayed(cnode, false);
-          if (wnode != null) {
-            wnode.set("label", "-");
-          } else {
-            cldrSurvey.updateIf(x, "-"); // non widget
-          }
-        }
-      },
-    };
-
-    /**
-     * Manage additional special pages
-     * @class OtherSpecial
+    /*
+     * Arrange for getInitialMenusEtc to be called soon after we've gotten the session id.
+     * Add a short timeout to avoid interrupting the code that sets the session id. 
      */
-    function OtherSpecial() {
-      // cached page list
-      this.pages = {};
+    cldrStatus.setSessionIdChangeCallback(function(sessionId) {
+      setTimeout(function () {
+        getInitialMenusEtc(sessionId);
+      }, 100 /* one tenth of a second */);
+    });
+  }
+
+  function getInitialMenusEtc(sessionId) {
+    parseHashAndUpdate(getHash()); // get the initial settings
+
+    let theLocale = cldrStatus.getCurrentLocale();
+    if (!theLocale) {
+      theLocale = "root"; // Default.
+    }
+    const xurl =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=menus&_=" +
+      theLocale +
+      "&locmap=" +
+      true +
+      "&s=" +
+      sessionId +
+      cldrSurvey.cacheKill();
+
+    myLoad(xurl, "initial menus for " + theLocale, function (json) {
+      loadInitialMenusFromJson(json, theLocale);
+    });
+  }
+
+  function loadInitialMenusFromJson(json, theLocale) {
+    if (!verifyJson(json, "locmap")) {
+      return;
+    }
+    locmap = new LocaleMap(json.locmap);
+    if (cldrStatus.getCurrentLocale() === "USER" && json.loc) {
+      cldrStatus.setCurrentLocale(json.loc);
+    }
+    // make this into a hashmap.
+    if (json.canmodify) {
+      for (let k in json.canmodify) {
+        canmodify[json.canmodify[k]] = true;
+      }
+    }
+    // update left sidebar with locale data
+    var theDiv = document.createElement("div");
+    theDiv.className = "localeList";
+
+    addTopLocale("root", theDiv);
+    // top locales
+    for (let n in locmap.locmap.topLocales) {
+      const topLoc = locmap.locmap.topLocales[n];
+      addTopLocale(topLoc, theDiv);
+    }
+    $("#locale-list").html(theDiv.innerHTML);
+
+    if (cldrStatus.isVisitor()) {
+      $("#show-read").prop("checked", true);
+    }
+    // tooltip locale
+    $("a.locName").tooltip();
+
+    cldrEvent.filterAllLocale();
+    // end of adding the locale data
+
+    cldrSurvey.updateCovFromJson(json);
+    // setup coverage level
+    const surveyLevels = json.menus.levels;
+    cldrSurvey.setSurveyLevels(surveyLevels);
+
+    let levelNums = []; // numeric levels
+    for (let k in surveyLevels) {
+      levelNums.push({
+        num: parseInt(surveyLevels[k].level),
+        level: surveyLevels[k],
+      });
+    }
+    levelNums.sort(function (a, b) {
+      return a.num - b.num;
+    });
+
+    let store = [];
+
+    store.push({
+      label: "Auto",
+      value: "auto",
+      title: cldrText.get("coverage_auto_desc"),
+    });
+
+    store.push({
+      type: "separator",
+    });
+
+    for (let j in levelNums) {
+      // use given order
+      if (levelNums[j].num == 0) {
+        continue; // none - skip
+      }
+      if (levelNums[j].num < cldrSurvey.covValue("minimal")) {
+        continue; // don't bother showing these
+      }
+      if (cldrStatus.getIsUnofficial() === false && levelNums[j].num == 101) {
+        continue; // hide Optional in production
+      }
+      const level = levelNums[j].level;
+      store.push({
+        label: cldrText.get("coverage_" + level.name),
+        value: level.name,
+        title: cldrText.get("coverage_" + level.name + "_desc"),
+      });
+    }
+    //coverage menu
+    let patternCoverage = $("#title-coverage .dropdown-menu");
+    if (store[0].value) {
+      $("#coverage-info").text(store[0].label);
+    }
+    for (let index = 0; index < store.length; ++index) {
+      const data = store[index];
+      if (data.value) {
+        var html =
+          '<li><a class="coverage-list" data-value="' +
+          data.value +
+          '"href="#">' +
+          data.label +
+          "</a></li>";
+        patternCoverage.append(html);
+      }
+    }
+    patternCoverage.find("li a").click(function (event) {
+      patternCoverageClick(event, theLocale, $(this));
+    });
+    if (json.canAutoImport) {
+      doAutoImport();
     }
 
-    /**
-     * @function getSpecial
-     */
-    OtherSpecial.prototype.getSpecial = function getSpecial(name) {
-      return this.pages[name];
-    };
+    reloadV();
 
-    /**
-     * @function loadSpecial
-     */
-    OtherSpecial.prototype.loadSpecial = function loadSpecial(
-      name,
-      onSuccess,
-      onFailure
-    ) {
-      var special = this.getSpecial(name);
-      var otherThis = this;
-      if (special) {
-        stdebug("OS: Using cached special: " + name);
-        onSuccess(special);
-      } else if (special === null) {
-        stdebug("OS: cached NULL: " + name);
-        onFailure("Special page failed to load: " + name);
-      } else {
-        stdebug("OS: Attempting load.." + name);
-        /***
-        try {
-          require(["js/special/" + name + ".js"], function (specialFn) {
-            stdebug("OS: Loaded, instantiatin':" + name);
-            var special = new specialFn();
-            special.name = name;
-            otherThis.pages[name] = special; // cache for next time
+    // watch for hashchange to make other changes; cf. old "/dojo/hashchange"
+    window.addEventListener("hashchange", doHashChange);
+  }
 
-            stdebug("OS: SUCCESS! " + name);
-            onSuccess(special);
-          });
-        } catch (e) {
-          stdebug("OS: Load FAIL!:" + name + " - " + e.message + " - " + e);
-          if (!otherThis.pages[name]) {
-            // if the load didn't complete:
-            otherThis.pages[name] = null; // mark as don't retry load.
+  function patternCoverageClick(event, theLocale, clickedElement) {
+    event.stopPropagation();
+    event.preventDefault();
+    var newValue = clickedElement.data("value");
+    var setUserCovTo = null;
+    if (newValue == "auto") {
+      setUserCovTo = null; // auto
+    } else {
+      setUserCovTo = newValue;
+    }
+    if (setUserCovTo === cldrSurvey.getSurveyUserCov()) {
+      console.log("No change in user cov: " + setUserCovTo);
+    } else {
+      cldrSurvey.setSurveyUserCov(setUserCovTo);
+      const updurl =
+        cldrStatus.getContextPath() +
+        "/SurveyAjax?what=pref&_=" +
+        theLocale +
+        "&pref=p_covlev&_v=" +
+        cldrSurvey.getSurveyUserCov() +
+        "&s=" +
+        cldrStatus.getSessionId() +
+        cldrSurvey.cacheKill(); // SurveyMain.PREF_COVLEV
+      myLoad(
+        updurl,
+        "updating covlev to  " + cldrSurvey.getSurveyUserCov(),
+        function (json) {
+          if (verifyJson(json, "pref")) {
+            cldrEvent.unpackMenuSideBar(json);
+            if (
+              cldrStatus.getCurrentSpecial() &&
+              isReport(cldrStatus.getCurrentSpecial())
+            ) {
+              reloadV();
+            }
+            console.log("Server set covlev successfully.");
           }
-          onFailure(e);
-        }
-        ***/
-      }
-    };
-
-    /**
-     * @function parseHash
-     */
-    OtherSpecial.prototype.parseHash = function parseHash(name, hash, pieces) {
-      this.loadSpecial(
-        name,
-        function onSuccess(special) {
-          special.parseHash(hash, pieces);
-        },
-        function onFailure(e) {
-          /*
-           * TODO: get rid of this console warning for name = "oldvotes".
-           * There's not a known problem with old votes. It's not clear why
-           * the warning occurs. See "window.parseHash(dojoHash())"
-           */
-          console.log(
-            "OtherSpecial.parseHash: Failed to load " + name + " - " + e
-          );
         }
       );
-    };
+    }
+    // still update these.
+    cldrSurvey.updateCoverage(flipper.get(pages.data)); // update CSS and 'auto' menu title
+    updateHashAndMenus(false); // TODO: why? Maybe to show an item?
+    $("#coverage-info").text(ucFirst(newValue));
+    clickedElement.parents(".dropdown-menu").dropdown("toggle");
+    if (!cldrStatus.isDashboard()) {
+      cldrSurvey.refreshCounterVetting();
+    }
+    return false;
+  }
 
-    /**
-     * @function handleIdChanged
-     */
-    OtherSpecial.prototype.handleIdChanged = function handleIdChanged(
-      name,
-      id
+  function doHashChange(event) {
+    const changedHash = getHash();
+    if (sliceHash(new URL(event.newURL).hash) !== changedHash) {
+      console.log(
+        "Error in doHashChange: expected " +
+          event.newURL.hash +
+          " === " +
+          changedHash
+      );
+    }
+    const oldLocale = trimNull(cldrStatus.getCurrentLocale());
+    const oldSpecial = trimNull(cldrStatus.getCurrentSpecial());
+    const oldPage = trimNull(cldrStatus.getCurrentPage());
+    const oldId = trimNull(cldrStatus.getCurrentId());
+
+    parseHashAndUpdate(changedHash);
+
+    cldrStatus.setCurrentId(trimNull(cldrStatus.getCurrentId()));
+
+    // did anything change?
+    if (
+      oldLocale != trimNull(cldrStatus.getCurrentLocale()) ||
+      oldSpecial != trimNull(cldrStatus.getCurrentSpecial()) ||
+      oldPage != trimNull(cldrStatus.getCurrentPage())
     ) {
-      this.loadSpecial(
-        name,
-        function onSuccess(special) {
-          special.handleIdChanged(id);
-        },
-        function onFailure(e) {
-          console.log(
-            "OtherSpecial.handleIdChanged: Failed to load " + name + " - " + e
-          );
-        }
-      );
-    };
+      console.log("# hash changed, (loc, etc) reloadingV..");
+      reloadV();
+    } else if (
+      oldId != cldrStatus.getCurrentId() &&
+      cldrStatus.getCurrentId() != ""
+    ) {
+      console.log("# just ID changed, to " + cldrStatus.getCurrentId());
+      // surveyCurrentID and the hash have already changed.
+      // Make sure the item is visible.
+      showCurrentId();
+    }
+  }
 
-    /**
-     * @function showPage
-     */
-    OtherSpecial.prototype.show = function show(name, params) {
-      this.loadSpecial(
-        name,
-        function onSuccess(special) {
-          // populate the params a little more
-          params.otherSpecial = this;
-          params.name = name;
-          params.special = special;
+  function addTopLocale(topLoc, theDiv) {
+    var topLocInfo = locmap.getLocaleInfo(topLoc);
 
-          // add anything from scope..
+    var topLocRow = document.createElement("div");
+    topLocRow.className = "topLocaleRow";
 
-          params.exports = {
-            // All things that should be separate AMD modules..
-            appendLocaleLink: appendLocaleLink,
-            handleDisconnect: handleDisconnect,
-            clickToSelect: cldrSurvey.clickToSelect,
-          };
+    var topLocDiv = document.createElement("div");
+    topLocDiv.className = "topLocale";
+    appendLocaleLink(topLocDiv, topLoc, topLocInfo);
 
-          special.show(params);
-        },
-        function onFailure(err) {
-          // extended error
-          var loadingChunk;
-          var msg_fmt = cldrText.sub("v_bad_special_msg", {
-            special: name,
-          });
-          params.flipper.flipTo(
-            params.pages.loading,
-            (loadingChunk = cldrSurvey.createChunk(msg_fmt, "p", "errCodeMsg"))
-          );
-          isLoading = false;
-        }
-      );
-    };
+    var topLocList = document.createElement("div");
+    topLocList.className = "subLocaleList";
 
-    /**
-     * instance of otherSpecial manager
-     * @property otherSpecial
-     */
-    var otherSpecial = new OtherSpecial();
+    addSubLocales(topLocList, topLocInfo);
 
-    /**
-     * Parse the hash string into surveyCurrent___ variables.
-     * Expected to update document.title also.
-     *
-     * @param {String} id
-     */
-    window.parseHash = function parseHash(hash) {
-      function updateWindowTitle() {
-        var t = cldrText.get("survey_title");
-        const curLocale = cldrStatus.getCurrentLocale();
-        if (curLocale && curLocale != "") {
-          t = t + ": " + locmap.getLocaleName(curLocale);
-        }
-        const curSpecial = cldrStatus.getCurrentSpecial();
-        if (curSpecial && curSpecial != "") {
-          t = t + ": " + cldrText.get("special_" + curSpecial);
-        }
-        const curPage = cldrStatus.getCurrentPage();
-        if (curPage && curPage != "") {
-          t = t + ": " + curPage;
-        }
-        document.title = t;
+    topLocRow.appendChild(topLocDiv);
+    topLocRow.appendChild(topLocList);
+    theDiv.appendChild(topLocRow);
+  }
+
+  /**
+   * Parse the hash string into surveyCurrent___ variables.
+   * Expected to update document.title also.
+   *
+   * @param {String} hash
+   */
+  function parseHashAndUpdate(hash) {
+    if (hash) {
+      var pieces = hash.substr(0).split("/");
+      if (pieces.length > 1) {
+        cldrStatus.setCurrentLocale(pieces[1]); // could be null
+        /*
+         * TODO: find a way if possible to fix here when cldrStatus.getCurrentLocale() === "USER".
+         * It may be necessary (and sufficient) to wait for server response, see "USER" elsewhere
+         * in this file. cachedJson.loc and _thePages.loc are generally (always?) undefined here.
+         * Reference: https://unicode.org/cldr/trac/ticket/11161
+         */
+      } else {
+        cldrStatus.setCurrentLocale("");
       }
-      if (hash) {
-        var pieces = hash.substr(0).split("/");
-        if (pieces.length > 1) {
-          cldrStatus.setCurrentLocale(pieces[1]); // could be null
-          /*
-           * TODO: find a way if possible to fix here when cldrStatus.getCurrentLocale() === "USER".
-           * It may be necessary (and sufficient) to wait for server response, see "USER" elsewhere
-           * in this file. cachedJson.loc and _thePages.loc are generally (always?) undefined here.
-           * Reference: https://unicode.org/cldr/trac/ticket/11161
-           */
+      const curLocale = cldrStatus.getCurrentLocale();
+      if (pieces[0].length == 0 && curLocale != "" && curLocale != null) {
+        if (pieces.length > 2) {
+          cldrStatus.setCurrentPage(pieces[2]);
+          if (pieces.length > 3) {
+            let id = pieces[3];
+            if (id.substr(0, 2) == "x@") {
+              id = id.substr(2);
+            }
+            cldrStatus.setCurrentId(id);
+          } else {
+            cldrStatus.setCurrentId("");
+          }
         } else {
-          cldrStatus.setCurrentLocale("");
+          cldrStatus.setCurrentPage("");
+          cldrStatus.setCurrentId("");
         }
-        const curLocale = cldrStatus.getCurrentLocale();
-        if (pieces[0].length == 0 && curLocale != "" && curLocale != null) {
+        cldrStatus.setCurrentSpecial(null);
+      } else {
+        const curSpec = pieces[0] ? pieces[0] : "locales";
+        cldrStatus.setCurrentSpecial(curSpec);
+        if (curSpec == "locales") {
+          // allow locales list to retain ID / Page string for passthrough.
+          cldrStatus.setCurrentLocale("");
           if (pieces.length > 2) {
             cldrStatus.setCurrentPage(pieces[2]);
             if (pieces.length > 3) {
@@ -336,1121 +422,285 @@ const cldrLoad = (function () {
             cldrStatus.setCurrentPage("");
             cldrStatus.setCurrentId("");
           }
-          cldrStatus.setCurrentSpecial(null);
-        } else {
-          cldrStatus.setCurrentSpecial(pieces[0]);
-          if (cldrStatus.getCurrentSpecial() == "") {
-            cldrStatus.setCurrentSpecial("locales");
-          }
-          if (cldrStatus.getCurrentSpecial() == "locales") {
-            // allow locales list to retain ID / Page string for passthrough.
-            cldrStatus.setCurrentLocale("");
-            if (pieces.length > 2) {
-              cldrStatus.setCurrentPage(pieces[2]);
-              if (pieces.length > 3) {
-                let id = pieces[3];
-                if (id.substr(0, 2) == "x@") {
-                  id = id.substr(2);
-                }
-                cldrStatus.setCurrentId(id);
-              } else {
-                cldrStatus.setCurrentId("");
-              }
+        } else if (isReport(curSpec)) {
+          // allow page and ID to fall through.
+          if (pieces.length > 2) {
+            cldrStatus.setCurrentPage(pieces[2]);
+            if (pieces.length > 3) {
+              cldrStatus.setCurrentId(pieces[3]);
             } else {
-              cldrStatus.setCurrentPage("");
-              cldrStatus.setCurrentId("");
-            }
-          } else if (cldrSurvey.isReport(cldrStatus.getCurrentSpecial())) {
-            // allow page and ID to fall through.
-            if (pieces.length > 2) {
-              cldrStatus.setCurrentPage(pieces[2]);
-              if (pieces.length > 3) {
-                cldrStatus.setCurrentId(pieces[3]);
-              } else {
-                cldrStatus.setCurrentId("");
-              }
-            } else {
-              cldrStatus.setCurrentPage("");
               cldrStatus.setCurrentId("");
             }
           } else {
-            otherSpecial.parseHash(
-              cldrStatus.getCurrentSpecial(),
-              hash,
-              pieces
-            );
+            cldrStatus.setCurrentPage("");
+            cldrStatus.setCurrentId("");
           }
+        } else if (curSpec === "about") {
+          cldrStatus.setCurrentPage("");
+          cldrStatus.setCurrentId("");
+        } else if (curSpec === "admin") {
+          cldrStatus.setCurrentPage("");
+          cldrStatus.setCurrentId("");
+        } else if (curSpec === "createLogin") {
+          cldrStatus.setCurrentPage("");
+          cldrStatus.setCurrentId("");
+        } else if (curSpec === "forum") {
+          cldrStatus.setCurrentPage("");
+          if (pieces && pieces.length > 3) {
+            if (!pieces[3] || pieces[3] == "") {
+              cldrStatus.setCurrentId("");
+            } else {
+              var id = new Number(pieces[3]);
+              if (id == NaN) {
+                cldrStatus.setCurrentId("");
+              } else {
+                // e.g., http://localhost:8080/cldr-apps/v#forum/ar//69009
+                const idStr = id.toString();
+                cldrStatus.setCurrentId(idStr);
+                cldrForum.handleIdChanged(idStr);
+              }
+            }
+          }
+        } else {
+          otherSpecial.parseHash(cldrStatus.getCurrentSpecial(), hash, pieces);
         }
-      } else {
-        cldrStatus.setCurrentLocale("");
-        cldrStatus.setCurrentSpecial("locales");
-        cldrStatus.setCurrentId("");
-        cldrStatus.setCurrentPage("");
-        cldrStatus.setCurrentSection("");
       }
-      updateWindowTitle();
+    } else {
+      cldrStatus.setCurrentLocale("");
+      cldrStatus.setCurrentSpecial("locales");
+      cldrStatus.setCurrentId("");
+      cldrStatus.setCurrentPage("");
+      cldrStatus.setCurrentSection("");
+    }
+    updateWindowTitle();
 
-      // if there is no locale id, refresh the search.
-      if (!cldrStatus.getCurrentLocale()) {
-        searchRefresh();
-      }
-    };
+    // if there is no locale id, refresh the search.
+    if (!cldrStatus.getCurrentLocale()) {
+      cldrEvent.searchRefresh();
+    }
+  }
 
-    /**
-     * Update hash (and title)
-     *
-     * @param doPush {Boolean} if true, do a push (instead of replace)
-     *
-     * Called by cldrForum.parseContent, as well as locally.
-     *
-     * TODO: avoid attaching this, or anything, to "window"! Define our own objects instead.
-     */
-    window.replaceHash = function replaceHash(doPush) {
-      if (!doPush) {
-        doPush = false; // by default -replace.
-      }
-      var theId = cldrStatus.getCurrentId();
-      if (theId == null) {
-        theId = "";
-      }
-      var theSpecial = cldrStatus.getCurrentSpecial();
-      if (theSpecial == null) {
-        theSpecial = "";
-      }
-      var thePage = cldrStatus.getCurrentPage();
-      if (thePage == null) {
-        thePage = "";
-      }
-      var theLocale = cldrStatus.getCurrentLocale();
-      if (theLocale == null) {
-        theLocale = "";
-      }
-      var newHash =
-        "#" + theSpecial + "/" + theLocale + "/" + thePage + "/" + theId;
-      if (newHash != dojoHash()) {
-        dojoHash(newHash, !doPush);
-      }
-    };
+  function updateWindowTitle() {
+    let t = cldrText.get("survey_title");
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale && curLocale != "") {
+      t = t + ": " + locmap.getLocaleName(curLocale);
+    }
+    const curSpecial = cldrStatus.getCurrentSpecial();
+    if (curSpecial && curSpecial != "") {
+      t = t + ": " + cldrText.get("special_" + curSpecial);
+    }
+    const curPage = cldrStatus.getCurrentPage();
+    if (curPage && curPage != "") {
+      t = t + ": " + curPage;
+    }
+    document.title = t;
+  }
 
-    window.updateCurrentId = function updateCurrentId(id) {
-      if (id == null) {
-        id = "";
-      }
-      if (cldrStatus.getCurrentId() != id) {
-        // don't set if already set.
-        cldrStatus.setCurrentId(id);
-        replaceHash(false); // usually don't want to save
-      }
-    };
+  function updateCurrentId(id) {
+    if (!id) {
+      id = "";
+    }
+    if (cldrStatus.getCurrentId() != id) {
+      // don't set if already set.
+      cldrStatus.setCurrentId(id);
+      replaceHash(false); // usually don't want to save
+    }
+  }
 
-    // (back to showV) some setup.
-    // click on the title to copy (permalink)
-    cldrSurvey.clickToSelect(document.getElementById("ariScroller"));
-    cldrSurvey.updateIf(
-      "title-dcontent-link",
-      cldrText.get("defaultContent_titleLink")
-    );
+  /**
+   * Update hash (and title)
+   *
+   * @param doPush {Boolean} if true, do a push (instead of replace)
+   *
+   * Called by cldrForum.parseContent (doPush false), as well as locally.
+   */
+  function replaceHash(doPush) {
+    if (!doPush) {
+      doPush = false; // by default -replace.
+    }
+    let theId = cldrStatus.getCurrentId();
+    if (theId == null) {
+      theId = "";
+    }
+    let theSpecial = cldrStatus.getCurrentSpecial();
+    if (theSpecial == null) {
+      theSpecial = "";
+    }
+    let thePage = cldrStatus.getCurrentPage();
+    if (thePage == null) {
+      thePage = "";
+    }
+    let theLocale = cldrStatus.getCurrentLocale();
+    if (theLocale == null) {
+      theLocale = "";
+    }
+    let newHash = theSpecial + "/" + theLocale + "/" + thePage + "/" + theId;
+    if (newHash != getHash()) {
+      setHash(newHash, !doPush);
+    }
+  }
 
-    // TODO - rewrite using AMD
-    /**
-     * @param postData optional - makes this a POST
-     */
-    window.myLoad = function myLoad(url, message, handler, postData, headers) {
-      var otime = new Date().getTime();
-      console.log("MyLoad: " + url + " for " + message);
-      var errorHandler = function (err) {
-        console.log("Error: " + err);
-        handleDisconnect(
-          "Could not fetch " +
-            message +
-            " - error " +
-            err +
-            "\n url: " +
-            url +
-            "\n",
-          null,
-          "disconnect"
-        );
+  /**
+   * Verify that the JSON returned is as expected.
+   *
+   * @param json the returned json
+   * @param subkey the key to look for,  json.subkey
+   * @return true if OK, false if bad
+   */
+  function verifyJson(json, subkey) {
+    if (!json) {
+      console.log("!json");
+      cldrSurvey.showLoader(
+        "Error while  loading " +
+          subkey +
+          ":  <br><div style='border: 1px solid red;'>" +
+          "no data!" +
+          "</div>"
+      );
+      return false;
+    } else if (json.err_code) {
+      var msg_fmt = cldrSurvey.formatErrMsg(json, subkey);
+      var loadingChunk = cldrDom.createChunk(msg_fmt, "p", "errCodeMsg");
+      flipper.flipTo(pages.loading, loadingChunk);
+      var retryButton = cldrDom.createChunk(
+        cldrText.get("loading_reload"),
+        "button"
+      );
+      loadingChunk.appendChild(retryButton);
+      retryButton.onclick = function () {
+        window.location.reload(true);
       };
-      var loadHandler = function (json) {
-        console.log(
-          "        " +
-            url +
-            " loaded in " +
-            (new Date().getTime() - otime) +
-            "ms"
-        );
-        try {
-          handler(json);
-          //resize height
-          $("#main-row").css({
-            height: $("#main-row>div").height(),
-          });
-        } catch (e) {
+      return false;
+    } else if (json.err) {
+      console.log("json.err!" + json.err);
+      cldrSurvey.showLoader(
+        "Error while  loading " +
+          subkey +
+          ": <br><div style='border: 1px solid red;'>" +
+          json.err +
+          "</div>"
+      );
+      cldrSurvey.handleDisconnect("while loading " + subkey + "", json);
+      return false;
+    } else if (!json[subkey]) {
+      console.log("!json." + subkey);
+      cldrSurvey.showLoader(
+        "Error while loading " +
+          subkey +
+          ": <br><div style='border: 1px solid red;'>" +
+          "no data" +
+          "</div>"
+      );
+      cldrSurvey.handleDisconnect("while loading- no " + subkey + "", json);
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  function showCurrentId() {
+    const curSpecial = cldrStatus.getCurrentSpecial();
+    if (curSpecial && curSpecial != "" && !cldrStatus.isDashboard()) {
+      otherSpecial.handleIdChanged(curSpecial, showCurrentId);
+    } else {
+      const curId = cldrStatus.getCurrentId();
+      if (curId) {
+        var xtr = document.getElementById("r@" + curId);
+        if (!xtr) {
+          console.log("Warning could not load id " + curId + " does not exist");
+          updateCurrentId(null);
+        } else if (xtr.proposedcell && xtr.proposedcell.showFn) {
+          // TODO: visible? coverage?
+          cldrInfo.showRowObjFunc(
+            xtr,
+            xtr.proposedcell,
+            xtr.proposedcell.showFn
+          );
+          console.log("Changed to " + cldrStatus.getCurrentId());
+          if (!cldrStatus.isDashboard()) {
+            scrollToItem();
+          }
+        } else {
           console.log(
-            "Error in ajax post [" +
-              message +
-              "]  " +
-              e.message +
-              " / " +
-              e.name
+            "Warning could not load id " +
+              curId +
+              " - not setup - " +
+              xtr.toString() +
+              " pc=" +
+              xtr.proposedcell +
+              " sf = " +
+              xtr.proposedcell.showFn
           );
-          handleDisconnect(
-            "Exception while loading: " +
-              message +
-              " - " +
-              e.message +
-              ", n=" +
-              e.name +
-              " \nStack:\n" +
-              (e.stack || "[none]"),
-            null
-          ); // in case the 2nd line doesn't work
         }
-      };
-      var xhrArgs = {
-        url: url,
-        handleAs: "json",
-        load: loadHandler,
-        error: errorHandler,
-        postData: postData,
-        headers: headers,
-      };
-      cldrAjax.queueXhr(xhrArgs);
-    };
-
-    /**
-     * Verify that the JSON returned is as expected.
-     *
-     * @param json the returned json
-     * @param subkey the key to look for,  json.subkey
-     * @return true if OK, false if bad
-     */
-    function verifyJson(json, subkey) {
-      if (!json) {
-        console.log("!json");
-        showLoader(
-          null,
-          "Error while  loading " +
-            subkey +
-            ":  <br><div style='border: 1px solid red;'>" +
-            "no data!" +
-            "</div>"
-        );
-        return false;
-      } else if (json.err_code) {
-        var msg_fmt = formatErrMsg(json, subkey);
-        var loadingChunk;
-        flipper.flipTo(
-          pages.loading,
-          (loadingChunk = cldrSurvey.createChunk(msg_fmt, "p", "errCodeMsg"))
-        );
-        var retryButton = cldrSurvey.createChunk(
-          cldrText.get("loading_reload"),
-          "button"
-        );
-        loadingChunk.appendChild(retryButton);
-        retryButton.onclick = function () {
-          window.location.reload(true);
-        };
-        return false;
-      } else if (json.err) {
-        console.log("json.err!" + json.err);
-        showLoader(
-          null,
-          "Error while  loading " +
-            subkey +
-            ": <br><div style='border: 1px solid red;'>" +
-            json.err +
-            "</div>"
-        );
-        handleDisconnect("while loading " + subkey + "", json);
-        return false;
-      } else if (!json[subkey]) {
-        console.log("!json.oldvotes");
-        showLoader(
-          null,
-          "Error while  loading " +
-            subkey +
-            ": <br><div style='border: 1px solid red;'>" +
-            "no data" +
-            "</div>"
-        );
-        handleDisconnect("while loading- no " + subkey + "", json);
-        return false;
-      } else {
-        return true;
       }
     }
+  }
 
-    window.showCurrentId = function () {
-      const curSpecial = cldrStatus.getCurrentSpecial();
-      if (curSpecial && curSpecial != "" && !isDashboard()) {
-        otherSpecial.handleIdChanged(curSpecial, showCurrentId);
-      } else {
-        const curId = cldrStatus.getCurrentId();
-        if (curId != "") {
-          var xtr = document.getElementById("r@" + curId);
-          if (!xtr) {
-            console.log(
-              "Warning could not load id " + curId + " does not exist"
-            );
-            window.updateCurrentId(null);
-          } else if (xtr.proposedcell && xtr.proposedcell.showFn) {
-            // TODO: visible? coverage?
-            cldrSurvey.showInPop(
-              "",
-              xtr,
-              xtr.proposedcell,
-              xtr.proposedcell.showFn,
-              true
-            );
-            console.log("Changed to " + cldrStatus.getCurrentId());
-            if (!isDashboard()) scrollToItem();
-          } else {
-            console.log(
-              "Warning could not load id " +
-                curId +
-                " - not setup - " +
-                xtr.toString() +
-                " pc=" +
-                xtr.proposedcell +
-                " sf = " +
-                xtr.proposedcell.showFn
-            );
-          }
-        }
+  /**
+   * Show the surveyCurrentId row
+   */
+  function scrollToItem() {
+    const curId = cldrStatus.getCurrentId();
+    if (curId != null && curId != "") {
+      const xtr = document.getElementById("r@" + curId);
+      if (xtr != null) {
+        console.log("Scrolling to " + curId);
+        xtr.scrollIntoView();
       }
-    };
+    }
+  }
 
-    // https://dojotoolkit.org/reference-guide/1.10/dijit/Dialog.html
-    const ariDialog = {
-      show: function () {
-        console.log("ariDialog.show not implemented yet!");
-      },
-      hide: function () {
-        console.log("ariDialog.hide not implemented yet!");
-      },
-    };
-
-    window.ariRetry = function () {
-      if (!ariDialog) {
-        console.log("Error: no ariDialog in window.ariRetry");
-      } else {
-        ariDialog.hide();
-      }
-      window.location.reload(true);
-    };
-
-    window.showARIDialog = function (why, json, word, oneword, p, what) {
-      console.log("showARIDialog");
-      p.parentNode.removeChild(p);
-
-      if (didUnbust) {
-        why = why + "\n\n" + cldrText.get("ari_force_reload");
-      }
-
-      // setup with why
-      var ari_message;
-
-      if (json && json.session_err) {
-        ari_message = cldrText.get("ari_sessiondisconnect_message");
-      } else {
-        ari_message = cldrText.get("ari_message");
-      }
-
-      var ari_submessage = formatErrMsg(json, what);
-
-      cldrSurvey.updateIf("ariMessage", ari_message.replace(/\n/g, "<br>"));
-      cldrSurvey.updateIf(
-        "ariSubMessage",
-        ari_submessage.replace(/\n/g, "<br>")
+  function updateCoverageMenuTitle() {
+    const cov = cldrSurvey.getSurveyUserCov();
+    if (cov) {
+      $("#cov-info").text(cldrText.get("coverage_" + cov));
+    } else {
+      $("#coverage-info").text(
+        cldrText.sub("coverage_auto_msg", {
+          surveyOrgCov: cldrText.get(
+            "coverage_" + cldrSurvey.getSurveyOrgCov()
+          ),
+        })
       );
-      cldrSurvey.updateIf(
-        "ariScroller",
-        window.location + "<br>" + why.replace(/\n/g, "<br>")
-      );
-      // TODO: update  ariMain and ariRetryBtn
-      hideOverlayAndSidebar();
-
-      if (!ariDialog) {
-        console.log("Error: no ariDialog in window.showARIDialog 1");
-      } else {
-        ariDialog.show();
-      }
-
-      var oneword = document.getElementById("progress_oneword");
-      oneword.onclick = function () {
-        if (cldrStatus.isDisconnected()) {
-          if (!ariDialog) {
-            console.log(
-              "Error: no ariDialog in window.showARIDialog 2 onclick"
-            );
-          } else {
-            ariDialog.show();
-          }
-        }
-      };
-    };
-
-    function updateCoverageMenuTitle() {
-      if (surveyUserCov) {
-        $("#coverage-info").text(cldrText.get("coverage_" + surveyUserCov));
-      } else {
-        $("#coverage-info").text(
-          cldrText.sub("coverage_auto_msg", {
-            surveyOrgCov: cldrText.get("coverage_" + surveyOrgCov),
-          })
-        );
-      }
     }
+  }
 
-    function updateLocaleMenu() {
-      const curLocale = cldrStatus.getCurrentLocale();
-      if (curLocale != null && curLocale != "" && curLocale != "-") {
-        cldrStatus.setCurrentLocaleName(locmap.getLocaleName(curLocale));
-        var bund = locmap.getLocaleInfo(curLocale);
-        if (bund) {
-          if (bund.readonly) {
-            cldrSurvey.addClass(
-              document.getElementById(menubuttons.locale),
-              "locked"
-            );
-          } else {
-            cldrSurvey.removeClass(
-              document.getElementById(menubuttons.locale),
-              "locked"
-            );
-          }
+  function insertLocaleSpecialNote(theDiv) {
+    const bund = locmap.getLocaleInfo(cldrStatus.getCurrentLocale());
+    let msg = null;
 
-          if (bund.dcChild) {
-            menubuttons.set(
-              menubuttons.dcontent,
-              cldrText.sub("defaultContent_header_msg", {
-                info: bund,
-                locale: cldrStatus.getCurrentLocale(),
-                dcChild: locmap.getLocaleName(bund.dcChild),
-              })
-            );
-          } else {
-            menubuttons.set(menubuttons.dcontent);
-          }
-        } else {
-          cldrSurvey.removeClass(
-            document.getElementById(menubuttons.locale),
-            "locked"
-          );
-          menubuttons.set(menubuttons.dcontent);
-        }
-      } else {
-        cldrStatus.setCurrentLocaleName("");
-        cldrSurvey.removeClass(
-          document.getElementById(menubuttons.locale),
-          "locked"
-        );
-        menubuttons.set(menubuttons.dcontent);
-      }
-      menubuttons.set(menubuttons.locale, cldrStatus.getCurrentLocaleName());
-    }
-
-    /**
-     * Update the #hash and menus to the current settings.
-     *
-     * @param doPush {Boolean} if false, do not add to history
-     */
-    function updateHashAndMenus(doPush) {
-      const sessionId = cldrStatus.getSessionId();
-      const surveyUser = cldrStatus.getSurveyUser();
-      const userID = surveyUser && surveyUser.id ? surveyUser.id : 0;
-      const surveyUserPerms = cldrStatus.getPermissions();
-      const surveyUserURL = {
-        myAccountSetting: "survey?do=listu",
-        disableMyAccount: "lock.jsp",
-        recentActivity: "myvotes.jsp?user=" + userID + "&s=" + sessionId,
-        xmlUpload: "upload.jsp?a=/cldr-apps/survey&s=" + sessionId,
-        manageUser: "survey?do=list",
-        flag: "tc-flagged.jsp?s=" + sessionId,
-        about: "about.jsp",
-        browse: "browse.jsp",
-        adminPanel: "SurveyAjax?what=admin_panel&s=" + sessionId,
-      };
-
-      /**
-       * 'name' - the js/special/___.js name
-       * 'hidden' - true to hide the item
-       * 'title' - override of menu name
-       * @property specialItems
-       */
-      var specialItems = new Array();
-      if (surveyUser != null) {
-        specialItems = [
-          {
-            divider: true,
-          },
-
-          {
-            title: "Admin Panel",
-            url: surveyUserURL.adminPanel,
-            display: surveyUser && surveyUser.userlevelName === "ADMIN",
-          },
-          {
-            divider: true,
-            display: surveyUser && surveyUser.userlevelName === "ADMIN",
-          },
-
-          {
-            title: "My Account",
-          }, // My Account section
-
-          {
-            title: "Settings",
-            level: 2,
-            url: surveyUserURL.myAccountSetting,
-            display: surveyUser && true,
-          },
-          {
-            title: "Lock (Disable) My Account",
-            level: 2,
-            url: surveyUserURL.disableMyAccount,
-            display: surveyUser && true,
-          },
-
-          {
-            divider: true,
-          },
-          {
-            title: "My Votes",
-          }, // My Votes section
-
-          /*
-           * This indirectly references "special_oldvotes" in cldrText.js
-           */
-          {
-            special: "oldvotes",
-            level: 2,
-            display: surveyUserPerms && surveyUserPerms.userCanImportOldVotes,
-          },
-          {
-            title: "See My Recent Activity",
-            level: 2,
-            url: surveyUserURL.recentActivity,
-          },
-          {
-            title: "Upload XML",
-            level: 2,
-            url: surveyUserURL.xmlUpload,
-          },
-
-          {
-            divider: true,
-          },
-          {
-            title: "My Organization(" + cldrStatus.getOrganizationName() + ")",
-          }, // My Organization section
-
-          {
-            special: "vsummary" /* Cf. special_vsummary */,
-            level: 2,
-            display:
-              surveyUserPerms && surveyUserPerms.userCanUseVettingSummary,
-          },
-          {
-            title: "List " + cldrStatus.getOrganizationName() + " Users",
-            level: 2,
-            url: surveyUserURL.manageUser,
-            display:
-              surveyUserPerms &&
-              (surveyUserPerms.userIsTC || surveyUserPerms.userIsVetter),
-          },
-          {
-            special:
-              "forum_participation" /* Cf. special_forum_participation */,
-            level: 2,
-            display: surveyUserPerms && surveyUserPerms.userCanMonitorForum,
-          },
-          {
-            special:
-              "vetting_participation" /* Cf. special_vetting_participation */,
-            level: 2,
-            display:
-              surveyUserPerms &&
-              (surveyUserPerms.userIsTC || surveyUserPerms.userIsVetter),
-          },
-          {
-            title: "LOCKED: Note: your account is currently locked.",
-            level: 2,
-            display: surveyUserPerms && surveyUserPerms.userIsLocked,
-            bold: true,
-          },
-
-          {
-            divider: true,
-          },
-          {
-            title: "Forum",
-          }, // Forum section
-
-          {
-            special: "flagged",
-            level: 2,
-            hasFlag: true,
-          },
-          {
-            special: "mail",
-            level: 2,
-            display: cldrStatus.getIsUnofficial(),
-          },
-          {
-            special: "bulk_close_posts" /* Cf. special_bulk_close_posts */,
-            level: 2,
-            display: surveyUser && surveyUser.userlevelName === "ADMIN",
-          },
-
-          {
-            divider: true,
-          },
-          {
-            title: "Informational",
-          }, // Informational section
-
-          {
-            special: "statistics",
-            level: 2,
-          },
-          {
-            title: "About",
-            level: 2,
-            url: surveyUserURL.about,
-          },
-          {
-            title: "Lookup a code or xpath",
-            level: 2,
-            url: surveyUserURL.browse,
-          },
-          {
-            title: "Error Subtypes",
-            level: 2,
-            url: "./tc-all-errors.jsp",
-            display: surveyUserPerms && surveyUserPerms.userIsTC,
-          },
-          {
-            divider: true,
-          },
-        ];
-      }
-      if (!doPush) {
-        doPush = false;
-      }
-      replaceHash(doPush); // update the hash
-      updateLocaleMenu();
-
-      if (cldrStatus.getCurrentLocale() == null) {
-        menubuttons.set(menubuttons.section);
-        const curSpecial = cldrStatus.getCurrentSpecial();
-        if (curSpecial != null) {
-          var specialId = "special_" + curSpecial;
-          menubuttons.set(menubuttons.page, cldrText.get(specialId));
-        } else {
-          menubuttons.set(menubuttons.page);
-        }
-        return; // nothing to do.
-      }
-      var titlePageContainer = document.getElementById("title-page-container");
-
-      /**
-       * Just update the titles of the menus. Internal to updateHashAndMenus
-       */
-      function updateMenuTitles(menuMap) {
-        if (menubuttons.lastspecial === undefined) {
-          menubuttons.lastspecial = null;
-
-          // Set up the menu here?
-          var parMenu = document.getElementById("manage-list");
-          for (var k = 0; k < specialItems.length; k++) {
-            var item = specialItems[k];
-            (function (item) {
-              if (item.display != false) {
-                var subLi = document.createElement("li");
-                if (item.special) {
-                  // special items so look up in cldrText.js
-                  item.title = cldrText.get("special_" + item.special);
-                  item.url = "#" + item.special;
-                  item.blank = false;
-                }
-                if (item.url) {
-                  var subA = document.createElement("a");
-
-                  if (item.hasFlag) {
-                    // forum may need images attached to it
-                    var Img = document.createElement("img");
-                    Img.setAttribute("src", "flag.png");
-                    Img.setAttribute("alt", "flag");
-                    Img.setAttribute("title", "flag.png");
-                    Img.setAttribute("border", 0);
-
-                    subA.appendChild(Img);
-                  }
-                  subA.appendChild(document.createTextNode(item.title + " "));
-                  subA.href = item.url;
-
-                  if (item.blank != false) {
-                    subA.target = "_blank";
-                    subA.appendChild(
-                      cldrSurvey.createChunk(
-                        "",
-                        "span",
-                        "glyphicon glyphicon-share manage-list-icon"
-                      )
-                    );
-                  }
-
-                  if (item.level) {
-                    // append it to appropriate levels
-                    var level = item.level;
-                    for (var i = 0; i < level - 1; i++) {
-                      /*
-                       * Indent by creating lists within lists, each list containing only one item.
-                       * TODO: indent by a better method. Note that for valid html, ul should contain li;
-                       * ul directly containing element other than li is generally invalid.
-                       */
-                      let ul = document.createElement("ul");
-                      let li = document.createElement("li");
-                      ul.setAttribute("style", "list-style-type:none");
-                      ul.appendChild(li);
-                      li.appendChild(subA);
-                      subA = ul;
-                    }
-                  }
-                  subLi.appendChild(subA);
-                }
-                if (!item.url && !item.divider) {
-                  // if it is pure text/html & not a divider
-                  if (!item.level) {
-                    subLi.appendChild(
-                      document.createTextNode(item.title + " ")
-                    );
-                  } else {
-                    var subA = null;
-                    if (item.bold) {
-                      subA = document.createElement("b");
-                    } else if (item.italic) {
-                      subA = document.createElement("i");
-                    } else {
-                      subA = document.createElement("span");
-                    }
-                    subA.appendChild(document.createTextNode(item.title + " "));
-
-                    var level = item.level;
-                    for (var i = 0; i < level - 1; i++) {
-                      let ul = document.createElement("ul");
-                      let li = document.createElement("li");
-                      ul.setAttribute("style", "list-style-type:none");
-                      ul.appendChild(li);
-                      li.appendChild(subA);
-                      subA = ul;
-                    }
-                    subLi.appendChild(subA);
-                  }
-                }
-                if (item.divider) {
-                  subLi.className = "nav-divider";
-                }
-                parMenu.appendChild(subLi);
-              }
-            })(item);
-          }
-        }
-
-        if (menubuttons.lastspecial) {
-          cldrSurvey.removeClass(menubuttons.lastspecial, "selected");
-        }
-
-        updateLocaleMenu(menuMap);
-        const curSpecial = cldrStatus.getCurrentSpecial();
-        if (curSpecial != null && curSpecial != "") {
-          var specialId = "special_" + curSpecial;
-          $("#section-current").html(cldrText.get(specialId));
-          setDisplayed(titlePageContainer, false);
-        } else if (!menuMap) {
-          setDisplayed(titlePageContainer, false);
-        } else {
-          const curPage = cldrStatus.getCurrentPage();
-          if (menuMap.sectionMap[curPage]) {
-            const curSection = curPage; // section = page
-            cldrStatus.setCurrentSection(curSection);
-            $("#section-current").html(menuMap.sectionMap[curSection].name);
-            setDisplayed(titlePageContainer, false); // will fix title later
-          } else if (menuMap.pageToSection[curPage]) {
-            var mySection = menuMap.pageToSection[curPage];
-            cldrStatus.setCurrentSection(mySection.id);
-            $("#section-current").html(mySection.name);
-            setDisplayed(titlePageContainer, false); // will fix title later
-          } else {
-            $("#section-current").html(cldrText.get("section_general"));
-            setDisplayed(titlePageContainer, false);
-          }
-        }
-      }
-
-      /**
-       * Update the menus
-       */
-      function updateMenus(menuMap) {
-        // initialize menus
-        if (!menuMap.menusSetup) {
-          menuMap.menusSetup = true;
-          menuMap.setCheck = function (menu, checked, disabled) {
-            menu.set(
-              "iconClass",
-              checked ? "dijitMenuItemIcon menu-x" : "dijitMenuItemIcon menu-o"
-            );
-            menu.set("disabled", disabled);
-          };
-          var menuSection = dijitRegistry.byId("menu-section");
-          menuMap.section_general = new dijitMenuItem({
-            label: cldrText.get("section_general"),
-            iconClass: "dijitMenuItemIcon ",
-            disabled: true,
-            onClick: function () {
-              if (
-                cldrStatus.getCurrentPage() != "" ||
-                (cldrStatus.getCurrentSpecial() != "" &&
-                  cldrStatus.getCurrentSpecial() != null)
-              ) {
-                cldrStatus.setCurrentId(""); // no id if jumping pages
-                cldrStatus.setCurrentPage("");
-                cldrStatus.setCurrentSection("");
-                cldrStatus.setCurrentSpecial("");
-                updateMenuTitles(menuMap);
-                reloadV();
-              }
-            },
-          });
-          menuSection.addChild(menuMap.section_general);
-          for (var j in menuMap.sections) {
-            (function (aSection) {
-              aSection.menuItem = new dijitMenuItem({
-                label: aSection.name,
-                iconClass: "dijitMenuItemIcon",
-                onClick: function () {
-                  cldrStatus.setCurrentId("!"); // no id if jumping pages
-                  cldrStatus.setCurrentPage(aSection.id);
-                  cldrStatus.setCurrentSpecial("");
-                  updateMenus(menuMap);
-                  updateMenuTitles(menuMap);
-                  reloadV();
-                },
-                disabled: true,
-              });
-
-              menuSection.addChild(aSection.menuItem);
-            })(menuMap.sections[j]);
-          }
-
-          menuSection.addChild(new dijitMenuSeparator());
-
-          menuMap.forumMenu = new dijitMenuItem({
-            label: cldrText.get("section_forum"),
-            iconClass: "dijitMenuItemIcon", // menu-chat
-            disabled: true,
-            onClick: function () {
-              cldrStatus.setCurrentId("!"); // no id if jumping pages
-              cldrStatus.setCurrentPage("");
-              cldrStatus.setCurrentSpecial("forum");
-              updateMenus(menuMap);
-              updateMenuTitles(menuMap);
-              reloadV();
-            },
-          });
-          menuSection.addChild(menuMap.forumMenu);
-        }
-
-        updateMenuTitles(menuMap);
-
-        var myPage = null;
-        var mySection = null;
-        const curSpecial = cldrStatus.getCurrentSpecial();
-        if (curSpecial == null || curSpecial == "") {
-          // first, update display names
-          const curPage = cldrStatus.getCurrentPage();
-          if (menuMap.sectionMap[curPage]) {
-            // page is really a section
-            mySection = menuMap.sectionMap[curPage];
-            myPage = null;
-          } else if (menuMap.pageToSection[curPage]) {
-            mySection = menuMap.pageToSection[curPage];
-            myPage = mySection.pageMap[curPage];
-          }
-          if (mySection !== null) {
-            // update menus under 'page' - peer pages
-            if (!titlePageContainer.menus) {
-              titlePageContainer.menus = {};
-            }
-
-            // hide all. TODO use a foreach model?
-            for (var zz in titlePageContainer.menus) {
-              var aMenu = titlePageContainer.menus[zz];
-              aMenu.set("label", "-");
-            }
-
-            var showMenu = titlePageContainer.menus[mySection.id];
-
-            if (!showMenu) {
-              // doesn't exist - add it.
-              var menuPage = new dijitDropDownMenu();
-              for (var k in mySection.pages) {
-                // use given order
-                (function (aPage) {
-                  var pageMenu = (aPage.menuItem = new dijitMenuItem({
-                    label: aPage.name,
-                    iconClass:
-                      aPage.id == cldrStatus.getCurrentPage()
-                        ? "dijitMenuItemIcon menu-x"
-                        : "dijitMenuItemIcon menu-o",
-                    onClick: function () {
-                      cldrStatus.setCurrentId(""); // no id if jumping pages
-                      cldrStatus.setCurrentPage(aPage.id);
-                      updateMenuTitles(menuMap);
-                      reloadV();
-                    },
-                    disabled:
-                      effectiveCoverage() <
-                      parseInt(aPage.levs[cldrStatus.getCurrentLocale()]),
-                  }));
-                })(mySection.pages[k]);
-              }
-
-              showMenu = new dijitDropDownButton({
-                label: "-",
-                dropDown: menuPage,
-              });
-
-              titlePageContainer.menus[
-                mySection.id
-              ] = mySection.pagesMenu = showMenu;
-            }
-
-            if (myPage !== null) {
-              /*
-               * TODO: if 'use strict' in this file, we get:
-               * Ignoring get or set of property that has [LenientThis] because the “this” object is incorrect.
-               */
-              $("#title-page-container")
-                .html("<h1>" + myPage.name + "</h1>")
-                .show();
-            } else {
-              $("#title-page-container").html("").hide();
-            }
-            setDisplayed(showMenu, true);
-            setDisplayed(titlePageContainer, true); // will fix title later
-          }
-        }
-
-        stdebug("Updating menus.. ecov = " + effectiveCoverage());
-
-        menuMap.setCheck(
-          menuMap.section_general,
-          cldrStatus.getCurrentPage() == "" &&
-            (cldrStatus.getCurrentSpecial() == "" ||
-              cldrStatus.getCurrentSpecial() == null),
-          false
-        );
-
-        // Update the status of the items in the Section menu
-        for (var j in menuMap.sections) {
-          var aSection = menuMap.sections[j];
-          // need to see if any items are visible @ current coverage
-          const curLocale = cldrStatus.getCurrentLocale();
-          stdebug(
-            "for " +
-              aSection.name +
-              " minLev[" +
-              curLocale +
-              "] = " +
-              aSection.minLev[curLocale]
-          );
-          const curSection = cldrStatus.getCurrentSection();
-          menuMap.setCheck(
-            aSection.menuItem,
-            curSection == aSection.id,
-            effectiveCoverage() < aSection.minLev[curLocale]
-          );
-
-          // update the items in that section's Page menu
-          if (curSection == aSection.id) {
-            for (var k in aSection.pages) {
-              var aPage = aSection.pages[k];
-              if (!aPage.menuItem) {
-                console.log("Odd - " + aPage.id + " has no menuItem");
-              } else {
-                menuMap.setCheck(
-                  aPage.menuItem,
-                  aPage.id == cldrStatus.getCurrentPage(),
-                  effectiveCoverage() < parseInt(aPage.levs[curLocale])
-                );
-              }
-            }
-          }
-        }
-        menuMap.setCheck(
-          menuMap.forumMenu,
-          cldrStatus.getCurrentSpecial() == "forum",
-          cldrStatus.getSurveyUser() === null
-        );
-        resizeSidebar();
-      }
-
-      const curLocale = cldrStatus.getCurrentLocale();
-      if (_thePages == null || _thePages.loc != curLocale) {
-        // show the raw IDs while loading.
-        updateMenuTitles(null);
-
-        if (curLocale != null && curLocale != "") {
-          var needLocTable = false;
-
-          var url =
-            cldrStatus.getContextPath() +
-            "/SurveyAjax?what=menus&_=" +
-            curLocale +
-            "&locmap=" +
-            needLocTable +
-            "&s=" +
-            cldrStatus.getSessionId() +
-            cacheKill();
-          myLoad(url, "menus", function (json) {
-            if (!verifyJson(json, "menus")) {
-              return; // busted?
-            }
-
-            if (json.locmap) {
-              locmap = new LocaleMap(locmap); // overwrite with real data
-            }
-
-            // make this into a hashmap.
-            if (json.canmodify) {
-              var canmodify = {};
-              for (var k in json.canmodify) {
-                canmodify[json.canmodify[k]] = true;
-              }
-              window.canmodify = canmodify;
-            }
-
-            updateCovFromJson(json);
-            updateCoverageMenuTitle();
-            updateCoverage(flipper.get(pages.data)); // update CSS and auto menu title
-
-            function unpackMenus(json) {
-              var menus = json.menus;
-
-              if (_thePages) {
-                stdebug("Updating cov info into menus for " + json.loc);
-                for (var k in menus.sections) {
-                  var oldSection = _thePages.sectionMap[menus.sections[k].id];
-                  for (var j in menus.sections[k].pages) {
-                    var oldPage =
-                      oldSection.pageMap[menus.sections[k].pages[j].id];
-
-                    // copy over levels
-                    oldPage.levs[json.loc] =
-                      menus.sections[k].pages[j].levs[json.loc];
-                  }
-                }
-              } else {
-                stdebug("setting up new hashes for " + json.loc);
-                // set up some hashes
-                menus.haveLocs = {};
-                menus.sectionMap = {};
-                menus.pageToSection = {};
-                for (var k in menus.sections) {
-                  menus.sectionMap[menus.sections[k].id] = menus.sections[k];
-                  menus.sections[k].pageMap = {};
-                  menus.sections[k].minLev = {};
-                  for (var j in menus.sections[k].pages) {
-                    menus.sections[k].pageMap[menus.sections[k].pages[j].id] =
-                      menus.sections[k].pages[j];
-                    menus.pageToSection[menus.sections[k].pages[j].id] =
-                      menus.sections[k];
-                  }
-                }
-                _thePages = menus;
-              }
-
-              stdebug("Calculating minimum section coverage for " + json.loc);
-              for (var k in _thePages.sectionMap) {
-                var min = 200;
-                for (var j in _thePages.sectionMap[k].pageMap) {
-                  var thisLev = parseInt(
-                    _thePages.sectionMap[k].pageMap[j].levs[json.loc]
-                  );
-                  if (min > thisLev) {
-                    min = thisLev;
-                  }
-                }
-                _thePages.sectionMap[k].minLev[json.loc] = min;
-              }
-
-              _thePages.haveLocs[json.loc] = true;
-            }
-
-            unpackMenus(json);
-            unpackMenuSideBar(json);
-            updateMenus(_thePages);
-          });
-        }
-      } else {
-        // go ahead and update
-        updateMenus(_thePages);
-      }
-    }
-
-    window.insertLocaleSpecialNote = function insertLocaleSpecialNote(theDiv) {
-      var bund = locmap.getLocaleInfo(cldrStatus.getCurrentLocale());
-      let msg = null;
-
-      if (bund) {
-        if (bund.readonly || bund.special_comment_raw) {
-          if (bund.readonly) {
-            if (bund.special_comment_raw) {
-              msg = bund.special_comment_raw;
-            } else {
-              msg = cldrText.get("readonly_unknown");
-            }
-            msg = cldrText.sub("readonly_msg", {
-              info: bund,
-              locale: cldrStatus.getCurrentLocale(),
-              msg: msg,
-            });
-          } else {
-            // Not readonly, could be a scratch locale
+    if (bund) {
+      if (bund.readonly || bund.special_comment_raw) {
+        if (bund.readonly) {
+          if (bund.special_comment_raw) {
             msg = bund.special_comment_raw;
+          } else {
+            msg = cldrText.get("readonly_unknown");
           }
-          if (msg) {
-            msg = locmap.linkify(msg);
-            var theChunk = cldrDomConstruct(msg);
-            var subDiv = document.createElement("div");
-            subDiv.appendChild(theChunk);
-            subDiv.className = "warnText";
-            theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
-          }
-        } else if (bund.dcChild) {
-          const html = cldrText.sub("defaultContentChild_msg", {
-            name: bund.name,
-            dcChild: bund.dcChild,
+          msg = cldrText.sub("readonly_msg", {
+            info: bund,
             locale: cldrStatus.getCurrentLocale(),
-            dcChildName: locmap.getLocaleName(bund.dcChild),
+            msg: msg,
           });
-          var theChunk = cldrDomConstruct(html);
+        } else {
+          // Not readonly, could be a scratch locale
+          msg = bund.special_comment_raw;
+        }
+        if (msg) {
+          msg = locmap.linkify(msg);
+          var theChunk = cldrDomConstruct(msg);
           var subDiv = document.createElement("div");
           subDiv.appendChild(theChunk);
           subDiv.className = "warnText";
           theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
         }
-      }
-      if (cldrStatus.getIsPhaseBeta()) {
-        const html = cldrText.sub("beta_msg", {
-          info: bund,
+      } else if (bund.dcChild) {
+        const html = cldrText.sub("defaultContentChild_msg", {
+          name: bund.name,
+          dcChild: bund.dcChild,
           locale: cldrStatus.getCurrentLocale(),
-          msg: msg,
+          dcChildName: locmap.getLocaleName(bund.dcChild),
         });
         var theChunk = cldrDomConstruct(html);
         var subDiv = document.createElement("div");
@@ -1458,1330 +708,1305 @@ const cldrLoad = (function () {
         subDiv.className = "warnText";
         theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
       }
+    }
+    if (cldrStatus.getIsPhaseBeta()) {
+      const html = cldrText.sub("beta_msg", {
+        info: bund,
+        locale: cldrStatus.getCurrentLocale(),
+        msg: msg,
+      });
+      const theChunk = cldrDomConstruct(html);
+      const subDiv = document.createElement("div");
+      subDiv.appendChild(theChunk);
+      subDiv.className = "warnText";
+      theDiv.insertBefore(subDiv, theDiv.childNodes[0]);
+    }
+  }
+
+  function updateLocaleMenu() {
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale != null && curLocale != "" && curLocale != "-") {
+      cldrStatus.setCurrentLocaleName(locmap.getLocaleName(curLocale));
+      var bund = locmap.getLocaleInfo(curLocale);
+      if (bund) {
+        if (bund.readonly) {
+          cldrDom.addClass(
+            document.getElementById(menubuttons.locale),
+            "locked"
+          );
+        } else {
+          cldrDom.removeClass(
+            document.getElementById(menubuttons.locale),
+            "locked"
+          );
+        }
+
+        if (bund.dcChild) {
+          menubuttons.set(
+            menubuttons.dcontent,
+            cldrText.sub("defaultContent_header_msg", {
+              info: bund,
+              locale: cldrStatus.getCurrentLocale(),
+              dcChild: locmap.getLocaleName(bund.dcChild),
+            })
+          );
+        } else {
+          menubuttons.set(menubuttons.dcontent);
+        }
+      } else {
+        cldrDom.removeClass(
+          document.getElementById(menubuttons.locale),
+          "locked"
+        );
+        menubuttons.set(menubuttons.dcontent);
+      }
+    } else {
+      cldrStatus.setCurrentLocaleName("");
+      cldrDom.removeClass(
+        document.getElementById(menubuttons.locale),
+        "locked"
+      );
+      menubuttons.set(menubuttons.dcontent);
+    }
+    menubuttons.set(menubuttons.locale, cldrStatus.getCurrentLocaleName());
+  }
+  function reloadV() {
+    if (cldrStatus.isDisconnected()) {
+      cldrSurvey.unbust();
+    }
+
+    document.getElementById("DynamicDataSection").innerHTML = ""; //reset the data
+    $("#nav-page").hide();
+    $("#nav-page-footer").hide();
+    isLoading = false;
+
+    /*
+     * Scroll back to top when loading a new page, to avoid a bug where, for
+     * example, having scrolled towards bottom, we switch from a Section page
+     * to the Forum page and the scrollbar stays where it was, making the new
+     * content effectively invisible.
+     */
+    window.scrollTo(0, 0);
+
+    const id = flipper.get(pages.data).id;
+    cldrSurvey.setShower(id, ignoreReloadRequest);
+
+    // assume parseHash was already called, if we are taking input from the hash
+
+    ariDialogHide();
+
+    updateHashAndMenus(true);
+
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale != null && curLocale != "" && curLocale != "-") {
+      var bund = locmap.getLocaleInfo(curLocale);
+      if (bund !== null && bund.dcParent) {
+        const html = cldrText.sub("defaultContent_msg", {
+          name: bund.name,
+          dcParent: bund.dcParent,
+          locale: curLocale,
+          dcParentName: locmap.getLocaleName(bund.dcParent),
+        });
+        var theChunk = cldrDomConstruct(html);
+        var theDiv = document.createElement("div");
+        theDiv.appendChild(theChunk);
+        theDiv.className = "ferrbox";
+        flipper.flipTo(pages.other, theDiv);
+        return;
+      }
+    }
+
+    flipper.flipTo(
+      pages.loading,
+      cldrDom.createChunk(cldrText.get("loading"), "i", "loadingMsg")
+    );
+
+    const itemLoadInfo = cldrDom.createChunk("", "div", "itemLoadInfo");
+
+    // Create a little spinner to spin "..." so the user knows we are doing something..
+    var spinChunk = cldrDom.createChunk("...", "i", "loadingMsgSpin");
+    var spin = 0;
+    var timerToKill = window.setInterval(function () {
+      var spinTxt = "";
+      spin++;
+      switch (spin % 3) {
+        case 0:
+          spinTxt = ".  ";
+          break;
+        case 1:
+          spinTxt = " . ";
+          break;
+        case 2:
+          spinTxt = "  .";
+          break;
+      }
+      cldrDom.removeAllChildNodes(spinChunk);
+      spinChunk.appendChild(document.createTextNode(spinTxt));
+    }, 1000);
+
+    // Add the "..." until the Flipper flips
+    flipper.addUntilFlipped(
+      function () {
+        var frag = document.createDocumentFragment();
+        frag.appendChild(spinChunk);
+        return frag;
+      },
+      function () {
+        window.clearInterval(timerToKill);
+      }
+    );
+
+    shower(itemLoadInfo); // first load
+
+    // set up the "show-er" function so that if this locale gets reloaded,
+    // the page will load again - except for the dashboard, where only the
+    // row get updated
+    if (!cldrStatus.isDashboard()) {
+      const id2 = flipper.get(pages.data).id;
+      cldrSurvey.setShower(id2, function () {
+        shower(itemLoadInfo);
+      });
+    }
+  } // end reloadV
+
+  function ignoreReloadRequest() {
+    console.log(
+      "reloadV()'s shower - ignoring reload request, we are in the middle of a load!"
+    );
+  }
+
+  function shower(itemLoadInfo) {
+    if (isLoading) {
+      console.log("reloadV inner shower: already isLoading, exiting.");
+      return;
+    }
+    isLoading = true;
+    let theDiv = flipper.get(pages.data);
+    let theTable = theDiv.theTable;
+    if (!theTable) {
+      const theTableList = theDiv.getElementsByTagName("table");
+      if (theTableList) {
+        theTable = theTableList[0];
+        theDiv.theTable = theTable;
+      }
+    }
+    cldrSurvey.showLoader(cldrText.get("loading"));
+
+    const curSpecial = cldrStatus.getCurrentSpecial();
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale && !curSpecial) {
+      const curPage = cldrStatus.getCurrentPage();
+      const curId = cldrStatus.getCurrentId();
+      if (!curPage && !curId) {
+        loadGeneral(itemLoadInfo);
+      } else if (curId === "!") {
+        loadExclamationPoint();
+      } else if (!cldrSurvey.isInputBusy()) {
+        /*
+         * Make “all rows” requests only when !isInputBusy, to avoid wasted requests
+         * if the user leaves the input box open for an extended time.
+         * Common case: this is an actual locale data page.
+         */
+        loadAllRows(itemLoadInfo, theDiv);
+      }
+    } else if (curSpecial === "none") {
+      cldrSurvey.hideLoader();
+      isLoading = false;
+      window.location = cldrStatus.getSurvUrl(); // redirect home
+    } else if (isReport(curSpecial)) {
+      loadReport();
+    } else if (curSpecial === "about") {
+      cldrAbout.load();
+    } else if (curSpecial === "admin") {
+      cldrAdmin.load();
+    } else if (curSpecial === "createAndLogin") {
+      cldrCreateLogin.load();
+    } else if (curSpecial === "forum") {
+      cldrForum.load();
+    } else if (curSpecial === "locales") {
+      loadLocales();
+    } else if (curSpecial === "mail") {
+      loadMail();
+    } else if (curSpecial === "oldvotes") {
+      cldrOldVotes.load();
+    } else {
+      otherSpecial.show(curSpecial, {
+        flipper: flipper,
+        pages: pages,
+      });
+    }
+  }
+
+  /**
+   * Is the given string for a report, that is, does it start with "r_"?
+   * Really only (?) 4: "r_vetting_json" (Dashboard), "r_datetime", "r_zones", "r_compact"
+   * Cf. SurveyMain.ReportMenu.PRIORITY_ITEMS
+   *
+   * @param str the string
+   * @return true if starts with "r_", else false
+   */
+  function isReport(str) {
+    return str[0] == "r" && str[1] == "_";
+  }
+
+  // the 'General Info' page.
+  function loadGeneral(itemLoadInfo) {
+    const curLocale = cldrStatus.getCurrentLocale();
+    const curLocaleName = locmap.getLocaleName(curLocale);
+    itemLoadInfo.appendChild(document.createTextNode(curLocaleName));
+    showPossibleProblems();
+    const message = cldrText.get("generalPageInitialGuidance");
+    cldrInfo.showMessage(message);
+    isLoading = false;
+  }
+
+  /**
+   * Show the "possible problems" section which has errors for the locale
+   */
+  function showPossibleProblems() {
+    const effectiveCov = cldrSurvey.covName(cldrSurvey.effectiveCoverage());
+    const requiredCov = effectiveCov;
+    const url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=possibleProblems&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      "&eff=" +
+      effectiveCov +
+      "&req=" +
+      requiredCov +
+      cldrSurvey.cacheKill();
+    myLoad(url, "possibleProblems", loadPossibleProblemsFromJson);
+  }
+
+  function loadPossibleProblemsFromJson(json) {
+    if (verifyJson(json, "possibleProblems")) {
+      if (json.dataLoadTime) {
+        cldrDom.updateIf("dynload", json.dataLoadTime);
+      }
+      const theDiv = flipper.flipToEmpty(pages.other);
+      insertLocaleSpecialNote(theDiv);
+      if (json.possibleProblems.length > 0) {
+        const subDiv = cldrDom.createChunk("", "div");
+        subDiv.className = "possibleProblems";
+        const h3 = cldrDom.createChunk(cldrText.get("possibleProblems"), "h3");
+        subDiv.appendChild(h3);
+        const div3 = document.createElement("div");
+        div3.innerHTML = cldrSurvey.testsToHtml(json.possibleProblems);
+        subDiv.appendChild(div3);
+        theDiv.appendChild(subDiv);
+      }
+      const theInfo = cldrDom.createChunk("", "p", "special_general");
+      theDiv.appendChild(theInfo);
+      theInfo.innerHTML = cldrText.get("special_general");
+      cldrSurvey.hideLoader();
+    }
+  }
+
+  function loadExclamationPoint() {
+    var frag = document.createDocumentFragment();
+    frag.appendChild(
+      cldrDom.createChunk(cldrText.get("section_help"), "p", "helpContent")
+    );
+    const curPage = cldrStatus.getCurrentPage();
+    const infoHtml = cldrText.get("section_info_" + curPage);
+    const infoChunk = document.createElement("div");
+    infoChunk.innerHTML = infoHtml;
+    frag.appendChild(infoChunk);
+    flipper.flipTo(pages.other, frag);
+    cldrSurvey.hideLoader();
+    isLoading = false;
+  }
+
+  function loadAllRows(itemLoadInfo, theDiv) {
+    const curId = cldrStatus.getCurrentId();
+    const curPage = cldrStatus.getCurrentPage();
+    const curLocale = cldrStatus.getCurrentLocale();
+    itemLoadInfo.appendChild(
+      document.createTextNode(
+        locmap.getLocaleName(curLocale) + "/" + curPage + "/" + curId
+      )
+    );
+    const url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=getrow&_=" +
+      curLocale +
+      "&x=" +
+      curPage +
+      "&strid=" +
+      curId +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      cldrSurvey.cacheKill();
+    $("#nav-page").show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
+    myLoad(url, "section", function (json) {
+      loadAllRowsFromJson(json, theDiv);
+    });
+  }
+
+  function loadAllRowsFromJson(json, theDiv) {
+    isLoading = false;
+    cldrSurvey.showLoader(cldrText.get("loading2"));
+    if (!verifyJson(json, "section")) {
+      return;
+    } else if (json.section.nocontent) {
+      cldrStatus.setCurrentSection("");
+      if (json.pageId) {
+        cldrStatus.setCurrentPage(json.pageId);
+      } else {
+        cldrStatus.setCurrentPage("");
+      }
+      cldrSurvey.showLoader(null);
+      updateHashAndMenus(false); // find out why there's no content. (locmap)
+    } else if (!json.section.rows) {
+      console.log("!json.section.rows");
+      cldrSurvey.showLoader(
+        "Error while  loading: <br><div style='border: 1px solid red;'>" +
+          "no rows" +
+          "</div>"
+      );
+      cldrSurvey.handleDisconnect("while loading- no rows", json);
+    } else {
+      cldrSurvey.showLoader("loading..");
+      if (json.dataLoadTime) {
+        cldrDom.updateIf("dynload", json.dataLoadTime);
+      }
+      cldrStatus.setCurrentSection("");
+      cldrStatus.setCurrentPage(json.pageId);
+      updateHashAndMenus(false); // now that we have a pageid
+      if (!cldrStatus.getSurveyUser()) {
+        const message = cldrText.get("loginGuidance");
+        cldrInfo.showMessage(message);
+      } else if (!json.canModify) {
+        const message = cldrText.get("readonlyGuidance");
+        cldrInfo.showMessage(message);
+      } else {
+        const message = cldrText.get("dataPageInitialGuidance");
+        cldrInfo.showMessage(message);
+      }
+      if (!cldrSurvey.isInputBusy()) {
+        cldrSurvey.showLoader(cldrText.get("loading3"));
+        cldrTable.insertRows(
+          theDiv,
+          json.pageId,
+          cldrStatus.getSessionId(),
+          json
+        ); // pageid is the xpath..
+        cldrSurvey.updateCoverage(flipper.get(pages.data)); // make sure cov is set right before we show.
+        flipper.flipTo(pages.data); // TODO now? or later?
+        showCurrentId(); // already calls scroll
+        cldrSurvey.refreshCounterVetting();
+        $("#nav-page-footer").show(); // make bottom "Prev/Next" buttons visible after building table
+      }
+    }
+  }
+
+  function loadMail() {
+    var url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=mail&s=" +
+      cldrStatus.getSessionId() +
+      "&fetchAll=true&" +
+      cldrSurvey.cacheKill();
+    myLoad(
+      url,
+      "(loading mail " + cldrStatus.getCurrentLocale() + ")",
+      function (json) {
+        cldrSurvey.hideLoader();
+        isLoading = false;
+        if (!verifyJson(json, "mail")) {
+          return;
+        }
+        if (json.dataLoadTime) {
+          cldrDom.updateIf("dynload", json.dataLoadTime);
+        }
+
+        var theDiv = flipper.flipToEmpty(pages.other); // clean slate, and proceed..
+
+        cldrDom.removeAllChildNodes(theDiv);
+
+        var listDiv = cldrDom.createChunk("", "div", "mailListChunk");
+        var contentDiv = cldrDom.createChunk("", "div", "mailContentChunk");
+
+        theDiv.appendChild(listDiv);
+        theDiv.appendChild(contentDiv);
+
+        cldrDom.setDisplayed(contentDiv, false);
+        var header = json.mail.header;
+        var data = json.mail.data;
+
+        if (data.length == 0) {
+          listDiv.appendChild(
+            cldrDom.createChunk(cldrText.get("mail_noMail"), "p", "helpContent")
+          );
+        } else {
+          for (var ii in data) {
+            var row = data[ii];
+            var li = cldrDom.createChunk(
+              row[header.QUEUE_DATE] + ": " + row[header.SUBJECT],
+              "li",
+              "mailRow"
+            );
+            if (row[header.READ_DATE]) {
+              cldrDom.addClass(li, "readMail");
+            }
+            if (header.USER !== undefined) {
+              li.appendChild(
+                document.createTextNode("(to " + row[header.USER] + ")")
+              );
+            }
+            if (row[header.SENT_DATE] !== false) {
+              li.appendChild(cldrDom.createChunk("(sent)", "span", "winner"));
+            } else if (row[header.TRY_COUNT] >= 3) {
+              li.appendChild(
+                cldrDom.createChunk(
+                  "(try#" + row[header.TRY_COUNT] + ")",
+                  "span",
+                  "loser"
+                )
+              );
+            } else if (row[header.TRY_COUNT] > 0) {
+              li.appendChild(
+                cldrDom.createChunk(
+                  "(try#" + row[header.TRY_COUNT] + ")",
+                  "span",
+                  "warning"
+                )
+              );
+            }
+            listDiv.appendChild(li);
+
+            li.onclick = (function (li, row, header) {
+              return function () {
+                if (!row[header.READ_DATE]) {
+                  myLoad(
+                    cldrStatus.getContextPath() +
+                      "/SurveyAjax?what=mail&s=" +
+                      cldrStatus.getSessionId() +
+                      "&markRead=" +
+                      row[header.ID] +
+                      "&" +
+                      cldrSurvey.cacheKill(),
+                    "Marking mail read",
+                    function (json) {
+                      if (!verifyJson(json, "mail")) {
+                        return;
+                      } else {
+                        cldrDom.addClass(li, "readMail"); // mark as read when server answers
+                        row[header.READ_DATE] = true; // close enough
+                      }
+                    }
+                  );
+                }
+                cldrDom.setDisplayed(contentDiv, false);
+
+                cldrDom.removeAllChildNodes(contentDiv);
+
+                contentDiv.appendChild(
+                  cldrDom.createChunk(
+                    "Date: " + row[header.QUEUE_DATE],
+                    "h2",
+                    "mailHeader"
+                  )
+                );
+                contentDiv.appendChild(
+                  cldrDom.createChunk(
+                    "Subject: " + row[header.SUBJECT],
+                    "h2",
+                    "mailHeader"
+                  )
+                );
+                contentDiv.appendChild(
+                  cldrDom.createChunk(
+                    "Message-ID: " + row[header.ID],
+                    "h2",
+                    "mailHeader"
+                  )
+                );
+                if (header.USER !== undefined) {
+                  contentDiv.appendChild(
+                    cldrDom.createChunk(
+                      "To: " + row[header.USER],
+                      "h2",
+                      "mailHeader"
+                    )
+                  );
+                }
+                contentDiv.appendChild(
+                  cldrDom.createChunk(row[header.TEXT], "p", "mailContent")
+                );
+
+                cldrDom.setDisplayed(contentDiv, true);
+              };
+            })(li, row, header);
+          }
+        }
+      }
+    );
+  }
+
+  function loadReport() {
+    cldrSurvey.showLoader(null);
+    const message = cldrText.get("reportGuidance");
+    cldrInfo.showMessage(message);
+    var url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=report&x=" +
+      cldrStatus.getCurrentSpecial() +
+      "&_=" +
+      cldrStatus.getCurrentLocale() +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      cldrSurvey.cacheKill();
+    var errFunction = function errFunction(err) {
+      console.log("Error: loading " + url + " -> " + err);
+      cldrSurvey.hideLoader();
+      isLoading = false;
+      const html =
+        "<div style='padding-top: 4em; font-size: x-large !important;' class='ferrorbox warning'>" +
+        "<span class='icon i-stop'>" +
+        " &nbsp; &nbsp;</span>Error: could not load: " +
+        err +
+        "</div>";
+      const frag = cldrDomConstruct(html);
+      flipper.flipTo(pages.other, frag);
+    };
+    if (cldrStatus.isDashboard()) {
+      if (!cldrStatus.isVisitor()) {
+        const loadHandler = function (json) {
+          cldrSurvey.hideLoader();
+          isLoading = false;
+          // further errors are handled in JSON
+          showReviewPage(json, function () {
+            // show function - flip to the 'other' page.
+            flipper.flipTo(pages.other, null);
+          });
+        };
+        const xhrArgs = {
+          url: url,
+          handleAs: "json",
+          load: loadHandler,
+          error: errFunction,
+        };
+        cldrAjax.queueXhr(xhrArgs);
+      } else {
+        alert("Please login to access Dashboard");
+        cldrStatus.setCurrentSpecial("");
+        cldrStatus.setCurrentLocale("");
+        reloadV();
+      }
+    } else {
+      cldrSurvey.hideLoader();
+      const loadHandler = function (html) {
+        cldrSurvey.hideLoader();
+        isLoading = false;
+        const frag = cldrDomConstruct(html);
+        flipper.flipTo(pages.other, frag);
+        cldrEvent.hideRightPanel(); // CLDR-14365
+      };
+      const xhrArgs = {
+        url: url,
+        handleAs: "text", // not "html"!
+        load: loadHandler,
+        error: errFunction,
+      };
+      cldrAjax.queueXhr(xhrArgs);
+    }
+  }
+
+  function loadLocales() {
+    cldrSurvey.hideLoader();
+    isLoading = false;
+    var theDiv = document.createElement("div");
+    theDiv.className = "localeList";
+
+    addTopLocale("root", theDiv);
+    // top locales
+    for (var n in locmap.locmap.topLocales) {
+      var topLoc = locmap.locmap.topLocales[n];
+      addTopLocale(topLoc, theDiv);
+    }
+    flipper.flipTo(pages.other, null);
+    cldrEvent.filterAllLocale(); // filter for init data
+    cldrEvent.forceSidebar();
+    cldrStatus.setCurrentLocale(null);
+    cldrStatus.setCurrentSpecial("locales");
+    const message = cldrText.get("localesInitialGuidance");
+    cldrInfo.showMessage(message);
+    $("#itemInfo").html("");
+  }
+
+  /**
+   * Update the #hash and menus to the current settings.
+   *
+   * @param doPush {Boolean} if false, do not add to history
+   */
+  function updateHashAndMenus(doPush) {
+    if (!doPush) {
+      doPush = false;
+    }
+    replaceHash(doPush); // update the hash
+    updateLocaleMenu();
+
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (curLocale == null) {
+      /* Do this for null, but not for empty string ""; it's originally null, later may be "".
+         Note that ("" == null) is false. */
+      menubuttons.set(menubuttons.section);
+      const curSpecial = cldrStatus.getCurrentSpecial();
+      if (curSpecial != null) {
+        const specialId = "special_" + curSpecial;
+        menubuttons.set(menubuttons.page, cldrText.get(specialId));
+      } else {
+        menubuttons.set(menubuttons.page);
+      }
+      return; // nothing to do.
+    }
+
+    const specialItems = makeMenuArray();
+    if (_thePages == null || _thePages.loc != curLocale) {
+      getMenusFromServer(specialItems);
+    } else {
+      // go ahead and update
+      updateMenus(_thePages, specialItems);
+    }
+  }
+
+  function makeMenuArray() {
+    const aboutMenu = {
+      title: "About",
+      special: "about",
+      level: 2, // TODO: no indent if !surveyUser; refactor to obviate "level"; make valid html
+    };
+    const surveyUser = cldrStatus.getSurveyUser();
+    if (!surveyUser) {
+      return [aboutMenu]; // TODO: enable more menu items when not logged in, e.g., browse
+    }
+    const sessionId = cldrStatus.getSessionId();
+    const userID = surveyUser.id ? surveyUser.id : 0;
+    const surveyUserPerms = cldrStatus.getPermissions();
+    const surveyUserURL = {
+      // TODO: make these all like #about -- no url or jsp here
+      myAccountSetting: "survey?do=listu",
+      disableMyAccount: "lock.jsp",
+      recentActivity: "myvotes.jsp?user=" + userID + "&s=" + sessionId,
+      xmlUpload: "upload.jsp?a=/cldr-apps/survey&s=" + sessionId,
+      manageUser: "survey?do=list",
+      flag: "tc-flagged.jsp?s=" + sessionId,
+      browse: "browse.jsp",
+      // adminPanel: "SurveyAjax?what=admin_panel&s=" + sessionId,
     };
 
     /**
-     * Show the "possible problems" section which has errors for the locale
+     * 'name' - the js/special/___.js name
+     * 'hidden' - true to hide the item
+     * 'title' - override of menu name
      */
-    function showPossibleProblems(
-      flipper,
-      flipPage,
-      loc,
-      session,
-      effectiveCov,
-      requiredCov
-    ) {
-      cldrStatus.setCurrentLocale(loc);
+    return [
+      {
+        title: "Admin Panel",
+        special: "admin",
+        // url: surveyUserURL.adminPanel,
+        display: surveyUser && surveyUser.userlevelName === "ADMIN",
+      },
+      {
+        divider: true,
+        display: surveyUser && surveyUser.userlevelName === "ADMIN",
+      },
 
-      var url =
-        cldrStatus.getContextPath() +
-        "/SurveyAjax?what=possibleProblems&_=" +
-        cldrStatus.getCurrentLocale() +
-        "&s=" +
-        session +
-        "&eff=" +
-        effectiveCov +
-        "&req=" +
-        requiredCov +
-        cacheKill();
-      myLoad(url, "possibleProblems", function (json) {
-        if (verifyJson(json, "possibleProblems")) {
-          stdebug("json.possibleProblems OK..");
-          if (json.dataLoadTime) {
-            cldrSurvey.updateIf("dynload", json.dataLoadTime);
-          }
+      {
+        title: "My Account",
+      }, // My Account section
 
-          var theDiv = flipper.flipToEmpty(flipPage);
+      {
+        title: "Settings",
+        level: 2,
+        url: surveyUserURL.myAccountSetting,
+        display: surveyUser && true,
+      },
+      {
+        title: "Lock (Disable) My Account",
+        level: 2,
+        url: surveyUserURL.disableMyAccount,
+        display: surveyUser && true,
+      },
 
-          insertLocaleSpecialNote(theDiv);
+      {
+        divider: true,
+      },
+      {
+        title: "My Votes",
+      }, // My Votes section
 
-          if (json.possibleProblems.length > 0) {
-            var subDiv = cldrSurvey.createChunk("", "div");
-            subDiv.className = "possibleProblems";
+      /*
+       * This indirectly references "special_oldvotes" in cldrText.js
+       */
+      {
+        special: "oldvotes",
+        level: 2,
+        display: surveyUserPerms && surveyUserPerms.userCanImportOldVotes,
+      },
+      {
+        title: "See My Recent Activity",
+        level: 2,
+        url: surveyUserURL.recentActivity,
+      },
+      {
+        title: "Upload XML",
+        level: 2,
+        url: surveyUserURL.xmlUpload,
+      },
 
-            var h3 = cldrSurvey.createChunk(
-              cldrText.get("possibleProblems"),
-              "h3"
-            );
-            subDiv.appendChild(h3);
+      {
+        divider: true,
+      },
+      {
+        title: "My Organization(" + cldrStatus.getOrganizationName() + ")",
+      }, // My Organization section
 
-            var div3 = document.createElement("div");
-            var newHtml = "";
-            newHtml += testsToHtml(json.possibleProblems);
-            div3.innerHTML = newHtml;
-            subDiv.appendChild(div3);
-            theDiv.appendChild(subDiv);
-          }
-          var theInfo = cldrSurvey.createChunk("", "p", "special_general");
-          theDiv.appendChild(theInfo);
-          theInfo.innerHTML = cldrText.get("special_general"); // TODO replace with … ?
-          hideLoader(null);
+      {
+        special: "vsummary" /* Cf. special_vsummary */,
+        level: 2,
+        display: surveyUserPerms && surveyUserPerms.userCanUseVettingSummary,
+      },
+      {
+        title: "List " + cldrStatus.getOrganizationName() + " Users",
+        level: 2,
+        url: surveyUserURL.manageUser,
+        display:
+          surveyUserPerms &&
+          (surveyUserPerms.userIsTC || surveyUserPerms.userIsVetter),
+      },
+      {
+        special: "forum_participation" /* Cf. special_forum_participation */,
+        level: 2,
+        display: surveyUserPerms && surveyUserPerms.userCanMonitorForum,
+      },
+      {
+        special:
+          "vetting_participation" /* Cf. special_vetting_participation */,
+        level: 2,
+        display:
+          surveyUserPerms &&
+          (surveyUserPerms.userIsTC || surveyUserPerms.userIsVetter),
+      },
+      {
+        title: "LOCKED: Note: your account is currently locked.",
+        level: 2,
+        display: surveyUserPerms && surveyUserPerms.userIsLocked,
+        bold: true,
+      },
+
+      {
+        divider: true,
+      },
+      {
+        title: "Forum",
+      }, // Forum section
+
+      {
+        special: "flagged",
+        level: 2,
+        hasFlag: true,
+      },
+      {
+        special: "mail",
+        level: 2,
+        display: cldrStatus.getIsUnofficial(),
+      },
+      {
+        special: "bulk_close_posts" /* Cf. special_bulk_close_posts */,
+        level: 2,
+        display: surveyUser && surveyUser.userlevelName === "ADMIN",
+      },
+
+      {
+        divider: true,
+      },
+      {
+        title: "Informational",
+      }, // Informational section
+
+      {
+        special: "statistics",
+        level: 2,
+      },
+
+      aboutMenu,
+
+      {
+        title: "Lookup a code or xpath",
+        level: 2,
+        url: surveyUserURL.browse,
+      },
+      {
+        title: "Error Subtypes",
+        level: 2,
+        url: "./tc-all-errors.jsp",
+        display: surveyUserPerms && surveyUserPerms.userIsTC,
+      },
+    ];
+  }
+
+  function getMenusFromServer(specialItems) {
+    // show the raw IDs while loading.
+    updateMenuTitles(null, specialItems);
+    const curLocale = cldrStatus.getCurrentLocale();
+    if (!curLocale) {
+      return;
+    }
+    const url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=menus&_=" +
+      curLocale +
+      "&locmap=" +
+      false +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      cldrSurvey.cacheKill();
+    myLoad(url, "menus", function (json) {
+      if (!verifyJson(json, "menus")) {
+        console.log("JSON verification failed for menus in cldrLoad");
+        return; // busted?
+      }
+      if (json.locmap) {
+        locmap = new LocaleMap(locmap); // overwrite with real data
+      }
+      // make this into a hashmap.
+      if (json.canmodify) {
+        for (let k in json.canmodify) {
+          canmodify[json.canmodify[k]] = true;
         }
+      }
+      cldrSurvey.updateCovFromJson(json);
+      updateCoverageMenuTitle();
+      cldrSurvey.updateCoverage(flipper.get(pages.data)); // update CSS and auto menu title
+      unpackMenus(json);
+      cldrEvent.unpackMenuSideBar(json);
+      updateMenus(_thePages, specialItems);
+    });
+  }
+
+  /**
+   * Update the menus
+   */
+  function updateMenus(menuMap, specialItems) {
+    if (!menuMap) {
+      console.log("❌ menuMap is FALSY in updateMenus!");
+    }
+    if (!specialItems) {
+      console.log("❌ specialItems is FALSY in updateMenus!");
+    }
+    // initialize menus
+    if (!menuMap.menusSetup) {
+      menuMap.menusSetup = true;
+      menuMap.setCheck = function (menu, checked, disabled) {
+        if (menu) {
+          menu.set(
+            "iconClass",
+            checked ? "dijitMenuItemIcon menu-x" : "dijitMenuItemIcon menu-o"
+          );
+          menu.set("disabled", disabled);
+        }
+      };
+      var menuSection = pseudoDijitRegistryById("menu-section");
+      menuMap.section_general = newPseudoDijitMenuItem({
+        label: cldrText.get("section_general"),
+        iconClass: "dijitMenuItemIcon ",
+        disabled: true,
+        onClick: function () {
+          if (
+            cldrStatus.getCurrentPage() != "" ||
+            (cldrStatus.getCurrentSpecial() != "" &&
+              cldrStatus.getCurrentSpecial() != null)
+          ) {
+            cldrStatus.setCurrentId(""); // no id if jumping pages
+            cldrStatus.setCurrentPage("");
+            cldrStatus.setCurrentSection("");
+            cldrStatus.setCurrentSpecial("");
+            updateMenuTitles(menuMap, specialItems);
+            reloadV();
+          }
+        },
       });
+      if (menuSection) {
+        menuSection.addChild(menuMap.section_general);
+      }
+      for (var j in menuMap.sections) {
+        (function (aSection) {
+          aSection.menuItem = newPseudoDijitMenuItem({
+            label: aSection.name,
+            iconClass: "dijitMenuItemIcon",
+            onClick: function () {
+              cldrStatus.setCurrentId("!"); // no id if jumping pages
+              cldrStatus.setCurrentPage(aSection.id);
+              cldrStatus.setCurrentSpecial("");
+              updateMenus(menuMap, specialItems);
+              updateMenuTitles(menuMap, specialItems);
+              reloadV();
+            },
+            disabled: true,
+          });
+          if (menuSection) {
+            menuSection.addChild(aSection.menuItem);
+          }
+        })(menuMap.sections[j]);
+      }
+
+      if (menuSection) {
+        menuSection.addChild(new dijitMenuSeparator());
+      }
+      menuMap.forumMenu = newPseudoDijitMenuItem({
+        label: cldrText.get("section_forum"),
+        iconClass: "dijitMenuItemIcon", // menu-chat
+        disabled: true,
+        onClick: function () {
+          cldrStatus.setCurrentId("!"); // no id if jumping pages
+          cldrStatus.setCurrentPage("");
+          cldrStatus.setCurrentSpecial("forum");
+          updateMenus(menuMap, specialItems);
+          updateMenuTitles(menuMap, specialItems);
+          reloadV();
+        },
+      });
+      if (menuSection) {
+        menuSection.addChild(menuMap.forumMenu);
+      }
     }
 
-    var isLoading = false;
+    updateMenuTitles(menuMap, specialItems);
 
-    window.reloadV = function reloadV() {
-      if (cldrStatus.isDisconnected()) {
-        unbust();
+    var myPage = null;
+    var mySection = null;
+    const curSpecial = cldrStatus.getCurrentSpecial();
+    if (curSpecial == null || curSpecial == "") {
+      // first, update display names
+      const curPage = cldrStatus.getCurrentPage();
+      if (menuMap.sectionMap[curPage]) {
+        // page is really a section
+        mySection = menuMap.sectionMap[curPage];
+        myPage = null;
+      } else if (menuMap.pageToSection[curPage]) {
+        mySection = menuMap.pageToSection[curPage];
+        myPage = mySection.pageMap[curPage];
       }
-
-      document.getElementById("DynamicDataSection").innerHTML = ""; //reset the data
-      $("#nav-page").hide();
-      $("#nav-page-footer").hide();
-      isLoading = false;
-
-      /*
-       * Scroll back to top when loading a new page, to avoid a bug where, for
-       * example, having scrolled towards bottom, we switch from a Section page
-       * to the Forum page and the scrollbar stays where it was, making the new
-       * content effectively invisible.
-       */
-      window.scrollTo(0, 0);
-
-      /*
-       * TODO: explain code related to "showers".
-       */
-      showers[flipper.get(pages.data).id] = function () {
-        console.log(
-          "reloadV()'s shower - ignoring reload request, we are in the middle of a load!"
+      if (mySection !== null) {
+        const titlePageContainer = document.getElementById(
+          "title-page-container"
         );
-      };
 
-      // assume parseHash was already called, if we are taking input from the hash
-      if (!ariDialog) {
-        console.log("Error: no ariDialog in window.reloadV");
-      } else {
-        ariDialog.hide();
-      }
-
-      updateHashAndMenus(true);
-
-      const curLocale = cldrStatus.getCurrentLocale();
-      if (curLocale != null && curLocale != "" && curLocale != "-") {
-        var bund = locmap.getLocaleInfo(curLocale);
-        if (bund !== null && bund.dcParent) {
-          const html = cldrText.sub("defaultContent_msg", {
-            name: bund.name,
-            dcParent: bund.dcParent,
-            locale: curLocale,
-            dcParentName: locmap.getLocaleName(bund.dcParent),
-          });
-          var theChunk = cldrDomConstruct(html);
-          var theDiv = document.createElement("div");
-          theDiv.appendChild(theChunk);
-          theDiv.className = "ferrbox";
-          flipper.flipTo(pages.other, theDiv);
-          return;
+        // update menus under 'page' - peer pages
+        if (!titlePageContainer.menus) {
+          titlePageContainer.menus = {};
         }
-      }
 
-      // TODO: don't even flip if it's quick.
-      var loadingChunk;
-      flipper.flipTo(
-        pages.loading,
-        (loadingChunk = cldrSurvey.createChunk(
-          cldrText.get("loading"),
-          "i",
-          "loadingMsg"
-        ))
-      );
-
-      var itemLoadInfo = cldrSurvey.createChunk("", "div", "itemLoadInfo");
-
-      // Create a little spinner to spin "..." so the user knows we are doing something..
-      var spinChunk = cldrSurvey.createChunk("...", "i", "loadingMsgSpin");
-      var spin = 0;
-      var timerToKill = window.setInterval(function () {
-        var spinTxt = "";
-        spin++;
-        switch (spin % 3) {
-          case 0:
-            spinTxt = ".  ";
-            break;
-          case 1:
-            spinTxt = " . ";
-            break;
-          case 2:
-            spinTxt = "  .";
-            break;
-        }
-        removeAllChildNodes(spinChunk);
-        spinChunk.appendChild(document.createTextNode(spinTxt));
-      }, 1000);
-
-      // Add the "..." until the Flipper flips
-      flipper.addUntilFlipped(
-        function () {
-          var frag = document.createDocumentFragment();
-          frag.appendChild(spinChunk);
-          return frag;
-        },
-        function () {
-          window.clearInterval(timerToKill);
-        }
-      );
-
-      // now, load. Use a show-er function for indirection.
-      var shower = function () {
-        if (isLoading) {
-          console.log("reloadV inner shower: already isLoading, exitting.");
-          return;
-        }
-        isLoading = true;
-        var theDiv = flipper.get(pages.data);
-        var theTable = theDiv.theTable;
-
-        if (!theTable) {
-          var theTableList = theDiv.getElementsByTagName("table");
-          if (theTableList) {
-            theTable = theTableList[0];
-            theDiv.theTable = theTable;
+        // hide all. TODO use a foreach model?
+        for (var zz in titlePageContainer.menus) {
+          var aMenu = titlePageContainer.menus[zz];
+          if (aMenu) {
+            aMenu.set("label", "-");
+          } else {
+            console.log("warning: aMenu is falsy in updateMenus");
           }
         }
 
-        showLoader(null, cldrText.get("loading"));
+        var showMenu = titlePageContainer.menus[mySection.id];
 
-        const curSpecial = cldrStatus.getCurrentSpecial();
-        const curLocale = cldrStatus.getCurrentLocale();
-        if (
-          (curSpecial == null || curSpecial == "") &&
-          curLocale != null &&
-          curLocale != ""
-        ) {
-          const curPage = cldrStatus.getCurrentPage();
-          if (
-            (curPage == null || curPage == "") &&
-            (cldrStatus.getCurrentId() == null ||
-              cldrStatus.getCurrentId() == "")
-          ) {
-            // the 'General Info' page.
-            itemLoadInfo.appendChild(
-              document.createTextNode(locmap.getLocaleName(curLocale))
-            );
-            showPossibleProblems(
-              flipper,
-              pages.other,
-              curLocale,
-              cldrStatus.getSessionId(),
-              covName(effectiveCoverage()),
-              covName(effectiveCoverage())
-            );
-            cldrSurvey.showInPop2(
-              cldrText.get("generalPageInitialGuidance"),
-              null,
-              null,
-              null,
-              true
-            ); /* show the box the first time */
-            isLoading = false;
-          } else if (cldrStatus.getCurrentId() == "!") {
-            var frag = document.createDocumentFragment();
-            frag.appendChild(
-              cldrSurvey.createChunk(
-                cldrText.get("section_help"),
-                "p",
-                "helpContent"
-              )
-            );
-            var infoHtml = cldrText.get("section_info_" + curPage);
-            var infoChunk = document.createElement("div");
-            infoChunk.innerHTML = infoHtml;
-            frag.appendChild(infoChunk);
-            flipper.flipTo(pages.other, frag);
-            hideLoader(null);
-            isLoading = false;
-          } else if (!cldrSurvey.isInputBusy()) {
-            /*
-             * Make “all rows” requests only when !isInputBusy, to avoid wasted requests
-             * if the user leaves the input box open for an extended time.
-             */
-            // (common case) this is an actual locale data page.
-            const curId = cldrStatus.getCurrentId();
-            const curPage = cldrStatus.getCurrentPage();
-            const curLocale = cldrStatus.getCurrentLocale();
-            itemLoadInfo.appendChild(
-              document.createTextNode(
-                locmap.getLocaleName(curLocale) + "/" + curPage + "/" + curId
-              )
-            );
-            var url =
-              cldrStatus.getContextPath() +
-              "/SurveyAjax?what=getrow&_=" +
-              curLocale +
-              "&x=" +
-              curPage +
-              "&strid=" +
-              curId +
-              "&s=" +
-              cldrStatus.getSessionId() +
-              cacheKill();
-            $("#nav-page").show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
-            myLoad(url, "section", function (json) {
-              isLoading = false;
-              showLoader(theDiv.loader, cldrText.get("loading2"));
-              if (!verifyJson(json, "section")) {
-                return;
-              } else if (json.section.nocontent) {
-                cldrStatus.setCurrentSection("");
-                if (json.pageId) {
-                  cldrStatus.setCurrentPage(json.pageId);
-                } else {
-                  cldrStatus.setCurrentPage("");
-                }
-                showLoader(null);
-                updateHashAndMenus(); // find out why there's no content. (locmap)
-              } else if (!json.section.rows) {
-                console.log("!json.section.rows");
-                showLoader(
-                  theDiv.loader,
-                  "Error while  loading: <br><div style='border: 1px solid red;'>" +
-                    "no rows" +
-                    "</div>"
-                );
-                handleDisconnect("while loading- no rows", json);
-              } else {
-                stdebug("json.section.rows OK..");
-                showLoader(theDiv.loader, "loading..");
-                if (json.dataLoadTime) {
-                  cldrSurvey.updateIf("dynload", json.dataLoadTime);
-                }
-
-                cldrStatus.setCurrentSection("");
-                cldrStatus.setCurrentPage(json.pageId);
-                updateHashAndMenus(); // now that we have a pageid
-                if (!cldrStatus.getSurveyUser()) {
-                  cldrSurvey.showInPop2(
-                    cldrText.get("loginGuidance"),
-                    null,
-                    null,
-                    null,
-                    true
-                  ); /* show the box the first time */
-                } else if (!json.canModify) {
-                  cldrSurvey.showInPop2(
-                    cldrText.get("readonlyGuidance"),
-                    null,
-                    null,
-                    null,
-                    true
-                  ); /* show the box the first time */
-                } else {
-                  cldrSurvey.showInPop2(
-                    cldrText.get("dataPageInitialGuidance"),
-                    null,
-                    null,
-                    null,
-                    true
-                  ); /* show the box the first time */
-                }
-                if (!cldrSurvey.isInputBusy()) {
-                  showLoader(theDiv.loader, cldrText.get("loading3"));
-                  cldrTable.insertRows(
-                    theDiv,
-                    json.pageId,
-                    cldrStatus.getSessionId(),
-                    json
-                  ); // pageid is the xpath..
-                  updateCoverage(flipper.get(pages.data)); // make sure cov is set right before we show.
-                  flipper.flipTo(pages.data); // TODO now? or later?
-                  window.showCurrentId(); // already calls scroll
-                  refreshCounterVetting();
-                  $("#nav-page-footer").show(); // make bottom "Prev/Next" buttons visible after building table
-                }
-              }
-            });
-          }
-        } else if (cldrStatus.getCurrentSpecial() == "oldvotes") {
-          const curLocale = cldrStatus.getCurrentLocale();
-          var url =
-            cldrStatus.getContextPath() +
-            "/SurveyAjax?what=oldvotes&_=" +
-            curLocale +
-            "&s=" +
-            cldrStatus.getSessionId() +
-            "&" +
-            cacheKill();
-          myLoad(url, "(loading oldvotes " + curLocale + ")", function (json) {
-            isLoading = false;
-            showLoader(null, cldrText.get("loading2"));
-            if (!verifyJson(json, "oldvotes")) {
-              return;
-            } else {
-              showLoader(null, "loading..");
-              if (json.dataLoadTime) {
-                cldrSurvey.updateIf("dynload", json.dataLoadTime);
-              }
-
-              var theDiv = flipper.flipToEmpty(pages.other); // clean slate, and proceed..
-
-              removeAllChildNodes(theDiv);
-
-              var h2txt = cldrText.get("v_oldvotes_title");
-              theDiv.appendChild(
-                cldrSurvey.createChunk(h2txt, "h2", "v-title")
-              );
-
-              if (!json.oldvotes.locale) {
-                cldrStatus.setCurrentLocale("");
-                updateHashAndMenus();
-
-                var ul = document.createElement("div");
-                ul.className = "oldvotes_list";
-                var data = json.oldvotes.locales.data;
-                var header = json.oldvotes.locales.header;
-
-                if (data.length > 0) {
-                  data.sort((a, b) =>
-                    a[header.LOCALE].localeCompare(b[header.LOCALE])
-                  );
-                  for (var k in data) {
-                    var li = document.createElement("li");
-
-                    var link = cldrSurvey.createChunk(
-                      data[k][header.LOCALE_NAME],
-                      "a"
-                    );
-                    link.href = "#" + data[k][header.LOCALE];
-                    (function (loc, link) {
-                      return function () {
-                        var clicky;
-                        listenFor(
-                          link,
-                          "click",
-                          (clicky = function (e) {
-                            cldrStatus.setCurrentLocale(loc);
-                            reloadV();
-                            cldrSurvey.stStopPropagation(e);
-                            return false;
-                          })
-                        );
-                        link.onclick = clicky;
-                      };
-                    })(data[k][header.LOCALE], link)();
-                    li.appendChild(link);
-                    li.appendChild(cldrSurvey.createChunk(" "));
-                    li.appendChild(
-                      cldrSurvey.createChunk("(" + data[k][header.COUNT] + ")")
-                    );
-
-                    ul.appendChild(li);
-                  }
-
-                  theDiv.appendChild(ul);
-
-                  theDiv.appendChild(
-                    cldrSurvey.createChunk(
-                      cldrText.get("v_oldvotes_locale_list_help_msg"),
-                      "p",
-                      "helpContent"
-                    )
-                  );
-                } else {
-                  theDiv.appendChild(
-                    cldrSurvey.createChunk(
-                      cldrText.get("v_oldvotes_no_old"),
-                      "i"
-                    )
-                  ); // TODO fix
-                }
-              } else {
-                cldrStatus.setCurrentLocale(json.oldvotes.locale);
-                updateHashAndMenus();
-                var loclink;
-                theDiv.appendChild(
-                  (loclink = cldrSurvey.createChunk(
-                    cldrText.get("v_oldvotes_return_to_locale_list"),
-                    "a",
-                    "notselected"
-                  ))
-                );
-                listenFor(loclink, "click", function (e) {
-                  cldrStatus.setCurrentLocale("");
+        if (!showMenu) {
+          // doesn't exist - add it.
+          var menuPage = newPseudoDijitDropDownMenu();
+          for (var k in mySection.pages) {
+            // use given order
+            (function (aPage) {
+              var pageMenu = (aPage.menuItem = newPseudoDijitMenuItem({
+                label: aPage.name,
+                iconClass:
+                  aPage.id == cldrStatus.getCurrentPage()
+                    ? "dijitMenuItemIcon menu-x"
+                    : "dijitMenuItemIcon menu-o",
+                onClick: function () {
+                  cldrStatus.setCurrentId(""); // no id if jumping pages
+                  cldrStatus.setCurrentPage(aPage.id);
+                  updateMenuTitles(menuMap, specialItems);
                   reloadV();
-                  cldrSurvey.stStopPropagation(e);
-                  return false;
-                });
-                theDiv.appendChild(
-                  cldrSurvey.createChunk(
-                    json.oldvotes.localeDisplayName,
-                    "h3",
-                    "v-title2"
+                },
+                disabled:
+                  cldrSurvey.effectiveCoverage() <
+                  parseInt(aPage.levs[cldrStatus.getCurrentLocale()]),
+              }));
+            })(mySection.pages[k]);
+          }
+
+          showMenu = newPseudoDijitDropDownButton({
+            label: "-",
+            dropDown: menuPage,
+          });
+
+          titlePageContainer.menus[
+            mySection.id
+          ] = mySection.pagesMenu = showMenu;
+        }
+
+        if (myPage !== null) {
+          $("#title-page-container")
+            .html("<h1>" + myPage.name + "</h1>")
+            .show();
+        } else {
+          $("#title-page-container").html("").hide();
+        }
+        cldrDom.setDisplayed(showMenu, true);
+        cldrDom.setDisplayed(titlePageContainer, true); // will fix title later
+      }
+    }
+
+    menuMap.setCheck(
+      menuMap.section_general,
+      cldrStatus.getCurrentPage() == "" &&
+        (cldrStatus.getCurrentSpecial() == "" ||
+          cldrStatus.getCurrentSpecial() == null),
+      false
+    );
+
+    // Update the status of the items in the Section menu
+    for (var j in menuMap.sections) {
+      var aSection = menuMap.sections[j];
+      // need to see if any items are visible @ current coverage
+      const curLocale = cldrStatus.getCurrentLocale();
+      const curSection = cldrStatus.getCurrentSection();
+      menuMap.setCheck(
+        aSection.menuItem,
+        curSection == aSection.id,
+        cldrSurvey.effectiveCoverage() < aSection.minLev[curLocale]
+      );
+
+      // update the items in that section's Page menu
+      if (curSection == aSection.id) {
+        for (var k in aSection.pages) {
+          var aPage = aSection.pages[k];
+          if (!aPage.menuItem) {
+            console.log("Odd - " + aPage.id + " has no menuItem");
+          } else {
+            menuMap.setCheck(
+              aPage.menuItem,
+              aPage.id == cldrStatus.getCurrentPage(),
+              cldrSurvey.effectiveCoverage() < parseInt(aPage.levs[curLocale])
+            );
+          }
+        }
+      }
+    }
+    menuMap.setCheck(
+      menuMap.forumMenu,
+      cldrStatus.getCurrentSpecial() == "forum",
+      cldrStatus.getSurveyUser() === null
+    );
+    cldrEvent.resizeSidebar();
+  }
+
+  /**
+   * Just update the titles of the menus
+   */
+  function updateMenuTitles(menuMap, specialItems) {
+    if (menubuttons.lastspecial === undefined) {
+      menubuttons.lastspecial = null;
+
+      // Set up the menu here?
+      var parMenu = document.getElementById("manage-list");
+      for (var k = 0; k < specialItems.length; k++) {
+        var item = specialItems[k];
+        (function (item) {
+          if (item.display != false) {
+            var subLi = document.createElement("li");
+            if (item.special) {
+              // special items so look up in cldrText.js
+              item.title = cldrText.get("special_" + item.special);
+              item.url = "#" + item.special;
+              item.blank = false;
+            }
+            if (item.url) {
+              var subA = document.createElement("a");
+
+              if (item.hasFlag) {
+                // forum may need images attached to it
+                var Img = document.createElement("img");
+                Img.setAttribute("src", "flag.png");
+                Img.setAttribute("alt", "flag");
+                Img.setAttribute("title", "flag.png");
+                Img.setAttribute("border", 0);
+
+                subA.appendChild(Img);
+              }
+              subA.appendChild(document.createTextNode(item.title + " "));
+              subA.href = item.url;
+
+              if (item.blank != false) {
+                subA.target = "_blank";
+                subA.appendChild(
+                  cldrDom.createChunk(
+                    "",
+                    "span",
+                    "glyphicon glyphicon-share manage-list-icon"
                   )
                 );
-                var oldVotesLocaleMsg = document.createElement("p");
-                oldVotesLocaleMsg.className = "helpContent";
-                oldVotesLocaleMsg.innerHTML = cldrText.sub(
-                  "v_oldvotes_locale_msg",
-                  {
-                    version: surveyLastVoteVersion,
-                    locale: json.oldvotes.localeDisplayName,
-                  }
-                );
-                theDiv.appendChild(oldVotesLocaleMsg);
-                if (
-                  (json.oldvotes.contested &&
-                    json.oldvotes.contested.length > 0) ||
-                  (json.oldvotes.uncontested &&
-                    json.oldvotes.uncontested.length > 0)
-                ) {
-                  var frag = document.createDocumentFragment();
-                  const oldVoteCount =
-                    (json.oldvotes.contested
-                      ? json.oldvotes.contested.length
-                      : 0) +
-                    (json.oldvotes.uncontested
-                      ? json.oldvotes.uncontested.length
-                      : 0);
-                  var summaryMsg = cldrText.sub("v_oldvotes_count_msg", {
-                    count: oldVoteCount,
-                  });
-                  frag.appendChild(
-                    cldrSurvey.createChunk(summaryMsg, "div", "")
-                  );
+              }
 
-                  var navChunk = document.createElement("div");
-                  navChunk.className = "v-oldVotes-nav";
-                  frag.appendChild(navChunk);
-
-                  var uncontestedChunk = null;
-                  var contestedChunk = null;
-
-                  function addOldvotesType(type, jsondata, frag, navChunk) {
-                    var content = cldrSurvey.createChunk(
-                      "",
-                      "div",
-                      "v-oldVotes-subDiv"
-                    );
-                    content.strid = "v_oldvotes_title_" + type; // v_oldvotes_title_contested or v_oldvotes_title_uncontested
-
-                    /* Normally this interface is for old "losing" (contested) votes only, since old "winning" (uncontested) votes
-                     * are imported automatically. An exception is for TC users, for whom auto-import is disabled. The server-side
-                     * code leaves json.oldvotes.uncontested undefined except for TC users.
-                     * Show headings for "Winning/Losing" only if json.oldvotes.uncontested is defined and non-empty.
-                     */
-                    if (
-                      json.oldvotes.uncontested &&
-                      json.oldvotes.uncontested.length > 0
-                    ) {
-                      var title = cldrText.get(content.strid);
-                      content.title = title;
-                      content.appendChild(
-                        cldrSurvey.createChunk(title, "h2", "v-oldvotes-sub")
-                      );
-                    }
-
-                    content.appendChild(
-                      showVoteTable(jsondata /* voteList */, type, json)
-                    );
-
-                    var submit = dojoxBusyButton({
-                      label: cldrText.get("v_submit_msg"),
-                      busyLabel: cldrText.get("v_submit_busy"),
-                    });
-
-                    submit.on("click", function (e) {
-                      setDisplayed(navChunk, false);
-                      var confirmList = []; // these will be revoted with current params
-
-                      // explicit confirm list -  save us desync hassle
-                      for (var kk in jsondata) {
-                        if (jsondata[kk].box.checked) {
-                          confirmList.push(jsondata[kk].strid);
-                        }
-                      }
-
-                      var saveList = {
-                        locale: cldrStatus.getCurrentLocale(),
-                        confirmList: confirmList,
-                      };
-
-                      console.log(saveList.toString());
-                      console.log(
-                        "Submitting " +
-                          type +
-                          " " +
-                          confirmList.length +
-                          " for confirm"
-                      );
-                      const curLocale = cldrStatus.getCurrentLocale();
-                      var url =
-                        cldrStatus.getContextPath() +
-                        "/SurveyAjax?what=oldvotes&_=" +
-                        curLocale +
-                        "&s=" +
-                        cldrStatus.getSessionId() +
-                        "&doSubmit=true&" +
-                        cacheKill();
-                      myLoad(
-                        url,
-                        "(submitting oldvotes " + curLocale + ")",
-                        function (json) {
-                          showLoader(theDiv.loader, cldrText.get("loading2"));
-                          if (!verifyJson(json, "oldvotes")) {
-                            handleDisconnect(
-                              "Error submitting votes!",
-                              json,
-                              "Error"
-                            );
-                            return;
-                          } else {
-                            reloadV();
-                          }
-                        },
-                        JSON.stringify(saveList),
-                        {
-                          "Content-Type": "application/json",
-                        }
-                      );
-                    });
-
-                    submit.placeAt(content);
-                    // hide by default
-                    setDisplayed(content, false);
-
-                    frag.appendChild(content);
-                    return content;
-                  }
-
-                  if (
-                    json.oldvotes.uncontested &&
-                    json.oldvotes.uncontested.length > 0
-                  ) {
-                    uncontestedChunk = addOldvotesType(
-                      "uncontested",
-                      json.oldvotes.uncontested,
-                      frag,
-                      navChunk
-                    );
-                  }
-                  if (
-                    json.oldvotes.contested &&
-                    json.oldvotes.contested.length > 0
-                  ) {
-                    contestedChunk = addOldvotesType(
-                      "contested",
-                      json.oldvotes.contested,
-                      frag,
-                      navChunk
-                    );
-                  }
-
-                  if (contestedChunk == null && uncontestedChunk != null) {
-                    setDisplayed(uncontestedChunk, true); // only item
-                  } else if (
-                    contestedChunk != null &&
-                    uncontestedChunk == null
-                  ) {
-                    setDisplayed(contestedChunk, true); // only item
-                  } else {
-                    // navigation
-                    navChunk.appendChild(
-                      cldrSurvey.createChunk(cldrText.get("v_oldvotes_show"))
-                    );
-                    navChunk.appendChild(
-                      cldrSurvey.createLinkToFn(
-                        uncontestedChunk.strid,
-                        function () {
-                          setDisplayed(contestedChunk, false);
-                          setDisplayed(uncontestedChunk, true);
-                        },
-                        "button"
-                      )
-                    );
-                    navChunk.appendChild(
-                      cldrSurvey.createLinkToFn(
-                        contestedChunk.strid,
-                        function () {
-                          setDisplayed(contestedChunk, true);
-                          setDisplayed(uncontestedChunk, false);
-                        },
-                        "button"
-                      )
-                    );
-
-                    contestedChunk.appendChild(
-                      cldrSurvey.createLinkToFn(
-                        "v_oldvotes_hide",
-                        function () {
-                          setDisplayed(contestedChunk, false);
-                        },
-                        "button"
-                      )
-                    );
-                    uncontestedChunk.appendChild(
-                      cldrSurvey.createLinkToFn(
-                        "v_oldvotes_hide",
-                        function () {
-                          setDisplayed(uncontestedChunk, false);
-                        },
-                        "button"
-                      )
-                    );
-                  }
-
-                  theDiv.appendChild(frag);
-                } else {
-                  theDiv.appendChild(
-                    cldrSurvey.createChunk(
-                      cldrText.get("v_oldvotes_no_old_here"),
-                      "i",
-                      ""
-                    )
-                  );
+              if (item.level) {
+                // append it to appropriate levels
+                var level = item.level;
+                for (var i = 0; i < level - 1; i++) {
+                  /*
+                   * Indent by creating lists within lists, each list containing only one item.
+                   * TODO: indent by a better method. Note that for valid html, ul should contain li;
+                   * ul directly containing element other than li is generally invalid.
+                   */
+                  let ul = document.createElement("ul");
+                  let li = document.createElement("li");
+                  ul.setAttribute("style", "list-style-type:none");
+                  ul.appendChild(li);
+                  li.appendChild(subA);
+                  subA = ul;
                 }
               }
+              subLi.appendChild(subA);
             }
-            hideLoader(null);
-          });
-        } else if (cldrStatus.getCurrentSpecial() == "mail") {
-          var url =
-            cldrStatus.getContextPath() +
-            "/SurveyAjax?what=mail&s=" +
-            cldrStatus.getSessionId() +
-            "&fetchAll=true&" +
-            cacheKill();
-          myLoad(
-            url,
-            "(loading mail " + cldrStatus.getCurrentLocale() + ")",
-            function (json) {
-              hideLoader(null, cldrText.get("loading2"));
-              isLoading = false;
-              if (!verifyJson(json, "mail")) {
-                return;
+            if (!item.url && !item.divider) {
+              // if it is pure text/html & not a divider
+              if (!item.level) {
+                subLi.appendChild(document.createTextNode(item.title + " "));
               } else {
-                if (json.dataLoadTime) {
-                  cldrSurvey.updateIf("dynload", json.dataLoadTime);
-                }
-
-                var theDiv = flipper.flipToEmpty(pages.other); // clean slate, and proceed..
-
-                removeAllChildNodes(theDiv);
-
-                var listDiv = cldrSurvey.createChunk(
-                  "",
-                  "div",
-                  "mailListChunk"
-                );
-                var contentDiv = cldrSurvey.createChunk(
-                  "",
-                  "div",
-                  "mailContentChunk"
-                );
-
-                theDiv.appendChild(listDiv);
-                theDiv.appendChild(contentDiv);
-
-                setDisplayed(contentDiv, false);
-                var header = json.mail.header;
-                var data = json.mail.data;
-
-                if (data.length == 0) {
-                  listDiv.appendChild(
-                    cldrSurvey.createChunk(
-                      cldrText.get("mail_noMail"),
-                      "p",
-                      "helpContent"
-                    )
-                  );
+                var subA = null;
+                if (item.bold) {
+                  subA = document.createElement("b");
+                } else if (item.italic) {
+                  subA = document.createElement("i");
                 } else {
-                  for (var ii in data) {
-                    var row = data[ii];
-                    var li = cldrSurvey.createChunk(
-                      row[header.QUEUE_DATE] + ": " + row[header.SUBJECT],
-                      "li",
-                      "mailRow"
-                    );
-                    if (row[header.READ_DATE]) {
-                      cldrSurvey.addClass(li, "readMail");
-                    }
-                    if (header.USER !== undefined) {
-                      li.appendChild(
-                        document.createTextNode("(to " + row[header.USER] + ")")
-                      );
-                    }
-                    if (row[header.SENT_DATE] !== false) {
-                      li.appendChild(
-                        cldrSurvey.createChunk("(sent)", "span", "winner")
-                      );
-                    } else if (row[header.TRY_COUNT] >= 3) {
-                      li.appendChild(
-                        cldrSurvey.createChunk(
-                          "(try#" + row[header.TRY_COUNT] + ")",
-                          "span",
-                          "loser"
-                        )
-                      );
-                    } else if (row[header.TRY_COUNT] > 0) {
-                      li.appendChild(
-                        cldrSurvey.createChunk(
-                          "(try#" + row[header.TRY_COUNT] + ")",
-                          "span",
-                          "warning"
-                        )
-                      );
-                    }
-                    listDiv.appendChild(li);
-
-                    li.onclick = (function (li, row, header) {
-                      return function () {
-                        if (!row[header.READ_DATE]) {
-                          myLoad(
-                            cldrStatus.getContextPath() +
-                              "/SurveyAjax?what=mail&s=" +
-                              cldrStatus.getSessionId() +
-                              "&markRead=" +
-                              row[header.ID] +
-                              "&" +
-                              cacheKill(),
-                            "Marking mail read",
-                            function (json) {
-                              if (!verifyJson(json, "mail")) {
-                                return;
-                              } else {
-                                cldrSurvey.addClass(li, "readMail"); // mark as read when server answers
-                                row[header.READ_DATE] = true; // close enough
-                              }
-                            }
-                          );
-                        }
-                        setDisplayed(contentDiv, false);
-
-                        removeAllChildNodes(contentDiv);
-
-                        contentDiv.appendChild(
-                          cldrSurvey.createChunk(
-                            "Date: " + row[header.QUEUE_DATE],
-                            "h2",
-                            "mailHeader"
-                          )
-                        );
-                        contentDiv.appendChild(
-                          cldrSurvey.createChunk(
-                            "Subject: " + row[header.SUBJECT],
-                            "h2",
-                            "mailHeader"
-                          )
-                        );
-                        contentDiv.appendChild(
-                          cldrSurvey.createChunk(
-                            "Message-ID: " + row[header.ID],
-                            "h2",
-                            "mailHeader"
-                          )
-                        );
-                        if (header.USER !== undefined) {
-                          contentDiv.appendChild(
-                            cldrSurvey.createChunk(
-                              "To: " + row[header.USER],
-                              "h2",
-                              "mailHeader"
-                            )
-                          );
-                        }
-                        contentDiv.appendChild(
-                          cldrSurvey.createChunk(
-                            row[header.TEXT],
-                            "p",
-                            "mailContent"
-                          )
-                        );
-
-                        setDisplayed(contentDiv, true);
-                      };
-                    })(li, row, header);
-                  }
+                  subA = document.createElement("span");
                 }
+                subA.appendChild(document.createTextNode(item.title + " "));
+
+                var level = item.level;
+                for (var i = 0; i < level - 1; i++) {
+                  let ul = document.createElement("ul");
+                  let li = document.createElement("li");
+                  ul.setAttribute("style", "list-style-type:none");
+                  ul.appendChild(li);
+                  li.appendChild(subA);
+                  subA = ul;
+                }
+                subLi.appendChild(subA);
               }
             }
-          );
-        } else if (cldrSurvey.isReport(cldrStatus.getCurrentSpecial())) {
-          showLoader(theDiv.loader);
-          cldrSurvey.showInPop2(
-            cldrText.get("reportGuidance"),
-            null,
-            null,
-            null,
-            true,
-            true
-          ); /* show the box the first time */
-          var url =
-            cldrStatus.getContextPath() +
-            "/SurveyAjax?what=report&x=" +
-            cldrStatus.getCurrentSpecial() +
-            "&_=" +
-            cldrStatus.getCurrentLocale() +
-            "&s=" +
-            cldrStatus.getSessionId() +
-            cacheKill();
-          var errFunction = function errFunction(err) {
-            console.log("Error: loading " + url + " -> " + err);
-            hideLoader(null, cldrText.get("loading2"));
-            isLoading = false;
-            const html =
-              "<div style='padding-top: 4em; font-size: x-large !important;' class='ferrorbox warning'>" +
-              "<span class='icon i-stop'>" +
-              " &nbsp; &nbsp;</span>Error: could not load: " +
-              err +
-              "</div>";
-            const frag = cldrDomConstruct(html);
-            flipper.flipTo(pages.other, frag);
-          };
-          if (isDashboard()) {
-            if (!cldrStatus.isVisitor()) {
-              const loadHandler = function (json) {
-                hideLoader(null, cldrText.get("loading2"));
-                isLoading = false;
-                // further errors are handled in JSON
-                showReviewPage(json, function () {
-                  // show function - flip to the 'other' page.
-                  flipper.flipTo(pages.other, null);
-                });
-              };
-              const xhrArgs = {
-                url: url,
-                handleAs: "json",
-                load: loadHandler,
-                error: errFunction,
-              };
-              cldrAjax.queueXhr(xhrArgs);
-            } else {
-              alert("Please login to access Dashboard");
-              cldrStatus.setCurrentSpecial("");
-              cldrStatus.setCurrentLocale("");
-              reloadV();
+            if (item.divider) {
+              subLi.className = "nav-divider";
             }
-          } else {
-            hideLoader(null, cldrText.get("loading2"));
-            const loadHandler = function (html) {
-              hideLoader(null, cldrText.get("loading2"));
-              isLoading = false;
-              const frag = cldrDomConstruct(html);
-              flipper.flipTo(pages.other, frag);
-              hideRightPanel(); // CLDR-14365
-            };
-            const xhrArgs = {
-              url: url,
-              handleAs: "html",
-              load: loadHandler,
-              error: errFunction,
-            };
-            cldrAjax.queueXhr(xhrArgs);
+            parMenu.appendChild(subLi);
           }
-        } else if (cldrStatus.getCurrentSpecial() == "none") {
-          // for now - redirect
-          hideLoader(null);
-          isLoading = false;
-          window.location = cldrStatus.getSurvUrl(); // redirect home
-        } else if (cldrStatus.getCurrentSpecial() == "locales") {
-          hideLoader(null);
-          isLoading = false;
-          var theDiv = document.createElement("div");
-          theDiv.className = "localeList";
-
-          var addSubLocale = function addSubLocale(parLocDiv, subLoc) {
-            var subLocInfo = locmap.getLocaleInfo(subLoc);
-            var subLocDiv = cldrSurvey.createChunk(null, "div", "subLocale");
-            appendLocaleLink(subLocDiv, subLoc, subLocInfo);
-
-            parLocDiv.appendChild(subLocDiv);
-          };
-
-          var addSubLocales = function addSubLocales(parLocDiv, subLocInfo) {
-            if (subLocInfo.sub) {
-              for (var n in subLocInfo.sub) {
-                var subLoc = subLocInfo.sub[n];
-                addSubLocale(parLocDiv, subLoc);
-              }
-            }
-          };
-
-          /*
-           * TODO: there are two functions named addTopLocale, clarify why
-           */
-          var addTopLocale = function addTopLocale(topLoc) {
-            var topLocInfo = locmap.getLocaleInfo(topLoc);
-
-            var topLocRow = document.createElement("div");
-            topLocRow.className = "topLocaleRow";
-
-            var topLocDiv = document.createElement("div");
-            topLocDiv.className = "topLocale";
-            appendLocaleLink(topLocDiv, topLoc, topLocInfo);
-
-            var topLocList = document.createElement("div");
-            topLocList.className = "subLocaleList";
-
-            addSubLocales(topLocList, topLocInfo);
-
-            topLocRow.appendChild(topLocDiv);
-            topLocRow.appendChild(topLocList);
-            theDiv.appendChild(topLocRow);
-          };
-
-          addTopLocale("root");
-          // top locales
-          for (var n in locmap.locmap.topLocales) {
-            var topLoc = locmap.locmap.topLocales[n];
-            addTopLocale(topLoc);
-          }
-          flipper.flipTo(pages.other, null);
-          filterAllLocale(); //filter for init data
-          forceSidebar();
-          cldrStatus.setCurrentLocale(null);
-          cldrStatus.setCurrentSpecial("locales");
-          cldrSurvey.showInPop2(
-            cldrText.get("localesInitialGuidance"),
-            null,
-            null,
-            null,
-            true
-          ); /* show the box the first time */
-          $("#itemInfo").html("");
-        } else {
-          otherSpecial.show(cldrStatus.getCurrentSpecial(), {
-            flipper: flipper,
-            pages: pages,
-          });
-        }
-      }; // end shower
-
-      shower(); // first load
-
-      // set up the "show-er" function so that if this locale gets reloaded,
-      // the page will load again - except for the dashboard, where only the
-      // row get updated
-      /*
-       * TODO: clarify the above comment, and relate it to the usage of "showers" in survey.js
-       * What does "this locale gets reloaded" mean?
-       * Typically (always?) id = "DynamicDataSection" here.
-       */
-      if (!isDashboard()) {
-        showers[flipper.get(pages.data).id] = shower;
+        })(item);
       }
-    }; // end reloadV
-
-    function trimNull(x) {
-      if (x == null) {
-        return "";
-      }
-      try {
-        x = x.toString().trim();
-      } catch (e) {
-        // do nothing
-      }
-      return x;
     }
 
-    /*
-     * Arrange for getInitialMenusEtc to be called after we've gotten the session id.
-     * There should be a better way to do this. For now, getInitialMenusEtc is deeply
-     * nested in legacy code, and this implementation avoids any complex linkage between
-     * this code and the code that's responsible for getting the session id from
-     * the server -- that is, updateStatus() in survey.js, as of 2020-12-10
-     */
-    getM();
-    function getM() {
-      const sessionId = cldrStatus.getSessionId();
-      if (sessionId) {
-        getInitialMenusEtc(sessionId);
+    if (menubuttons.lastspecial) {
+      cldrDom.removeClass(menubuttons.lastspecial, "selected");
+    }
+
+    updateLocaleMenu(menuMap);
+
+    const curSpecial = cldrStatus.getCurrentSpecial();
+    const titlePageContainer = document.getElementById("title-page-container");
+
+    if (curSpecial != null && curSpecial != "") {
+      const specialId = "special_" + curSpecial;
+      $("#section-current").html(cldrText.get(specialId));
+      cldrDom.setDisplayed(titlePageContainer, false);
+    } else if (!menuMap) {
+      cldrDom.setDisplayed(titlePageContainer, false);
+    } else {
+      const curPage = cldrStatus.getCurrentPage();
+      if (menuMap.sectionMap[curPage]) {
+        const curSection = curPage; // section = page
+        cldrStatus.setCurrentSection(curSection);
+        $("#section-current").html(menuMap.sectionMap[curSection].name);
+        cldrDom.setDisplayed(titlePageContainer, false); // will fix title later
+      } else if (menuMap.pageToSection[curPage]) {
+        const mySection = menuMap.pageToSection[curPage];
+        cldrStatus.setCurrentSection(mySection.id);
+        $("#section-current").html(mySection.name);
+        cldrDom.setDisplayed(titlePageContainer, false); // will fix title later
       } else {
-        setTimeout(getM, 100); // try again after 1/10 second
+        $("#section-current").html(cldrText.get("section_general"));
+        cldrDom.setDisplayed(titlePageContainer, false);
       }
     }
+  }
 
-    function getInitialMenusEtc(sessionId) {
-      window.parseHash(dojoHash()); // get the initial settings
-      // load the menus - first.
+  function unpackMenus(json) {
+    const menus = json.menus;
 
-      var theLocale = cldrStatus.getCurrentLocale();
-      if (theLocale === null || theLocale == "") {
-        theLocale = "root"; // Default.
-      }
-      var xurl =
-        cldrStatus.getContextPath() +
-        "/SurveyAjax?what=menus&_=" +
-        theLocale +
-        "&locmap=" +
-        true +
-        "&s=" +
-        sessionId +
-        cacheKill();
-      myLoad(xurl, "initial menus for " + theLocale, function (json) {
-        if (!verifyJson(json, "locmap")) {
-          return;
-        } else {
-          locmap = new LocaleMap(json.locmap);
-          if (cldrStatus.getCurrentLocale() === "USER" && json.loc) {
-            cldrStatus.setCurrentLocale(json.loc);
-          }
-          // make this into a hashmap.
-          if (json.canmodify) {
-            var canmodify = {};
-            for (var k in json.canmodify) {
-              canmodify[json.canmodify[k]] = true;
-            }
-            window.canmodify = canmodify;
-          }
+    if (_thePages) {
+      for (let k in menus.sections) {
+        const oldSection = _thePages.sectionMap[menus.sections[k].id];
+        for (let j in menus.sections[k].pages) {
+          const oldPage = oldSection.pageMap[menus.sections[k].pages[j].id];
 
-          // update left sidebar with locale data
-          var theDiv = document.createElement("div");
-          theDiv.className = "localeList";
-
-          var addSubLocale;
-
-          addSubLocale = function addSubLocale(parLocDiv, subLoc) {
-            var subLocInfo = locmap.getLocaleInfo(subLoc);
-            var subLocDiv = cldrSurvey.createChunk(null, "div", "subLocale");
-            appendLocaleLink(subLocDiv, subLoc, subLocInfo);
-
-            parLocDiv.appendChild(subLocDiv);
-          };
-
-          var addSubLocales = function addSubLocales(parLocDiv, subLocInfo) {
-            if (subLocInfo.sub) {
-              for (var n in subLocInfo.sub) {
-                var subLoc = subLocInfo.sub[n];
-                addSubLocale(parLocDiv, subLoc);
-              }
-            }
-          };
-
-          var addTopLocale = function addTopLocale(topLoc) {
-            var topLocInfo = locmap.getLocaleInfo(topLoc);
-
-            var topLocRow = document.createElement("div");
-            topLocRow.className = "topLocaleRow";
-
-            var topLocDiv = document.createElement("div");
-            topLocDiv.className = "topLocale";
-            appendLocaleLink(topLocDiv, topLoc, topLocInfo);
-
-            var topLocList = document.createElement("div");
-            topLocList.className = "subLocaleList";
-
-            addSubLocales(topLocList, topLocInfo);
-
-            topLocRow.appendChild(topLocDiv);
-            topLocRow.appendChild(topLocList);
-            theDiv.appendChild(topLocRow);
-          };
-
-          addTopLocale("root");
-          // top locales
-          for (var n in locmap.locmap.topLocales) {
-            var topLoc = locmap.locmap.topLocales[n];
-            addTopLocale(topLoc);
-          }
-          $("#locale-list").html(theDiv.innerHTML);
-
-          if (cldrStatus.isVisitor()) $("#show-read").prop("checked", true);
-          //tooltip locale
-          $("a.locName").tooltip();
-
-          filterAllLocale();
-          //end of adding the locale data
-
-          updateCovFromJson(json);
-          // setup coverage level
-          window.surveyLevels = json.menus.levels;
-
-          var titleCoverage = document.getElementById("title-coverage"); // coverage label
-
-          var levelNums = []; // numeric levels
-          for (var k in window.surveyLevels) {
-            levelNums.push({
-              num: parseInt(window.surveyLevels[k].level),
-              level: window.surveyLevels[k],
-            });
-          }
-          levelNums.sort(function (a, b) {
-            return a.num - b.num;
-          });
-
-          var store = [];
-
-          store.push({
-            label: "Auto",
-            value: "auto",
-            title: cldrText.get("coverage_auto_desc"),
-          });
-
-          store.push({
-            type: "separator",
-          });
-
-          for (var j in levelNums) {
-            // use given order
-            if (levelNums[j].num == 0) continue; // none - skip
-            if (levelNums[j].num < covValue("minimal")) continue; // don't bother showing these
-            if (
-              cldrStatus.getIsUnofficial() === false &&
-              levelNums[j].num == 101
-            )
-              continue; // hide Optional in production
-            var level = levelNums[j].level;
-            store.push({
-              label: cldrText.get("coverage_" + level.name),
-              value: level.name,
-              title: cldrText.get("coverage_" + level.name + "_desc"),
-            });
-          }
-          //coverage menu
-          var patternCoverage = $("#title-coverage .dropdown-menu");
-          if (store[0].value) {
-            $("#coverage-info").text(store[0].label);
-          }
-          for (var index = 0; index < store.length; ++index) {
-            var data = store[index];
-            if (data.value) {
-              var html =
-                '<li><a class="coverage-list" data-value="' +
-                data.value +
-                '"href="#">' +
-                data.label +
-                "</a></li>";
-              patternCoverage.append(html);
-            }
-          }
-          patternCoverage.find("li a").click(function (event) {
-            event.stopPropagation();
-            event.preventDefault();
-            var newValue = $(this).data("value");
-            var setUserCovTo = null;
-            if (newValue == "auto") {
-              setUserCovTo = null; // auto
-            } else {
-              setUserCovTo = newValue;
-            }
-            if (setUserCovTo === window.surveyUserCov) {
-              console.log("No change in user cov: " + setUserCovTo);
-            } else {
-              window.surveyUserCov = setUserCovTo;
-              var updurl =
-                cldrStatus.getContextPath() +
-                "/SurveyAjax?what=pref&_=" +
-                theLocale +
-                "&pref=p_covlev&_v=" +
-                window.surveyUserCov +
-                "&s=" +
-                cldrStatus.getSessionId() +
-                cacheKill(); // SurveyMain.PREF_COVLEV
-              myLoad(
-                updurl,
-                "updating covlev to  " + surveyUserCov,
-                function (json) {
-                  if (!verifyJson(json, "pref")) {
-                    return;
-                  } else {
-                    unpackMenuSideBar(json);
-                    if (
-                      cldrStatus.getCurrentSpecial() &&
-                      cldrSurvey.isReport(cldrStatus.getCurrentSpecial())
-                    )
-                      reloadV();
-                    console.log("Server set  covlev successfully.");
-                  }
-                }
-              );
-            }
-            // still update these.
-            updateCoverage(flipper.get(pages.data)); // update CSS and 'auto' menu title
-            updateHashAndMenus(false); // TODO: why? Maybe to show an item?
-            $("#coverage-info").text(newValue.ucFirst());
-            $(this).parents(".dropdown-menu").dropdown("toggle");
-            if (!isDashboard()) refreshCounterVetting();
-            return false;
-          });
-
-          /**
-           * Automatically import old winning votes
-           */
-          function doAutoImport() {
-            "use strict";
-            var autoImportProgressDialog = new dijitDialog({
-              title: cldrText.get("v_oldvote_auto_msg"),
-              content: cldrText.get("v_oldvote_auto_progress_msg"),
-            });
-            autoImportProgressDialog.show();
-            window.haveDialog = true;
-            hideOverlayAndSidebar();
-            /*
-             * See WHAT_AUTO_IMPORT = "auto_import" in SurveyAjax.java
-             */
-            var url =
-              cldrStatus.getContextPath() +
-              "/SurveyAjax?what=auto_import&s=" +
-              cldrStatus.getSessionId() +
-              cacheKill();
-            myLoad(url, "auto-importing votes", function (json) {
-              autoImportProgressDialog.hide();
-              window.haveDialog = false;
-              if (json.autoImportedOldWinningVotes) {
-                var vals = {
-                  count: json.autoImportedOldWinningVotes,
-                };
-                var autoImportedDialog = new dijitDialog({
-                  title: cldrText.get("v_oldvote_auto_msg"),
-                  content: cldrText.sub("v_oldvote_auto_desc_msg", vals),
-                });
-                autoImportedDialog.addChild(
-                  new dijitButton({
-                    label: "OK",
-                    onClick: function () {
-                      window.haveDialog = false;
-                      autoImportedDialog.hide();
-                      reloadV();
-                    },
-                  })
-                );
-                autoImportedDialog.show();
-                window.haveDialog = true;
-                hideOverlayAndSidebar();
-              }
-            });
-          }
-
-          if (json.canAutoImport) {
-            doAutoImport();
-          }
-
-          window.reloadV(); // call it
-
-          // watch for hashchange to make other changes..
-          dojoTopic.subscribe("/dojo/hashchange", function (changedHash) {
-            var oldLocale = trimNull(cldrStatus.getCurrentLocale());
-            var oldSpecial = trimNull(cldrStatus.getCurrentSpecial());
-            var oldPage = trimNull(cldrStatus.getCurrentPage());
-            var oldId = trimNull(cldrStatus.getCurrentId());
-
-            window.parseHash(changedHash);
-
-            cldrStatus.setCurrentId(trimNull(cldrStatus.getCurrentId()));
-
-            // did anything change?
-            if (
-              oldLocale != trimNull(cldrStatus.getCurrentLocale()) ||
-              oldSpecial != trimNull(cldrStatus.getCurrentSpecial()) ||
-              oldPage != trimNull(cldrStatus.getCurrentPage())
-            ) {
-              console.log("# hash changed, (loc, etc) reloadingV..");
-              reloadV();
-            } else if (
-              oldId != cldrStatus.getCurrentId() &&
-              cldrStatus.getCurrentId() != ""
-            ) {
-              console.log("# just ID changed, to " + cldrStatus.getCurrentId());
-              // surveyCurrentID and the hash have already changed.
-              // just call showInPop if the item is present. If not present, make sure it's visible.
-              window.showCurrentId();
-            }
-          });
+          // copy over levels
+          oldPage.levs[json.loc] = menus.sections[k].pages[j].levs[json.loc];
         }
-      }); // end myLoad
-    } // end getInitialMenusEtc
-  } // end showV
+      }
+    } else {
+      // set up some hashes
+      menus.haveLocs = {};
+      menus.sectionMap = {};
+      menus.pageToSection = {};
+      for (let k in menus.sections) {
+        menus.sectionMap[menus.sections[k].id] = menus.sections[k];
+        menus.sections[k].pageMap = {};
+        menus.sections[k].minLev = {};
+        for (let j in menus.sections[k].pages) {
+          menus.sections[k].pageMap[menus.sections[k].pages[j].id] =
+            menus.sections[k].pages[j];
+          menus.pageToSection[menus.sections[k].pages[j].id] =
+            menus.sections[k];
+        }
+      }
+      _thePages = menus;
+    }
+
+    for (let k in _thePages.sectionMap) {
+      let min = 200;
+      for (let j in _thePages.sectionMap[k].pageMap) {
+        const thisLev = parseInt(
+          _thePages.sectionMap[k].pageMap[j].levs[json.loc]
+        );
+        if (min > thisLev) {
+          min = thisLev;
+        }
+      }
+      _thePages.sectionMap[k].minLev[json.loc] = min;
+    }
+
+    _thePages.haveLocs[json.loc] = true;
+  }
+
+  function trimNull(x) {
+    if (x == null) {
+      return "";
+    }
+    try {
+      x = x.toString().trim();
+    } catch (e) {
+      // do nothing
+    }
+    return x;
+  }
+
+  /**
+   * Uppercase the first letter of a sentence
+   * @return {String} string with first letter uppercase
+   */
+  function ucFirst(s) {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
 
   // replacement for dojo/dom-construct domConstruct.toDom
   function cldrDomConstruct(html) {
@@ -2790,17 +2015,354 @@ const cldrLoad = (function () {
     return renderer.content;
   }
 
+  /**
+   * Automatically import old winning votes
+   */
+  function doAutoImport() {
+    const autoImportProgressDialog = newProgressDialog({
+      title: cldrText.get("v_oldvote_auto_msg"),
+      content: cldrText.get("v_oldvote_auto_progress_msg"),
+    });
+    if (autoImportProgressDialog) {
+      autoImportProgressDialog.show();
+    }
+    haveDialog = true;
+    cldrEvent.hideOverlayAndSidebar();
+    /*
+     * See WHAT_AUTO_IMPORT = "auto_import" in SurveyAjax.java
+     */
+    const url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=auto_import&s=" +
+      cldrStatus.getSessionId() +
+      cldrSurvey.cacheKill();
+    myLoad(url, "auto-importing votes", function (json) {
+      if (autoImportProgressDialog) {
+        autoImportProgressDialog.hide();
+      }
+      haveDialog = false;
+      if (json.autoImportedOldWinningVotes) {
+        const vals = {
+          count: json.autoImportedOldWinningVotes,
+        };
+        const autoImportedDialog = newProgressDialog({
+          title: cldrText.get("v_oldvote_auto_msg"),
+          content: cldrText.sub("v_oldvote_auto_desc_msg", vals),
+        });
+        if (autoImportedDialog) {
+          autoImportedDialog.addChild(
+            new dijitButton({
+              label: "OK",
+              onClick: function () {
+                haveDialog = false;
+                autoImportedDialog.hide();
+                reloadV();
+              },
+            })
+          );
+          autoImportedDialog.show();
+        }
+        haveDialog = true;
+        cldrEvent.hideOverlayAndSidebar();
+      }
+    });
+  }
+
+  /**
+   * @param postData optional - makes this a POST
+   */
+  function myLoad(url, message, handler, postData, headers) {
+    const otime = new Date().getTime();
+    console.log("MyLoad: " + url + " for " + message);
+    const errorHandler = function (err) {
+      console.log("Error: " + err);
+      cldrSurvey.handleDisconnect(
+        "Could not fetch " +
+          message +
+          " - error " +
+          err +
+          "\n url: " +
+          url +
+          "\n",
+        null,
+        "disconnect"
+      );
+    };
+    const loadHandler = function (json) {
+      console.log(
+        "        " + url + " loaded in " + (new Date().getTime() - otime) + "ms"
+      );
+      try {
+        handler(json);
+        //resize height
+        $("#main-row").css({
+          height: $("#main-row>div").height(),
+        });
+      } catch (e) {
+        console.log(
+          "Error in ajax post [" + message + "]  " + e.message + " / " + e.name
+        );
+        cldrSurvey.handleDisconnect(
+          "Exception while loading: " +
+            message +
+            " - " +
+            e.message +
+            ", n=" +
+            e.name +
+            " \nStack:\n" +
+            (e.stack || "[none]"),
+          null
+        ); // in case the 2nd line doesn't work
+      }
+    };
+    const xhrArgs = {
+      url: url,
+      handleAs: "json",
+      load: loadHandler,
+      error: errorHandler,
+      postData: postData,
+      headers: headers,
+    };
+    cldrAjax.queueXhr(xhrArgs);
+  }
+
+  function addSubLocales(parLocDiv, subLocInfo) {
+    if (subLocInfo.sub) {
+      for (let n in subLocInfo.sub) {
+        const subLoc = subLocInfo.sub[n];
+        addSubLocale(parLocDiv, subLoc);
+      }
+    }
+  }
+
+  function addSubLocale(parLocDiv, subLoc) {
+    const subLocInfo = locmap.getLocaleInfo(subLoc);
+    const subLocDiv = cldrDom.createChunk(null, "div", "subLocale");
+    appendLocaleLink(subLocDiv, subLoc, subLocInfo);
+    parLocDiv.appendChild(subLocDiv);
+  }
+
+  function appendLocaleLink(subLocDiv, subLoc, subInfo, fullTitle) {
+    let name = locmap.getRegionAndOrVariantName(subLoc);
+    if (fullTitle) {
+      name = locmap.getLocaleName(subLoc);
+    }
+    const clickyLink = cldrDom.createChunk(name, "a", "locName");
+    clickyLink.href = linkToLocale(subLoc);
+    subLocDiv.appendChild(clickyLink);
+    if (subInfo == null) {
+      console.log("* internal: subInfo is null for " + name + " / " + subLoc);
+    }
+    if (subInfo.name_var) {
+      cldrDom.addClass(clickyLink, "name_var");
+    }
+    clickyLink.title = subLoc; // remove auto generated "locName.title"
+
+    if (subInfo.readonly) {
+      cldrDom.addClass(clickyLink, "locked");
+      cldrDom.addClass(subLocDiv, "hide");
+
+      if (subInfo.special_comment) {
+        clickyLink.title = subInfo.special_comment;
+      } else if (subInfo.dcChild) {
+        clickyLink.title = cldrText.sub("defaultContentChild_msg", {
+          name: subInfo.name,
+          dcChild: subInfo.dcChild,
+          dcChildName: locmap.getLocaleName(subInfo.dcChild),
+        });
+      } else {
+        clickyLink.title = cldrText.get("readonlyGuidance");
+      }
+    } else if (subInfo.special_comment) {
+      // could be the sandbox locale, or some other comment.
+      clickyLink.title = subInfo.special_comment;
+    }
+
+    if (canmodify && subLoc in canmodify) {
+      cldrDom.addClass(clickyLink, "canmodify");
+    } else {
+      cldrDom.addClass(subLocDiv, "hide"); // not modifiable
+    }
+    return clickyLink;
+  }
+
+  function getThePages() {
+    return _thePages;
+  }
+
+  function getTheLocaleMap() {
+    return locmap;
+  }
+
+  // getHash and setHash are replacements for dojo/hash
+  // https://dojotoolkit.org/reference-guide/1.10/dojo/hash.html
+  // return "locales///";
+
+  /**
+   * Get the window location hash
+   *
+   * For example, if the current URL is "https:...#bar", return "bar".
+   *
+   * Typically the first value we return is "locales///"
+   */
+  function getHash() {
+    // https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/location
+    let hash = sliceHash(window.location.hash);
+    console.log("getHash returning " + hash);
+    return hash;
+  }
+
+  /**
+   * Set the window location hash
+   *
+   * ... TODO: implement setHash with "replace"
+   */
+  function setHash(newHash, replace) {
+    // To manipulate the value of the hash, simply call dojo/hash with the new value.
+    // It will be added to the browser history stack and it will publish a /dojo/hashchange topic,
+    // triggering anything subscribed
+
+    // In order to not to add to the history stack, pass true as the second parameter (replace).
+    // This will update the current browser URL and replace the current history state
+
+    newHash = sliceHash(newHash);
+    if (newHash !== sliceHash(window.location.hash)) {
+      const oldUrl = window.location.href;
+      const newUrl = oldUrl.split("#")[0] + "#" + newHash;
+      console.log(
+        "setHash going to " +
+          newUrl +
+          " - Called with: " +
+          newHash +
+          " - " +
+          replace
+      );
+      window.location.href = newUrl;
+    }
+  }
+
+  // given "#foo" or "foo", return "foo"
+  function sliceHash(hash) {
+    return hash.charAt(0) === "#" ? hash.slice(1) : hash;
+  }
+
+  // Note: "ARI" probably stands for "Abort, Retry, Ignore".
+  function ariRetry() {
+    ariDialogHide();
+    window.location.reload(true);
+  }
+
+  function ariDialogShow() {
+    // TODO: implement a replacement for dijit/Dialog
+    // https://dojotoolkit.org/reference-guide/1.10/dijit/Dialog.html
+    // "<div data-dojo-type='dijit/Dialog' data-dojo-id='ariDialog' title=...
+    console.log("ariDialogShow not implemented yet!");
+  }
+
+  function ariDialogHide() {
+    console.log("ariDialogHide not implemented yet!");
+  }
+
+  function dialogIsOpen() {
+    return haveDialog;
+  }
+
+  function pseudoDijitRegistryById(id) {
+    // TODO: implement a replacement for dijit/Registry byId()
+    // https://dojotoolkit.org/reference-guide/1.10/dijit/registry.html
+    console.log("pseudoDijitRegistryById not implemented yet! id = " + id);
+    return null;
+  }
+
+  function newProgressDialog(args) {
+    // TODO: implement a replacement for dijit/Dialog (or something simpler)
+    console.log("newProgressDialog not implemented yet! args = " + args);
+    return null;
+  }
+
+  function newPseudoDijitMenuItem(args) {
+    // TODO: implement a replacement for dijit/MenuItem (or something simpler)
+    console.log("newPseudoDijitMenuItem not implemented yet! args = " + args);
+    return null;
+  }
+
+  function newPseudoDijitDropDownMenu(args) {
+    // TODO: implement a replacement for dijit/DropDownMenu (or something simpler)
+    console.log(
+      "newPseudoDijitDropDownMenu not implemented yet! args = " + args
+    );
+    return null;
+  }
+
+  function newPseudoDijitDropDownButton(args) {
+    // TODO: implement a replacement for dijit/DropDownButton (or something simpler)
+    console.log(
+      "newPseudoDijitDropDownButton not implemented yet! args = " + args
+    );
+    return null;
+  }
+
+  function flipToOtherDiv(div) {
+    flipper.flipTo(pages.other, div);
+  }
+
+  function flipToGenericNoLocale() {
+    cldrSurvey.hideLoader();
+    flipper.flipTo(
+      pages.other,
+      cldrDom.createChunk(cldrText.get("generic_nolocale"), "p", "helpContent")
+    );
+  }
+
+  function flipToEmptyOther() {
+    return flipper.flipToEmpty(pages.other);
+  }
+
+  function setLoading(loading) {
+    isLoading = loading;
+  }
+
+  function linkToLocale(subLoc) {
+    return (
+      "#/" +
+      subLoc +
+      "/" +
+      cldrStatus.getCurrentPage() +
+      "/" +
+      cldrStatus.getCurrentId()
+    );
+  }
   /*
    * Make only these functions accessible from other files:
    */
   return {
+    appendLocaleLink: appendLocaleLink,
+    ariDialogShow: ariDialogShow,
+    ariRetry: ariRetry,
+    dialogIsOpen: dialogIsOpen,
+    flipToEmptyOther: flipToEmptyOther,
+    flipToGenericNoLocale: flipToGenericNoLocale,
+    flipToOtherDiv: flipToOtherDiv,
+    getTheLocaleMap: getTheLocaleMap,
+    getThePages: getThePages,
+    insertLocaleSpecialNote: insertLocaleSpecialNote,
+    linkToLocale: linkToLocale,
+    myLoad: myLoad,
+    reloadV: reloadV,
+    replaceHash: replaceHash,
+    setLoading: setLoading,
+    showCurrentId: showCurrentId,
     showV: showV,
-    // updateWithStatus: updateWithStatus,
+    updateCurrentId: updateCurrentId,
+    updateHashAndMenus: updateHashAndMenus,
+    verifyJson: verifyJson,
+
     /*
      * The following are meant to be accessible for unit testing only:
      */
     // test: {
-    // getBodyHtml: getBodyHtml,
+    //   f: f,
     // },
   };
 })();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrLocaleMap.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrLocaleMap.js
@@ -1,4 +1,6 @@
 "use strict";
+// TODO: modernize; possibly make into a class
+// though it seems we currently only have one instance at a time?
 
 /**
  * @param aLocmap the map object from json
@@ -32,17 +34,6 @@ LocaleMap.prototype.canonicalizeLocaleId = function canonicalizeLocaleId(
   return locid;
 };
 
-window.linkToLocale = function linkToLocale(subLoc) {
-  return (
-    "#/" +
-    subLoc +
-    "/" +
-    cldrStatus.getCurrentPage() +
-    "/" +
-    cldrStatus.getCurrentId()
-  );
-};
-
 /**
  * Linkify text like '@de' into some link to German.
  *
@@ -64,7 +55,7 @@ LocaleMap.prototype.linkify = function linkify(str) {
         out =
           out +
           "<a href='" +
-          linkToLocale(match[1]) +
+          cldrLoad.linkToLocale(match[1]) +
           "' title='" +
           match[1] +
           "'>" +

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrOldVotes.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrOldVotes.js
@@ -1,0 +1,569 @@
+"use strict";
+
+/**
+ * cldrOldVotes: encapsulate the Import Old Votes feature.
+ *
+ * Use an IIFE pattern to create a namespace for the public functions,
+ * and to hide everything else, minimizing global scope pollution.
+ * Ideally this should be a module (in the sense of using import/export),
+ * but not all Survey Tool JavaScript code is capable yet of being in modules
+ * and running in strict mode.
+ */
+const cldrOldVotes = (function () {
+  // TODO: shorten this function by means of subroutines
+  function load() {
+    const curLocale = cldrStatus.getCurrentLocale();
+    const url =
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=oldvotes&_=" +
+      curLocale +
+      "&s=" +
+      cldrStatus.getSessionId() +
+      "&" +
+      cldrSurvey.cacheKill();
+    cldrLoad.myLoad(
+      url,
+      "(loading oldvotes " + curLocale + ")",
+      function (json) {
+        cldrLoad.setLoading(false);
+        cldrSurvey.showLoader(cldrText.get("loading2"));
+        if (!cldrLoad.verifyJson(json, "oldvotes")) {
+          return;
+        } else {
+          cldrSurvey.showLoader("loading..");
+          if (json.dataLoadTime) {
+            cldrDom.updateIf("dynload", json.dataLoadTime);
+          }
+          // clean slate, and proceed
+          const theDiv = cldrLoad.flipToEmptyOther();
+          cldrDom.removeAllChildNodes(theDiv);
+
+          const h2txt = cldrText.get("v_oldvotes_title");
+          theDiv.appendChild(cldrDom.createChunk(h2txt, "h2", "v-title"));
+
+          if (!json.oldvotes.locale) {
+            cldrStatus.setCurrentLocale("");
+            cldrLoad.updateHashAndMenus(false);
+
+            const ul = document.createElement("div");
+            ul.className = "oldvotes_list";
+            const data = json.oldvotes.locales.data;
+            const header = json.oldvotes.locales.header;
+
+            if (data.length > 0) {
+              data.sort((a, b) =>
+                a[header.LOCALE].localeCompare(b[header.LOCALE])
+              );
+              for (let k in data) {
+                var li = document.createElement("li");
+
+                var link = cldrDom.createChunk(
+                  data[k][header.LOCALE_NAME],
+                  "a"
+                );
+                link.href = "#" + data[k][header.LOCALE];
+                (function (loc, link) {
+                  return function () {
+                    var clicky;
+                    cldrDom.listenFor(
+                      link,
+                      "click",
+                      (clicky = function (e) {
+                        cldrStatus.setCurrentLocale(loc);
+                        cldrLoad.reloadV();
+                        cldrEvent.stopPropagation(e);
+                        return false;
+                      })
+                    );
+                    link.onclick = clicky;
+                  };
+                })(data[k][header.LOCALE], link)();
+                li.appendChild(link);
+                li.appendChild(cldrDom.createChunk(" "));
+                li.appendChild(
+                  cldrDom.createChunk("(" + data[k][header.COUNT] + ")")
+                );
+
+                ul.appendChild(li);
+              }
+
+              theDiv.appendChild(ul);
+
+              theDiv.appendChild(
+                cldrDom.createChunk(
+                  cldrText.get("v_oldvotes_locale_list_help_msg"),
+                  "p",
+                  "helpContent"
+                )
+              );
+            } else {
+              theDiv.appendChild(
+                cldrDom.createChunk(cldrText.get("v_oldvotes_no_old"), "i")
+              ); // TODO fix
+            }
+          } else {
+            cldrStatus.setCurrentLocale(json.oldvotes.locale);
+            cldrLoad.updateHashAndMenus(false);
+            var loclink;
+            theDiv.appendChild(
+              (loclink = cldrDom.createChunk(
+                cldrText.get("v_oldvotes_return_to_locale_list"),
+                "a",
+                "notselected"
+              ))
+            );
+            cldrDom.listenFor(loclink, "click", function (e) {
+              cldrStatus.setCurrentLocale("");
+              cldrLoad.reloadV();
+              cldrEvent.stopPropagation(e);
+              return false;
+            });
+            theDiv.appendChild(
+              cldrDom.createChunk(
+                json.oldvotes.localeDisplayName,
+                "h3",
+                "v-title2"
+              )
+            );
+            var oldVotesLocaleMsg = document.createElement("p");
+            oldVotesLocaleMsg.className = "helpContent";
+            oldVotesLocaleMsg.innerHTML = cldrText.sub(
+              "v_oldvotes_locale_msg",
+              {
+                version: json.oldvotes.lastVoteVersion,
+                locale: json.oldvotes.localeDisplayName,
+              }
+            );
+            theDiv.appendChild(oldVotesLocaleMsg);
+            if (
+              (json.oldvotes.contested && json.oldvotes.contested.length > 0) ||
+              (json.oldvotes.uncontested &&
+                json.oldvotes.uncontested.length > 0)
+            ) {
+              var frag = document.createDocumentFragment();
+              const oldVoteCount =
+                (json.oldvotes.contested ? json.oldvotes.contested.length : 0) +
+                (json.oldvotes.uncontested
+                  ? json.oldvotes.uncontested.length
+                  : 0);
+              var summaryMsg = cldrText.sub("v_oldvotes_count_msg", {
+                count: oldVoteCount,
+              });
+              frag.appendChild(cldrDom.createChunk(summaryMsg, "div", ""));
+
+              var navChunk = document.createElement("div");
+              navChunk.className = "v-oldVotes-nav";
+              frag.appendChild(navChunk);
+
+              var uncontestedChunk = null;
+              var contestedChunk = null;
+
+              function addOldvotesType(type, jsondata, frag, navChunk) {
+                var content = cldrDom.createChunk(
+                  "",
+                  "div",
+                  "v-oldVotes-subDiv"
+                );
+                content.strid = "v_oldvotes_title_" + type; // v_oldvotes_title_contested or v_oldvotes_title_uncontested
+
+                /* Normally this interface is for old "losing" (contested) votes only, since old "winning" (uncontested) votes
+                 * are imported automatically. An exception is for TC users, for whom auto-import is disabled. The server-side
+                 * code leaves json.oldvotes.uncontested undefined except for TC users.
+                 * Show headings for "Winning/Losing" only if json.oldvotes.uncontested is defined and non-empty.
+                 */
+                if (
+                  json.oldvotes.uncontested &&
+                  json.oldvotes.uncontested.length > 0
+                ) {
+                  var title = cldrText.get(content.strid);
+                  content.title = title;
+                  content.appendChild(
+                    cldrDom.createChunk(title, "h2", "v-oldvotes-sub")
+                  );
+                }
+
+                content.appendChild(
+                  showVoteTable(jsondata /* voteList */, type, json)
+                );
+
+                const button = document.createElement("button");
+                button.innerHTML = cldrText.get("v_submit_msg");
+                content.appendChild(button);
+                cldrDom.listenFor(button, "click", function (e) {
+                  button.innerHTML = cldrText.get("v_submit_busy");
+                  button.disabled = true;
+                  cldrDom.setDisplayed(navChunk, false);
+                  var confirmList = []; // these will be revoted with current params
+
+                  // explicit confirm list -  save us desync hassle
+                  for (var kk in jsondata) {
+                    if (jsondata[kk].box.checked) {
+                      confirmList.push(jsondata[kk].strid);
+                    }
+                  }
+
+                  var saveList = {
+                    locale: cldrStatus.getCurrentLocale(),
+                    confirmList: confirmList,
+                  };
+
+                  console.log(saveList.toString());
+                  console.log(
+                    "Submitting " +
+                      type +
+                      " " +
+                      confirmList.length +
+                      " for confirm"
+                  );
+                  const curLocale = cldrStatus.getCurrentLocale();
+                  var url =
+                    cldrStatus.getContextPath() +
+                    "/SurveyAjax?what=oldvotes&_=" +
+                    curLocale +
+                    "&s=" +
+                    cldrStatus.getSessionId() +
+                    "&doSubmit=true&" +
+                    cldrSurvey.cacheKill();
+                  cldrLoad.myLoad(
+                    url,
+                    "(submitting oldvotes " + curLocale + ")",
+                    function (json) {
+                      cldrSurvey.showLoader(cldrText.get("loading2"));
+                      if (!cldrLoad.verifyJson(json, "oldvotes")) {
+                        cldrSurvey.handleDisconnect(
+                          "Error submitting votes!",
+                          json,
+                          "Error"
+                        );
+                        return;
+                      } else {
+                        cldrLoad.reloadV();
+                      }
+                    },
+                    JSON.stringify(saveList),
+                    {
+                      "Content-Type": "application/json",
+                    }
+                  );
+                });
+
+                // hide by default
+                cldrDom.setDisplayed(content, false);
+
+                frag.appendChild(content);
+                return content;
+              }
+
+              if (
+                json.oldvotes.uncontested &&
+                json.oldvotes.uncontested.length > 0
+              ) {
+                uncontestedChunk = addOldvotesType(
+                  "uncontested",
+                  json.oldvotes.uncontested,
+                  frag,
+                  navChunk
+                );
+              }
+              if (
+                json.oldvotes.contested &&
+                json.oldvotes.contested.length > 0
+              ) {
+                contestedChunk = addOldvotesType(
+                  "contested",
+                  json.oldvotes.contested,
+                  frag,
+                  navChunk
+                );
+              }
+
+              if (contestedChunk == null && uncontestedChunk != null) {
+                cldrDom.setDisplayed(uncontestedChunk, true); // only item
+              } else if (contestedChunk != null && uncontestedChunk == null) {
+                cldrDom.setDisplayed(contestedChunk, true); // only item
+              } else {
+                // navigation
+                navChunk.appendChild(
+                  cldrDom.createChunk(cldrText.get("v_oldvotes_show"))
+                );
+                navChunk.appendChild(
+                  cldrDom.createLinkToFn(
+                    uncontestedChunk.strid,
+                    function () {
+                      cldrDom.setDisplayed(contestedChunk, false);
+                      cldrDom.setDisplayed(uncontestedChunk, true);
+                    },
+                    "button"
+                  )
+                );
+                navChunk.appendChild(
+                  cldrDom.createLinkToFn(
+                    contestedChunk.strid,
+                    function () {
+                      cldrDom.setDisplayed(contestedChunk, true);
+                      cldrDom.setDisplayed(uncontestedChunk, false);
+                    },
+                    "button"
+                  )
+                );
+
+                contestedChunk.appendChild(
+                  cldrDom.createLinkToFn(
+                    "v_oldvotes_hide",
+                    function () {
+                      cldrDom.setDisplayed(contestedChunk, false);
+                    },
+                    "button"
+                  )
+                );
+                uncontestedChunk.appendChild(
+                  cldrDom.createLinkToFn(
+                    "v_oldvotes_hide",
+                    function () {
+                      cldrDom.setDisplayed(uncontestedChunk, false);
+                    },
+                    "button"
+                  )
+                );
+              }
+              theDiv.appendChild(frag);
+            } else {
+              theDiv.appendChild(
+                cldrDom.createChunk(
+                  cldrText.get("v_oldvotes_no_old_here"),
+                  "i",
+                  ""
+                )
+              );
+            }
+          }
+        }
+        cldrSurvey.hideLoader();
+      }
+    );
+  }
+
+  /**
+   * Get a table showing old votes available for importing, along with
+   * controls for choosing which votes to import.
+   *
+   * @param voteList the array of old votes
+   * @param type "contested" for losing votes or "uncontested" for winning votes
+   * @param translationHintsLanguage a string indicating the translation hints language, generally "English"
+   * @param dir the direction, such as "ltr" for left-to-right
+   * @returns a new div element containing the table and controls
+   *
+   * Called only by addOldvotesType
+   * TODO: move this to cldrOldVotes.js
+   */
+  function showVoteTable(voteList, type, json) {
+    let translationHintsLanguage = json.TRANS_HINT_LANGUAGE_NAME;
+    let dir = json.oldvotes.dir;
+    let lastVoteVersion = json.oldvotes.lastVoteVersion;
+
+    var voteTableDiv = document.createElement("div");
+    var t = document.createElement("table");
+    t.id = "oldVotesAcceptList";
+    voteTableDiv.appendChild(t);
+    var th = document.createElement("thead");
+    var tb = document.createElement("tbody");
+    var tr = document.createElement("tr");
+    tr.appendChild(
+      cldrDom.createChunk(cldrText.get("v_oldvotes_path"), "th", "code")
+    );
+    tr.appendChild(
+      cldrDom.createChunk(translationHintsLanguage, "th", "v-comp")
+    );
+    tr.appendChild(
+      cldrDom.createChunk(
+        cldrText.sub("v_oldvotes_winning_msg", {
+          version: lastVoteVersion,
+        }),
+        "th",
+        "v-win"
+      )
+    );
+    tr.appendChild(
+      cldrDom.createChunk(cldrText.get("v_oldvotes_mine"), "th", "v-mine")
+    );
+    tr.appendChild(
+      cldrDom.createChunk(cldrText.get("v_oldvotes_accept"), "th", "v-accept")
+    );
+    th.appendChild(tr);
+    t.appendChild(th);
+    var oldSplit = [];
+    var mainCategories = [];
+    for (var k in voteList) {
+      var row = voteList[k];
+      var tr = document.createElement("tr");
+      var tdp;
+      var rowTitle = "";
+
+      // delete common substring
+      var pathSplit = row.pathHeader.split("	");
+      for (var nn in pathSplit) {
+        if (pathSplit[nn] != oldSplit[nn]) {
+          break;
+        }
+      }
+      if (nn != pathSplit.length - 1) {
+        // need a header row.
+        var trh = document.createElement("tr");
+        trh.className = "subheading";
+        var tdh = document.createElement("th");
+        tdh.colSpan = 5;
+        for (var nn in pathSplit) {
+          if (nn < pathSplit.length - 1) {
+            tdh.appendChild(
+              cldrDom.createChunk(pathSplit[nn], "span", "pathChunk")
+            );
+          }
+        }
+        trh.appendChild(tdh);
+        tb.appendChild(trh);
+      }
+      if (mainCategories.indexOf(pathSplit[0]) === -1) {
+        mainCategories.push(pathSplit[0]);
+      }
+      oldSplit = pathSplit;
+      rowTitle = pathSplit[pathSplit.length - 1];
+
+      tdp = cldrDom.createChunk("", "td", "v-path");
+
+      var dtpl = cldrDom.createChunk(rowTitle, "a");
+      dtpl.href = "v#/" + cldrStatus.getCurrentLocale() + "//" + row.strid;
+      dtpl.target = "_CLDR_ST_view";
+      tdp.appendChild(dtpl);
+
+      tr.appendChild(tdp);
+      var td00 = cldrDom.createChunk(row.baseValue, "td", "v-comp"); // english
+      tr.appendChild(td00);
+      var td0 = cldrDom.createChunk("", "td", "v-win");
+      if (row.winValue) {
+        var span0 = cldrSurvey.appendItem(td0, row.winValue, "winner");
+        span0.dir = dir;
+      }
+      tr.appendChild(td0);
+      var td1 = cldrDom.createChunk("", "td", "v-mine");
+      var label = cldrDom.createChunk("", "label", "");
+      var span1 = cldrSurvey.appendItem(label, row.myValue, "value");
+      td1.appendChild(label);
+      span1.dir = dir;
+      tr.appendChild(td1);
+      var td2 = cldrDom.createChunk("", "td", "v-accept");
+      var box = cldrDom.createChunk("", "input", "");
+      box.type = "checkbox";
+      if (type == "uncontested") {
+        // uncontested true by default
+        box.checked = true;
+      }
+      row.box = box; // backlink
+      td2.appendChild(box);
+      tr.appendChild(td2);
+
+      (function (tr, box, tdp) {
+        return function () {
+          // allow click anywhere
+          cldrDom.listenFor(tr, "click", function (e) {
+            box.checked = !box.checked;
+            cldrEvent.stopPropagation(e);
+            return false;
+          });
+          // .. but not on the path.  Also listen to the box and do nothing
+          cldrDom.listenFor([tdp, box], "click", function (e) {
+            cldrEvent.stopPropagation(e);
+            return false;
+          });
+        };
+      })(tr, box, tdp)();
+
+      tb.appendChild(tr);
+    }
+    t.appendChild(tb);
+    addImportVotesFooter(voteTableDiv, voteList, mainCategories);
+    return voteTableDiv;
+  }
+
+  /**
+   * Add to the given div a footer with buttons for choosing all or none
+   * of the old votes, and with checkboxes for choosing all or none within
+   * each of two or more main categories such as "Locale Display Names".
+   *
+   * @param voteTableDiv the div to add to
+   * @param voteList the list of old votes
+   * @param mainCategories the list of main categories
+   *
+   * Called only by showVoteTable
+   *
+   * Reference: https://unicode.org/cldr/trac/ticket/11517
+   */
+  function addImportVotesFooter(voteTableDiv, voteList, mainCategories) {
+    voteTableDiv.appendChild(
+      cldrDom.createLinkToFn(
+        "v_oldvotes_all",
+        function () {
+          for (var k in voteList) {
+            voteList[k].box.checked = true;
+          }
+          for (var cat in mainCategories) {
+            $("#cat" + cat).prop("checked", true);
+          }
+        },
+        "button"
+      )
+    );
+
+    voteTableDiv.appendChild(
+      cldrDom.createLinkToFn(
+        "v_oldvotes_none",
+        function () {
+          for (var k in voteList) {
+            voteList[k].box.checked = false;
+          }
+          for (var cat in mainCategories) {
+            $("#cat" + cat).prop("checked", false);
+          }
+        },
+        "button"
+      )
+    );
+
+    if (mainCategories.length > 1) {
+      voteTableDiv.appendChild(
+        document.createTextNode(cldrText.get("v_oldvotes_all_section"))
+      );
+      for (var cat in mainCategories) {
+        let mainCat = mainCategories[cat];
+        var checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.id = "cat" + cat;
+        voteTableDiv.appendChild(checkbox);
+        voteTableDiv.appendChild(document.createTextNode(mainCat + " "));
+        cldrDom.listenFor(checkbox, "click", function (e) {
+          for (var k in voteList) {
+            var row = voteList[k];
+            if (row.pathHeader.startsWith(mainCat)) {
+              row.box.checked = this.checked;
+            }
+          }
+          cldrEvent.stopPropagation(e);
+          return false;
+        });
+      }
+    }
+  }
+
+  /*
+   * Make only these functions accessible from other files:
+   */
+  return {
+    load: load,
+
+    /*
+     * The following are meant to be accessible for unit testing only:
+     */
+    test: {
+      // getHtml: getHtml,
+    },
+  };
+})();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrOtherSpecial.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrOtherSpecial.js
@@ -1,0 +1,146 @@
+// "use strict";
+// TODO: modernize, make strict, possibly a class
+/**
+ * Manage additional special pages
+ * @class OtherSpecial
+ */
+function OtherSpecial() {
+  // cached page list
+  this.pages = {};
+}
+
+const OTHER_SPECIAL_DEBUG = true;
+
+/**
+ * @function getSpecial
+ */
+OtherSpecial.prototype.getSpecial = function getSpecial(name) {
+  return this.pages[name];
+};
+
+/**
+ * @function loadSpecial
+ */
+OtherSpecial.prototype.loadSpecial = function loadSpecial(
+  name,
+  onSuccess,
+  onFailure
+) {
+  var special = this.getSpecial(name);
+  var otherThis = this;
+  if (special) {
+    if (OTHER_SPECIAL_DEBUG) {
+      console.log("OS: Using cached special: " + name);
+    }
+    onSuccess(special);
+  } else if (special === null) {
+    if (OTHER_SPECIAL_DEBUG) {
+      console.log("OS: cached NULL: " + name);
+    }
+    onFailure("Special page failed to load: " + name);
+  } else {
+    if (OTHER_SPECIAL_DEBUG) {
+      console.log("OS: Attempting load.." + name);
+    }
+    /***
+        try {
+          require(["js/special/" + name + ".js"], function (specialFn) {
+            if (OTHER_SPECIAL_DEBUG) {
+    	      console.log("OS: Loaded, instantiatin':" + name);
+    	    }
+            var special = new specialFn();
+            special.name = name;
+            otherThis.pages[name] = special; // cache for next time
+
+            if (OTHER_SPECIAL_DEBUG) {
+    	      console.log("OS: SUCCESS! " + name);
+    	    }
+            onSuccess(special);
+          });
+        } catch (e) {
+          if (OTHER_SPECIAL_DEBUG) {
+    	    console.log("OS: Load FAIL!:" + name + " - " + e.message + " - " + e);
+    	  }
+          if (!otherThis.pages[name]) {
+            // if the load didn't complete:
+            otherThis.pages[name] = null; // mark as don't retry load.
+          }
+          onFailure(e);
+        }
+        ***/
+  }
+};
+
+/**
+ * @function parseHash
+ */
+OtherSpecial.prototype.parseHash = function parseHash(name, hash, pieces) {
+  this.loadSpecial(
+    name,
+    function onSuccess(special) {
+      special.parseHash(hash, pieces);
+    },
+    function onFailure(e) {
+      /*
+       * TODO: get rid of this console warning for name = "oldvotes".
+       * There's not a known problem with old votes. It's not clear why
+       * the warning occurs...
+       */
+      console.log("OtherSpecial.parseHash: Failed to load " + name + " - " + e);
+    }
+  );
+};
+
+/**
+ * @function handleIdChanged
+ */
+OtherSpecial.prototype.handleIdChanged = function handleIdChanged(name, id) {
+  this.loadSpecial(
+    name,
+    function onSuccess(special) {
+      special.handleIdChanged(id);
+    },
+    function onFailure(e) {
+      console.log(
+        "OtherSpecial.handleIdChanged: Failed to load " + name + " - " + e
+      );
+    }
+  );
+};
+
+/**
+ * @function showPage
+ */
+OtherSpecial.prototype.show = function show(name, params) {
+  this.loadSpecial(
+    name,
+    function onSuccess(special) {
+      // populate the params a little more
+      params.otherSpecial = this;
+      params.name = name;
+      params.special = special;
+
+      // add anything from scope..
+
+      params.exports = {
+        appendLocaleLink: cldrLoad.appendLocaleLink,
+        handleDisconnect: cldrSurvey.handleDisconnect,
+        clickToSelect: cldrDom.clickToSelect,
+      };
+
+      special.show(params);
+    },
+    function onFailure(err) {
+      // extended error
+      var loadingChunk;
+      var msg_fmt = cldrText.sub("v_bad_special_msg", {
+        special: name,
+      });
+      params.flipper.flipTo(
+        params.pages.loading,
+        (loadingChunk = cldrDom.createChunk(msg_fmt, "p", "errCodeMsg"))
+      );
+      isLoading = false;
+    }
+  );
+};

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrStatus.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrStatus.js
@@ -114,9 +114,7 @@ const cldrStatus = (function () {
   }
 
   function setCurrentId(id) {
-    if (id || id === "") {
-      currentId = id;
-    }
+    currentId = id ? id : "";
   }
 
   /**
@@ -154,6 +152,10 @@ const cldrStatus = (function () {
   /**
    * A string such as 'en', 'fr', etc., identifying a locale
    * a.k.a. surveyCurrentLocale
+   * Caution: cldrLoad.updateHashAndMenus makes a distinction between null and
+   * empty string "" for getCurrentLocale, seemingly with the assumption that
+   * null is the original value. Later it may become empty string "", and
+   * cldrLoad.updateHashAndMenus doesn't treat that the same way.
    */
   let currentLocale = null;
 
@@ -250,13 +252,24 @@ const cldrStatus = (function () {
    * a.k.a. surveySessionId
    */
   let sessionId = null;
+  let sessionIdChangeCallback = null;
 
   function getSessionId() {
     return sessionId;
   }
 
   function setSessionId(i) {
-    sessionId = i;
+    if (i !== sessionId) {
+      sessionId = i;
+      if (sessionIdChangeCallback) {
+        sessionIdChangeCallback(sessionId);
+        sessionIdChangeCallback = null;
+      }
+    }
+  }
+
+  function setSessionIdChangeCallback(func) {
+    sessionIdChangeCallback = func;
   }
 
   /**
@@ -345,6 +358,15 @@ const cldrStatus = (function () {
     );
   }
 
+  function logoIcon() {
+    const src = cldrStatus.getContextPath() + "/STLogo.png";
+    return (
+      "<img src='" +
+      src +
+      "' align='right' border='0' title='[logo]' alt='[logo]' />"
+    );
+  }
+
   function getSurvUrl() {
     return getContextPath() + "/survey";
   }
@@ -364,6 +386,15 @@ const cldrStatus = (function () {
 
   function setIsDisconnected(d) {
     disconnected = d;
+  }
+
+  /**
+   * Are we in the Dashboard or not?
+   *
+   * @return true or false
+   */
+  function isDashboard() {
+    return getCurrentSpecial() === "r_vetting_json";
   }
 
   /*
@@ -410,6 +441,7 @@ const cldrStatus = (function () {
 
     getSessionId: getSessionId,
     setSessionId: setSessionId,
+    setSessionIdChangeCallback: setSessionIdChangeCallback,
 
     getSessionMessage: getSessionMessage,
     setSessionMessage: setSessionMessage,
@@ -428,6 +460,7 @@ const cldrStatus = (function () {
 
     stopIcon: stopIcon,
     warnIcon: warnIcon,
+    logoIcon: logoIcon,
 
     getSurvUrl: getSurvUrl,
 
@@ -435,5 +468,7 @@ const cldrStatus = (function () {
 
     isDisconnected: isDisconnected,
     setIsDisconnected: setIsDisconnected,
+
+    isDashboard: isDashboard,
   };
 })();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrSurvey.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrSurvey.js
@@ -12,98 +12,95 @@
  */
 
 const cldrSurvey = (function () {
-  const SURVEY_DEBUG = true;
-
   /*
    * INHERITANCE_MARKER indicates that the value of a candidate item is inherited.
    * Compare INHERITANCE_MARKER in CldrUtility.java.
    */
   const INHERITANCE_MARKER = "↑↑↑";
 
-  /**
-   * Is the given string for a report, that is, does it start with "r_"?
-   *
-   * @class GLOBAL
-   *
-   * @param str the string
-   * @return true if starts with "r_", else false
-   */
-  function isReport(str) {
-    return str[0] == "r" && str[1] == "_";
-  }
+  let xpathMap = null;
+
+  let wasBusted = false;
+  let didUnbust = false;
+
+  let loadOnOk = null; // TODO: SurveyMain.java writes scripts that try to reference loadOnOk
+
+  let clickContinue = null; // TODO: SurveyMain.java writes scripts that try to reference clickContinue
+
+  let surveyNextLocaleStamp = 0;
+
+  let showers = {};
+
+  let progressWord = null;
+  let ajaxWord = null;
+  let specialHeader = null; // TODO: supposed to be same as specialHeader in cldrStatus.js, or not?
+
+  let saidDisconnect = false;
+
+  let updateParts = null;
+
+  let cacheKillStamp = null;
 
   /**
-   * Remove a CSS class from a node
-   *
-   * @param {Node} obj
-   * @param {String} className
+   * Table mapping CheckCLDR.StatusAction into capabilities
+   * @property statusActionTable
    */
-  function removeClass(obj, className) {
-    if (!obj) {
-      return obj;
-    }
-    if (obj.className.indexOf(className) > -1) {
-      obj.className = obj.className.substring(className.length + 1);
-    }
-    return obj;
-  }
+  const statusActionTable = {
+    ALLOW: {
+      vote: true,
+      ticket: false,
+      change: true,
+    },
+    ALLOW_VOTING_AND_TICKET: {
+      vote: true,
+      ticket: true,
+      change: false,
+    },
+    ALLOW_VOTING_BUT_NO_ADD: {
+      vote: true,
+      ticket: false,
+      change: false,
+    },
+    ALLOW_TICKET_ONLY: {
+      vote: false,
+      ticket: true,
+      change: true,
+    },
+    DEFAULT: {
+      vote: false,
+      ticket: false,
+      change: false,
+    },
+  };
 
   /**
-   * Add a CSS class from a node
-   *
-   * @param {Node} obj
-   * @param {String} className
+   * How often to fetch updates. Default 15s.
+   * Used only for delay in calling updateStatus.
+   * May (theoretically, if it were visible) be changed by js written by SurveyMain.showOfflinePage, etc.
+   * @property timerSpeed
    */
-  function addClass(obj, className) {
-    if (!obj) {
-      return obj;
-    }
-    if (obj.className.indexOf(className) == -1) {
-      obj.className = className + " " + obj.className;
-    }
-    return obj;
+  let timerSpeed = 15000; // 15 seconds
+
+  let surveyLevels = null;
+
+  let surveyOrgCov = null;
+
+  let surveyUserCov = null;
+
+  let overridedir = null;
+
+  /************************/
+
+  function getDidUnbust() {
+    return didUnbust;
   }
 
-  /**
-   * Remove all subnodes
-   *
-   * @param {Node} td
-   */
-  function removeAllChildNodes(td) {
-    if (td == null) {
-      return;
+  function getXpathMap() {
+    if (!xpathMap) {
+      xpathMap = new XpathMap(); // TODO: is it really a singleton?
     }
-    while (td.firstChild) {
-      td.removeChild(td.firstChild);
-    }
+    return xpathMap;
   }
-
-  /**
-   * Set/remove style.display
-   */
-  function setDisplayed(div, visible) {
-    if (div === null) {
-      console.log("cldrSurvey.setDisplayed: called on null");
-      return;
-    } else if (div.domNode) {
-      cldrSurvey.setDisplayed(div.domNode, visible); // recurse, it's a dijit
-    } else if (!div.style) {
-      console.log(
-        "cldrSurvey.setDisplayed: called on malformed node " +
-          div +
-          " - no style! " +
-          Object.keys(div)
-      );
-    } else {
-      if (visible) {
-        div.style.display = "";
-      } else {
-        div.style.display = "none";
-      }
-    }
-  }
-
-  var xpathMap = new XpathMap();
 
   /**
    * Is the keyboard or input widget 'busy'? i.e., it's a bad time to change the DOM
@@ -135,64 +132,9 @@ const cldrSurvey = (function () {
     return false;
   }
 
-  /**
-   * Create a DOM object with the specified text, tag, and HTML class.
-   *
-   * @param {String} text textual content of the new object, or null for none
-   * @param {String} tag which element type to create, or null for "span"
-   * @param {String} className CSS className, or null for none.
-   * @return {Object} new DOM object
-   */
-  function createChunk(text, tag, className) {
-    if (!tag) {
-      tag = "span";
-    }
-    var chunk = document.createElement(tag);
-    if (className) {
-      chunk.className = className;
-    }
-    if (text) {
-      chunk.appendChild(document.createTextNode(text));
-    }
-    return chunk;
-  }
-
-  /**
-   * Uppercase the first letter of a sentence
-   * @return {String} string with first letter uppercase
-   */
-  String.prototype.ucFirst = function () {
-    return this.charAt(0).toUpperCase() + this.slice(1);
-  };
-
-  /**
-   * Create a 'link' that goes to a function. By default it's an 'a', but could be a button, etc.
-   * @param strid  {String} string to be used with cldrText.get
-   * @param fn {function} function, given the DOM obj as param
-   * @param tag {String}  tag of new obj.  'a' by default.
-   * @return {Element} newobj
-   */
-  function createLinkToFn(strid, fn, tag) {
-    if (!tag) {
-      tag = "a";
-    }
-    var msg = cldrText.get(strid);
-    var obj = document.createElement(tag);
-    obj.appendChild(document.createTextNode(msg));
-    if (tag == "a") {
-      obj.href = "";
-    }
-    listenFor(obj, "click", function (e) {
-      fn(obj);
-      stStopPropagation(e);
-      return false;
-    });
-    return obj;
-  }
-
-  function createGravitar(user) {
+  function createGravatar(user) {
     if (user.emailHash) {
-      var gravatar = document.createElement("img");
+      const gravatar = document.createElement("img");
       gravatar.src =
         "https://www.gravatar.com/avatar/" +
         user.emailHash +
@@ -214,187 +156,58 @@ const cldrSurvey = (function () {
     var userLevelLc = user.userlevelName.toLowerCase();
     var userLevelClass = "userlevel_" + userLevelLc;
     var userLevelStr = cldrText.get(userLevelClass);
-    var div = createChunk(null, "div", "adminUserUser");
-    div.appendChild(createGravitar(user));
-    div.userLevel = createChunk(userLevelStr, "i", userLevelClass);
+    var div = cldrDom.createChunk(null, "div", "adminUserUser");
+    div.appendChild(createGravatar(user));
+    div.userLevel = cldrDom.createChunk(userLevelStr, "i", userLevelClass);
     div.appendChild(div.userLevel);
     div.appendChild(
-      (div.userName = createChunk(user.name, "span", "adminUserName"))
+      (div.userName = cldrDom.createChunk(user.name, "span", "adminUserName"))
     );
     if (!user.orgName) {
       user.orgName = user.org;
     }
     div.appendChild(
-      (div.userOrg = createChunk(
+      (div.userOrg = cldrDom.createChunk(
         user.orgName + " #" + user.id,
         "span",
         "adminOrgName"
       ))
     );
     div.appendChild(
-      (div.userEmail = createChunk(user.email, "address", "adminUserAddress"))
+      (div.userEmail = cldrDom.createChunk(
+        user.email,
+        "address",
+        "adminUserAddress"
+      ))
     );
     return div;
   }
 
   /**
-   * Used from within event handlers. cross platform 'stop propagation'
-   *
-   * @param e event
-   * @returns true or false
-   *
-   * Called from numerous js files
-   */
-  function stStopPropagation(e) {
-    if (!e) {
-      return false;
-    } else if (e.stopPropagation) {
-      return e.stopPropagation();
-    } else if (e.cancelBubble) {
-      return e.cancelBubble();
-    } else {
-      // hope for the best
-      return false;
-    }
-  }
-
-  /**
-   * Is debugging enabled?
-   *
-   * @property stdebug_enabled
-   */
-  var stdebug_enabled = window.location.search.indexOf("&stdebug=") > -1;
-
-  function stdebug(x) {
-    if (stdebug_enabled) {
-      console.log(x);
-    }
-  }
-
-  stdebug("stdebug is enabled.");
-
-  /**
-   * Update the item, if it exists
-   *
-   * @param id ID of DOM node, or a Node itself
-   * @param txt text to replace with - should just be plaintext, but currently can be HTML
-   */
-  function updateIf(id, txt) {
-    var something;
-    if (id instanceof Node) {
-      something = id;
-    } else {
-      something = document.getElementById(id);
-    }
-    if (something != null) {
-      something.innerHTML = txt; // TODO shold only use for plain text
-    }
-  }
-
-  /**
-   * Add an event listener function to the object.
-   *
-   * @param {DOM} what object to listen to (or array of them)
-   * @param {String} what event, bare name such as 'click'
-   * @param {Function} fn function, of the form:  function(e) { 	doSomething();  	stStopPropagation(e);  	return false; }
-   * @param {String} ievent IE name of an event, if not 'on'+what
-   * @return {DOM} returns the object what (or the array)
-   */
-  function listenFor(whatArray, event, fn, ievent) {
-    function listenForOne(what, event, fn, ievent) {
-      if (!what._stlisteners) {
-        what._stlisteners = {};
-      }
-
-      if (what.addEventListener) {
-        if (what._stlisteners[event]) {
-          if (what.removeEventListener) {
-            what.removeEventListener(event, what._stlisteners[event], false);
-          } else {
-            console.log("Err: no removeEventListener on " + what);
-          }
-        }
-        what.addEventListener(event, fn, false);
-      } else {
-        if (!ievent) {
-          ievent = "on" + event;
-        }
-        if (what._stlisteners[event]) {
-          what.detachEvent(ievent, what._stlisteners[event]);
-        }
-        what.attachEvent(ievent, fn);
-      }
-      what._stlisteners[event] = fn;
-
-      return what;
-    }
-
-    if (Array.isArray(whatArray)) {
-      for (var k in whatArray) {
-        listenForOne(whatArray[k], event, fn, ievent);
-      }
-      return whatArray;
-    } else {
-      return listenForOne(whatArray, event, fn, ievent);
-    }
-  }
-
-  /**
-   * On click, select all
-   *
-   * @param {Node} obj to listen to
-   * @param {Node} targ to select
-   */
-  function clickToSelect(obj, targ) {
-    if (!targ) {
-      targ = obj;
-    }
-    listenFor(obj, "click", function (e) {
-      if (window.getSelection) {
-        window.getSelection().selectAllChildren(targ);
-      }
-      stStopPropagation(e);
-      return false;
-    });
-    return obj;
-  }
-
-  var wasBusted = false;
-  var wasOk = false;
-  var loadOnOk = null;
-  var clickContinue = null;
-  var surveyNextLocaleStamp = 0;
-  var surveyNextLocaleStampId = "";
-
-  /**
    * Mark the page as busted. Don't do any more requests.
    */
   function busted() {
-    setIsDisconnected(true);
-    stdebug("disconnected.");
-    addClass(document.getElementsByTagName("body")[0], "disconnected");
+    cldrStatus.setIsDisconnected(true);
+    cldrDom.addClass(document.getElementsByTagName("body")[0], "disconnected");
   }
 
-  var didUnbust = false;
-
+  // referenced in cldrGui.js but not actually called yet for non-dojo, due to data-dojo-props dependency
   function unbust() {
     didUnbust = true;
     console.log("Un-busting");
     progressWord = "unbusted";
-    setIsDisconnected(false);
+    cldrStatus.setIsDisconnected(false);
     saidDisconnect = false;
-    removeClass(document.getElementsByTagName("body")[0], "disconnected");
+    cldrDom.removeClass(
+      document.getElementsByTagName("body")[0],
+      "disconnected"
+    );
     wasBusted = false;
     cldrAjax.clearXhr();
     hideLoader();
     saidDisconnect = false;
     updateStatus(); // will restart regular status updates
   }
-
-  // hashtable of items already verified
-  var alreadyVerifyValue = {};
-
-  var showers = {};
 
   /**
    * Process that the locale has changed under us.
@@ -421,25 +234,21 @@ const cldrSurvey = (function () {
        * TODO: explain this code. When, if ever, is it executed, and why?
        * Typically Object.keys(showers).length != 0.
        */
-      updateIf("stchanged_loc", name);
+      cldrDom.updateIf("stchanged_loc", name);
       var locDiv = document.getElementById("stchanged");
       if (locDiv) {
         locDiv.style.display = "block";
       }
     } else {
-      for (i in showers) {
-        var fn = showers[i];
+      for (let i in showers) {
+        const fn = showers[i];
         if (fn) {
           fn();
         }
       }
     }
-    stdebug("Reloaded due to change: " + stamp);
     surveyNextLocaleStamp = stamp;
   }
-  var progressWord = null;
-  var ajaxWord = null;
-  var specialHeader = null;
 
   /**
    * Update the 'status' if need be.
@@ -457,7 +266,10 @@ const cldrSurvey = (function () {
       (progressWord && progressWord == "error")
     ) {
       // top priority
-      popupAlert("danger", cldrStatus.stopIcon() + cldrText.get(progressWord));
+      cldrEvent.popupAlert(
+        "danger",
+        cldrStatus.stopIcon() + cldrText.get(progressWord)
+      );
       busted(); // no further processing.
     } else if (ajaxWord) {
       p.className = "progress-ok";
@@ -469,7 +281,7 @@ const cldrSurvey = (function () {
       }
     } else if (progressWord == "startup") {
       p.className = "progress-ok";
-      popupAlert("warning", cldrText.get("online"));
+      cldrEvent.popupAlert("warning", cldrText.get("online"));
     }
   }
 
@@ -491,31 +303,6 @@ const cldrSurvey = (function () {
   function updateAjaxWord(ajax) {
     ajaxWord = ajax;
     showWord();
-  }
-
-  var saidDisconnect = false;
-
-  /**
-   * @param why
-   * @param json
-   * @param word
-   * @param oneword
-   * @param p
-   */
-  function showARIDialog(why, json, word, oneword, p) {
-    console.log("Can't recover, not in /v or not loaded yet.");
-    // has not been loaded yet.
-  }
-
-  /**
-   * @param why
-   * @param json
-   * @param word
-   * @param oneword
-   * @param p
-   */
-  function ariRetry() {
-    window.location.reload(true);
   }
 
   /**
@@ -569,7 +356,7 @@ const cldrSurvey = (function () {
           subDiv.appendChild(chunk);
           p.appendChild(subDiv);
           if (oneword.details) {
-            cldrSurvey.setDisplayed(oneword.details, false);
+            cldrDom.setDisplayed(oneword.details, false);
           }
           oneword.onclick = null;
           return false;
@@ -586,17 +373,47 @@ const cldrSurvey = (function () {
         subDiv.appendChild(detailsButton);
         oneword.details = detailsButton;
         p.appendChild(subDiv);
-        showARIDialog(why, json, word, oneword, subDiv, what);
-      }
-      if (json) {
-        stdebug("JSON: " + json.toString());
+        showARIDialog(why, json, oneword, subDiv, what);
       }
     }
   }
 
-  var updateParts = null;
+  function showARIDialog(why, json, oneword, p, what) {
+    console.log("showARIDialog");
+    p.parentNode.removeChild(p);
 
-  var cacheKillStamp = null;
+    if (didUnbust) {
+      why = why + "\n\n" + cldrText.get("ari_force_reload");
+    }
+
+    // setup with why
+    var ari_message;
+
+    if (json && json.session_err) {
+      ari_message = cldrText.get("ari_sessiondisconnect_message");
+    } else {
+      ari_message = cldrText.get("ari_message");
+    }
+
+    var ari_submessage = formatErrMsg(json, what);
+
+    cldrDom.updateIf("ariMessage", ari_message.replace(/\n/g, "<br>"));
+    cldrDom.updateIf("ariSubMessage", ari_submessage.replace(/\n/g, "<br>"));
+    cldrDom.updateIf(
+      "ariScroller",
+      window.location + "<br>" + why.replace(/\n/g, "<br>")
+    );
+    cldrEvent.hideOverlayAndSidebar();
+
+    cldrLoad.ariDialogShow();
+
+    var oneword = document.getElementById("progress_oneword");
+    oneword.onclick = function () {
+      if (cldrStatus.isDisconnected()) {
+        ariDialogShow();
+      }
+    };
+  }
 
   /**
    * Return a string to be used with a URL to avoid caching. Ignored by the server.
@@ -636,11 +453,6 @@ const cldrSurvey = (function () {
     } catch (e) {}
   }
 
-  var lastJsonStatus = null;
-
-  /*
-   * TODO: formatErrMsg is called only in CldrSurveyVettingLoader.js, so move it there
-   */
   function formatErrMsg(json, subkey) {
     if (!subkey) {
       subkey = "unknown";
@@ -720,7 +532,6 @@ const cldrSurvey = (function () {
     }
 
     if (json.status) {
-      lastJsonStatus = json.status;
       cldrStatus.updateAll(json.status);
       cldrGui.updateWithStatus();
       if (!updateParts) {
@@ -740,15 +551,15 @@ const cldrSurvey = (function () {
         ugtext = ugtext + json.status.guests + " guests, ";
       }
       ugtext = ugtext + json.status.pages + "pg/" + json.status.uptime;
-      removeAllChildNodes(updateParts.ug);
+      cldrDom.removeAllChildNodes(updateParts.ug);
       updateParts.ug.appendChild(document.createTextNode(ugtext));
 
-      removeAllChildNodes(updateParts.load);
+      cldrDom.removeAllChildNodes(updateParts.load);
       updateParts.load.appendChild(
         document.createTextNode("Load:" + json.status.sysload)
       );
 
-      removeAllChildNodes(updateParts.db);
+      cldrDom.removeAllChildNodes(updateParts.db);
       updateParts.db.appendChild(
         document.createTextNode(
           "db:" + json.status.dbopen + "/" + json.status.dbused
@@ -763,18 +574,12 @@ const cldrSurvey = (function () {
       fragment.appendChild(updateParts.db);
 
       if (updateParts.visitors) {
-        removeAllChildNodes(updateParts.visitors);
+        cldrDom.removeAllChildNodes(updateParts.visitors);
         updateParts.visitors.appendChild(fragment);
       }
 
       function standOutMessage(txt) {
         return "<b style='font-size: x-large; color: red;'>" + txt + "</b>";
-      }
-
-      if (window.kickMe) {
-        json.millisTillKick = 0;
-      } else if (window.kickMeSoon) {
-        json.millisTillKick = 5000;
       }
 
       const surveyUser = cldrStatus.getSurveyUser();
@@ -798,8 +603,11 @@ const cldrSurvey = (function () {
         var kmsg = cldrText.get("ari_sessiondisconnect_message");
         console.log(kmsg);
         updateSpecialHeader(standOutMessage(kmsg));
-        cldrStatus.setDisconnected(true);
-        addClass(document.getElementsByTagName("body")[0], "disconnected");
+        cldrStatus.setIsDisconnected(true);
+        cldrDom.addClass(
+          document.getElementsByTagName("body")[0],
+          "disconnected"
+        );
         if (!json.session_err) {
           json.session_err = "disconnected";
         }
@@ -816,24 +624,26 @@ const cldrSurvey = (function () {
   }
 
   /**
-   * How often to fetch updates. Default 15s.
-   * Used only for delay in calling updateStatus.
-   * May be changed by resetTimerSpeed -- but resetTimerSpeed is NEVER called
-   * @property timerSpeed
-   */
-  var timerSpeed = 15000; // 15 seconds
-
-  /**
    * This is called periodically to fetch latest ST status
    */
   function updateStatus() {
     if (cldrStatus.isDisconnected()) {
-      stdebug("Not updating status - disconnected.");
       return;
     }
 
-    var surveyLocaleUrl = "";
-    var surveySessionUrl = "";
+    const xhrArgs = {
+      url: makeUpdateStatusUrl(),
+      handleAs: "json",
+      load: updateStatusLoadHandler,
+      error: updateStatusErrHandler,
+    };
+
+    cldrAjax.sendXhr(xhrArgs);
+  }
+
+  function makeUpdateStatusUrl() {
+    let surveyLocaleUrl = "";
+    let surveySessionUrl = "";
     const curLocale = cldrStatus.getCurrentLocale();
     if (curLocale !== null && curLocale != "") {
       surveyLocaleUrl = "&_=" + curLocale;
@@ -842,155 +652,101 @@ const cldrSurvey = (function () {
     if (sessionId) {
       surveySessionUrl = "&s=" + sessionId;
     }
-
-    cldrAjax.sendXhr({
-      url:
-        cldrStatus.getContextPath() +
-        "/SurveyAjax?what=status" +
-        surveyLocaleUrl +
-        surveySessionUrl +
-        cacheKill(),
-      handleAs: "json",
-      load: function (json) {
-        if (json == null || (json.status && json.status.isBusted)) {
-          wasBusted = true;
-          busted();
-          return; // don't thrash
-        }
-        var st_err = document.getElementById("st_err");
-        if (!st_err) {
-          /*
-           * This happens if updateStatus is called for a page like about.jsp, browse.jsp;
-           * it shouldn't be called in such cases.
-           */
-          return;
-        }
-        if (json.err != null && json.err.length > 0) {
-          st_err.innerHTML = json.err;
-          if (
-            json.status &&
-            cldrStatus.runningStampChanged(json.status.surveyRunningStamp)
-          ) {
-            st_err.innerHTML =
-              st_err.innerHTML +
-              " <b>Note: Lost connection with Survey Tool or it restarted.</b>";
-            updateStatusBox({
-              disconnected: true,
-            });
-          }
-          st_err.className = "ferrbox";
-          wasBusted = true;
-          busted();
-        } else {
-          if (cldrStatus.runningStampChanged(json.status.surveyRunningStamp)) {
-            st_err.className = "ferrbox";
-            st_err.innerHTML =
-              "The SurveyTool has been restarted. Please reload this page to continue.";
-            wasBusted = true;
-            busted();
-            // TODO: show ARI for reconnecting
-          } else if (
-            (wasBusted == true && !json.status.isBusted) ||
-            cldrStatus.runningStampChanged(json.status.surveyRunningStamp)
-          ) {
-            st_err.innerHTML =
-              "Note: Lost connection with Survey Tool or it restarted.";
-            if (clickContinue != null) {
-              st_err.innerHTML =
-                st_err.innerHTML +
-                " Please <a href='" +
-                clickContinue +
-                "'>click here</a> to continue.";
-            } else {
-              st_err.innerHTML =
-                st_err.innerHTML + " Please reload this page to continue.";
-            }
-            st_err.className = "ferrbox";
-            busted();
-          } else {
-            st_err.className = "";
-            removeAllChildNodes(st_err);
-          }
-        }
-        updateStatusBox(json);
-
-        if (json.localeStamp) {
-          if (surveyNextLocaleStamp == 0) {
-            surveyNextLocaleStamp = json.localeStamp;
-            stdebug(
-              "STATUS0: " + json.localeStampName + "=" + json.localeStamp
-            );
-          } else {
-            if (json.localeStamp > surveyNextLocaleStamp) {
-              stdebug(
-                "STATUS=: " +
-                  json.localeStampName +
-                  "=" +
-                  json.localeStamp +
-                  " > " +
-                  surveyNextLocaleStamp
-              );
-              handleChangedLocaleStamp(json.localeStamp, json.localeStampName);
-            } else {
-              stdebug(
-                "STATUS=: " +
-                  json.localeStampName +
-                  "=" +
-                  json.localeStamp +
-                  " <= " +
-                  surveyNextLocaleStamp
-              );
-            }
-          }
-        }
-
-        if (wasBusted == false && json.status.isSetup && loadOnOk != null) {
-          window.location.replace(loadOnOk);
-        } else {
-          setTimeout(updateStatus, timerSpeed);
-        }
-      },
-      error: function (err) {
-        wasBusted = true;
-        updateStatusBox({
-          err: err,
-          disconnected: true,
-        });
-      },
-    });
+    return (
+      cldrStatus.getContextPath() +
+      "/SurveyAjax?what=status" +
+      surveyLocaleUrl +
+      surveySessionUrl +
+      cacheKill()
+    );
   }
 
-  /**
-   * Table mapping CheckCLDR.StatusAction into capabilities
-   * @property statusActionTable
-   */
-  var statusActionTable = {
-    ALLOW: {
-      vote: true,
-      ticket: false,
-      change: true,
-    },
-    ALLOW_VOTING_AND_TICKET: {
-      vote: true,
-      ticket: true,
-      change: false,
-    },
-    ALLOW_VOTING_BUT_NO_ADD: {
-      vote: true,
-      ticket: false,
-      change: false,
-    },
-    ALLOW_TICKET_ONLY: {
-      vote: false,
-      ticket: true,
-      change: true,
-    },
-    DEFAULT: {
-      vote: false,
-      ticket: false,
-      change: false,
-    },
-  };
+  function updateStatusLoadHandler(json) {
+    if (json == null || (json.status && json.status.isBusted)) {
+      wasBusted = true;
+      busted();
+      return; // don't thrash
+    }
+    const st_err = document.getElementById("st_err");
+    if (!st_err) {
+      /*
+       * This happens if updateStatus is called for a page like about.jsp, browse.jsp;
+       * it shouldn't be called in such cases.
+       */
+      return;
+    }
+    if (json.err != null && json.err.length > 0) {
+      st_err.innerHTML = json.err;
+      if (
+        json.status &&
+        cldrStatus.runningStampChanged(json.status.surveyRunningStamp)
+      ) {
+        st_err.innerHTML =
+          st_err.innerHTML +
+          " <b>Note: Lost connection with Survey Tool or it restarted.</b>";
+        updateStatusBox({
+          disconnected: true,
+        });
+      }
+      st_err.className = "ferrbox";
+      wasBusted = true;
+      busted();
+    } else {
+      if (cldrStatus.runningStampChanged(json.status.surveyRunningStamp)) {
+        st_err.className = "ferrbox";
+        st_err.innerHTML =
+          "The SurveyTool has been restarted. Please reload this page to continue.";
+        wasBusted = true;
+        busted();
+        // TODO: show ARI for reconnecting
+      } else if (
+        (wasBusted == true && !json.status.isBusted) ||
+        cldrStatus.runningStampChanged(json.status.surveyRunningStamp)
+      ) {
+        st_err.innerHTML =
+          "Note: Lost connection with Survey Tool or it restarted.";
+        if (clickContinue != null) {
+          st_err.innerHTML =
+            st_err.innerHTML +
+            " Please <a href='" +
+            clickContinue +
+            "'>click here</a> to continue.";
+        } else {
+          st_err.innerHTML =
+            st_err.innerHTML + " Please reload this page to continue.";
+        }
+        st_err.className = "ferrbox";
+        busted();
+      } else {
+        st_err.className = "";
+        cldrDom.removeAllChildNodes(st_err);
+      }
+    }
+    updateStatusBox(json);
+
+    if (json.localeStamp) {
+      if (surveyNextLocaleStamp == 0) {
+        surveyNextLocaleStamp = json.localeStamp;
+      } else {
+        if (json.localeStamp > surveyNextLocaleStamp) {
+          handleChangedLocaleStamp(json.localeStamp, json.localeStampName);
+        }
+      }
+    }
+    if (wasBusted == false && json.status.isSetup && loadOnOk != null) {
+      window.location.replace(loadOnOk);
+    } else {
+      setTimeout(updateStatus, timerSpeed);
+    }
+  }
+
+  function updateStatusErrHandler(err) {
+    wasBusted = true;
+    updateStatusBox({
+      err: err,
+      disconnected: true,
+    });
+  }
 
   /**
    * Parse a CheckCLDR.StatusAction and return the capabilities table
@@ -1136,25 +892,6 @@ const cldrSurvey = (function () {
   }
 
   /**
-   * Show the 'loading' sign
-   *
-   * @param loaderDiv ignored
-   * @param {String} text text to use
-   */
-  function showLoader(loaderDiv, text) {
-    updateAjaxWord(text);
-  }
-
-  /**
-   * Hide the 'loading' sign
-   *
-   * @param loaderDiv ignored
-   */
-  function hideLoader(loaderDiv) {
-    updateAjaxWord(null);
-  }
-
-  /**
    * Wire up the button to perform a submit
    *
    * @param button
@@ -1187,9 +924,9 @@ const cldrSurvey = (function () {
     } else {
       button.id = "v" + vHash + "_" + tr.rowHash;
     }
-    listenFor(button, "click", function (e) {
+    cldrDom.listenFor(button, "click", function (e) {
       handleWiredClick(tr, theRow, vHash, box, button);
-      stStopPropagation(e);
+      cldrEvent.stopPropagation(e);
       return false;
     });
 
@@ -1227,729 +964,12 @@ const cldrSurvey = (function () {
     return star;
   }
 
-  var gPopStatus = {
-    unShow: null,
-    lastShown: null,
-    lastTr: null,
-    popToken: 0,
-  };
-
-  /**
-   * This is the actual function is called to display the right-hand "info" panel.
-   *
-   * @param {String} str the string to show at the top
-   * @param {Node} tr the <TR> of the row
-   * @param {Boolean} hideIfLast
-   * @param {Function} fn
-   * @param {Boolean} immediate
-   */
-  function showInPop(str, tr, theObj, fn, immediate) {
-    showInPop2(str, tr, hideIfLast, fn);
-  }
-
-  /**
-   * Make the object "theObj" cause the infowindow to show when clicked.
-   *
-   * @param {String} str
-   * @param {Node} tr the TR element that is clicked
-   * @param {Node} theObj to listen to
-   * @param {Function} fn the draw function
-   * @returns {Function}
-   */
-  function listenToPop(str, tr, theObj, fn) {
-    var theFn;
-    listenFor(
-      theObj,
-      "click",
-      (theFn = function (e) {
-        showInPop(str, tr, theObj, fn, true);
-        stStopPropagation(e);
-        return false;
-      })
-    );
-    return theFn;
-  }
-
-  function getPopToken() {
-    return gPopStatus.popToken;
-  }
-
-  function incrPopToken(x) {
-    ++gPopStatus.popToken;
-    return gPopStatus.popToken;
-  }
-
-  /**
-   * Timeout for showing sideways view
-   */
-  var sidewaysShowTimeout = -1;
-
-  /**
-   *  Array storing all only-1 sublocale
-   */
-  var oneLocales = [];
-
-  /**
-   * Called when showing the popup each time
-   *
-   * @param {Node} frag
-   * @param {Node} forumDivClone = tr.forumDiv.cloneNode(true)
-   * @param {Node} tr
-   *
-   * TODO: shorten this function
-   */
-  function showForumStuff(frag, forumDivClone, tr) {
-    var isOneLocale = false;
-    if (oneLocales[cldrStatus.getCurrentLocale()]) {
-      isOneLocale = true;
-    }
-    if (!isOneLocale) {
-      var sidewaysControl = createChunk(
-        cldrText.get("sideways_loading0"),
-        "div",
-        "sidewaysArea"
-      );
-      frag.appendChild(sidewaysControl);
-
-      function clearMyTimeout() {
-        if (sidewaysShowTimeout != -1) {
-          window.clearInterval(sidewaysShowTimeout);
-          sidewaysShowTimeout = -1;
-        }
-      }
-      clearMyTimeout();
-      sidewaysShowTimeout = window.setTimeout(function () {
-        clearMyTimeout();
-        updateIf(sidewaysControl, cldrText.get("sideways_loading1"));
-
-        var url =
-          cldrStatus.getContextPath() +
-          "/SurveyAjax?what=getsideways&_=" +
-          cldrStatus.getCurrentLocale() +
-          "&s=" +
-          cldrStatus.getSessionId() +
-          "&xpath=" +
-          tr.theRow.xpstrid +
-          cacheKill();
-        myLoad(url, "sidewaysView", function (json) {
-          /*
-           * Count the number of unique locales in json.others and json.novalue.
-           */
-          var relatedLocales = json.novalue.slice();
-          for (var s in json.others) {
-            for (var t in json.others[s]) {
-              relatedLocales[json.others[s][t]] = true;
-            }
-          }
-          // if there is 1 sublocale (+ 1 default), we do nothing
-          if (Object.keys(relatedLocales).length <= 2) {
-            oneLocales[cldrStatus.getCurrentLocale()] = true;
-            updateIf(sidewaysControl, "");
-          } else {
-            if (!json.others) {
-              updateIf(sidewaysControl, ""); // no sibling locales (or all null?)
-            } else {
-              updateIf(sidewaysControl, ""); // remove string
-
-              var topLocale = json.topLocale;
-              var curLocale = locmap.getRegionAndOrVariantName(topLocale);
-              var readLocale = null;
-
-              // merge the read-only sublocale to base locale
-              var mergeReadBase = function mergeReadBase(list) {
-                var baseValue = null;
-                // find the base locale, remove it and store its value
-                for (var l = 0; l < list.length; l++) {
-                  var loc = list[l][0];
-                  if (loc === topLocale) {
-                    baseValue = list[l][1];
-                    list.splice(l, 1);
-                    break;
-                  }
-                }
-
-                // replace the default locale(read-only) with base locale, store its name for label
-                for (var l = 0; l < list.length; l++) {
-                  var loc = list[l][0];
-                  var bund = locmap.getLocaleInfo(loc);
-                  if (bund && bund.readonly) {
-                    readLocale = locmap.getRegionAndOrVariantName(loc);
-                    list[l][0] = topLocale;
-                    list[l][1] = baseValue;
-                    break;
-                  }
-                }
-              };
-
-              // compare all sublocale values
-              var appendLocaleList = function appendLocaleList(list, curValue) {
-                var group = document.createElement("optGroup");
-                var br = document.createElement("optGroup");
-                group.appendChild(br);
-
-                group.setAttribute(
-                  "label",
-                  "Regional Variants for " + curLocale
-                );
-                group.setAttribute(
-                  "title",
-                  "Regional Variants for " + curLocale
-                );
-
-                var escape = "\u00A0\u00A0\u00A0";
-                var unequalSign = "\u2260\u00A0";
-
-                for (var l = 0; l < list.length; l++) {
-                  var loc = list[l][0];
-                  var title = list[l][1];
-                  var item = document.createElement("option");
-                  item.setAttribute("value", loc);
-                  if (title == null) {
-                    item.setAttribute("title", "undefined");
-                  } else {
-                    item.setAttribute("title", title);
-                  }
-
-                  var str = locmap.getRegionAndOrVariantName(loc);
-                  if (loc === topLocale) {
-                    str = str + " (= " + readLocale + ")";
-                  }
-
-                  if (loc === cldrStatus.getCurrentLocale()) {
-                    str = escape + str;
-                    item.setAttribute("selected", "selected");
-                    item.setAttribute("disabled", "disabled");
-                  } else if (title != curValue) {
-                    str = unequalSign + str;
-                  } else {
-                    str = escape + str;
-                  }
-                  item.appendChild(document.createTextNode(str));
-                  group.appendChild(item);
-                }
-                popupSelect.appendChild(group);
-              };
-
-              var dataList = [];
-
-              var popupSelect = document.createElement("select");
-              for (var s in json.others) {
-                for (var t in json.others[s]) {
-                  dataList.push([json.others[s][t], s]);
-                }
-              }
-
-              /*
-               * Set curValue = the value for cldrStatus.getCurrentLocale()
-               */
-              var curValue = null;
-              for (var l = 0; l < dataList.length; l++) {
-                var loc = dataList[l][0];
-                if (loc === cldrStatus.getCurrentLocale()) {
-                  curValue = dataList[l][1];
-                  break;
-                }
-              }
-              /*
-               * Force the use of unequalSign in the regional comparison pop-up for locales in
-               * json.novalue, by assigning a value that's different from curValue.
-               *
-               * Formerly the inherited value (based on topLocale) was used here; that was a bug.
-               * If the server doesn't know the winning value, then the client shouldn't pretend to know.
-               * The server code has been fixed to resolve most such cases.
-               *
-               * Reference: https://unicode.org/cldr/trac/ticket/11688
-               */
-              if (json.novalue) {
-                const differentValue = curValue === "A" ? "B" : "A"; // anything different from curValue
-                for (s in json.novalue) {
-                  dataList.push([json.novalue[s], differentValue]);
-                }
-              }
-              mergeReadBase(dataList);
-
-              // then sort by sublocale name
-              dataList = dataList.sort(function (a, b) {
-                return (
-                  locmap.getRegionAndOrVariantName(a[0]) >
-                  locmap.getRegionAndOrVariantName(b[0])
-                );
-              });
-              appendLocaleList(dataList, curValue);
-
-              var group = document.createElement("optGroup");
-              popupSelect.appendChild(group);
-
-              listenFor(popupSelect, "change", function (e) {
-                var newLoc = popupSelect.value;
-                if (newLoc !== cldrStatus.getCurrentLocale()) {
-                  cldrStatus.setCurrentLocale(newLoc);
-                  reloadV();
-                }
-                return stStopPropagation(e);
-              });
-
-              sidewaysControl.appendChild(popupSelect);
-            }
-          }
-        });
-      }, 2000); // wait 2 seconds before loading this.
-    }
-
-    if (tr.theRow) {
-      const theRow = tr.theRow;
-      const couldFlag =
-        theRow.canFlagOnLosing &&
-        theRow.voteVhash !== theRow.winningVhash &&
-        theRow.voteVhash !== "" &&
-        !theRow.rowFlagged;
-      const myValue = theRow.hasVoted ? getUsersValue(theRow) : null;
-      cldrForum.addNewPostButtons(
-        frag,
-        cldrStatus.getCurrentLocale(),
-        couldFlag,
-        theRow.xpstrid,
-        theRow.code,
-        myValue
-      );
-    }
-
-    var loader2 = createChunk(cldrText.get("loading"), "i");
-    frag.appendChild(loader2);
-
-    /**
-     * @param {Integer} nrPosts
-     */
-    function havePosts(nrPosts) {
-      cldrSurvey.setDisplayed(loader2, false); // not needed
-      tr.forumDiv.forumPosts = nrPosts;
-
-      if (nrPosts == 0) {
-        return; // nothing to do,
-      }
-
-      var showButton = createChunk(
-        "Show " + tr.forumDiv.forumPosts + " posts",
-        "button",
-        "forumShow"
-      );
-
-      forumDivClone.appendChild(showButton);
-
-      var theListen = function (e) {
-        cldrSurvey.setDisplayed(showButton, false);
-        updateInfoPanelForumPosts(tr);
-        stStopPropagation(e);
-        return false;
-      };
-      listenFor(showButton, "click", theListen);
-      listenFor(showButton, "mouseover", theListen);
-    }
-
-    // lazy load post count!
-    // load async
-    var ourUrl = tr.forumDiv.url + "&what=forum_count" + cacheKill();
-    window.setTimeout(function () {
-      var xhrArgs = {
-        url: ourUrl,
-        handleAs: "json",
-        load: function (json) {
-          if (json && json.forum_count !== undefined) {
-            havePosts(parseInt(json.forum_count));
-          } else {
-            console.log("Some error loading post count??");
-          }
-        },
-      };
-      cldrAjax.queueXhr(xhrArgs);
-    }, 1900);
-
-    function getUsersValue(theRow) {
-      "use strict";
-      const surveyUser = cldrStatus.getSurveyUser();
-      if (surveyUser && surveyUser.id) {
-        if (theRow.voteVhash && theRow.voteVhash !== "") {
-          const item = theRow.items[theRow.voteVhash];
-          if (item && item.votes && item.votes[surveyUser.id]) {
-            if (item.value === INHERITANCE_MARKER) {
-              return theRow.inheritedValue;
-            }
-            return item.value;
-          }
-        }
-      }
-      return null;
-    }
-  }
-
-  /**
-   * Update the forum posts in the Info Panel
-   *
-   * This includes the version of the Info Panel displayed in the Dashboard "Fix" window
-   *
-   * @param tr the table-row element with which the forum posts are associated,
-   *		and whose info is shown in the Info Panel; or null, to get the
-   *		tr from surveyCurrentId
-   */
-  function updateInfoPanelForumPosts(tr) {
-    if (!tr) {
-      if (cldrStatus.getCurrentId() !== "") {
-        /*
-         * TODO: encapsulate this usage of 'r@' somewhere
-         */
-        tr = document.getElementById("r@" + cldrStatus.getCurrentId());
-      } else {
-        /*
-         * This is normal when adding a post in the main forum interface, which has no Info Panel).
-         */
-        return;
-      }
-    }
-    if (!tr || !tr.forumDiv || !tr.forumDiv.url) {
-      /*
-       * This is normal for updateInfoPanelForumPosts(null) called by success handler
-       * for submitPost, from Dashboard, since Fix window is no longer open
-       */
-      return;
-    }
-    let ourUrl = tr.forumDiv.url + "&what=forum_fetch";
-
-    let errorHandler = function (err) {
-      console.log("Error in showForumStuff: " + err);
-      showInPop(
-        cldrStatus.stopIcon() +
-          " Couldn't load forum post for this row- please refresh the page. <br>Error: " +
-          err +
-          "</td>",
-        tr,
-        null
-      );
-      handleDisconnect("Could not showForumStuff:" + err, null);
-    };
-
-    let loadHandler = function (json) {
-      try {
-        if (json && json.ret) {
-          const posts = json.ret;
-          const content = cldrForum.parseContent(posts, "info");
-          /*
-           * Reality check: the json should refer to the same path as tr, which in practice
-           * always matches cldrStatus.getCurrentId(). If not, log a warning and substitute "Please reload"
-           * for the content.
-           */
-          let xpstrid = posts[0].xpath;
-          if (xpstrid !== tr.xpstrid || xpstrid !== cldrStatus.getCurrentId()) {
-            console.log(
-              "Warning: xpath strid mismatch in updateInfoPanelForumPosts loadHandler:"
-            );
-            console.log("posts[0].xpath = " + posts[0].xpath);
-            console.log("tr.xpstrid = " + tr.xpstrid);
-            console.log("surveyCurrentId = " + cldrStatus.getCurrentId());
-
-            content = "Please reload";
-          }
-          /*
-           * Update the element whose class is 'forumDiv'.
-           * Note: When updateInfoPanelForumPosts is called by the mouseover event handler for
-           * the "Show n posts" button set up by havePosts, a clone of tr.forumDiv is created
-           * (for mysterious reasons) by that event handler, and we could pass forumDivClone
-           * as a parameter to updateInfoPanelForumPosts, then do forumDivClone.appendChild(content)
-           * here, which is essentially how it formerly worked. However, that wouldn't work when
-           * we're called by the success handler for submitPost. This works in all cases.
-           */
-          $(".forumDiv").first().html(content);
-        }
-      } catch (e) {
-        console.log("Error in ajax forum read ", e.message);
-        console.log(" response: " + json);
-        showInPop(
-          cldrStatus.stopIcon() + " exception in ajax forum read: " + e.message,
-          tr,
-          null,
-          true
-        );
-      }
-    };
-
-    let xhrArgs = {
-      url: ourUrl,
-      handleAs: "json",
-      load: loadHandler,
-      error: errorHandler,
-    };
-    cldrAjax.queueXhr(xhrArgs);
-  }
-
-  /**
-   * Called when initially setting up the section.
-   *
-   * @param {Node} tr
-   * @param {Node} theRow
-   * @param {Node} forumDiv
-   */
-  function appendForumStuff(tr, theRow, forumDiv) {
-    cldrForum.setUserCanPost(tr.theTable.json.canModify);
-
-    removeAllChildNodes(forumDiv); // we may be updating.
-    var theForum = locmap.getLanguage(cldrStatus.getCurrentLocale());
-    forumDiv.replyStub =
-      cldrStatus.getContextPath() +
-      "/survey?forum=" +
-      theForum +
-      "&_=" +
-      cldrStatus.getCurrentLocale() +
-      "&replyto=";
-    forumDiv.postUrl = forumDiv.replyStub + "x" + theRow;
-    /*
-     * Note: SurveyAjax requires a "what" parameter for SurveyAjax.
-     * It is not supplied here, but may be added later with code such as:
-     *	var ourUrl = tr.forumDiv.url + "&what=forum_count" + cacheKill() ;
-     *	var ourUrl = tr.forumDiv.url + "&what=forum_fetch";
-     * Unfortunately that means "what" is not the first argument, as it would
-     * be ideally for human readability of request urls.
-     */
-    forumDiv.url =
-      cldrStatus.getContextPath() +
-      "/SurveyAjax?xpath=" +
-      theRow.xpathId +
-      "&_=" +
-      cldrStatus.getCurrentLocale() +
-      "&fhash=" +
-      theRow.rowHash +
-      "&vhash=" +
-      "&s=" +
-      tr.theTable.session +
-      "&voteinfo=t";
-  }
-
-  /**
-   * Change the current id
-   *
-   * @param id the id to set
-   */
-  window.updateCurrentId = function updateCurrentId(id) {
-    if (id == null) {
-      id = "";
-    }
-    if (cldrStatus.getCurrentId() != id) {
-      // don't set if already set.
-      cldrStatus.setCurrentId(id);
-    }
-  };
-
-  // window loader stuff
-  $(function () {
-    var unShow = null;
-    var pucontent = document.getElementById("itemInfo");
-    if (!pucontent) {
-      return;
-    }
-
-    var hideInterval = null;
-
-    function parentOfType(tag, obj) {
-      if (!obj) return null;
-      if (obj.nodeName === tag) return obj;
-      return parentOfType(tag, obj.parentElement);
-    }
-
-    function setLastShown(obj) {
-      if (gPopStatus.lastShown && obj != gPopStatus.lastShown) {
-        removeClass(gPopStatus.lastShown, "pu-select");
-        var partr = parentOfType("TR", gPopStatus.lastShown);
-        if (partr) {
-          removeClass(partr, "selectShow");
-        }
-      }
-      if (obj) {
-        addClass(obj, "pu-select");
-        var partr = parentOfType("TR", obj);
-        if (partr) {
-          addClass(partr, "selectShow");
-        }
-      }
-      gPopStatus.lastShown = obj;
-    }
-
-    function clearLastShown() {
-      setLastShown(null);
-    }
-
-    /**
-     * This is the actual function called to display the right-hand "info" panel.
-     *
-     * @param {String} str the string to show at the top
-     * @param {Node} tr the <TR> of the row
-     * @param {Boolean} hideIfLast
-     * @param {Function} fn
-     * @param {Boolean} immediate
-     * @returns {Node} a reference to the right hand panel, if not in Dashboard mode
-     */
-    function showInPop2(str, tr, hideIfLast, fn, immediate, hide) {
-      if (unShow) {
-        unShow();
-        unShow = null;
-      }
-      incrPopToken("newShow" + str);
-      if (hideInterval) {
-        clearTimeout(hideInterval);
-        hideInterval = null;
-      }
-
-      if (tr && tr.sethash) {
-        window.updateCurrentId(tr.sethash);
-      }
-      setLastShown(hideIfLast);
-
-      /*
-       * This is the temporary fragment used for the
-       * "info panel" contents.
-       */
-      var fragment = document.createDocumentFragment();
-
-      if (tr && tr.theRow) {
-        const { theRow } = tr;
-        const { helpHtml, rdf } = theRow;
-        if (helpHtml || rdf) {
-          cldrDeferHelp.addDeferredHelpTo(fragment, helpHtml, rdf);
-        }
-        // extra attributes
-        if (
-          theRow.extraAttributes &&
-          Object.keys(theRow.extraAttributes).length > 0
-        ) {
-          var extraHeading = createChunk(
-            cldrText.get("extraAttribute_heading"),
-            "h3",
-            "extraAttribute_heading"
-          );
-          var extraContainer = createChunk("", "div", "extraAttributes");
-          appendExtraAttributes(extraContainer, theRow);
-          theHelp.appendChild(extraHeading);
-          theHelp.appendChild(extraContainer);
-        }
-      }
-
-      if (isDashboard()) {
-        fixPopoverVotePos();
-      }
-
-      if (str) {
-        // If a simple string, clone the string
-        var div2 = document.createElement("div");
-        div2.innerHTML = str;
-        fragment.appendChild(div2);
-      }
-      // If a generator fn (common case), call it.
-      if (fn != null) {
-        unShow = fn(fragment);
-      }
-
-      var theVoteinfo = null;
-      if (tr && tr.voteDiv) {
-        theVoteinfo = tr.voteDiv;
-      }
-      if (theVoteinfo) {
-        fragment.appendChild(theVoteinfo.cloneNode(true));
-      }
-      if (tr && tr.ticketLink) {
-        fragment.appendChild(tr.ticketLink.cloneNode(true));
-      }
-
-      // forum stuff
-      if (tr && tr.forumDiv) {
-        /*
-         * The name forumDivClone is a reminder that forumDivClone !== tr.forumDiv.
-         * TODO: explain the reason for using cloneNode here, rather than using
-         * tr.forumDiv directly. Would it work as well to set tr.forumDiv = forumDivClone,
-         * after cloning?
-         */
-        var forumDivClone = tr.forumDiv.cloneNode(true);
-        showForumStuff(fragment, forumDivClone, tr); // give a chance to update anything else
-        fragment.appendChild(forumDivClone);
-      }
-
-      if (tr && tr.theRow && tr.theRow.xpath) {
-        fragment.appendChild(
-          clickToSelect(createChunk(tr.theRow.xpath, "div", "xpath"))
-        );
-      }
-
-      // Now, copy or append the 'fragment' to the
-      // appropriate spot. This depends on how we were called.
-      if (tr) {
-        if (isDashboard()) {
-          showHelpFixPanel(fragment);
-        } else {
-          removeAllChildNodes(pucontent);
-          pucontent.appendChild(fragment);
-        }
-      } else {
-        if (!isDashboard()) {
-          // show, for example, dataPageInitialGuidance in Info Panel
-          var clone = fragment.cloneNode(true);
-          removeAllChildNodes(pucontent);
-          pucontent.appendChild(clone);
-        }
-      }
-      fragment = null;
-
-      // for the voter
-      $(".voteInfo_voterInfo").hover(
-        function () {
-          var email = $(this).data("email").replace(" (at) ", "@");
-          if (email !== "") {
-            $(this).html(
-              '<a href="mailto:' +
-                email +
-                '" title="' +
-                email +
-                '" style="color:black"><span class="glyphicon glyphicon-envelope"></span></a>'
-            );
-            $(this).closest("td").css("text-align", "center");
-            $(this).children("a").tooltip().tooltip("show");
-          } else {
-            $(this).html($(this).data("name"));
-            $(this).closest("td").css("text-align", "left");
-          }
-        },
-        function () {
-          $(this).html($(this).data("name"));
-          $(this).closest("td").css("text-align", "left");
-        }
-      );
-      if (!isDashboard()) {
-        return pucontent;
-      } else {
-        return null;
-      }
-    }
-
-    /***
-    // delay before show
-    window.showInPop = function (str, tr, hideIfLast, fn, immediate) {
-      if (hideInterval) {
-        clearTimeout(hideInterval);
-        hideInterval = null;
-      }
-      if (immediate) {
-        return showInPop2(str, tr, hideIfLast, fn);
-      }
-    };
-    ***/
-
-    window.resetPop = function () {
-      lastShown = null;
-    };
-  });
-
   /**
    * Check if we need LRM/RLM marker to display
    * @param field choice field to append if needed
-   * @param dir direction of current locale (control float direction0
    * @param value the value of votes (check &lrm; &rlm)
    */
-  function checkLRmarker(field, dir, value) {
+  function checkLRmarker(field, value) {
     if (value) {
       if (value.indexOf("\u200E") > -1 || value.indexOf("\u200F") > -1) {
         value = value
@@ -1969,10 +989,9 @@ const cldrSurvey = (function () {
    * @param div {DOM} div to append to
    * @param value {String} string value
    * @param pClass {String} html class for the voting item
-   * @param tr {DOM} ignored, but the tr the span belongs to
    * @return {DOM} the new span
    */
-  function appendItem(div, value, pClass, tr) {
+  function appendItem(div, value, pClass) {
     if (!value) {
       return;
     }
@@ -2092,7 +1111,7 @@ const cldrSurvey = (function () {
         ourDiv.appendChild(wrap);
       }
       var h3 = document.createElement("span");
-      var span = appendItem(h3, value, "value", tr);
+      var span = appendItem(h3, value, "value");
       setLang(span);
       ourDiv.appendChild(h3);
       if (otherCell) {
@@ -2134,7 +1153,7 @@ const cldrSurvey = (function () {
         if (tr.myProposal) tr.myProposal.style.display = "none";
       }
       if (ourItem || (replaceErrors && value === "") /* Abstain */) {
-        str = cldrText.sub(
+        let str = cldrText.sub(
           "StatusAction_msg",
           [cldrText.get("StatusAction_" + json.statusAction)],
           "p",
@@ -2150,18 +1169,14 @@ const cldrSurvey = (function () {
         alert(str2);
 
         // show this message in a sidebar also
-        showInPop(cldrStatus.stopIcon() + str, tr, null, null, true);
+        const message = cldrStatus.stopIcon() + str;
+        cldrInfo.showWithRow(message, tr);
       }
       return;
     } else if (json && json.didNotSubmit) {
       ourDiv.className = "d-item-err";
-      showInPop(
-        "(ERROR: Unknown error - did not submit this value.)",
-        tr,
-        null,
-        null,
-        true
-      );
+      const message = "(ERROR: Unknown error - did not submit this value.)";
+      cldrInfo.showWithRow(message, tr);
       return;
     } else {
       setDivClass(ourDiv, testKind);
@@ -2174,7 +1189,7 @@ const cldrSurvey = (function () {
 
       if (!ourItem) {
         var h3 = document.createElement("h3");
-        var span = appendItem(h3, value, "value", tr);
+        var span = appendItem(h3, value, "value");
         setLang(span);
         h3.className = "span";
         div3.appendChild(h3);
@@ -2184,7 +1199,7 @@ const cldrSurvey = (function () {
       newDiv.innerHTML = newHtml;
       if (json && !parseStatusAction(json.statusAction).vote) {
         div3.appendChild(
-          createChunk(
+          cldrDom.createChunk(
             cldrText.sub(
               "StatusAction_msg",
               [cldrText.get("StatusAction_" + json.statusAction)],
@@ -2211,8 +1226,8 @@ const cldrSurvey = (function () {
         }
         return retFn;
       };
-      listenToPop(null, tr, ourDiv, ourShowFn);
-      showInPop(null, tr, ourDiv, ourShowFn, true);
+      cldrInfo.listen(null, tr, ourDiv, ourShowFn);
+      cldrInfo.showRowObjFunc(tr, ourDiv, ourShowFn);
     }
 
     return false;
@@ -2235,11 +1250,7 @@ const cldrSurvey = (function () {
         displayValue = theRow.inheritedValue;
       }
 
-      var span = appendItem(
-        h3,
-        displayValue,
-        item.pClass
-      ); /* no need to pass in 'tr' - clicking this span would have no effect. */
+      var span = appendItem(h3, displayValue, item.pClass);
       setLang(span);
       h3.className = "span";
       td.appendChild(h3);
@@ -2253,7 +1264,7 @@ const cldrSurvey = (function () {
          *  TODO: why not show stars, etc., here?
          */
         h3.appendChild(
-          createChunk(
+          cldrDom.createChunk(
             cldrText.sub("pClass_" + item.pClass, item),
             "p",
             "pClassExplain"
@@ -2318,10 +1329,14 @@ const cldrSurvey = (function () {
         // current locale
         // i.e., following the alias would come back to the current item
         el.appendChild(
-          createChunk(cldrText.get("noFollowAlias"), "span", "followAlias")
+          cldrDom.createChunk(
+            cldrText.get("noFollowAlias"),
+            "span",
+            "followAlias"
+          )
         );
       } else {
-        var clickyLink = createChunk(
+        var clickyLink = cldrDom.createChunk(
           cldrText.get("followAlias"),
           "a",
           "followAlias"
@@ -2375,11 +1390,11 @@ const cldrSurvey = (function () {
     }
     var subSpan = document.createElement("span");
     subSpan.className = "subSpan";
-    var span = appendItem(subSpan, displayValue, item.pClass, tr);
+    var span = appendItem(subSpan, displayValue, item.pClass);
     choiceField.appendChild(subSpan);
 
     setLang(span);
-    checkLRmarker(choiceField, span.dir, item.value);
+    checkLRmarker(choiceField, item.value);
 
     if (item.isBaselineValue == true) {
       appendIcon(choiceField, "i-star", cldrText.get("voteInfo_baseline_desc"));
@@ -2390,7 +1405,7 @@ const cldrSurvey = (function () {
         theRow.canFlagOnLosing &&
         !theRow.rowFlagged
       ) {
-        var newIcon = addIcon(choiceField, "i-stop"); // DEBUG
+        addIcon(choiceField, "i-stop"); // DEBUG
       }
     }
 
@@ -2401,9 +1416,9 @@ const cldrSurvey = (function () {
      */
     if (item.history) {
       const historyText = " ☛" + item.history;
-      const historyTag = createChunk(historyText, "span", "");
+      const historyTag = cldrDom.createChunk(historyText, "span", "");
       choiceField.appendChild(historyTag);
-      listenToPop(historyText, tr, historyTag);
+      cldrInfo.listen(historyText, tr, historyTag, null);
     }
 
     const surveyUser = cldrStatus.getSurveyUser();
@@ -2414,7 +1429,7 @@ const cldrSurvey = (function () {
       theRow.items[theRow.voteVhash].votes[surveyUser.id] &&
       theRow.items[theRow.voteVhash].votes[surveyUser.id].overridedVotes
     ) {
-      var overrideTag = createChunk(
+      var overrideTag = cldrDom.createChunk(
         theRow.items[theRow.voteVhash].votes[surveyUser.id].overridedVotes,
         "span",
         "i-override"
@@ -2427,7 +1442,7 @@ const cldrSurvey = (function () {
     // wire up the onclick function for the Info Panel
     td.showFn = item.showFn = showItemInfoFn(theRow, item);
     div.popParent = tr;
-    listenToPop(null, tr, div, td.showFn);
+    cldrInfo.listen(null, tr, div, td.showFn);
     td.appendChild(div);
 
     if (item.example && item.value != item.examples) {
@@ -2438,13 +1453,21 @@ const cldrSurvey = (function () {
   function appendExtraAttributes(container, theRow) {
     for (var attr in theRow.extraAttributes) {
       var attrval = theRow.extraAttributes[attr];
-      var extraChunk = createChunk(
+      var extraChunk = cldrDom.createChunk(
         attr + "=" + attrval,
         "span",
         "extraAttribute"
       );
       container.appendChild(extraChunk);
     }
+  }
+
+  function getSurveyLevels() {
+    return surveyLevels;
+  }
+
+  function setSurveyLevels(levs) {
+    return (surveyLevels = levs);
   }
 
   /**
@@ -2455,19 +1478,21 @@ const cldrSurvey = (function () {
    */
   function covValue(lev) {
     lev = lev.toUpperCase();
-    if (window.surveyLevels && window.surveyLevels[lev]) {
-      return parseInt(window.surveyLevels[lev].level);
+    const levs = getSurveyLevels();
+    if (levs && levs[lev]) {
+      return parseInt(levs[lev].level);
     } else {
       return 0;
     }
   }
 
   function covName(lev) {
-    if (!window.surveyLevels) {
+    const levs = getSurveyLevels();
+    if (!levs) {
       return null;
     }
-    for (var k in window.surveyLevels) {
-      if (parseInt(window.surveyLevels[k].level) == lev) {
+    for (var k in levs) {
+      if (parseInt(levs[k].level) == lev) {
         return k.toLowerCase();
       }
     }
@@ -2475,28 +1500,45 @@ const cldrSurvey = (function () {
   }
 
   function effectiveCoverage() {
-    if (!window.surveyOrgCov) {
+    const orgCov = getSurveyOrgCov();
+    if (!orgCov) {
       throw new Error("surveyOrgCov not yet initialized");
     }
-
-    if (surveyUserCov) {
-      return covValue(surveyUserCov);
+    const userCov = getSurveyUserCov();
+    if (userCov) {
+      return covValue(userCov);
     } else {
-      return covValue(surveyOrgCov);
+      return covValue(orgCov);
     }
+  }
+
+  function getSurveyOrgCov() {
+    return surveyOrgCov;
+  }
+
+  function setSurveyOrgCov(cov) {
+    surveyOrgCov = cov;
+  }
+
+  function getSurveyUserCov() {
+    return surveyUserCov;
+  }
+
+  function setSurveyUserCov(cov) {
+    surveyUserCov = cov;
   }
 
   function updateCovFromJson(json) {
     if (json.covlev_user && json.covlev_user != "default") {
-      window.surveyUserCov = json.covlev_user;
+      setSurveyUserCov(json.covlev_user);
     } else {
-      window.surveyUserCov = null;
+      setSurveyUserCov(null);
     }
 
     if (json.covlev_org) {
-      window.surveyOrgCov = json.covlev_org;
+      setSurveyOrgCov(json.covlev_org);
     } else {
-      window.surveyOrgCov = null;
+      setSurveyOrgCov(null);
     }
   }
 
@@ -2510,11 +1552,12 @@ const cldrSurvey = (function () {
     if (!theTable.origClass) {
       theTable.origClass = theTable.className;
     }
-    if (window.surveyLevels != null) {
+    const levs = getSurveyLevels();
+    if (levs != null) {
       var effective = effectiveCoverage();
       var newStyle = theTable.origClass;
-      for (var k in window.surveyLevels) {
-        var level = window.surveyLevels[k];
+      for (var k in levs) {
+        var level = levs[k];
 
         if (effective < parseInt(level.level)) {
           newStyle = newStyle + " hideCov" + level.level;
@@ -2526,12 +1569,8 @@ const cldrSurvey = (function () {
     }
   }
 
-  function firstword(str) {
-    return str.split(" ")[0];
-  }
-
   function appendIcon(toElement, className, title) {
-    var e = createChunk(null, "div", className);
+    var e = cldrDom.createChunk(null, "div", className);
     e.title = title;
     toElement.appendChild(e);
     return e;
@@ -2548,120 +1587,26 @@ const cldrSurvey = (function () {
       whom.style.opacity = "0.5";
     }, when / 2);
     setTimeout(function () {
-      cldrSurvey.setDisplayed(whom, false);
+      cldrDom.setDisplayed(whom, false);
     }, when);
     return whom;
   }
 
-  function appendInputBox(parent, which) {
-    var label = createChunk(cldrText.get(which), "div", which);
-    var input = document.createElement("input");
-    input.stChange = function (onOk, onErr) {};
-    var change = createChunk(
-      cldrText.get("appendInputBoxChange"),
-      "button",
-      "appendInputBoxChange"
-    );
-    var cancel = createChunk(
-      cldrText.get("appendInputBoxCancel"),
-      "button",
-      "appendInputBoxCancel"
-    );
-    var notify = document.createElement("div");
-    notify.className = "appendInputBoxNotify";
-    input.className = "appendInputBox";
-    label.appendChild(change);
-    label.appendChild(cancel);
-    label.appendChild(notify);
-    label.appendChild(input);
-    parent.appendChild(label);
-    input.label = label;
-
-    var doChange = function () {
-      addClass(label, "d-item-selected");
-      removeAllChildNodes(notify);
-      notify.appendChild(createChunk(cldrText.get("loading"), "i"));
-      var onOk = function (msg) {
-        removeClass(label, "d-item-selected");
-        removeAllChildNodes(notify);
-        notify.appendChild(hideAfter(createChunk(msg, "span", "okayText")));
-      };
-      var onErr = function (msg) {
-        removeClass(label, "d-item-selected");
-        removeAllChildNodes(notify);
-        notify.appendChild(createChunk(msg, "span", "stopText"));
-      };
-
-      input.stChange(onOk, onErr);
-    };
-
-    var changeFn = function (e) {
-      doChange();
-      stStopPropagation(e);
-      return false;
-    };
-    var cancelFn = function (e) {
-      input.value = "";
-      doChange();
-      stStopPropagation(e);
-      return false;
-    };
-    var keypressFn = function (e) {
-      if (!e || !e.keyCode) {
-        return true; // not getting the point here.
-      } else if (e.keyCode == 13) {
-        doChange();
-        return false;
-      } else {
-        return true;
-      }
-    };
-    listenFor(change, "click", changeFn);
-    listenFor(cancel, "click", cancelFn);
-    listenFor(input, "keypress", keypressFn);
-    return input;
-  }
-
   /**
-   * Show the surveyCurrentId row
-   */
-  function scrollToItem() {
-    const curId = cldrStatus.getCurrentId();
-    if (curId != null && curId != "") {
-      // TODO
-      console.log("scrollToItem not implemented yet; curId = " + curId);
-      /****
-      require(["dojo/window"], function (win) {
-        var xtr = document.getElementById("r@" + curId);
-        if (xtr != null) {
-          console.log("Scrolling to " + curId);
-          win.scrollIntoView("r@" + curId);
-        }
-      });
-      ***/
-    }
-  }
-
-  /**
-   * copy of menu data
-   * @property _thePages
-   */
-  var _thePages = null;
-
-  window.locmap = new LocaleMap(null);
-
-  /**
-   * @param loc  optional
+   * @param loc optional
    * @returns locale bundle
    */
   function locInfo(loc) {
     if (!loc) {
       loc = cldrStatus.getCurrentLocale();
     }
+    const locmap = cldrLoad.getTheLocaleMap();
     return locmap.getLocaleInfo(loc);
   }
 
-  var overridedir = null;
+  function setOverrideDir(dir) {
+    overridedir = dir;
+  }
 
   function setLang(node, loc) {
     var info = locInfo(loc);
@@ -2678,221 +1623,14 @@ const cldrSurvey = (function () {
   }
 
   /**
-   * Get a table showing old votes available for importing, along with
-   * controls for choosing which votes to import.
-   *
-   * @param voteList the array of old votes
-   * @param type "contested" for losing votes or "uncontested" for winning votes
-   * @param translationHintsLanguage a string indicating the translation hints language, generally "English"
-   * @param dir the direction, such as "ltr" for left-to-right
-   * @returns a new div element containing the table and controls
-   *
-   * Called only by addOldvotesType
-   */
-  function showVoteTable(voteList, type, json) {
-    "use strict";
-
-    let translationHintsLanguage = json.TRANS_HINT_LANGUAGE_NAME;
-    let dir = json.oldvotes.dir;
-    let lastVoteVersion = json.oldvotes.lastVoteVersion;
-
-    var voteTableDiv = document.createElement("div");
-    var t = document.createElement("table");
-    t.id = "oldVotesAcceptList";
-    voteTableDiv.appendChild(t);
-    var th = document.createElement("thead");
-    var tb = document.createElement("tbody");
-    var tr = document.createElement("tr");
-    tr.appendChild(createChunk(cldrText.get("v_oldvotes_path"), "th", "code"));
-    tr.appendChild(createChunk(translationHintsLanguage, "th", "v-comp"));
-    tr.appendChild(
-      createChunk(
-        cldrText.sub("v_oldvotes_winning_msg", {
-          version: lastVoteVersion,
-        }),
-        "th",
-        "v-win"
-      )
-    );
-    tr.appendChild(
-      createChunk(cldrText.get("v_oldvotes_mine"), "th", "v-mine")
-    );
-    tr.appendChild(
-      createChunk(cldrText.get("v_oldvotes_accept"), "th", "v-accept")
-    );
-    th.appendChild(tr);
-    t.appendChild(th);
-    var oldPath = "";
-    var oldSplit = [];
-    var mainCategories = [];
-    for (var k in voteList) {
-      var row = voteList[k];
-      var tr = document.createElement("tr");
-      var tdp;
-      var rowTitle = "";
-
-      // delete common substring
-      var pathSplit = row.pathHeader.split("	");
-      for (var nn in pathSplit) {
-        if (pathSplit[nn] != oldSplit[nn]) {
-          break;
-        }
-      }
-      if (nn != pathSplit.length - 1) {
-        // need a header row.
-        var trh = document.createElement("tr");
-        trh.className = "subheading";
-        var tdh = document.createElement("th");
-        tdh.colSpan = 5;
-        for (var nn in pathSplit) {
-          if (nn < pathSplit.length - 1) {
-            tdh.appendChild(createChunk(pathSplit[nn], "span", "pathChunk"));
-          }
-        }
-        trh.appendChild(tdh);
-        tb.appendChild(trh);
-      }
-      if (mainCategories.indexOf(pathSplit[0]) === -1) {
-        mainCategories.push(pathSplit[0]);
-      }
-      oldSplit = pathSplit;
-      rowTitle = pathSplit[pathSplit.length - 1];
-
-      tdp = createChunk("", "td", "v-path");
-
-      var dtpl = createChunk(rowTitle, "a");
-      dtpl.href = "v#/" + cldrStatus.getCurrentLocale() + "//" + row.strid;
-      dtpl.target = "_CLDR_ST_view";
-      tdp.appendChild(dtpl);
-
-      tr.appendChild(tdp);
-      var td00 = createChunk(row.baseValue, "td", "v-comp"); // english
-      tr.appendChild(td00);
-      var td0 = createChunk("", "td", "v-win");
-      if (row.winValue) {
-        var span0 = appendItem(td0, row.winValue, "winner");
-        span0.dir = dir;
-      }
-      tr.appendChild(td0);
-      var td1 = createChunk("", "td", "v-mine");
-      var label = createChunk("", "label", "");
-      var span1 = appendItem(label, row.myValue, "value");
-      td1.appendChild(label);
-      span1.dir = dir;
-      tr.appendChild(td1);
-      var td2 = createChunk("", "td", "v-accept");
-      var box = createChunk("", "input", "");
-      box.type = "checkbox";
-      if (type == "uncontested") {
-        // uncontested true by default
-        box.checked = true;
-      }
-      row.box = box; // backlink
-      td2.appendChild(box);
-      tr.appendChild(td2);
-
-      (function (tr, box, tdp) {
-        return function () {
-          // allow click anywhere
-          listenFor(tr, "click", function (e) {
-            box.checked = !box.checked;
-            stStopPropagation(e);
-            return false;
-          });
-          // .. but not on the path.  Also listen to the box and do nothing
-          listenFor([tdp, box], "click", function (e) {
-            stStopPropagation(e);
-            return false;
-          });
-        };
-      })(tr, box, tdp)();
-
-      tb.appendChild(tr);
-    }
-    t.appendChild(tb);
-    addImportVotesFooter(voteTableDiv, voteList, mainCategories);
-    return voteTableDiv;
-  }
-
-  /**
-   * Add to the given div a footer with buttons for choosing all or none
-   * of the old votes, and with checkboxes for choosing all or none within
-   * each of two or more main categories such as "Locale Display Names".
-   *
-   * @param voteTableDiv the div to add to
-   * @param voteList the list of old votes
-   * @param mainCategories the list of main categories
-   *
-   * Called only by showVoteTable
-   *
-   * Reference: https://unicode.org/cldr/trac/ticket/11517
-   */
-  function addImportVotesFooter(voteTableDiv, voteList, mainCategories) {
-    "use strict";
-    voteTableDiv.appendChild(
-      createLinkToFn(
-        "v_oldvotes_all",
-        function () {
-          for (var k in voteList) {
-            voteList[k].box.checked = true;
-          }
-          for (var cat in mainCategories) {
-            $("#cat" + cat).prop("checked", true);
-          }
-        },
-        "button"
-      )
-    );
-
-    voteTableDiv.appendChild(
-      createLinkToFn(
-        "v_oldvotes_none",
-        function () {
-          for (var k in voteList) {
-            voteList[k].box.checked = false;
-          }
-          for (var cat in mainCategories) {
-            $("#cat" + cat).prop("checked", false);
-          }
-        },
-        "button"
-      )
-    );
-
-    if (mainCategories.length > 1) {
-      voteTableDiv.appendChild(
-        document.createTextNode(cldrText.get("v_oldvotes_all_section"))
-      );
-      for (var cat in mainCategories) {
-        let mainCat = mainCategories[cat];
-        var checkbox = document.createElement("input");
-        checkbox.type = "checkbox";
-        checkbox.id = "cat" + cat;
-        voteTableDiv.appendChild(checkbox);
-        voteTableDiv.appendChild(document.createTextNode(mainCat + " "));
-        listenFor(checkbox, "click", function (e) {
-          for (var k in voteList) {
-            var row = voteList[k];
-            if (row.pathHeader.startsWith(mainCat)) {
-              row.box.checked = this.checked;
-            }
-          }
-          stStopPropagation(e);
-          return false;
-        });
-      }
-    }
-  }
-
-  /**
    * Reload a specific row
    *
    * Called by loadHandler in handleWiredClick
    */
   function refreshSingleRow(tr, theRow, onSuccess, onFailure) {
-    showLoader(tr.theTable.theDiv.loader, cldrText.get("loadingOneRow"));
+    showLoader(cldrText.get("loadingOneRow"));
 
-    var ourUrl =
+    let ourUrl =
       cldrStatus.getContextPath() +
       "/SurveyAjax?what=getrow" +
       "&_=" +
@@ -2905,7 +1643,7 @@ const cldrSurvey = (function () {
       cldrStatus.getSessionId() +
       "&automatic=t";
 
-    if (isDashboard()) {
+    if (cldrStatus.isDashboard()) {
       ourUrl += "&dashboard=true";
     }
 
@@ -2916,17 +1654,15 @@ const cldrSurvey = (function () {
           tr.theTable.json.section.rows[tr.rowHash] = theRow;
           cldrTable.updateRow(tr, theRow);
 
-          hideLoader(tr.theTable.theDiv.loader);
+          hideLoader();
           onSuccess(theRow);
-          if (isDashboard()) {
+          if (cldrStatus.isDashboard()) {
             refreshFixPanel(json);
           } else {
-            window.showInPop(
-              "",
+            cldrInfo.showRowObjFunc(
               tr,
               tr.proposedcell,
-              tr.proposedcell.showFn,
-              true /* immediate */
+              tr.proposedcell.showFn
             );
             refreshCounterVetting();
           }
@@ -2989,16 +1725,16 @@ const cldrSurvey = (function () {
     }
     if (what == "submit") {
       button.className = "ichoice-x-ok"; // TODO: ichoice-inprogress? spinner?
-      showLoader(tr.theTable.theDiv.loader, cldrText.get("voting"));
+      showLoader(cldrText.get("voting"));
     } else {
-      showLoader(tr.theTable.theDiv.loader, cldrText.get("checking"));
+      showLoader(cldrText.get("checking"));
     }
 
     // select
-    updateCurrentId(theRow.xpstrid);
+    cldrLoad.updateCurrentId(theRow.xpstrid);
 
     // and scroll
-    showCurrentId();
+    cldrLoad.showCurrentId();
 
     if (tr.myProposal) {
       const otherCell = tr.querySelector(".othercell");
@@ -3012,7 +1748,7 @@ const cldrSurvey = (function () {
       tr.wait = false;
     };
     tr.wait = true;
-    resetPop(tr);
+    cldrInfo.reset();
     theRow.proposedResults = null;
 
     console.log(
@@ -3027,7 +1763,7 @@ const cldrSurvey = (function () {
       s: tr.theTable.session,
     };
 
-    var ourUrl = cldrStatus.getContextPath() + "/SurveyAjax";
+    let ourUrl = cldrStatus.getContextPath() + "/SurveyAjax";
 
     var voteLevelChanged = document.getElementById("voteLevelChanged");
     if (voteLevelChanged) {
@@ -3066,7 +1802,7 @@ const cldrSurvey = (function () {
                 // submit went through. Now show the pop.
                 button.className = "ichoice-o";
                 button.checked = false;
-                hideLoader(tr.theTable.theDiv.loader);
+                hideLoader();
                 if (
                   json.testResults &&
                   (json.testWarnings || json.testErrors)
@@ -3111,7 +1847,7 @@ const cldrSurvey = (function () {
             }
             button.className = "ichoice-o";
             button.checked = false;
-            hideLoader(tr.theTable.theDiv.loader);
+            hideLoader();
             myUnDefer();
           }
         }
@@ -3142,7 +1878,6 @@ const cldrSurvey = (function () {
       myUnDefer();
     };
     if (box) {
-      stdebug("this is a post: " + value);
       ourContent.value = value;
     }
     var xhrArgs = {
@@ -3156,648 +1891,26 @@ const cldrSurvey = (function () {
   }
 
   /**
-   * Load the Admin Panel
+   * Show the 'loading' sign
    *
-   * TODO move admin panel code to separate module
+   * @param {String} text text to use
    */
-  function loadAdminPanel() {
-    if (!vap) {
-      return;
-    }
-    var adminStuff = document.getElementById("adminStuff");
-    if (!adminStuff) {
-      return;
-    }
-    {
-      var content = document.createDocumentFragment();
+  function showLoader(text) {
+    updateAjaxWord(text);
+  }
 
-      var list = document.createElement("ul");
-      list.className = "adminList";
-      content.appendChild(list);
-
-      function loadOrFail(urlAppend, theDiv, loadHandler, postData) {
-        var ourUrl =
-          cldrStatus.getContextPath() +
-          "/AdminAjax.jsp?vap=" +
-          vap +
-          "&" +
-          urlAppend;
-        var errorHandler = function (err) {
-          console.log("adminload " + urlAppend + " Error: " + err);
-          theDiv.className = "ferrbox";
-          theDiv.innerHTML =
-            "Error while loading: <div style='border: 1px solid red;'>" +
-            err +
-            "</div>";
-        };
-        var xhrArgs = {
-          url: ourUrl + cacheKill(),
-          handleAs: "json",
-          load: loadHandler,
-          error: errorHandler,
-          postData: postData,
-        };
-        if (!loadHandler) {
-          xhrArgs.handleAs = "text";
-          xhrArgs.load = function (text) {
-            theDiv.innerHTML = text;
-          };
-        }
-        if (xhrArgs.postData) {
-          /*
-           * Make a POST request
-           */
-          console.log("admin post: ourUrl: " + ourUrl + " data:" + postData);
-          xhrArgs.headers = {
-            "Content-Type": "text/plain",
-          };
-        } else {
-          /*
-           * Make a GET request
-           */
-          console.log("admin get: ourUrl: " + ourUrl);
-        }
-        cldrAjax.sendXhr(xhrArgs);
-      }
-      var panelLast = null;
-      var panels = {};
-      var panelFirst = null;
-
-      function panelSwitch(name) {
-        if (panelLast) {
-          panelLast.div.style.display = "none";
-          panelLast.listItem.className = "notselected";
-          panelLast = null;
-        }
-        if (name && panels[name]) {
-          panelLast = panels[name];
-          panelLast.listItem.className = "selected";
-          panelLast.fn(panelLast.udiv);
-          panelLast.div.style.display = "block";
-          window.location.hash = "#!" + name;
-        }
-      }
-
-      function addAdminPanel(type, fn) {
-        var panel = (panels[type] = {
-          type: type,
-          name: cldrText.get(type) || type,
-          desc:
-            cldrText.get(type + "_desc") ||
-            "(no description - missing from cldrText)",
-          fn: fn,
-        });
-        panel.div = document.createElement("div");
-        panel.div.style.display = "none";
-        panel.div.className = "adminPanel";
-
-        var h = document.createElement("h3");
-        h.className = "adminTitle";
-        h.appendChild(document.createTextNode(panel.desc || type));
-        panel.div.appendChild(h);
-
-        panel.udiv = document.createElement("div");
-        panel.div.appendChild(panel.udiv);
-
-        panel.listItem = document.createElement("li");
-        panel.listItem.appendChild(document.createTextNode(panel.name || type));
-        panel.listItem.title = panel.desc || type;
-        panel.listItem.className = "notselected";
-        panel.listItem.onclick = function (e) {
-          panelSwitch(panel.type);
-          return false;
-        };
-        list.appendChild(panel.listItem);
-
-        content.appendChild(panel.div);
-
-        if (!panelFirst) {
-          panelFirst = panel;
-        }
-      }
-
-      addAdminPanel("admin_users", function (div) {
-        var frag = document.createDocumentFragment();
-
-        var u = document.createElement("div");
-        u.appendChild(document.createTextNode("Loading..."));
-        frag.appendChild(u);
-
-        removeAllChildNodes(div);
-        div.appendChild(frag);
-        loadOrFail("do=users", u, function (json) {
-          var frag2 = document.createDocumentFragment();
-
-          if (!json || !json.users || Object.keys(json.users) == 0) {
-            frag2.appendChild(
-              document.createTextNode(cldrText.get("No users."))
-            );
-          } else {
-            for (sess in json.users) {
-              var cs = json.users[sess];
-              var user = createChunk(null, "div", "adminUser");
-              user.appendChild(
-                createChunk("Session: " + sess, "span", "adminUserSession")
-              );
-              if (cs.user) {
-                user.appendChild(createUser(cs.user));
-              } else {
-                user.appendChild(
-                  createChunk("(anonymous)", "div", "adminUserUser")
-                );
-              }
-              /*
-               * cs.lastBrowserCallMillisSinceEpoch = time elapsed in millis since server heard from client
-               * cs.lastActionMillisSinceEpoch = time elapsed in millis since user did active action
-               * cs.millisTillKick = how many millis before user will be kicked if inactive
-               */
-              user.appendChild(
-                createChunk(
-                  "LastCall: " +
-                    cs.lastBrowserCallMillisSinceEpoch +
-                    ", LastAction: " +
-                    cs.lastActionMillisSinceEpoch +
-                    ", IP: " +
-                    cs.ip +
-                    ", ttk:" +
-                    (parseInt(cs.millisTillKick) / 1000).toFixed(1) +
-                    "s",
-                  "span",
-                  "adminUserInfo"
-                )
-              );
-
-              var unlinkButton = createChunk(
-                cldrText.get("admin_users_action_kick"),
-                "button",
-                "admin_users_action_kick"
-              );
-              user.appendChild(unlinkButton);
-              unlinkButton.onclick = function (e) {
-                unlinkButton.className = "deactivated";
-                unlinkButton.onclick = null;
-                loadOrFail(
-                  "do=unlink&s=" + cs.id,
-                  unlinkButton,
-                  function (json) {
-                    removeAllChildNodes(unlinkButton);
-                    if (json.removing == null) {
-                      unlinkButton.appendChild(
-                        document.createTextNode("Already Removed")
-                      );
-                    } else {
-                      unlinkButton.appendChild(
-                        document.createTextNode("Removed.")
-                      );
-                    }
-                  }
-                );
-                return stStopPropagation(e);
-              };
-              frag2.appendChild(user);
-              frag2.appendChild(document.createElement("hr"));
-            }
-          }
-          removeAllChildNodes(u);
-          u.appendChild(frag2);
-        });
-      });
-
-      addAdminPanel("admin_threads", function (div) {
-        var frag = document.createDocumentFragment();
-
-        div.className = "adminThreads";
-        var u = createChunk("Loading...", "div", "adminThreadList");
-        var stack = createChunk(null, "div", "adminThreadStack");
-        frag.appendChild(u);
-        frag.appendChild(stack);
-        var c2s = createChunk(
-          cldrText.get("clickToSelect"),
-          "button",
-          "clickToSelect"
-        );
-        clickToSelect(c2s, stack);
-
-        removeAllChildNodes(div);
-        div.appendChild(c2s);
-        var clicked = null;
-
-        div.appendChild(frag);
-        loadOrFail("do=threads", u, function (json) {
-          if (!json || !json.threads || Object.keys(json.threads.all) == 0) {
-            removeAllChildNodes(u);
-            u.appendChild(document.createTextNode(cldrText.get("No threads.")));
-          } else {
-            var frag2 = document.createDocumentFragment();
-            removeAllChildNodes(stack);
-            stack.innerHTML = cldrText.get("adminClickToViewThreads");
-            deadThreads = {};
-            if (json.threads.dead) {
-              var header = createChunk(
-                cldrText.get("adminDeadThreadsHeader"),
-                "div",
-                "adminDeadThreadsHeader"
-              );
-              var deadul = createChunk("", "ul", "adminDeadThreads");
-              for (var jj = 0; jj < json.threads.dead.length; jj++) {
-                var theThread = json.threads.dead[jj];
-                var deadLi = createChunk("#" + theThread.id, "li");
-                //deadLi.appendChild(createChunk(theThread.text,"pre"));
-                deadThreads[theThread.id] = theThread.text;
-                deadul.appendChild(deadLi);
-              }
-              header.appendChild(deadul);
-              stack.appendChild(header);
-            }
-            for (id in json.threads.all) {
-              var t = json.threads.all[id];
-              var thread = createChunk(null, "div", "adminThread");
-              var tid;
-              thread.appendChild(
-                (tid = createChunk(id, "span", "adminThreadId"))
-              );
-              if (deadThreads[id]) {
-                tid.className = tid.className + " deadThread";
-              }
-              thread.appendChild(
-                createChunk(t.name, "span", "adminThreadName")
-              );
-              thread.appendChild(
-                createChunk(
-                  cldrText.get(t.state),
-                  "span",
-                  "adminThreadState_" + t.state
-                )
-              );
-              thread.onclick = (function (t, id) {
-                return function () {
-                  stack.innerHTML = "<b>" + id + ":" + t.name + "</b>\n";
-                  if (deadThreads[id]) {
-                    stack.appendChild(
-                      createChunk(deadThreads[id], "pre", "deadThreadInfo")
-                    );
-                  }
-                  stack.appendChild(
-                    createChunk("\n\n```\n", "pre", "textForTrac")
-                  );
-                  for (var q in t.stack) {
-                    stack.innerHTML = stack.innerHTML + t.stack[q] + "\n";
-                  }
-                  stack.appendChild(
-                    createChunk("```\n\n", "pre", "textForTrac")
-                  );
-                };
-              })(t, id);
-              frag2.appendChild(thread);
-            }
-
-            removeAllChildNodes(u);
-            u.appendChild(frag2);
-          }
-        });
-      });
-
-      addAdminPanel("admin_exceptions", function (div) {
-        var frag = document.createDocumentFragment();
-
-        div.className = "adminThreads";
-        var v = createChunk(null, "div", "adminExceptionList");
-        var stack = createChunk(null, "div", "adminThreadStack");
-        frag.appendChild(v);
-        var u = createChunk(null, "div");
-        v.appendChild(u);
-        frag.appendChild(stack);
-
-        var c2s = createChunk(
-          cldrText.get("clickToSelect"),
-          "button",
-          "clickToSelect"
-        );
-        clickToSelect(c2s, stack);
-
-        removeAllChildNodes(div);
-        div.appendChild(c2s);
-        var clicked = null;
-
-        var last = -1;
-
-        var exceptions = [];
-
-        var exceptionNames = {};
-
-        div.appendChild(frag);
-        var more = createChunk(
-          cldrText.get("more_exceptions"),
-          "p",
-          "adminExceptionMore adminExceptionFooter"
-        );
-        var loading = createChunk(
-          cldrText.get("loading"),
-          "p",
-          "adminExceptionFooter"
-        );
-
-        v.appendChild(loading);
-        var loadNext = function (from) {
-          var append = "do=exceptions";
-          if (from) {
-            append = append + "&before=" + from;
-          }
-          console.log("Loading: " + append);
-          loadOrFail(append, u, function (json) {
-            if (!json || !json.exceptions || !json.exceptions.entry) {
-              if (!from) {
-                v.appendChild(
-                  createChunk(
-                    cldrText.get("no_exceptions"),
-                    "p",
-                    "adminExceptionFooter"
-                  )
-                );
-              } else {
-                v.removeChild(loading);
-                v.appendChild(
-                  createChunk(
-                    cldrText.get("last_exception"),
-                    "p",
-                    "adminExceptionFooter"
-                  )
-                );
-                // just the last one.
-              }
-            } else {
-              if (json.exceptions.entry.time == from) {
-                console.log("Asked for <" + from + " but got =" + from);
-                v.removeChild(loading);
-                return; //
-              }
-              var frag2 = document.createDocumentFragment();
-              if (!from) {
-                removeAllChildNodes(stack);
-                stack.innerHTML = cldrText.get("adminClickToViewExceptions");
-              }
-              // TODO: if(json.threads.dead) frag2.appendChunk(json.threads.dead.toString(),"span","adminDeadThreads");
-              last = json.exceptions.lastTime;
-              if (json.exceptions.entry) {
-                var e = json.exceptions.entry;
-                exceptions.push(json.exceptions.entry);
-                var exception = createChunk(null, "div", "adminException");
-                if (e.header && e.header.length < 80) {
-                  exception.appendChild(
-                    createChunk(e.header, "span", "adminExceptionHeader")
-                  );
-                } else {
-                  var t;
-                  exception.appendChild(
-                    (t = createChunk(
-                      e.header.substring(0, 80) + "...",
-                      "span",
-                      "adminExceptionHeader"
-                    ))
-                  );
-                  t.title = e.header;
-                }
-                exception.appendChild(
-                  createChunk(e.DATE, "span", "adminExceptionDate")
-                );
-                var clicky = (function (e) {
-                  return function (ee) {
-                    var frag3 = document.createDocumentFragment();
-                    frag3.appendChild(
-                      createChunk(e.header, "span", "adminExceptionHeader")
-                    );
-                    frag3.appendChild(
-                      createChunk(e.DATE, "span", "adminExceptionDate")
-                    );
-
-                    if (e.UPTIME) {
-                      frag3.appendChild(
-                        createChunk(e.UPTIME, "span", "adminExceptionUptime")
-                      );
-                    }
-                    if (e.CTX) {
-                      frag3.appendChild(
-                        createChunk(e.CTX, "span", "adminExceptionUptime")
-                      );
-                    }
-                    for (var q in e.fields) {
-                      var f = e.fields[q];
-                      var k = Object.keys(f);
-                      frag3.appendChild(createChunk(k[0], "h4", "textForTrac"));
-                      frag3.appendChild(
-                        createChunk("\n```", "pre", "textForTrac")
-                      );
-                      frag3.appendChild(
-                        createChunk(f[k[0]], "pre", "adminException" + k[0])
-                      );
-                      frag3.appendChild(
-                        createChunk("```\n", "pre", "textForTrac")
-                      );
-                    }
-
-                    if (e.LOGSITE) {
-                      frag3.appendChild(
-                        createChunk("LOGSITE\n", "h4", "textForTrac")
-                      );
-                      frag3.appendChild(
-                        createChunk("\n```", "pre", "textForTrac")
-                      );
-                      frag3.appendChild(
-                        createChunk(e.LOGSITE, "pre", "adminExceptionLogsite")
-                      );
-                      frag3.appendChild(
-                        createChunk("```\n", "pre", "textForTrac")
-                      );
-                    }
-                    removeAllChildNodes(stack);
-                    stack.appendChild(frag3);
-                    stStopPropagation(ee);
-                    return false;
-                  };
-                })(e);
-                listenFor(exception, "click", clicky);
-                var head = exceptionNames[e.header];
-                if (head) {
-                  if (!head.others) {
-                    head.others = [];
-                    head.count = document.createTextNode("");
-                    var countSpan = document.createElement("span");
-                    countSpan.appendChild(head.count);
-                    countSpan.className = "adminExceptionCount";
-                    listenFor(countSpan, "click", function (e) {
-                      // prepare div
-                      if (!head.otherdiv) {
-                        head.otherdiv = createChunk(
-                          null,
-                          "div",
-                          "adminExceptionOtherList"
-                        );
-                        head.otherdiv.appendChild(
-                          createChunk(
-                            cldrText.get("adminExceptionDupList"),
-                            "h4"
-                          )
-                        );
-                        for (k in head.others) {
-                          head.otherdiv.appendChild(head.others[k]);
-                        }
-                      }
-                      removeAllChildNodes(stack);
-                      stack.appendChild(head.otherdiv);
-                      stStopPropagation(e);
-                      return false;
-                    });
-                    head.appendChild(countSpan);
-                  }
-                  head.others.push(exception);
-                  head.count.nodeValue = cldrText.sub("adminExceptionDup", [
-                    head.others.length,
-                  ]);
-                  head.otherdiv = null; // reset
-                } else {
-                  frag2.appendChild(exception);
-                  exceptionNames[e.header] = exception;
-                }
-              }
-              u.appendChild(frag2);
-
-              if (json.exceptions.entry && json.exceptions.entry.time) {
-                if (exceptions.length > 0 && exceptions.length % 8 == 0) {
-                  v.removeChild(loading);
-                  v.appendChild(more);
-                  more.onclick = more.onmouseover = function () {
-                    v.removeChild(more);
-                    v.appendChild(loading);
-                    loadNext(json.exceptions.entry.time);
-                    return false;
-                  };
-                } else {
-                  setTimeout(function () {
-                    loadNext(json.exceptions.entry.time);
-                  }, 500);
-                }
-              }
-            }
-          });
-        };
-        loadNext(); // load the first exception
-      });
-
-      addAdminPanel("admin_settings", function (div) {
-        var frag = document.createDocumentFragment();
-
-        div.className = "adminSettings";
-        var u = createChunk("Loading...", "div", "adminSettingsList");
-        frag.appendChild(u);
-        loadOrFail("do=settings", u, function (json) {
-          if (!json || !json.settings || Object.keys(json.settings.all) == 0) {
-            removeAllChildNodes(u);
-            u.appendChild(document.createTextNode(cldrText.get("nosettings")));
-          } else {
-            var frag2 = document.createDocumentFragment();
-            for (id in json.settings.all) {
-              var t = json.settings.all[id];
-
-              var thread = createChunk(null, "div", "adminSetting");
-
-              thread.appendChild(createChunk(id, "span", "adminSettingId"));
-              if (id == "CLDR_HEADER") {
-                (function (theHeader, theValue) {
-                  var setHeader = null;
-                  setHeader = appendInputBox(thread, "adminSettingsChangeTemp");
-                  setHeader.value = theValue;
-                  setHeader.stChange = function (onOk, onErr) {
-                    loadOrFail(
-                      "do=settings_set&setting=" + theHeader,
-                      u,
-                      function (json) {
-                        if (
-                          !json ||
-                          !json.settings_set ||
-                          !json.settings_set.ok
-                        ) {
-                          onErr(cldrText.get("failed"));
-                          onErr(json.settings_set.err);
-                        } else {
-                          if (json.settings_set[theHeader]) {
-                            setHeader.value = json.settings_set[theHeader];
-                            if (theHeader == "CLDR_HEADER") {
-                              updateSpecialHeader(setHeader.value);
-                            }
-                          } else {
-                            setHeader.value = "";
-                            if (theHeader == "CLDR_HEADER") {
-                              updateSpecialHeader(null);
-                            }
-                          }
-                          onOk(cldrText.get("changed"));
-                        }
-                      },
-                      setHeader.value
-                    );
-                    return false;
-                  };
-                })(id, t); // call it
-
-                if (id == "CLDR_HEADER") {
-                  updateSpecialHeader(t);
-                }
-              } else {
-                thread.appendChild(createChunk(t, "span", "adminSettingValue"));
-              }
-              frag2.appendChild(thread);
-            }
-            removeAllChildNodes(u);
-            u.appendChild(frag2);
-          }
-        });
-
-        removeAllChildNodes(div);
-        div.appendChild(frag);
-      });
-
-      addAdminPanel("admin_ops", function (div) {
-        var frag = document.createDocumentFragment();
-
-        div.className = "adminThreads";
-
-        var baseUrl =
-          cldrStatus.getContextPath() + "/AdminPanel.jsp?vap=" + vap + "&do=";
-        var hashSuff = ""; //  "#" + window.location.hash;
-
-        var actions = ["rawload"];
-        for (var k in actions) {
-          var action = actions[k];
-          var newUrl = baseUrl + action + hashSuff;
-          var b = createChunk(cldrText.get(action), "button");
-          b.onclick = function () {
-            window.location = newUrl;
-            return false;
-          };
-          frag.appendChild(b);
-        }
-        removeAllChildNodes(div);
-        div.appendChild(frag);
-      });
-
-      // last panel loaded.
-      // If it's in the hashtag, use it, otherwise first.
-      if (window.location.hash && window.location.hash.indexOf("#!") == 0) {
-        panelSwitch(window.location.hash.substring(2));
-      }
-      if (!panelLast) {
-        // not able to load anything.
-        panelSwitch(panelFirst.type);
-      }
-      adminStuff.appendChild(content);
-    }
+  /**
+   * Hide the 'loading' sign
+   */
+  function hideLoader() {
+    updateAjaxWord(null);
   }
 
   /**
    * Update the counter on top of the vetting page
    */
   function refreshCounterVetting() {
-    if (cldrStatus.isVisitor() || isDashboard()) {
+    if (cldrStatus.isVisitor() || cldrStatus.isDashboard()) {
       // if the user is a visitor, or this is the Dashboard, don't display the counter information
       $("#nav-page .counter-infos, #nav-page .nav-progress").hide();
       return;
@@ -3841,6 +1954,7 @@ const cldrSurvey = (function () {
    */
   function chgPage(shift) {
     // no page, or wrong shift
+    const _thePages = cldrLoad.getThePages();
     if (!_thePages || (shift !== -1 && shift !== 1)) {
       return;
     }
@@ -3887,7 +2001,7 @@ const cldrSurvey = (function () {
     cldrStatus.setCurrentSection(menus[parentIndex].id);
     cldrStatus.setCurrentPage(menus[parentIndex].pagesFiltered[index].id);
 
-    reloadV();
+    cldrLoad.reloadV();
 
     var sidebar = $("#locale-menu #" + cldrStatus.getCurrentPage());
     sidebar.closest(".open-menu").click();
@@ -3899,13 +2013,14 @@ const cldrSurvey = (function () {
    * @return {Array} list of all the menus under this coverage
    */
   function getMenusFilteredByCov() {
+    const _thePages = cldrLoad.getThePages();
     if (!_thePages) {
       return;
     }
     // get name of current coverage
-    var cov = surveyUserCov;
+    var cov = getSurveyUserCov();
     if (!cov) {
-      cov = surveyOrgCov;
+      cov = getSurveyOrgCov();
     }
 
     // get the value
@@ -3930,70 +2045,24 @@ const cldrSurvey = (function () {
     return menus;
   }
 
-  ///////////////////
-
-  /**
-   * For vetting
-   *
-   * @param hideRegex
-   */
-  function changeStyle(hideRegex) {
-    for (m in document.styleSheets) {
-      var theRules;
-      if (document.styleSheets[m].cssRules) {
-        theRules = document.styleSheets[m].cssRules;
-      } else if (document.styleSheets[m].rules) {
-        theRules = document.styleSheets[m].rules;
-      }
-      for (n in theRules) {
-        var rule = theRules[n];
-        var sel = rule.selectorText;
-        if (sel != undefined && sel.match(/vv/)) {
-          var theStyle = rule.style;
-          if (sel.match(hideRegex)) {
-            if (theStyle.display == "table-row") {
-              theStyle.display = null;
-            }
-          } else {
-            if (theStyle.display != "table-row") {
-              theStyle.display = "table-row";
-            }
-          }
-        }
-      }
-    }
-  }
-
-  function setStyles() {
-    var hideRegexString = "X1234X";
-    for (var i = 0; i < document.checkboxes.elements.length; i++) {
-      var item = document.checkboxes.elements[i];
-      if (!item.checked) {
-        hideRegexString += "|";
-        hideRegexString += item.name;
-      }
-    }
-    var hideRegex = new RegExp(hideRegexString);
-    changeStyle(hideRegex);
-  }
-
   function createLocLink(loc, locName, className) {
-    var cl = createChunk(locName, "a", "localeChunk " + className);
+    var cl = cldrDom.createChunk(locName, "a", "localeChunk " + className);
     cl.title = loc;
     cl.href = "survey?_=" + loc;
     return cl;
   }
 
+  // called only from myvotes.jsp
   function showAllItems(divName, user) {
     var div = document.getElementById(divName);
     div.className = "recentList";
     div.update = function () {
-      var ourUrl =
+      let ourUrl =
         cldrStatus.getContextPath() + "/SurveyAjax?what=mylocales&user=" + user;
       var errorHandler = function (err) {
         handleDisconnect("Error in showrecent: " + err);
       };
-      showLoader(null, "Loading recent items");
+      showLoader("Loading recent items");
       var loadHandler = function (json) {
         try {
           if (json && json.mine) {
@@ -4001,13 +2070,19 @@ const cldrSurvey = (function () {
             var header = json.mine.header;
             var data = json.mine.data;
             if (data.length == 0) {
-              frag.appendChild(createChunk(cldrText.get("recentNone"), "i"));
+              frag.appendChild(
+                cldrDom.createChunk(cldrText.get("recentNone"), "i")
+              );
             } else {
               var rowDiv = document.createElement("div");
               frag.appendChild(rowDiv);
 
-              rowDiv.appendChild(createChunk(cldrText.get("recentLoc"), "b"));
-              rowDiv.appendChild(createChunk(cldrText.get("recentCount"), "b"));
+              rowDiv.appendChild(
+                cldrDom.createChunk(cldrText.get("recentLoc"), "b")
+              );
+              rowDiv.appendChild(
+                cldrDom.createChunk(cldrText.get("recentCount"), "b")
+              );
 
               for (var q in data) {
                 var row = data[q];
@@ -4021,12 +2096,12 @@ const cldrSurvey = (function () {
                 var locname = row[header.LOCALE_NAME];
                 rowDiv.appendChild(createLocLink(loc, locname, "recentLoc"));
                 rowDiv.appendChild(
-                  createChunk(count, "span", "value recentCount")
+                  cldrDom.createChunk(count, "span", "value recentCount")
                 );
 
                 const sessionId = cldrStatus.getSessionId();
                 if (sessionId) {
-                  var dlLink = createChunk(
+                  var dlLink = cldrDom.createChunk(
                     cldrText.get("downloadXmlLink"),
                     "a",
                     "notselected"
@@ -4044,9 +2119,9 @@ const cldrSurvey = (function () {
               }
             }
 
-            removeAllChildNodes(div);
+            cldrDom.removeAllChildNodes(div);
             div.appendChild(frag);
-            hideLoader(null);
+            hideLoader();
           } else {
             handleDisconnect("Failed to load JSON recent items", json);
           }
@@ -4067,6 +2142,7 @@ const cldrSurvey = (function () {
     div.update();
   }
 
+  // called from myvotes.jsp and (theoretically) special/statistics.js
   function showRecent(divName, locale, user) {
     if (!locale) {
       locale = "";
@@ -4082,7 +2158,7 @@ const cldrSurvey = (function () {
     }
     div.className = "recentList";
     div.update = function () {
-      var ourUrl =
+      let ourUrl =
         cldrStatus.getContextPath() +
         "/SurveyAjax?what=recent_items&_=" +
         locale +
@@ -4093,7 +2169,7 @@ const cldrSurvey = (function () {
       var errorHandler = function (err) {
         handleDisconnect("Error in showrecent: " + err);
       };
-      showLoader(null, "Loading recent items");
+      showLoader("Loading recent items");
       var loadHandler = function (json) {
         try {
           if (json && json.recent) {
@@ -4102,17 +2178,25 @@ const cldrSurvey = (function () {
             var data = json.recent.data;
 
             if (data.length == 0) {
-              frag.appendChild(createChunk(cldrText.get("recentNone"), "i"));
+              frag.appendChild(
+                cldrDom.createChunk(cldrText.get("recentNone"), "i")
+              );
             } else {
               var rowDiv = document.createElement("div");
               frag.appendChild(rowDiv);
 
-              rowDiv.appendChild(createChunk(cldrText.get("recentLoc"), "b"));
               rowDiv.appendChild(
-                createChunk(cldrText.get("recentXpathCode"), "b")
+                cldrDom.createChunk(cldrText.get("recentLoc"), "b")
               );
-              rowDiv.appendChild(createChunk(cldrText.get("recentValue"), "b"));
-              rowDiv.appendChild(createChunk(cldrText.get("recentWhen"), "b"));
+              rowDiv.appendChild(
+                cldrDom.createChunk(cldrText.get("recentXpathCode"), "b")
+              );
+              rowDiv.appendChild(
+                cldrDom.createChunk(cldrText.get("recentValue"), "b")
+              );
+              rowDiv.appendChild(
+                cldrDom.createChunk(cldrText.get("recentWhen"), "b")
+              );
 
               for (var q in data) {
                 var row = data[q];
@@ -4132,14 +2216,18 @@ const cldrSurvey = (function () {
                 var xpathItem;
                 xpath_code = xpath_code.replace(/\t/g, " / ");
                 rowDiv.appendChild(
-                  (xpathItem = createChunk(xpath_code, "a", "recentXpath"))
+                  (xpathItem = cldrDom.createChunk(
+                    xpath_code,
+                    "a",
+                    "recentXpath"
+                  ))
                 );
                 xpathItem.href = "survey?_=" + loc + "&strid=" + xpath_hash;
                 rowDiv.appendChild(
-                  createChunk(value, "span", "value recentValue")
+                  cldrDom.createChunk(value, "span", "value recentValue")
                 );
                 rowDiv.appendChild(
-                  createChunk(
+                  cldrDom.createChunk(
                     new Date(last_mod).toLocaleString(),
                     "span",
                     "recentWhen"
@@ -4147,9 +2235,9 @@ const cldrSurvey = (function () {
                 );
               }
             }
-            removeAllChildNodes(div);
+            cldrDom.removeAllChildNodes(div);
             div.appendChild(frag);
-            hideLoader(null);
+            hideLoader();
           } else {
             handleDisconnect("Failed to load JSON recent items", json);
           }
@@ -4178,34 +2266,34 @@ const cldrSurvey = (function () {
    * @returns
    */
 
-  const dom = null;
+  const dojoDom = null;
   const dojoNumber = null;
 
+  // referenced by js written by SurveyMain.doList()
   function showUserActivity(list, tableRef) {
-    window._userlist = list; // DEBUG
-    var table = dom.byId(tableRef);
+    var table = dojoDom.byId(tableRef);
 
     var rows = [];
     var theadChildren = getTagChildren(
       table.getElementsByTagName("thead")[0].getElementsByTagName("tr")[0]
     );
 
-    cldrSurvey.setDisplayed(theadChildren[1], false);
+    cldrDom.setDisplayed(theadChildren[1], false);
     var rowById = [];
 
     for (var k in list) {
       var user = list[k];
-      var tr = dom.byId("u@" + user.id);
+      var tr = dojoDom.byId("u@" + user.id);
 
       rowById[user.id] = parseInt(k); // ?!
 
       var rowChildren = getTagChildren(tr);
 
-      removeAllChildNodes(rowChildren[1]); // org
-      removeAllChildNodes(rowChildren[2]); // name
+      cldrDom.removeAllChildNodes(rowChildren[1]); // org
+      cldrDom.removeAllChildNodes(rowChildren[2]); // name
 
       var theUser;
-      cldrSurvey.setDisplayed(rowChildren[1], false);
+      cldrDom.setDisplayed(rowChildren[1], false);
       rowChildren[2].appendChild((theUser = createUser(user)));
 
       rows.push({
@@ -4217,8 +2305,6 @@ const cldrSurvey = (function () {
         total: 0,
       });
     }
-
-    window._rrowById = rowById;
 
     var loc2name = {};
     request
@@ -4252,15 +2338,19 @@ const cldrSurvey = (function () {
           if (count > userRow.stats.length) {
             count = userRow.stats.length;
           }
-          removeAllChildNodes(userRow.seenSub);
+          cldrDom.removeAllChildNodes(userRow.seenSub);
           for (var k = 0; k < count; k++) {
             var theStat = userRow.stats[k];
-            var chartRow = createChunk("", "div", "chartRow");
+            var chartRow = cldrDom.createChunk("", "div", "chartRow");
 
-            var chartDay = createChunk(theStat.day, "span", "chartDay");
-            var chartLoc = createChunk(theStat.locale, "span", "chartLoc");
+            var chartDay = cldrDom.createChunk(theStat.day, "span", "chartDay");
+            var chartLoc = cldrDom.createChunk(
+              theStat.locale,
+              "span",
+              "chartLoc"
+            );
             chartLoc.title = loc2name[theStat.locale];
-            var chartCount = createChunk(
+            var chartCount = cldrDom.createChunk(
               dojoNumber.format(theStat.count),
               "span",
               "chartCount"
@@ -4280,7 +2370,7 @@ const cldrSurvey = (function () {
         for (var k in rows) {
           var userRow = rows[k];
           if (userRow.total > 0) {
-            addClass(userRow.tr, "hadActivity");
+            cldrDom.addClass(userRow.tr, "hadActivity");
             userRow.tr
               .getElementsByClassName("recentActivity")[0]
               .appendChild(
@@ -4296,61 +2386,136 @@ const cldrSurvey = (function () {
             appendMiniChart(userRow, 3);
             if (userRow.stats.length > 3) {
               var chartMore, chartLess;
-              chartMore = createChunk("+", "span", "chartMore");
-              chartLess = createChunk("-", "span", "chartMore");
+              chartMore = cldrDom.createChunk("+", "span", "chartMore");
+              chartLess = cldrDom.createChunk("-", "span", "chartMore");
               chartMore.onclick = (function (chartMore, chartLess, userRow) {
                 return function () {
-                  cldrSurvey.setDisplayed(chartMore, false);
-                  cldrSurvey.setDisplayed(chartLess, true);
+                  cldrDom.setDisplayed(chartMore, false);
+                  cldrDom.setDisplayed(chartLess, true);
                   appendMiniChart(userRow, userRow.stats.length);
                   return false;
                 };
               })(chartMore, chartLess, userRow);
               chartLess.onclick = (function (chartMore, chartLess, userRow) {
                 return function () {
-                  cldrSurvey.setDisplayed(chartMore, true);
-                  cldrSurvey.setDisplayed(chartLess, false);
+                  cldrDom.setDisplayed(chartMore, true);
+                  cldrDom.setDisplayed(chartLess, false);
                   appendMiniChart(userRow, 3);
                   return false;
                 };
               })(chartMore, chartLess, userRow);
               userRow.seen.appendChild(chartMore);
-              cldrSurvey.setDisplayed(chartLess, false);
+              cldrDom.setDisplayed(chartLess, false);
               userRow.seen.appendChild(chartLess);
             }
           } else {
-            addClass(userRow.tr, "noActivity");
+            cldrDom.addClass(userRow.tr, "noActivity");
           }
         }
       });
   }
 
+  function setShower(id, func) {
+    showers[id] = func;
+  }
+
+  /**
+   * Add to the radio button, a more button style
+   *
+   * @param button
+   * @returns a newly created label element
+   */
+  function wrapRadio(button) {
+    var label = document.createElement("label");
+    label.title = "Vote";
+    label.className = "btn btn-default";
+    label.appendChild(button);
+    $(label).tooltip();
+    return label;
+  }
+
+  /**
+   * Show the vote summary part of the Fix panel
+   *
+   * @param cont
+   *
+   * This was in review.js; for Dashboard
+   */
+  function showHelpFixPanel(cont) {
+    $(".fix-parent .data-vote").html("");
+    $(".fix-parent .data-vote").append(cont);
+
+    $(".data-vote > .span, .data-vote > .pClassExplain").remove();
+    $(".data-vote > .span, .data-vote > .d-example").remove();
+
+    var helpBox = $(".data-vote > *:not(.voteDiv)").add(".data-vote hr");
+    $(".data-vote table:last").after(helpBox);
+
+    if ($(".trInfo").length != 0) {
+      $(".voteDiv").prepend("<hr/>");
+      $(".voteDiv").prepend($(".trInfo").parent());
+    }
+
+    // move the element
+    labelizeIcon();
+  }
   /*
    * Make only these functions accessible from other files:
    */
   return {
-    updateIf: updateIf,
-    isReport: isReport,
-    addClass: addClass,
-    removeClass: removeClass,
-    removeAllChildNodes: removeAllChildNodes,
-    setDisplayed: setDisplayed,
-    isInputBusy: isInputBusy,
-    createChunk: createChunk,
-    clickToSelect: clickToSelect,
-    createLinkToFn: createLinkToFn,
-    createGravitar: createGravitar,
-    stStopPropagation: stStopPropagation,
-    showInPop: showInPop,
-    showInPop2: showInPop2,
-    showLoader: showLoader,
+    INHERITANCE_MARKER: INHERITANCE_MARKER,
+    addIcon: addIcon,
+    addVitem: addVitem,
+    appendExample: appendExample,
+    appendExtraAttributes: appendExtraAttributes,
+    appendIcon: appendIcon,
+    appendItem: appendItem,
+    cacheKill: cacheKill,
+    chgPage: chgPage,
+    cloneAnon: cloneAnon,
+    cloneLocalizeAnon: cloneLocalizeAnon,
+    covName: covName,
+    covValue: covValue,
+    createGravatar: createGravatar,
+    createUser: createUser,
+    effectiveCoverage: effectiveCoverage,
+    findItemByValue: findItemByValue,
+    formatErrMsg: formatErrMsg,
+    getDidUnbust: getDidUnbust,
+    getSurveyLevels: getSurveyLevels,
+    getSurveyOrgCov: getSurveyOrgCov,
+    getSurveyUserCov: getSurveyUserCov,
+    getTagChildren: getTagChildren,
+    getXpathMap: getXpathMap,
+    handleDisconnect: handleDisconnect,
+    handleWiredClick: handleWiredClick,
     hideLoader: hideLoader,
+    isInputBusy: isInputBusy,
+    localizeFlyover: localizeFlyover,
+    parseStatusAction: parseStatusAction,
+    refreshCounterVetting: refreshCounterVetting,
+    setLang: setLang,
+    setOverrideDir: setOverrideDir,
+    setShower: setShower,
+    setSurveyLevels: setSurveyLevels,
+    setSurveyUserCov: setSurveyUserCov,
+    showAllItems: showAllItems,
+    showHelpFixPanel: showHelpFixPanel,
+    showLoader: showLoader,
+    testsToHtml: testsToHtml,
+    unbust: unbust,
+    updateCovFromJson: updateCovFromJson,
+    updateCoverage: updateCoverage,
+    updateSpecialHeader: updateSpecialHeader,
+    updateStatus: updateStatus,
+    wireUpButton: wireUpButton,
+    wrapRadio: wrapRadio,
 
     /*
      * The following are meant to be accessible for unit testing only:
      */
     // test: {
-    // getBodyHtml: getBodyHtml,
+    //   f: f,
     // },
   };
 })();

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrTable.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrTable.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * cldrText: encapsulate code related to the main Survey Tool html table,
+ * cldrTable: encapsulate code related to the main Survey Tool html table,
  * whose rows describe xpaths.
  * This is the non-dojo version. For dojo, see CldrDojoTable.js
  *
@@ -18,6 +18,7 @@
  * and running in strict mode.
  */
 const cldrTable = (function () {
+  const CLDR_TABLE_DEBUG = false;
   /*
    * ALWAYS_REMOVE_ALL_CHILD_NODES and NEVER_REUSE_TABLE should both be false for efficiency,
    * but if necessary they can be made true to revert to old less efficient behavior.
@@ -44,11 +45,11 @@ const cldrTable = (function () {
    */
   function insertRows(theDiv, xpath, session, json) {
     if (ALWAYS_REMOVE_ALL_CHILD_NODES) {
-      removeAllChildNodes(theDiv); // maybe superfluous if always recreate the table, and wrong if we don't always recreate the table
+      cldrDom.removeAllChildNodes(theDiv); // maybe superfluous if always recreate the table, and wrong if we don't always recreate the table
     }
 
     $(".warnText").remove(); // remove any pre-existing "special notes", before insertLocaleSpecialNote
-    window.insertLocaleSpecialNote(theDiv);
+    cldrLoad.insertLocaleSpecialNote(theDiv);
 
     var theTable = null;
     const reuseTable =
@@ -67,11 +68,13 @@ const cldrTable = (function () {
        * Re-create the table from scratch
        */
       // console.log('🦞🦞🦞 make new table, ' + Object.keys(json.section.rows).length + ' rows');
-      theTable = cloneLocalizeAnon(document.getElementById("proto-datatable"));
+      theTable = cldrSurvey.cloneLocalizeAnon(
+        document.getElementById("proto-datatable")
+      );
       /*
-       * Note: isDashboard() is currently never true here; see comments in insertRowsIntoTbody and updateRow
+       * Note: cldrStatus.isDashboard() is currently never true here; see comments in insertRowsIntoTbody and updateRow
        */
-      if (isDashboard()) {
+      if (cldrStatus.isDashboard()) {
         theTable.className += " dashboard";
       } else {
         theTable.className += " vetting-page";
@@ -91,25 +94,25 @@ const cldrTable = (function () {
        * a prototype for each row that gets added to the real (not hidden) table.
        * TODO: simplify.
        */
-      localizeFlyover(theTable); // Replace titles starting with $ with strings from cldrText
-      const headChildren = getTagChildren(
+      cldrSurvey.localizeFlyover(theTable); // Replace titles starting with $ with strings from cldrText
+      const headChildren = cldrSurvey.getTagChildren(
         theTable.getElementsByTagName("tr")[0]
       );
       var toAdd = document.getElementById("proto-datarow"); // loaded from "hidden.html", which see.
-      var rowChildren = getTagChildren(toAdd);
+      var rowChildren = cldrSurvey.getTagChildren(toAdd);
       for (var c in rowChildren) {
         rowChildren[c].title = headChildren[c].title;
       }
       theTable.toAdd = toAdd;
     }
-    updateCoverage(theDiv);
+    cldrSurvey.updateCoverage(theDiv);
     if (!json.canModify) {
       /*
        * Remove the "Abstain" column from the header since user can't modify.
        */
       const headAbstain = theTable.querySelector("th.d-no");
       if (headAbstain) {
-        setDisplayed(headAbstain, false);
+        cldrDom.setDisplayed(headAbstain, false);
       }
     }
     theDiv.theTable = theTable;
@@ -137,7 +140,7 @@ const cldrTable = (function () {
       theDiv.appendChild(theTable);
     }
     insertRowsIntoTbody(theTable, reuseTable);
-    hideLoader(theDiv.loader);
+    cldrSurvey.hideLoader();
   }
 
   /**
@@ -176,7 +179,7 @@ const cldrTable = (function () {
    * Called by insertRows only.
    *
    * This function is not currently used for the Dashboard, only for the main vetting table.
-   * Still we may want to keep the calls to isDashboard for future use. Also note that updateRow,
+   * Still we may want to keep the calls to cldrStatus.isDashboard for future use. Also note that updateRow,
    * which is called from here, IS also used for the Dashboard.
    */
   function insertRowsIntoTbody(theTable, reuseTable) {
@@ -186,7 +189,7 @@ const cldrTable = (function () {
     var parRow = document.getElementById("proto-parrow");
 
     if (ALWAYS_REMOVE_ALL_CHILD_NODES) {
-      removeAllChildNodes(tbody);
+      cldrDom.removeAllChildNodes(tbody);
     }
 
     var theSort = theTable.json.displaySets[theTable.curSortMode]; // typically (always?) curSortMode = "ph"
@@ -198,12 +201,12 @@ const cldrTable = (function () {
       var k = rowList[i];
       var theRow = theRows[k];
       var dir = theRow.dir;
-      overridedir = dir != null ? dir : null;
+      cldrSurvey.setOverrideDir(dir != null ? dir : null);
       /*
        * There is no partition (section headings) in the Dashboard.
        * Also we don't regenerate the headings if we're re-using an existing table.
        */
-      if (!reuseTable && !isDashboard()) {
+      if (!reuseTable && !cldrStatus.isDashboard()) {
         var newPartition = findPartition(
           partitions,
           partitionList,
@@ -213,9 +216,9 @@ const cldrTable = (function () {
 
         if (newPartition != curPartition) {
           if (newPartition.name != "") {
-            var newPar = cloneAnon(parRow);
-            var newTd = getTagChildren(newPar);
-            var newHeading = getTagChildren(newTd[0]);
+            var newPar = cldrSurvey.cloneAnon(parRow);
+            var newTd = cldrSurvey.getTagChildren(newPar);
+            var newHeading = cldrSurvey.getTagChildren(newTd[0]);
             newHeading[0].innerHTML = newPartition.name;
             newHeading[0].id = newPartition.name;
             tbody.appendChild(newPar);
@@ -244,7 +247,7 @@ const cldrTable = (function () {
         ? document.getElementById("r@" + theRow.xpstrid)
         : null;
       if (!tr) {
-        tr = cloneAnon(toAdd);
+        tr = cldrSurvey.cloneAnon(toAdd);
         tbody.appendChild(tr);
         // console.log("🦞 make new table row for " + theRow.xpstrid);
       } else {
@@ -258,6 +261,7 @@ const cldrTable = (function () {
        * curPartition.name isn't defined, and anyway xpathMap shouldn't need changing.
        */
       if (!reuseTable) {
+        const xpathMap = cldrSurvey.getXpathMap();
         xpathMap.put({
           id: theRow.xpathId,
           hex: theRow.xpstrid,
@@ -326,8 +330,8 @@ const cldrTable = (function () {
    * IMPORTANT: this function is used for the Dashboard as well as the main Vetting table.
    * Mostly the Dashboard tables are currently created by review.js showReviewPage
    * (invoked through writeVettingViewerOutput);
-   * they're not created here. Nevertheless the calls here to isDashboard() do serve a purpose,
-   * isDashboard() is true here when called by insertFixInfo in review.js. To see this, put
+   * they're not created here. Nevertheless the calls here to cldrStatus.isDashboard() do serve a purpose,
+   * cldrStatus.isDashboard() is true here when called by insertFixInfo in review.js. To see this, put
    * a breakpoint in this function, go to Dashboard, and click on a "Fix" button, whose pop-up
    * window then will include portions of the item's row as well as a version of the Info Panel.
    *
@@ -396,7 +400,7 @@ const cldrTable = (function () {
       tr.voteDiv = null;
     }
 
-    tr.statusAction = parseStatusAction(theRow.statusAction);
+    tr.statusAction = cldrSurvey.parseStatusAction(theRow.statusAction);
     tr.canModify = tr.theTable.json.canModify && tr.statusAction.vote;
     tr.ticketOnly = tr.theTable.json.canModify && tr.statusAction.ticket;
     tr.canChange = tr.canModify && tr.statusAction.change;
@@ -494,17 +498,17 @@ const cldrTable = (function () {
      * If the user can make changes, add "+" button for adding new candidate item.
      *
      * This code is for Dashboard as well as the basic vetting table.
-     * This block concerns the "other" cell if isDashboard(), otherwise it concerns the "add" cell.
+     * This block concerns the "other" cell if cldrStatus.isDashboard(), otherwise it concerns the "add" cell.
      */
     if (tr.canChange) {
-      if (isDashboard()) {
+      if (cldrStatus.isDashboard()) {
         if (otherCell) {
           otherCell.appendChild(document.createElement("hr"));
           otherCell.appendChild(formAdd);
         }
       } else {
         if (addCell) {
-          removeAllChildNodes(addCell);
+          cldrDom.removeAllChildNodes(addCell);
           addCell.appendChild(formAdd);
         }
       }
@@ -529,7 +533,7 @@ const cldrTable = (function () {
      */
     const curId = cldrStatus.getCurrentId();
     if (curId !== "" && curId === tr.id) {
-      window.showCurrentId(); // refresh again - to get the updated voting status.
+      cldrLoad.showCurrentId(); // refresh again - to get the updated voting status.
     }
   }
 
@@ -566,7 +570,7 @@ const cldrTable = (function () {
 
     for (var k in theRow.items) {
       var item = theRow.items[k];
-      if (item.value === INHERITANCE_MARKER) {
+      if (item.value === cldrSurvey.INHERITANCE_MARKER) {
         if (!theRow.inheritedValue) {
           /*
            * In earlier implementation, essentially the same error was reported as "... there is no Bailey Target item!").
@@ -580,7 +584,7 @@ const cldrTable = (function () {
           }
         } else if (!theRow.inheritedLocale && !theRow.inheritedXpid) {
           /*
-           * It is probably a bug if item.value === INHERITANCE_MARKER but theRow.inheritedLocale and
+           * It is probably a bug if item.value === cldrSurvey.INHERITANCE_MARKER but theRow.inheritedLocale and
            * theRow.inheritedXpid are both undefined (null on server).
            * This happens with "example C" in
            *     https://unicode.org/cldr/trac/ticket/11299#comment:15
@@ -636,7 +640,7 @@ const cldrTable = (function () {
     cell.className = "d-dr-" + statusClass + " d-dr-status statuscell";
 
     if (!cell.isSetup) {
-      listenToPop("", tr, cell);
+      cldrInfo.listen("", tr, cell, null);
       cell.isSetup = true;
     }
 
@@ -645,7 +649,7 @@ const cldrTable = (function () {
   }
 
   /**
-   * On the client only, make further status distinctions when winning value is INHERITANCE_MARKER,
+   * On the client only, make further status distinctions when winning value is cldrSurvey.INHERITANCE_MARKER,
    * "inherited-unconfirmed" (red up-arrow icon) and "inherited-provisional" (orange up-arrow icon).
    * Reference: http://unicode.org/cldr/trac/ticket/11103
    *
@@ -654,7 +658,7 @@ const cldrTable = (function () {
   function getRowApprovalStatusClass(theRow) {
     var statusClass = theRow.confirmStatus;
 
-    if (theRow.winningValue === INHERITANCE_MARKER) {
+    if (theRow.winningValue === cldrSurvey.INHERITANCE_MARKER) {
       if (statusClass === "unconfirmed") {
         statusClass = "inherited-unconfirmed";
       } else if (statusClass === "provisional") {
@@ -694,7 +698,7 @@ const cldrTable = (function () {
         voteForItem.votes[surveyUser.id].overridedVotes
       ) {
         tr.voteDiv.appendChild(
-          createChunk(
+          cldrDom.createChunk(
             cldrText.sub("override_explain_msg", {
               overrideVotes: voteForItem.votes[surveyUser.id].overridedVotes,
               votes: surveyUser.votecount,
@@ -706,26 +710,26 @@ const cldrTable = (function () {
       }
       if (theRow.voteVhash !== theRow.winningVhash && theRow.canFlagOnLosing) {
         if (!theRow.rowFlagged) {
-          addIcon(tr.voteDiv, "i-stop");
+          cldrSurvey.addIcon(tr.voteDiv, "i-stop");
           tr.voteDiv.appendChild(
-            createChunk(
+            cldrDom.createChunk(
               cldrText.sub("mustflag_explain_msg", {}),
               "p",
               "helpContent"
             )
           );
         } else {
-          addIcon(tr.voteDiv, "i-flag");
+          cldrSurvey.addIcon(tr.voteDiv, "i-flag");
           tr.voteDiv.appendChild(
-            createChunk(cldrText.get("flag_desc", "p", "helpContent"))
+            cldrDom.createChunk(cldrText.get("flag_desc", "p", "helpContent"))
           );
         }
       }
     }
     if (!theRow.rowFlagged && theRow.canFlagOnLosing) {
-      addIcon(tr.voteDiv, "i-flag-d");
+      cldrSurvey.addIcon(tr.voteDiv, "i-flag-d");
       tr.voteDiv.appendChild(
-        createChunk(cldrText.get("flag_d_desc", "p", "helpContent"))
+        cldrDom.createChunk(cldrText.get("flag_d_desc", "p", "helpContent"))
       );
     }
     /*
@@ -743,43 +747,51 @@ const cldrTable = (function () {
       if (item == null) {
         continue;
       }
-      var vdiv = createChunk(
+      var vdiv = cldrDom.createChunk(
         null,
         "table",
         "voteInfo_perValue table table-vote"
       );
-      var valdiv = createChunk(
+      var valdiv = cldrDom.createChunk(
         null,
         "div",
         n > 2 ? "value-div" : "value-div first"
       );
       // heading row
-      var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_tr_heading");
+      var vrow = cldrDom.createChunk(
+        null,
+        "tr",
+        "voteInfo_tr voteInfo_tr_heading"
+      );
       if (
-        item.rawValue === INHERITANCE_MARKER ||
+        item.rawValue === cldrSurvey.INHERITANCE_MARKER ||
         (item.votes && Object.keys(item.votes).length > 0)
       ) {
         vrow.appendChild(
-          createChunk(
+          cldrDom.createChunk(
             cldrText.get("voteInfo_orgColumn"),
             "td",
             "voteInfo_orgColumn voteInfo_td"
           )
         );
       }
-      var isection = createChunk(null, "div", "voteInfo_iconBar");
+      var isection = cldrDom.createChunk(null, "div", "voteInfo_iconBar");
       var isectionIsUsed = false;
-      var vvalue = createChunk("User", "td", "voteInfo_valueTitle voteInfo_td");
-      var vbadge = createChunk(vote, "span", "badge");
+      var vvalue = cldrDom.createChunk(
+        "User",
+        "td",
+        "voteInfo_valueTitle voteInfo_td"
+      );
+      var vbadge = cldrDom.createChunk(vote, "span", "badge");
 
       /*
        * Note: we can't just check for item.pClass === "winner" here, since, for example, the winning value may
-       * have value = INHERITANCE_MARKER and item.pClass = "alias".
+       * have value = cldrSurvey.INHERITANCE_MARKER and item.pClass = "alias".
        */
       if (value === theRow.winningValue) {
         const statusClass = getRowApprovalStatusClass(theRow);
         const statusTitle = cldrText.get(statusClass);
-        appendIcon(
+        cldrSurvey.appendIcon(
           isection,
           "voteInfo_winningItem d-dr-" + statusClass,
           cldrText.sub("draftStatus", [statusTitle])
@@ -787,30 +799,39 @@ const cldrTable = (function () {
         isectionIsUsed = true;
       }
       if (item.isBaselineValue) {
-        appendIcon(isection, "i-star", cldrText.get("voteInfo_baseline_desc"));
+        cldrSurvey.appendIcon(
+          isection,
+          "i-star",
+          cldrText.get("voteInfo_baseline_desc")
+        );
         isectionIsUsed = true;
       }
-      setLang(valdiv);
-      if (value === INHERITANCE_MARKER) {
+      cldrSurvey.setLang(valdiv);
+      if (value === cldrSurvey.INHERITANCE_MARKER) {
         /*
          * theRow.inheritedValue can be undefined here; then do not append
          */
         if (theRow.inheritedValue) {
-          appendItem(valdiv, theRow.inheritedValue, item.pClass, tr);
+          cldrSurvey.appendItem(valdiv, theRow.inheritedValue, item.pClass);
           valdiv.appendChild(
-            createChunk(cldrText.get("voteInfo_votesForInheritance"), "p")
+            cldrDom.createChunk(
+              cldrText.get("voteInfo_votesForInheritance"),
+              "p"
+            )
           );
         }
       } else {
-        appendItem(
+        cldrSurvey.appendItem(
           valdiv,
           value,
-          value === theRow.winningValue ? "winner" : "value",
-          tr
+          value === theRow.winningValue ? "winner" : "value"
         );
         if (value === theRow.inheritedValue) {
           valdiv.appendChild(
-            createChunk(cldrText.get("voteInfo_votesForSpecificValue"), "p")
+            cldrDom.createChunk(
+              cldrText.get("voteInfo_votesForSpecificValue"),
+              "p"
+            )
           );
         }
       }
@@ -818,7 +839,7 @@ const cldrTable = (function () {
         valdiv.appendChild(isection);
       }
       vrow.appendChild(vvalue);
-      var cell = createChunk(
+      var cell = cldrDom.createChunk(
         null,
         "td",
         "voteInfo_voteTitle voteInfo_voteCount voteInfo_td" + ""
@@ -831,9 +852,13 @@ const cldrTable = (function () {
         itemVotesLength == 1 &&
         item.votes[Object.keys(item.votes)[0]].level === "anonymous";
       if (itemVotesLength == 0 || anon) {
-        var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_orgHeading");
+        var vrow = cldrDom.createChunk(
+          null,
+          "tr",
+          "voteInfo_tr voteInfo_orgHeading"
+        );
         vrow.appendChild(
-          createChunk(
+          cldrDom.createChunk(
             cldrText.get("voteInfo_noVotes"),
             "td",
             "voteInfo_noVotes voteInfo_td"
@@ -841,7 +866,7 @@ const cldrTable = (function () {
         );
         const anonVoter = anon ? cldrText.get("voteInfo_anon") : null;
         vrow.appendChild(
-          createChunk(anonVoter, "td", "voteInfo_noVotes voteInfo_td")
+          cldrDom.createChunk(anonVoter, "td", "voteInfo_noVotes voteInfo_td")
         );
         vdiv.appendChild(vrow);
       } else {
@@ -852,7 +877,7 @@ const cldrTable = (function () {
     }
     if (vr.valueIsLocked) {
       tr.voteDiv.appendChild(
-        createChunk(
+        cldrDom.createChunk(
           cldrText.get("valueIsLocked"),
           "p",
           "alert alert-warning fix-popover-help"
@@ -863,12 +888,12 @@ const cldrTable = (function () {
         requiredVotes: vr.requiredVotes,
       });
       tr.voteDiv.appendChild(
-        createChunk(msg, "p", "alert alert-warning fix-popover-help")
+        cldrDom.createChunk(msg, "p", "alert alert-warning fix-popover-help")
       );
     }
     // done with voteresolver table
-    if (stdebug_enabled) {
-      tr.voteDiv.appendChild(createChunk(vr.raw, "p", "debugStuff"));
+    if (CLDR_TABLE_DEBUG) {
+      tr.voteDiv.appendChild(cldrDom.createChunk(vr.raw, "p", "debugStuff"));
     }
   }
 
@@ -880,7 +905,7 @@ const cldrTable = (function () {
    * @param vr the vote resolver
    * @param value the value of the candidate item
    * @param item the candidate item
-   * @param vdiv a table created by the caller as vdiv = createChunk(null, "table", "voteInfo_perValue table table-vote")
+   * @param vdiv a table created by the caller as vdiv = cldrDom.createChunk(null, "table", "voteInfo_perValue table table-vote")
    */
   function updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv) {
     for (let org in vr.orgs) {
@@ -943,10 +968,16 @@ const cldrTable = (function () {
          * item.pClass is "alias", "fallback_root", etc.
          */
         var baileyClass =
-          item.rawValue === INHERITANCE_MARKER ? " " + item.pClass : "";
-        var vrow = createChunk(null, "tr", "voteInfo_tr voteInfo_orgHeading");
+          item.rawValue === cldrSurvey.INHERITANCE_MARKER
+            ? " " + item.pClass
+            : "";
+        var vrow = cldrDom.createChunk(
+          null,
+          "tr",
+          "voteInfo_tr voteInfo_orgHeading"
+        );
         vrow.appendChild(
-          createChunk(org, "td", "voteInfo_orgColumn voteInfo_td")
+          cldrDom.createChunk(org, "td", "voteInfo_orgColumn voteInfo_td")
         );
         if (item.votes[topVoter]) {
           vrow.appendChild(createVoter(item.votes[topVoter])); // voteInfo_td
@@ -954,16 +985,16 @@ const cldrTable = (function () {
           vrow.appendChild(createVoter(null));
         }
         if (orgsVote) {
-          var cell = createChunk(
+          var cell = cldrDom.createChunk(
             null,
             "td",
             "voteInfo_orgsVote voteInfo_voteCount voteInfo_td" + baileyClass
           );
-          cell.appendChild(createChunk(orgVoteValue, "span", "badge"));
+          cell.appendChild(cldrDom.createChunk(orgVoteValue, "span", "badge"));
           vrow.appendChild(cell);
         } else {
           vrow.appendChild(
-            createChunk(
+            cldrDom.createChunk(
               orgVoteValue,
               "td",
               "voteInfo_orgsNonVote voteInfo_voteCount voteInfo_td" +
@@ -982,13 +1013,13 @@ const cldrTable = (function () {
             continue; // skip
           }
           // OTHER VOTER row
-          var vrow = createChunk(null, "tr", "voteInfo_tr");
+          var vrow = cldrDom.createChunk(null, "tr", "voteInfo_tr");
           vrow.appendChild(
-            createChunk("", "td", "voteInfo_orgColumn voteInfo_td")
+            cldrDom.createChunk("", "td", "voteInfo_orgColumn voteInfo_td")
           ); // spacer
           vrow.appendChild(createVoter(item.votes[voter])); // voteInfo_td
           vrow.appendChild(
-            createChunk(
+            cldrDom.createChunk(
               item.votes[voter].votes,
               "td",
               "voteInfo_orgsNonVote voteInfo_voteCount voteInfo_td" +
@@ -1009,9 +1040,9 @@ const cldrTable = (function () {
    */
   function createVoter(v) {
     if (v == null) {
-      return createChunk("(missing information)!", "i", "stopText");
+      return cldrDom.createChunk("(missing information)!", "i", "stopText");
     }
-    var div = createChunk(
+    var div = cldrDom.createChunk(
       v.name || cldrText.get("emailHidden"),
       "td",
       "voteInfo_voterInfo voteInfo_td"
@@ -1031,28 +1062,28 @@ const cldrTable = (function () {
    * Called by updateRow.
    */
   function updateRowCodeCell(tr, theRow, cell) {
-    removeAllChildNodes(cell);
+    cldrDom.removeAllChildNodes(cell);
     var codeStr = theRow.code;
-    if (theRow.coverageValue == 101 && !stdebug_enabled) {
+    if (theRow.coverageValue == 101) {
       codeStr = codeStr + " (optional)";
     }
-    cell.appendChild(createChunk(codeStr));
+    cell.appendChild(cldrDom.createChunk(codeStr));
     if (cldrStatus.getSurveyUser()) {
       cell.className = "d-code codecell";
       if (!tr.forumDiv) {
         tr.forumDiv = document.createElement("div");
         tr.forumDiv.className = "forumDiv";
       }
-      appendForumStuff(tr, theRow, tr.forumDiv);
+      cldrForumPanel.appendForumStuff(tr, theRow, tr.forumDiv);
     }
     // extra attributes
     if (
       theRow.extraAttributes &&
       Object.keys(theRow.extraAttributes).length > 0
     ) {
-      appendExtraAttributes(cell, theRow);
+      cldrSurvey.appendExtraAttributes(cell, theRow);
     }
-    if (stdebug_enabled) {
+    if (CLDR_TABLE_DEBUG) {
       var anch = document.createElement("i");
       anch.className = "anch";
       anch.id = theRow.xpathId;
@@ -1072,16 +1103,16 @@ const cldrTable = (function () {
       js.className = "anch-go";
       js.appendChild(document.createTextNode("{JSON}"));
       js.popParent = tr;
-      listenToPop(JSON.stringify(theRow), tr, js);
+      cldrInfo.listen(JSON.stringify(theRow), tr, js, null);
       cell.appendChild(js);
-      cell.appendChild(createChunk(" c=" + theRow.coverageValue));
+      cell.appendChild(cldrDom.createChunk(" c=" + theRow.coverageValue));
     }
     if (!cell.isSetup) {
       var xpathStr = "";
-      if (stdebug_enabled) {
+      if (CLDR_TABLE_DEBUG) {
         xpathStr = "XPath: " + theRow.xpath;
       }
-      listenToPop(xpathStr, tr, cell);
+      cldrInfo.listen(xpathStr, tr, cell, null);
       cell.isSetup = true;
     }
   }
@@ -1110,11 +1141,13 @@ const cldrTable = (function () {
             : "");
         theRow.displayName = theRow.displayName.substr(0, hintPos);
       }
-      cell.appendChild(createChunk(theRow.displayName, "span", "subSpan"));
+      cell.appendChild(
+        cldrDom.createChunk(theRow.displayName, "span", "subSpan")
+      );
       const TRANS_HINT_ID = "en_ZZ"; // must match SurveyMain.TRANS_HINT_ID
-      setLang(cell, TRANS_HINT_ID);
+      cldrSurvey.setLang(cell, TRANS_HINT_ID);
       if (theRow.displayExample) {
-        appendExample(cell, theRow.displayExample, TRANS_HINT_ID);
+        cldrSurvey.appendExample(cell, theRow.displayExample, TRANS_HINT_ID);
       }
       if (hintPos != -1 || hasExample) {
         var infos = document.createElement("div");
@@ -1136,11 +1169,7 @@ const cldrTable = (function () {
     } else {
       cell.appendChild(document.createTextNode(""));
     }
-    /* The next line (listenToPop...) had been commented out, for unknown reasons.
-     * Restored (uncommented) for http://unicode.org/cldr/trac/ticket/10573 so that
-     * the right-side panel info changes when you click on the English column.
-     */
-    listenToPop(null, tr, cell);
+    cldrInfo.listen(null, tr, cell, null);
     cell.isSetup = true;
   }
 
@@ -1155,15 +1184,15 @@ const cldrTable = (function () {
    * Called by updateRow.
    */
   function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
-    removeAllChildNodes(cell); // win
+    cldrDom.removeAllChildNodes(cell); // win
     if (theRow.rowFlagged) {
-      var flagIcon = addIcon(cell, "s-flag");
+      var flagIcon = cldrSurvey.addIcon(cell, "s-flag");
       flagIcon.title = cldrText.get("flag_desc");
     } else if (theRow.canFlagOnLosing) {
-      var flagIcon = addIcon(cell, "s-flag-d");
+      var flagIcon = cldrSurvey.addIcon(cell, "s-flag-d");
       flagIcon.title = cldrText.get("flag_d_desc");
     }
-    setLang(cell);
+    cldrSurvey.setLang(cell);
     tr.proposedcell = cell;
 
     /*
@@ -1172,17 +1201,17 @@ const cldrTable = (function () {
      * in that case, though the consistency checking really should happen earlier, see checkRowConsistency.
      */
     if (getValidWinningValue(theRow) !== null) {
-      addVitem(
+      cldrSurvey.addVitem(
         cell,
         tr,
         theRow,
         theRow.items[theRow.winningVhash],
-        cloneAnon(protoButton)
+        cldrSurvey.cloneAnon(protoButton)
       );
     } else {
       cell.showFn = function () {}; // nothing else to show
     }
-    listenToPop(null, tr, cell, cell.showFn);
+    cldrInfo.listen(null, tr, cell, cell.showFn);
   }
 
   /**
@@ -1198,8 +1227,8 @@ const cldrTable = (function () {
    */
   function updateRowOthersCell(tr, theRow, cell, protoButton, formAdd) {
     var hadOtherItems = false;
-    removeAllChildNodes(cell); // other
-    setLang(cell);
+    cldrDom.removeAllChildNodes(cell); // other
+    cldrSurvey.setLang(cell);
 
     if (tr.canModify) {
       formAdd.role = "form";
@@ -1225,7 +1254,7 @@ const cldrTable = (function () {
         '<span class="glyphicon glyphicon-arrow-right"></span> Winning';
       copyWinning.onclick = function (e) {
         var theValue = getValidWinningValue(theRow);
-        if (theValue === INHERITANCE_MARKER || theValue === null) {
+        if (theValue === cldrSurvey.INHERITANCE_MARKER || theValue === null) {
           theValue = theRow.inheritedValue;
         }
         input.value = theValue || null;
@@ -1281,7 +1310,7 @@ const cldrTable = (function () {
                   tr,
                   theRow,
                   newValue,
-                  cloneAnon(protoButton)
+                  cldrSurvey.cloneAnon(protoButton)
                 );
               } else {
                 toAddVoteButton(btn);
@@ -1294,14 +1323,20 @@ const cldrTable = (function () {
           var newValue = input.value;
 
           if (newValue) {
-            addValueVote(cell, tr, theRow, newValue, cloneAnon(protoButton));
+            addValueVote(
+              cell,
+              tr,
+              theRow,
+              newValue,
+              cldrSurvey.cloneAnon(protoButton)
+            );
           } else {
             toAddVoteButton(btn);
           }
-          stStopPropagation(e);
+          cldrEvent.stopPropagation(e);
           return false;
         }
-        stStopPropagation(e);
+        cldrEvent.stopPropagation(e);
         return false;
       };
     }
@@ -1314,23 +1349,74 @@ const cldrTable = (function () {
         continue;
       }
       hadOtherItems = true;
-      addVitem(cell, tr, theRow, theRow.items[k], cloneAnon(protoButton));
+      cldrSurvey.addVitem(
+        cell,
+        tr,
+        theRow,
+        theRow.items[k],
+        cldrSurvey.cloneAnon(protoButton)
+      );
       cell.appendChild(document.createElement("hr"));
     }
 
     if (!hadOtherItems /*!onIE*/) {
-      listenToPop(null, tr, cell);
+      cldrInfo.listen(null, tr, cell);
     }
     if (
       tr.myProposal &&
       tr.myProposal.value &&
-      !findItemByValue(theRow.items, tr.myProposal.value)
+      !cldrSurvey.findItemByValue(theRow.items, tr.myProposal.value)
     ) {
       // add back my proposal
       cell.appendChild(tr.myProposal);
     } else {
       tr.myProposal = null; // not needed
     }
+  }
+
+  /**
+   * Handle new value submission
+   *
+   * @param td
+   * @param tr
+   * @param theRow
+   * @param newValue
+   * @param newButton
+   */
+  function addValueVote(td, tr, theRow, newValue, newButton) {
+    tr.inputTd = td; // cause the proposed item to show up in the right box
+    cldrSurvey.handleWiredClick(tr, theRow, "", { value: newValue }, newButton);
+  }
+
+  /**
+   * Transform input + submit button to the add button for the "add translation"
+   *
+   * @param btn
+   */
+  function toAddVoteButton(btn) {
+    btn.className = "btn btn-primary";
+    btn.title = "Add";
+    btn.type = "submit";
+    btn.innerHTML = '<span class="glyphicon glyphicon-plus"></span>';
+    $(btn).parent().popover("destroy");
+    $(btn).tooltip("destroy").tooltip();
+    $(btn).closest("form").next(".subSpan").show();
+    $(btn).parent().children("input").remove();
+  }
+
+  /**
+   * Transform the add button to a submit
+   *
+   * @param btn the button
+   * @return the transformed button (return value is ignored by caller)
+   */
+  function toSubmitVoteButton(btn) {
+    btn.innerHTML = '<span class="glyphicon glyphicon-ok-circle"></span>';
+    btn.className = "btn btn-success vote-submit";
+    btn.title = "Submit";
+    $(btn).tooltip("destroy").tooltip();
+    $(btn).closest("form").next(".subSpan").hide();
+    return btn;
   }
 
   /**
@@ -1356,25 +1442,25 @@ const cldrTable = (function () {
     protoButton
   ) {
     if (tr.canModify) {
-      removeAllChildNodes(noCell); // no opinion
-      var noOpinion = cloneAnon(protoButton);
-      wireUpButton(noOpinion, tr, theRow, null);
+      cldrDom.removeAllChildNodes(noCell); // no opinion
+      var noOpinion = cldrSurvey.cloneAnon(protoButton);
+      cldrSurvey.wireUpButton(noOpinion, tr, theRow, null);
       noOpinion.value = null;
-      var wrap = wrapRadio(noOpinion);
+      var wrap = cldrSurvey.wrapRadio(noOpinion);
       noCell.appendChild(wrap);
-      listenToPop(null, tr, noCell);
+      cldrInfo.listen(null, tr, noCell);
     } else if (tr.ticketOnly) {
       // ticket link
       if (!tr.theTable.json.canModify) {
         // only if hidden in the header
-        setDisplayed(noCell, false);
+        cldrDom.setDisplayed(noCell, false);
       }
       proposedCell.className = "d-change-confirmonly";
       var surlink = document.createElement("div");
       surlink.innerHTML =
         '<span class="glyphicon glyphicon-list-alt"></span>&nbsp;&nbsp;';
       surlink.className = "alert alert-info fix-popover-help";
-      var link = createChunk(cldrText.get("file_a_ticket"), "a");
+      var link = cldrDom.createChunk(cldrText.get("file_a_ticket"), "a");
       const curLocale = cldrStatus.getCurrentLocale();
       var newUrl =
         "http://unicode.org/cldr/trac" +
@@ -1390,7 +1476,7 @@ const cldrTable = (function () {
         cldrStatus.getNewVersion();
       link.href = newUrl;
       link.target = "cldr-target-trac";
-      theRow.proposedResults = createChunk(
+      theRow.proposedResults = cldrDom.createChunk(
         cldrText.get("file_ticket_must"),
         "a",
         "fnotebox"
@@ -1398,7 +1484,7 @@ const cldrTable = (function () {
       theRow.proposedResults.href = newUrl;
       if (cldrStatus.getIsUnofficial()) {
         link.appendChild(
-          createChunk(
+          cldrDom.createChunk(
             " (Note: this is not the production SurveyTool! Do not submit a ticket!) ",
             "p"
           )
@@ -1406,7 +1492,7 @@ const cldrTable = (function () {
         link.href = link.href + "&description=NOT+PRODUCTION+SURVEYTOOL!";
       }
       proposedCell.appendChild(
-        createChunk(cldrText.get("file_ticket_notice"), "i", "fnotebox")
+        cldrDom.createChunk(cldrText.get("file_ticket_notice"), "i", "fnotebox")
       );
       surlink.appendChild(link);
       tr.ticketLink = surlink;
@@ -1414,7 +1500,7 @@ const cldrTable = (function () {
       // no change possible
       if (!tr.theTable.json.canModify) {
         // only if hidden in the header
-        setDisplayed(noCell, false);
+        cldrDom.setDisplayed(noCell, false);
       }
     }
   }

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrText.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrText.js
@@ -289,6 +289,8 @@ const cldrText = (function () {
       "${count} old winning votes were automatically imported",
     "v-title_desc":
       "This area shows the date before which votes are considered “old”.",
+    special_admin: "Admin Panel",
+    special_createAndLogin: "Create and Login",
     special_oldvotes: "Import Old Votes",
     special_locales: "Locale List",
     section_general: "General Info",
@@ -347,6 +349,7 @@ const cldrText = (function () {
     users_infoVotesButton: "View Old Vote Stats",
     users_loadVotesButton: "Transfer Old Votes...",
 
+    special_about: "About Survey Tool",
     special_general:
       "Please hover over the sidebar to choose a section to begin entering data. If you have not already done so, please read the <a target='_blank' href='http://www.unicode.org/cldr/survey_tool.html'>Instructions</a>, particularly the Guide and the Walkthrough. You can also use the Dashboard to see all the errors, warnings, and missing items in one place.",
     special_forum: "Forum Posts",
@@ -396,6 +399,7 @@ const cldrText = (function () {
 
     special_vsummary: "Priority Items Summary (slow)",
     special_flagged: "Flagged Items",
+
     flaggedGuidance:
       "This shows a list of items which are flagged for TC review. Items are sorted by locale and then date. ",
     flaggedTotalCount: "Total: ",

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrXpathMap.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrXpathMap.js
@@ -1,4 +1,7 @@
 "use strict";
+// TODO: modernize, possibly make into a class; though it seems to be used as a singleton?
+
+const CLDR_XPATH_DEBUG = true;
 
 /**
  * @class XpathMap
@@ -50,7 +53,7 @@ function XpathMap() {
  */
 XpathMap.prototype.get = function get(search, onResult) {
   // see if we have anything immediately
-  result = null;
+  let result = null;
   if (!result && search.hex) {
     result = this.stridToInfo[search.hex];
   }
@@ -69,9 +72,11 @@ XpathMap.prototype.get = function get(search, onResult) {
       result: result,
     });
   } else {
-    stdebug(
-      "XpathMap search failed for " + JSON.stringify(search) + " - doing rpc"
-    );
+    if (CLDR_XPATH_DEBUG) {
+      console.log(
+        "XpathMap search failed for " + JSON.stringify(search) + " - doing rpc"
+      );
+    }
     var querystr = null;
     if (search.hex) {
       querystr = search.hex;
@@ -84,6 +89,7 @@ XpathMap.prototype.get = function get(search, onResult) {
     }
     const loadHandler = function (json) {
       if (json.getxpath) {
+        const xpathMap = cldrSurvey.getXpathMap();
         xpathMap.put(json.getxpath); // store back first, then
         onResult({
           search: search,
@@ -120,18 +126,24 @@ XpathMap.prototype.get = function get(search, onResult) {
  */
 XpathMap.prototype.put = function put(info) {
   if (!info || !info.id || !info.path || !info.hex || !info.ph) {
-    stdebug(
-      "XpathMap: rejecting incomplete contribution " + JSON.stringify(info)
-    );
+    if (CLDR_XPATH_DEBUG) {
+      console.log(
+        "XpathMap: rejecting incomplete contribution " + JSON.stringify(info)
+      );
+    }
   } else if (this.stridToInfo[info.hex]) {
-    stdebug(
-      "XpathMap: rejecting duplicate contribution " + JSON.stringify(info)
-    );
+    if (CLDR_XPATH_DEBUG) {
+      console.log(
+        "XpathMap: rejecting duplicate contribution " + JSON.stringify(info)
+      );
+    }
   } else {
     this.stridToInfo[info.hex] = this.xpidToInfo[info.id] = this.xpathToInfo[
       info.path
     ] = info;
-    stdebug("XpathMap: adding contribution " + JSON.stringify(info));
+    if (CLDR_XPATH_DEBUG) {
+      console.log("XpathMap: adding contribution " + JSON.stringify(info));
+    }
   }
 };
 

--- a/tools/cldr-apps/src/main/webapp/js/redesign.js
+++ b/tools/cldr-apps/src/main/webapp/js/redesign.js
@@ -1,4 +1,4 @@
-// This is the dojo version. A non-dojo version doesn't exist yet.
+// This is the dojo version. For non-dojo, see cldrEvent.js and others
 
 /*
  * TODO: rename this file to reflect its current role rather than its history.


### PR DESCRIPTION
-Fix bug in PR #893: in cldrAjax.js, only use responseText if responseType is text

-Section view, Reports, Forum, AdminPanel are now mostly working without dojo

-Add placeholders for old dojo-dependent features

-New cldrEvent.js has most of the code from old redesign.js

-New cldrAbout.js and AboutST.java make the About page instead of about.jsp

-New TestCldrAbout.js has unit test for cldrAbout.js

-New cldrAdmin.js has Admin Panel code from old survey.js

-Move OtherSpecial to new cldrOtherSpecial.js

-Move showForumStuff, etc., to new cldrForumPanel.js

-Move showInPop, etc., to new cldrInfo.js

-Move createChunk, etc., to new cldrDom.js

-Move old votes code to new cldrOldVotes.js

-Remove Toggle Sidebar from the gear menu

-Show About in the gear menu even if not logged in

-Avoid nested functions; reduce function length by using subroutines

-Remove dead code; clean up

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14251
- [x] Updated PR title and link in previous line to include Issue number

