### PR TITLE
CLDR-14323 add new CLDRCacheDir service

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRCacheDir.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRCacheDir.java
@@ -1,0 +1,205 @@
+package org.unicode.cldr.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.apache.commons.io.FileUtils;
+
+import com.google.common.io.Files;
+
+/**
+ * Central management for cache files.
+ */
+public class CLDRCacheDir {
+    private static final String CACHE_SUBDIR = ".cache";
+    /**
+     * All users of the cache must have an enum entry here
+     *
+     */
+    public enum CacheType {
+        abstracts("Article excerpts from DBPedia"),
+        xmlCache("Precomputed XML metadata and validity"),
+        sandbox("Temporary locales that may be used for user experimentation, data may not be persisted."),
+        urlmap("URL-to-Subtype mapping");
+
+        private String description;
+
+        public String getDescription() {
+            return description;
+        }
+        /**
+         *
+         */
+        CacheType(String description) {
+            this.description = description;
+        }
+        /**
+         * Get the 'latest good' date before which a cached item is considered stale.
+         * For example, if the expiry is 3 days, then the Instant will reflect a date 3 days ago.
+         * For some item, if "item.isBefore(latestGoodInstant)" then the item is stale.
+         *
+         * This is overridable by a property, such as CLDR_ABSTRACT_EXPIRE_DAYS
+         * @param expireDays the default days if the property is not set
+         * @return
+         */
+        public Instant getLatestGoodInstant(int expireDays) {
+            return CLDRCacheDir.getLatestGoodInstant(getExpiryProperty(), expireDays);
+        }
+        private String getExpiryProperty() {
+            return "CLDR_"+name().toUpperCase()+"_EXPIRE_DAYS";
+        }
+    }
+
+    /**
+     * Get the 'latest good' date before which a cached item is considered stale.
+     * For example, if the expiry is 3 days, then the Instant will reflect a date 3 days ago.
+     * For some item, if "item.isBefore(latestGoodInstant)" then the item is stale.
+     * @param propName property that can override the expiry
+     * @param expireDays the default days if the property is not set
+     * @return
+     */
+    static Instant getLatestGoodInstant(final String propName, int expireDays) {
+        Instant now = Instant.now();
+        Instant latestGood = now.minus(CLDRConfig.getInstance().getProperty(propName, expireDays), ChronoUnit.DAYS);
+        return latestGood;
+    }
+
+    private final CacheType type;
+
+    private File file;
+
+    CLDRCacheDir(CacheType type) {
+        this.type = type;
+        CACHE_HELPER.assertOK(); // throw any exception needed
+        this.file = getFile(this.type);
+    }
+
+    /**
+     * Construct a new CLDRCacheDir handle using the specified type.
+     * This can be called from a servlet environment or from within unit tests
+     * (for unit testing some submodule), however, if called in the servlet environment it should be
+     * called after
+     * @param type
+     * @return
+     */
+    public static CLDRCacheDir getInstance(CacheType type) {
+        return new CLDRCacheDir(type);
+    }
+
+    private static File getFile(CacheType type) {
+        return new File(CACHE_HELPER.rootDir, type.name());
+    }
+
+    /**
+     * Get the File pertaining to this cache entry.
+     * @return
+     */
+    public File getDir() {
+        return file;
+    }
+
+    /**
+     * Return the file, as an empty dir.
+     * This is the function most callers will want to use.
+     * @return
+     */
+    public File getEmptyDir() {
+        getDir().mkdirs();
+        return getDir();
+    }
+
+    public CacheType getType() {
+        return type;
+    }
+
+    /**
+     * Delete the specified cache entry.
+     * @throws IOException
+     */
+    void remove() throws IOException {
+        FileUtils.deleteDirectory(getDir());
+    }
+
+    /**
+     * Remove all cache entries.
+     * Leaves the cache directory itself.
+     * @throws IOException
+     */
+    static void removeAll() throws IOException {
+        for (final CacheType t : CacheType.values()) {
+            FileUtils.deleteDirectory(getFile(t));
+        }
+    }
+
+    /**
+     * Bill Pugh style singleton for setting up caches.
+     * This function needs to always "succeed",
+     * but will defer errors into the 'err' field.
+     */
+    static final class CacheHelper {
+        File rootDir = null;
+        Throwable err = null;
+
+        CacheHelper() {
+            try {
+                // Make sure CLDRConfig is loaded.
+                final CLDRConfig config = CLDRConfig.getInstance();
+                if(config instanceof CLDRConfigImpl) {
+                    File homeFile = CLDRConfigImpl.getInstance().getHomeFile();
+                    if(homeFile == null) {
+                        err = new IllegalArgumentException("CLDRConfigImpl present but getHomeFile() returned null.");
+                    } else {
+                        rootDir = new File(homeFile, CACHE_SUBDIR);
+                    }
+                } else {
+                    // CLDRConfigImpl isn't around to give us a proper home file, so just use a temporary directory.
+                    // We are probably not within a servlet environment.
+                    // In any event, these are only cache files.
+                    rootDir = Files.createTempDir();
+                }
+                System.out.println("CLDRCacheDir: " + rootDir.getAbsolutePath());
+                setup();
+            } catch(Throwable t) {
+                err = t;
+            }
+        }
+
+        void assertOK() throws IllegalArgumentException {
+            if(err != null) {
+                throw new IllegalArgumentException("Not setup OK", err);
+            }
+        }
+
+        /**
+         * Make sure the cache directory is setup.
+         * @throws IOException
+         */
+        void setup() throws IOException {
+            if(rootDir != null) {
+                if(!rootDir.isDirectory()) {
+                    System.err.println("Creating cache directory " + rootDir.getAbsolutePath());
+                    rootDir.mkdirs();
+                }
+                File tag = new File(rootDir, "CACHEDIR.TAG");
+                if(!tag.exists()) {
+                    System.err.println("Writing cache tag " + tag.getAbsolutePath());
+                    Files.asCharSink(tag, StandardCharsets.UTF_8).write("Signature: 8a477f597d28d172789f06886806bc55\n"
+                        + "# This file is a cache directory tag created by the CLDR Survey Tool <https://unicode.org/cldr>\n"
+                        + "# For information about cache directory tags, see:\n"
+                        + "#   https://bford.info/cachedir/\n"
+                        + "");
+                }
+            } else {
+                throw new NullPointerException("CLDRCacheDir could not calculate rootDir. Make sure caches are not accessed prior to servlet initialization.");
+            }
+        }
+    }
+    static final CacheHelper CACHE_HELPER = new CacheHelper();
+
+    public static void main(String args[]) {
+        new CLDRCacheDir(CacheType.abstracts);
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -66,6 +66,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.test.HelpMessages;
+import org.unicode.cldr.util.CLDRCacheDir;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfigImpl;
 import org.unicode.cldr.util.CLDRFile;
@@ -903,7 +904,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         synchronized(SurveyMain.class) {
             if(sandbox == null) {
                 try {
-                    sandbox = new SandboxLocales(new File(getSurveyHome(), "sandbox"));
+                    sandbox = new SandboxLocales(CLDRCacheDir.getInstance(CLDRCacheDir.CacheType.sandbox).getEmptyDir());
                 } catch (IOException e) {
                     SurveyMain.busted("Could not initialize sandbox locales", e);
                     /** NOTREACHED **/
@@ -3434,23 +3435,24 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         ElapsedTimer et = new ElapsedTimer();
         CLDRProgressTask progress = openProgress("Parse locales from XML", locales.size());
         try {
-            File vetdir = getVetdir();
-            File xmlCache = new File(vetdir, XML_CACHE_PROPERTIES);
-            File xmlCacheBack = new File(vetdir, XML_CACHE_PROPERTIES + ".backup");
+            File xmlCacheDir = CLDRCacheDir.getInstance(CLDRCacheDir.CacheType.xmlCache).getEmptyDir();
+            File xmlCache = new File(xmlCacheDir, XML_CACHE_PROPERTIES);
+            File xmlCacheBack = new File(xmlCacheDir, XML_CACHE_PROPERTIES + ".backup");
             Properties xmlCacheProps = new java.util.Properties();
             Properties xmlCachePropsNew = new java.util.Properties();
-            if (useCache && xmlCache.exists())
+            if (useCache && xmlCache.exists()) {
                 try {
-                java.io.FileInputStream is = new java.io.FileInputStream(xmlCache);
-                xmlCacheProps.load(is);
-                is.close();
+                    java.io.FileInputStream is = new java.io.FileInputStream(xmlCache);
+                    xmlCacheProps.load(is);
+                    is.close();
                 } catch (java.io.IOException ioe) {
-                /* throw new UnavailableException */
-                SurveyLog.logger.log(java.util.logging.Level.SEVERE, "Couldn't load XML Cache file from '" + "(home)" + "/"
-                    + XML_CACHE_PROPERTIES + ": ", ioe);
-                busted("Couldn't load XML Cache file from '" + "(home)" + "/" + XML_CACHE_PROPERTIES + ": ", ioe);
-                return;
+                    /* throw new UnavailableException */
+                    SurveyLog.logger.log(java.util.logging.Level.SEVERE, "Couldn't load XML Cache file from '" + "(home)" + "/"
+                        + XML_CACHE_PROPERTIES + ": ", ioe);
+                    busted("Couldn't load XML Cache file from '" + "(home)" + "/" + XML_CACHE_PROPERTIES + ": ", ioe);
+                    return;
                 }
+            }
 
             int n = 0;
             int cachehit = 0;
@@ -3526,26 +3528,27 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                 }
             }
 
-            if (useCache)
+            if (useCache) {
                 try {
-                // delete old stuff
-                if (xmlCacheBack.exists()) {
-                xmlCacheBack.delete();
-                }
-                if (xmlCache.exists()) {
-                xmlCache.renameTo(xmlCacheBack);
-                }
-                java.io.FileOutputStream os = new java.io.FileOutputStream(xmlCache);
-                xmlCachePropsNew.store(os, "YOU MAY DELETE THIS CACHE. Cache updated at " + new Date());
-                progress.update(n++, "Loading configuration..");
-                os.close();
+                    // delete old stuff
+                    if (xmlCacheBack.exists()) {
+                        xmlCacheBack.delete();
+                    }
+                    if (xmlCache.exists()) {
+                        xmlCache.renameTo(xmlCacheBack);
+                    }
+                    java.io.FileOutputStream os = new java.io.FileOutputStream(xmlCache);
+                    xmlCachePropsNew.store(os, "YOU MAY DELETE THIS CACHE. Cache updated at " + new Date());
+                    progress.update(n++, "Loading configuration..");
+                    os.close();
                 } catch (java.io.IOException ioe) {
-                /* throw new UnavailableException */
-                SurveyLog.logger.log(java.util.logging.Level.SEVERE, "Couldn't write " + xmlCache + " file from '" + cldrHome
-                    + "': ", ioe);
-                busted("Couldn't write " + xmlCache + " file from '" + cldrHome + "': ", ioe);
-                return;
+                    /* throw new UnavailableException */
+                    SurveyLog.logger.log(java.util.logging.Level.SEVERE, "Couldn't write " + xmlCache + " file from '" + cldrHome
+                        + "': ", ioe);
+                    busted("Couldn't write " + xmlCache + " file from '" + cldrHome + "': ", ioe);
+                    return;
                 }
+            }
 
             if (!failedSuppTest.isEmpty()) {
                 busted("Supplemental Data Test failed on startup for: " + ListFormatter.getInstance().format(failedSuppTest));
@@ -3724,18 +3727,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             newVersion = survprops.getProperty(CLDR_NEWVERSION, CLDR_NEWVERSION);
             oldVersion = survprops.getProperty(CLDR_OLDVERSION, CLDR_OLDVERSION);
             lastVoteVersion = survprops.getProperty(CLDR_LASTVOTEVERSION, oldVersion);
-            progress.update("Setup dirs..");
 
-            getVetdir();
-            final File cldrHomeDir = new File(cldrHome);
-
-            // load abstracts in a separate thread.
-            startupThread.addTask(new SurveyThread.SurveyTask("load abstract") {
-                @Override
-                public void run() throws Throwable {
-                    AbstractCacheManager.getInstance().setHome(cldrHomeDir);
-                }
-            });
+            setupHomeDir(progress);
 
             progress.update("Setup vap and message..");
             testpw = survprops.getProperty("CLDR_TESTPW"); // Vet Access
@@ -3855,6 +3848,29 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             SurveyLog.logger.info("------- SurveyTool FAILED TO STARTUP, " + setupTime + "/" + uptime + ". Memory in use: " + usedK()
                 + "----------------------------\n\n\n");
         }
+    }
+
+    /**
+     * Setup things that are dependent on the CLDR home directory being set.
+     * @param progress
+     */
+    private void setupHomeDir(CLDRProgressTask progress) {
+        progress.update("Setup the Home dir..");
+
+        // load abstracts in a separate thread.
+        startupThread.addTask(new SurveyThread.SurveyTask("load abstract") {
+            @Override
+            public void run() throws Throwable {
+                AbstractCacheManager.getInstance().setup();
+            }
+        });
+
+        // we could setup the url subtype mapper here, but instead we leave that
+        // to be lazily loaded.
+
+        // Ensure that the vetdata/ directory is present.
+        progress.update("Setup vetdata/..");
+        getVetdir();
     }
 
     private static void stopIfMaintenance() {


### PR DESCRIPTION
CLDR-14323

- make XML cache, Abstract cache, Subtype URL, and Sandbox locales all use the new
cache facility
- the cache dir is under 'cldr/.cache' where .cache is a sibling of cldr.properties, etc.
- implements https://bford.info/cachedir/ recommendation for cache dir tagging (that is the `CACHEDIR.TAG` file)

Example of cache in use: (all of these files were in random places previously)

```shell
$ (cd eclipse-workspace/.metadata/.plugins/org.eclipse.wst.server.core/tmp0  ; find ./cldr/.cache -print)
./cldr/.cache
./cldr/.cache/CACHEDIR.TAG
./cldr/.cache/urlmap
./cldr/.cache/urlmap/urlmap-cache.txt
./cldr/.cache/abstracts
./cldr/.cache/abstracts/xpath-to-resource.properties
./cldr/.cache/sandbox
./cldr/.cache/sandbox/annotations
./cldr/.cache/sandbox/annotations/mul.xml
./cldr/.cache/sandbox/annotations/mul_AQ.xml
./cldr/.cache/sandbox/annotations/mul_ZZ.xml
./cldr/.cache/sandbox/main
./cldr/.cache/sandbox/main/mul.xml
./cldr/.cache/sandbox/main/mul_AQ.xml
./cldr/.cache/sandbox/main/mul_ZZ.xml
./cldr/.cache/xmlCache
./cldr/.cache/xmlCache/xmlCache.properties.backup
./cldr/.cache/xmlCache/xmlCache.properties
```