### PR TITLE
CLDR-14251 make USE_DOJO a server side and a request-time param

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -569,7 +569,7 @@ public class SurveyAjax extends HttpServlet {
                     if (what.equals(WHAT_ADMIN_PANEL)) {
                         mySession.userDidAction();
                         if (UserRegistry.userIsAdmin(mySession.user)) {
-                            if (SurveyTool.USE_DOJO) {
+                            if (SurveyTool.useDojo(request)) {
                                 response.sendRedirect(request.getContextPath() + "/AdminPanel.jsp" + "?vap=" + SurveyMain.vap);
                             } else {
                                 mySession.userDidAction();
@@ -3163,7 +3163,7 @@ public class SurveyAjax extends HttpServlet {
                 out.write("<td title='vote:' style='" + resultStyle + "'>\n");
                 if (!checkResult.isEmpty()) {
                     out.write("<script>\n");
-                    String testsToHtml = SurveyTool.USE_DOJO ? "cldrSurvey.testsToHtml" : "testsToHtml";
+                    String testsToHtml = SurveyTool.useDojo(request) ? "cldrSurvey.testsToHtml" : "testsToHtml";
                     out.write("document.write(" + testsToHtml + "(" + SurveyAjax.JSONWriter.wrap(checkResult) + ")");
                     out.write("</script>\n");
                 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -2277,7 +2277,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                  * TODO: implement this with strict js, without using java to write js!
                  * ...this function SurveyMain.doList() is over 666 lines long...
                  */
-                if (SurveyTool.USE_DOJO) {
+                if (SurveyTool.useDojo(ctx)) {
                     ctx.println("<script>var shownUsers = " + shownUsers.toString() + ";\n" +
                         "showUserActivity(shownUsers, 'userListTable');\n</script>\n");
 

--- a/tools/cldr-apps/src/main/webapp/AdminPanel.jsp
+++ b/tools/cldr-apps/src/main/webapp/AdminPanel.jsp
@@ -9,6 +9,11 @@ if(vap==null ||
 	response.sendRedirect("http://cldr.unicode.org"); // Get out.
 	return;
 }
+if (SurveyTool.useDojo(request) == false) {
+    // AdminPanel.jsp is the dojo version. Redirect to the new one.
+    response.sendRedirect("./v?USE_DOJO=false#admin///");
+    return;
+}
 
 String action  = request.getParameter("do");
 

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrAjax.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrAjax.js
@@ -158,8 +158,12 @@ const cldrAjax = (function () {
     } else {
       options.method = "GET";
     }
-
     const request = new XMLHttpRequest();
+    if(xhrArgs.url.indexOf('?') == -1) {
+      xhrArgs.url += '?USE_DOJO='+USE_DOJO;
+    } else {
+      xhrArgs.url += '&USE_DOJO='+USE_DOJO;
+    }
     request.open(options.method, xhrArgs.url);
     request.responseType = options.handleAs ? options.handleAs : "text";
     request.timeout = ajaxTimeout;

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
@@ -607,6 +607,7 @@ const cldrLoad = (function () {
       r_vetting_json: cldrDash,
       recent_activity: cldrRecentActivity,
       retry: cldrRetry,
+      admin: cldrAdmin,
     };
     if (str in specials) {
       return specials[str];

--- a/tools/cldr-apps/src/main/webapp/js/special/admin.js
+++ b/tools/cldr-apps/src/main/webapp/js/special/admin.js
@@ -1,0 +1,30 @@
+/**
+ * Example special module that shows a blank page.
+ * Modify 'js/special/blank.js' below to reflect your special page's name.
+ * @module blank
+ */
+define("js/special/admin.js", ["js/special/SpecialPage.js"], function (
+  SpecialPage
+) {
+  var _super;
+
+  function Page() {
+    // constructor
+  }
+
+  // set up the inheritance before defining other functions
+  _super = Page.prototype = new SpecialPage();
+
+  Page.prototype.show = function show(params) {
+    // set up the DIV you want to show the world
+    var ourDiv = createChunk("Please access the Admin Panel using the gear menu.", "i", "warn");
+
+    // No longer loading
+    hideLoader(null);
+
+    // Flip to the new DIV
+    params.flipper.flipTo(params.pages.other, ourDiv);
+  };
+
+  return Page;
+});


### PR DESCRIPTION
CLDR-14251
`USE_DOJO` (default true) can now be set in cldr.properties
also, any request can have `?USE_DOJO=false` or `?USE_DOJO=true` to override

It turned out to be very simple to make this switchable. Could be helpful in testing old vs. new behavior.