### PR TITLE
CLDR-10823 Fix in German RBNF numbering-year

### DIFF
--- a/common/rbnf/de.xml
+++ b/common/rbnf/de.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -16,8 +16,8 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="-x">minus →→;</rbnfrule>
                 <rbnfrule value="x.x">=0.0=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
-                <rbnfrule value="1100" radix="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-                <rbnfrule value="10000">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="1100" radix="100">←←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="2000">=%spellout-numbering=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering">
                 <rbnfrule value="-x">minus →→;</rbnfrule>

--- a/common/rbnf/de_CH.xml
+++ b/common/rbnf/de_CH.xml
@@ -1,207 +1,207 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2020 Unicode, Inc.
-For terms of use, see http://www.unicode.org/copyright.html
-Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+<!--
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+For terms of use, see http://www.unicode.org/copyright.html
 -->
 <ldml>
-	<identity>
-		<version number="$Revision$"/>
-		<language type="de"/>
-		<territory type="CH"/>
-	</identity>
-	<rbnf>
-		<rulesetGrouping type="SpelloutRules">
-			<ruleset type="spellout-numbering-year">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">=0.0=;</rbnfrule>
-				<rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
-				<rbnfrule value="1100" radix="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="10000">=%spellout-numbering=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-numbering">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">←← Komma →→;</rbnfrule>
-				<rbnfrule value="0">null;</rbnfrule>
-				<rbnfrule value="1">eins;</rbnfrule>
-				<rbnfrule value="2">zwei;</rbnfrule>
-				<rbnfrule value="3">drei;</rbnfrule>
-				<rbnfrule value="4">vier;</rbnfrule>
-				<rbnfrule value="5">fünf;</rbnfrule>
-				<rbnfrule value="6">sechs;</rbnfrule>
-				<rbnfrule value="7">sieben;</rbnfrule>
-				<rbnfrule value="8">acht;</rbnfrule>
-				<rbnfrule value="9">neun;</rbnfrule>
-				<rbnfrule value="10">zehn;</rbnfrule>
-				<rbnfrule value="11">elf;</rbnfrule>
-				<rbnfrule value="12">zwölf;</rbnfrule>
-				<rbnfrule value="13">→→zehn;</rbnfrule>
-				<rbnfrule value="16">sechzehn;</rbnfrule>
-				<rbnfrule value="17">siebzehn;</rbnfrule>
-				<rbnfrule value="18">→→zehn;</rbnfrule>
-				<rbnfrule value="20">[→%spellout-cardinal-masculine→­und­]zwanzig;</rbnfrule>
-				<rbnfrule value="30">[→%spellout-cardinal-masculine→­und­]dreissig;</rbnfrule>
-				<rbnfrule value="40">[→%spellout-cardinal-masculine→­und­]vierzig;</rbnfrule>
-				<rbnfrule value="50">[→%spellout-cardinal-masculine→­und­]fünfzig;</rbnfrule>
-				<rbnfrule value="60">[→%spellout-cardinal-masculine→­und­]sechzig;</rbnfrule>
-				<rbnfrule value="70">[→%spellout-cardinal-masculine→­und­]siebzig;</rbnfrule>
-				<rbnfrule value="80">[→%spellout-cardinal-masculine→­und­]achtzig;</rbnfrule>
-				<rbnfrule value="90">[→%spellout-cardinal-masculine→­und­]neunzig;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
-				<rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-cardinal-neuter">
-				<rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-cardinal-masculine">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">←← Komma →→;</rbnfrule>
-				<rbnfrule value="0">null;</rbnfrule>
-				<rbnfrule value="1">ein;</rbnfrule>
-				<rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
-				<rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-cardinal-feminine">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">←← Komma →→;</rbnfrule>
-				<rbnfrule value="0">null;</rbnfrule>
-				<rbnfrule value="1">eine;</rbnfrule>
-				<rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
-				<rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-cardinal-n">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">←← Komma →→;</rbnfrule>
-				<rbnfrule value="0">null;</rbnfrule>
-				<rbnfrule value="1">einen;</rbnfrule>
-				<rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
-				<rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-cardinal-r">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">←← Komma →→;</rbnfrule>
-				<rbnfrule value="0">null;</rbnfrule>
-				<rbnfrule value="1">einer;</rbnfrule>
-				<rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
-				<rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-cardinal-s">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">←← Komma →→;</rbnfrule>
-				<rbnfrule value="0">null;</rbnfrule>
-				<rbnfrule value="1">eines;</rbnfrule>
-				<rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
-				<rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-			</ruleset>
-			<ruleset type="ste" access="private">
-				<rbnfrule value="0">ste;</rbnfrule>
-				<rbnfrule value="1">­=%spellout-ordinal=;</rbnfrule>
-			</ruleset>
-			<ruleset type="ste2" access="private">
-				<rbnfrule value="0">ste;</rbnfrule>
-				<rbnfrule value="1">' =%spellout-ordinal=;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-ordinal">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
-				<rbnfrule value="0">nullte;</rbnfrule>
-				<rbnfrule value="1">erste;</rbnfrule>
-				<rbnfrule value="2">zweite;</rbnfrule>
-				<rbnfrule value="3">dritte;</rbnfrule>
-				<rbnfrule value="4">vierte;</rbnfrule>
-				<rbnfrule value="5">fünfte;</rbnfrule>
-				<rbnfrule value="6">sechste;</rbnfrule>
-				<rbnfrule value="7">siebte;</rbnfrule>
-				<rbnfrule value="8">achte;</rbnfrule>
-				<rbnfrule value="9">=%spellout-numbering=te;</rbnfrule>
-				<rbnfrule value="20">=%spellout-numbering=ste;</rbnfrule>
-				<rbnfrule value="100">←%spellout-cardinal-masculine←­hundert→%%ste→;</rbnfrule>
-				<rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend→%%ste→;</rbnfrule>
-				<rbnfrule value="1000000">eine Million→%%ste2→;</rbnfrule>
-				<rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen→%%ste2→;</rbnfrule>
-				<rbnfrule value="1000000000">eine Milliarde→%%ste2→;</rbnfrule>
-				<rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden→%%ste2→;</rbnfrule>
-				<rbnfrule value="1000000000000">eine Billion→%%ste→;</rbnfrule>
-				<rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen→%%ste2→;</rbnfrule>
-				<rbnfrule value="1000000000000000">eine Billiarde→%%ste2→;</rbnfrule>
-				<rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden→%%ste2→;</rbnfrule>
-				<rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-ordinal-n">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
-				<rbnfrule value="0">=%spellout-ordinal=n;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-ordinal-r">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
-				<rbnfrule value="0">=%spellout-ordinal=r;</rbnfrule>
-			</ruleset>
-			<ruleset type="spellout-ordinal-s">
-				<rbnfrule value="-x">minus →→;</rbnfrule>
-				<rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
-				<rbnfrule value="0">=%spellout-ordinal=s;</rbnfrule>
-			</ruleset>
-		</rulesetGrouping>
-	</rbnf>
+    <identity>
+        <version number="$Revision$"/>
+        <language type="de"/>
+        <territory type="CH"/>
+    </identity>
+    <rbnf>
+        <rulesetGrouping type="SpelloutRules">
+            <ruleset type="spellout-numbering-year">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=0.0=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="1100" radix="100">←←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="2000">=%spellout-numbering=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-numbering">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">eins;</rbnfrule>
+                <rbnfrule value="2">zwei;</rbnfrule>
+                <rbnfrule value="3">drei;</rbnfrule>
+                <rbnfrule value="4">vier;</rbnfrule>
+                <rbnfrule value="5">fünf;</rbnfrule>
+                <rbnfrule value="6">sechs;</rbnfrule>
+                <rbnfrule value="7">sieben;</rbnfrule>
+                <rbnfrule value="8">acht;</rbnfrule>
+                <rbnfrule value="9">neun;</rbnfrule>
+                <rbnfrule value="10">zehn;</rbnfrule>
+                <rbnfrule value="11">elf;</rbnfrule>
+                <rbnfrule value="12">zwölf;</rbnfrule>
+                <rbnfrule value="13">→→zehn;</rbnfrule>
+                <rbnfrule value="16">sechzehn;</rbnfrule>
+                <rbnfrule value="17">siebzehn;</rbnfrule>
+                <rbnfrule value="18">→→zehn;</rbnfrule>
+                <rbnfrule value="20">[→%spellout-cardinal-masculine→­und­]zwanzig;</rbnfrule>
+                <rbnfrule value="30">[→%spellout-cardinal-masculine→­und­]dreissig;</rbnfrule>
+                <rbnfrule value="40">[→%spellout-cardinal-masculine→­und­]vierzig;</rbnfrule>
+                <rbnfrule value="50">[→%spellout-cardinal-masculine→­und­]fünfzig;</rbnfrule>
+                <rbnfrule value="60">[→%spellout-cardinal-masculine→­und­]sechzig;</rbnfrule>
+                <rbnfrule value="70">[→%spellout-cardinal-masculine→­und­]siebzig;</rbnfrule>
+                <rbnfrule value="80">[→%spellout-cardinal-masculine→­und­]achtzig;</rbnfrule>
+                <rbnfrule value="90">[→%spellout-cardinal-masculine→­und­]neunzig;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-neuter">
+                <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-masculine">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">ein;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-feminine">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">eine;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-n">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">einen;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-r">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">einer;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-s">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">←← Komma →→;</rbnfrule>
+                <rbnfrule value="0">null;</rbnfrule>
+                <rbnfrule value="1">eines;</rbnfrule>
+                <rbnfrule value="2">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert[­→→];</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend[­→→];</rbnfrule>
+                <rbnfrule value="1000000">eine Million[ →→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde[ →→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="ste" access="private">
+                <rbnfrule value="0">ste;</rbnfrule>
+                <rbnfrule value="1">­=%spellout-ordinal=;</rbnfrule>
+            </ruleset>
+            <ruleset type="ste2" access="private">
+                <rbnfrule value="0">ste;</rbnfrule>
+                <rbnfrule value="1">' =%spellout-ordinal=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
+                <rbnfrule value="0">nullte;</rbnfrule>
+                <rbnfrule value="1">erste;</rbnfrule>
+                <rbnfrule value="2">zweite;</rbnfrule>
+                <rbnfrule value="3">dritte;</rbnfrule>
+                <rbnfrule value="4">vierte;</rbnfrule>
+                <rbnfrule value="5">fünfte;</rbnfrule>
+                <rbnfrule value="6">sechste;</rbnfrule>
+                <rbnfrule value="7">siebte;</rbnfrule>
+                <rbnfrule value="8">achte;</rbnfrule>
+                <rbnfrule value="9">=%spellout-numbering=te;</rbnfrule>
+                <rbnfrule value="20">=%spellout-numbering=ste;</rbnfrule>
+                <rbnfrule value="100">←%spellout-cardinal-masculine←­hundert→%%ste→;</rbnfrule>
+                <rbnfrule value="1000">←%spellout-cardinal-masculine←­tausend→%%ste→;</rbnfrule>
+                <rbnfrule value="1000000">eine Million→%%ste2→;</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← Millionen→%%ste2→;</rbnfrule>
+                <rbnfrule value="1000000000">eine Milliarde→%%ste2→;</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← Milliarden→%%ste2→;</rbnfrule>
+                <rbnfrule value="1000000000000">eine Billion→%%ste→;</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← Billionen→%%ste2→;</rbnfrule>
+                <rbnfrule value="1000000000000000">eine Billiarde→%%ste2→;</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← Billiarden→%%ste2→;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-n">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-ordinal=n;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-r">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-ordinal=r;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-s">
+                <rbnfrule value="-x">minus →→;</rbnfrule>
+                <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-ordinal=s;</rbnfrule>
+            </ruleset>
+        </rulesetGrouping>
+    </rbnf>
 </ldml>


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10823
- [x] Updated PR title and link in previous line to include Issue number

This will have to be merged after https://github.com/unicode-org/cldr/pull/921 because there are file conflicts, but I wanted to get this started for a review.

After consulting with @markusicu and our fellow German experts, we determined the following.

- The range of 2000-2099 should be using the thousands (e.g. zweitausendeins for 2001). While the English style "twenty twenty" could be used for 2020-2099, it's perhaps a little too casual. The original ticket didn't mention the range, and we're explicitly stating for future posterity why we didn't go this route. @markusicu did state "1100..1999 are of the form 'eleven hundred' .. 'nineteen hundred ninety nine' in German." Our German experts agree on this point.
- The ein should still precede the tausend and hundert. As one our German expert stated, "it sounds more eloquent." So we're leaving these forms untouched. If people desire to really omit the ein, it should be submitted in a separate ticket for discussion and reviewed for all of the numbers in German and not just the numbering-year.