### PR TITLE
CLDR-14392 Modernize Bulk Close Posts in gear menu

### DIFF
--- a/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrLoad.js
@@ -594,6 +594,8 @@ const cldrLoad = (function () {
   function getSpecial(str) {
     const specials = {
       about: cldrAbout,
+      admin: cldrAdmin,
+      bulk_close_posts: cldrBulkClosePosts,
       createAndLogin: cldrCreateLogin,
       error_subtypes: cldrErrorSubtypes,
       forum: cldrForum,
@@ -607,7 +609,6 @@ const cldrLoad = (function () {
       r_vetting_json: cldrDash,
       recent_activity: cldrRecentActivity,
       retry: cldrRetry,
-      admin: cldrAdmin,
     };
     if (str in specials) {
       return specials[str];

--- a/tools/cldr-apps/src/main/webapp/js/new/cldrSurvey.js
+++ b/tools/cldr-apps/src/main/webapp/js/new/cldrSurvey.js
@@ -496,6 +496,7 @@ const cldrSurvey = (function () {
       handleAs: "json",
       load: updateStatusLoadHandler,
       error: updateStatusErrHandler,
+      timeout: cldrAjax.mediumTimeout(),
     };
 
     cldrAjax.sendXhr(xhrArgs);
@@ -1560,6 +1561,7 @@ const cldrSurvey = (function () {
       handleAs: "json",
       load: loadHandler,
       error: errorHandler,
+      timeout: cldrAjax.mediumTimeout(),
     };
     cldrAjax.queueXhr(xhrArgs);
   }
@@ -1752,6 +1754,7 @@ const cldrSurvey = (function () {
       content: ourContent,
       load: loadHandler,
       error: errorHandler,
+      timeout: cldrAjax.mediumTimeout(),
     };
     cldrAjax.queueXhr(xhrArgs);
   }

--- a/tools/cldr-apps/src/main/webapp/js/survey.js
+++ b/tools/cldr-apps/src/main/webapp/js/survey.js
@@ -1257,6 +1257,7 @@ function updateStatus() {
       surveySessionUrl +
       cacheKill(),
     handleAs: "json",
+    timeout: cldrAjax.mediumTimeout(),
     load: function (json) {
       if (json == null || (json.status && json.status.isBusted)) {
         wasBusted = true;
@@ -3362,6 +3363,7 @@ function refreshSingleRow(tr, theRow, onSuccess, onFailure) {
     handleAs: "json",
     load: loadHandler,
     error: errorHandler,
+    timeout: cldrAjax.mediumTimeout(),
   };
   cldrAjax.queueXhr(xhrArgs);
 }
@@ -3552,6 +3554,7 @@ function handleWiredClick(tr, theRow, vHash, box, button, what) {
     content: ourContent,
     load: loadHandler,
     error: errorHandler,
+    timeout: cldrAjax.mediumTimeout(),
   };
   cldrAjax.queueXhr(xhrArgs);
 }


### PR DESCRIPTION
-For new (non-dojo) front end: include bulk_close_posts in getSpecial; no load params

-Write progress to java log so Admin user can see it

-Fix cldrAjax timeout handling (dojo and non-dojo): err if timeout; default no timeout

-Add new cldrAjax.mediumTimeout to restore old 2-sec timeout for certain requests

-Alphabetize specials array including admin

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14392
- [x] Updated PR title and link in previous line to include Issue number

