### PR TITLE
CLDR-11268 Portugal Portuguese should use the long scale and Brazil should use the short scale

### DIFF
--- a/common/rbnf/pt.xml
+++ b/common/rbnf/pt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -65,14 +65,10 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="900">novecentos[ e →→];</rbnfrule>
                 <rbnfrule value="1000">mil[ e →→];</rbnfrule>
                 <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">um milhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000">←← milhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">um bilhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000">←← bilhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">um trilhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←← trilhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">um quatrilhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←← quatrilhões[ e →→];</rbnfrule>
+                <rbnfrule value="1000000">←← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000">←← $(cardinal,one{bilhão}other{bilhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←← $(cardinal,one{trilhão}other{trilhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←← $(cardinal,one{quatrilhão}other{quatrilhões})$[ e →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-feminine">
@@ -102,14 +98,10 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="900">novecentas[ e →→];</rbnfrule>
                 <rbnfrule value="1000">mil[ e →→];</rbnfrule>
                 <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">um milhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-masculine← milhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">um bilhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-masculine← bilhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">um trilhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-masculine← trilhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">um quatrilhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-masculine← quatrilhões[ e →→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-masculine← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← $(cardinal,one{bilhão}other{bilhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← $(cardinal,one{trilhão}other{trilhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← $(cardinal,one{quatrilhão}other{quatrilhões})$[ e →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-masculine">
@@ -144,15 +136,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="800">octingentésimo[ →→];</rbnfrule>
                 <rbnfrule value="900">noningentésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000">milésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000">←%spellout-cardinal-masculine← ­milésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000">um milionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-masculine← milionésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000000">um bilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-masculine← bilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000">um trilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-masculine← trilionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">um quadrilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-masculine← quadrilionésimo[ →→];</rbnfrule>
+                <rbnfrule value="2000">←%spellout-cardinal-masculine← milésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-masculine← milionésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← bilionésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← trilionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← quadrilionésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=º;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-feminine">
@@ -187,15 +175,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="800">octingentésima[ →→];</rbnfrule>
                 <rbnfrule value="900">noningentésima[ →→];</rbnfrule>
                 <rbnfrule value="1000">milésima[ →→];</rbnfrule>
-                <rbnfrule value="2000">←%spellout-cardinal-feminine← ­milésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000">uma milionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-feminine← milionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000">uma bilionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← bilionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000">uma trilionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← trilionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">uma quadrilionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← quadrilionésima[ →→];</rbnfrule>
+                <rbnfrule value="2000">←%spellout-cardinal-feminine← milésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-feminine← milionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-feminine← bilionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-feminine← trilionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-feminine← quadrilionésima[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=ª;</rbnfrule>
             </ruleset>
         </rulesetGrouping>

--- a/common/rbnf/pt_PT.xml
+++ b/common/rbnf/pt_PT.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -66,14 +66,10 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="900">novecentos[ e →→];</rbnfrule>
                 <rbnfrule value="1000">mil[ e →→];</rbnfrule>
                 <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">um milhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000">←← milhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">um bilião[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000">←← biliões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">um trilião[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←← triliões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">um quatrilião[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←← quatriliões[ e →→];</rbnfrule>
+                <rbnfrule value="1000000">←← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000">←← mil milhões[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←← $(cardinal,one{bilião}other{biliões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←← mil biliões[ e →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-feminine">
@@ -103,14 +99,10 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="900">novecentas[ e →→];</rbnfrule>
                 <rbnfrule value="1000">mil[ e →→];</rbnfrule>
                 <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">um milhão[ e →→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-masculine← milhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">um bilião[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-masculine← biliões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">um trilião[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-masculine← triliões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">um quatrilião[ e →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-masculine← quatriliões[ e →→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-masculine← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← mil milhões[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← $(cardinal,one{bilião}other{biliões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← mil biliões[ e →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-masculine">
@@ -145,15 +137,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="800">octingentésimo[ →→];</rbnfrule>
                 <rbnfrule value="900">noningentésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000">milésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000">←%spellout-cardinal-masculine← ­milésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000">um milionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-masculine← milionésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000000">um bilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-masculine← bilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000">um trilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-masculine← trilionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">um quadrilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-masculine← quadrilionésimo[ →→];</rbnfrule>
+                <rbnfrule value="2000">←%spellout-cardinal-masculine← milésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-masculine← milionésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← mil milionésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← bilionésimo[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← mil bilionésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=º;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-feminine">
@@ -188,15 +176,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="800">octingentésima[ →→];</rbnfrule>
                 <rbnfrule value="900">noningentésima[ →→];</rbnfrule>
                 <rbnfrule value="1000">milésima[ →→];</rbnfrule>
-                <rbnfrule value="2000">←%spellout-cardinal-feminine← ­milésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000">uma milionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-feminine← milionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000">uma bilionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← bilionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000">uma trilionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← trilionésima[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">uma quadrilionésima[ →→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← quadrilionésima[ →→];</rbnfrule>
+                <rbnfrule value="2000">←%spellout-cardinal-feminine← milésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-feminine← milionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-feminine← mil milionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-feminine← bilionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-feminine← mil bilionésima[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=ª;</rbnfrule>
             </ruleset>
         </rulesetGrouping>


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11268
- [x] Updated PR title and link in previous line to include Issue number

In addition to the short scale versus long scale difference, I simplified the rule logic and mirrored the style between the two Portuguese variants to make it easier to compare for differences in the future.

I used https://www.flip.pt/Duvidas-Linguisticas/Duvida-Linguistica/DID/4389 for reference to determine the scale used.