### PR TITLE
CLDR-14182 23000 is misspelled in Italian

### DIFF
--- a/common/rbnf/it.xml
+++ b/common/rbnf/it.xml
@@ -157,7 +157,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             </ruleset>
             <ruleset type="msc-with-i-nofinal" access="private">
                 <rbnfrule value="0">=%%msc-with-i=;</rbnfrule>
-                <rbnfrule value="3">a­tre;</rbnfrule>
+                <rbnfrule value="3">i­tre;</rbnfrule>
                 <rbnfrule value="4">=%%msc-with-i=;</rbnfrule>
             </ruleset>
             <ruleset type="msc-with-a-nofinal" access="private">


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14182
- [x] Updated PR title and link in previous line to include Issue number

This looks like a copy and paste typo.