### PR TITLE
CLDR-13418 German cardinal doesn't have spellout-cardinal-m rule

### DIFF
--- a/common/rbnf/de.xml
+++ b/common/rbnf/de.xml
@@ -59,6 +59,14 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
+            <!--
+            Here is what the inflection table looks like for this language, and how they map to the various rule names.
+            case        masculine                feminine                 neuter
+            nominative  ein (cardinal-masculine) eine (cardinal-feminine) ein (cardinal-neuter)
+            genitive    eines (cardinal-s)       einer (cardinal-r)       eines (cardinal-s)
+            dative      einem (cardinal-m)       einer (cardinal-r)       einem (cardinal-m)
+            accusative  einen (cardinal-n)       eine (cardinal-feminine) ein (cardinal-neuter)
+            -->
             <ruleset type="spellout-cardinal-neuter">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>
             </ruleset>
@@ -152,6 +160,24 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
+            <ruleset type="spellout-cardinal-m">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">einem;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
             <ruleset type="ste" access="private">
                 <rbnfrule value="0">ste;</rbnfrule>
                 <rbnfrule value="1">­=%spellout-ordinal=;</rbnfrule>
@@ -200,6 +226,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="-x">minus →→;</rbnfrule>
                 <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-ordinal=s;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-m">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-ordinal=m;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>

--- a/common/rbnf/de_CH.xml
+++ b/common/rbnf/de_CH.xml
@@ -60,6 +60,14 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
+            <!--
+            Here is what the inflection table looks like for this language, and how they map to the various rule names.
+            case        masculine                feminine                 neuter
+            nominative  ein (cardinal-masculine) eine (cardinal-feminine) ein (cardinal-neuter)
+            genitive    eines (cardinal-s)       einer (cardinal-r)       eines (cardinal-s)
+            dative      einem (cardinal-m)       einer (cardinal-r)       einem (cardinal-m)
+            accusative  einen (cardinal-n)       eine (cardinal-feminine) ein (cardinal-neuter)
+            -->
             <ruleset type="spellout-cardinal-neuter">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>
             </ruleset>
@@ -153,6 +161,24 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
+            <ruleset type="spellout-cardinal-m">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">einem;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
             <ruleset type="ste" access="private">
                 <rbnfrule value="0">ste;</rbnfrule>
                 <rbnfrule value="1">­=%spellout-ordinal=;</rbnfrule>
@@ -201,6 +227,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="-x">minus →→;</rbnfrule>
                 <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-ordinal=s;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-m">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-ordinal=m;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13418
- [x] Updated PR title and link in previous line to include Issue number

For completeness, I added one for the ordinal too. For consistency, I used the same naming scheme of cardinal-m as the other rules. This rule seems to apply to the masculine dative and neuter dative case only in German.

I got a German expert to review the changes. The changes seem fine within the scope of the changes. There were some additional comments about other existing rules, but that should be handled with separate tickets.