### PR TITLE
CLDR-9291 Spell out large Portuguese number with fewer conjunctions

### DIFF
--- a/common/rbnf/pt.xml
+++ b/common/rbnf/pt.xml
@@ -22,6 +22,14 @@ For terms of use, see http://www.unicode.org/copyright.html
             <ruleset type="spellout-numbering">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>
             </ruleset>
+            <ruleset type="optional-e" access="private">
+                <rbnfrule value="0">' e ;</rbnfrule>
+                <rbnfrule value="1">' ;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-masculine-with-e" access="private">
+                <rbnfrule value="0">' e =%spellout-cardinal-masculine=;</rbnfrule>
+                <rbnfrule value="100">→%%optional-e→=%spellout-cardinal-masculine=;</rbnfrule>
+            </ruleset>
             <ruleset type="spellout-cardinal-masculine">
                 <rbnfrule value="-x">menos →→;</rbnfrule>
                 <rbnfrule value="x.x">←← vírgula →→;</rbnfrule>
@@ -63,13 +71,17 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="700">setecentos[ e →→];</rbnfrule>
                 <rbnfrule value="800">oitocentos[ e →→];</rbnfrule>
                 <rbnfrule value="900">novecentos[ e →→];</rbnfrule>
-                <rbnfrule value="1000">mil[ e →→];</rbnfrule>
-                <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">←← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">←← $(cardinal,one{bilhão}other{bilhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">←← $(cardinal,one{trilhão}other{trilhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">←← $(cardinal,one{quatrilhão}other{quatrilhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000">mil[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="2000">←← mil[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000">←← $(cardinal,one{milhão}other{milhões})$[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000">←← $(cardinal,one{bilhão}other{bilhões})$[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000">←← $(cardinal,one{trilhão}other{trilhões})$[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←← $(cardinal,one{quatrilhão}other{quatrilhões})$[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-feminine-with-e" access="private">
+                <rbnfrule value="0">' e =%spellout-cardinal-feminine=;</rbnfrule>
+                <rbnfrule value="100">→%%optional-e→=%spellout-cardinal-feminine=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-feminine">
                 <rbnfrule value="-x">menos →→;</rbnfrule>
@@ -96,12 +108,12 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="700">setecentas[ e →→];</rbnfrule>
                 <rbnfrule value="800">oitocentas[ e →→];</rbnfrule>
                 <rbnfrule value="900">novecentas[ e →→];</rbnfrule>
-                <rbnfrule value="1000">mil[ e →→];</rbnfrule>
-                <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">←%spellout-cardinal-masculine← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← $(cardinal,one{bilhão}other{bilhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← $(cardinal,one{trilhão}other{trilhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← $(cardinal,one{quatrilhão}other{quatrilhões})$[ e →→];</rbnfrule>
+                <rbnfrule value="1000">mil[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="2000">←← mil[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-masculine← $(cardinal,one{milhão}other{milhões})$[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← $(cardinal,one{bilhão}other{bilhões})$[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← $(cardinal,one{trilhão}other{trilhões})$[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← $(cardinal,one{quatrilhão}other{quatrilhões})$[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-masculine">

--- a/common/rbnf/pt_PT.xml
+++ b/common/rbnf/pt_PT.xml
@@ -23,6 +23,14 @@ For terms of use, see http://www.unicode.org/copyright.html
             <ruleset type="spellout-numbering">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>
             </ruleset>
+            <ruleset type="optional-e" access="private">
+                <rbnfrule value="0">' e ;</rbnfrule>
+                <rbnfrule value="1">' ;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-masculine-with-e" access="private">
+                <rbnfrule value="0">' e =%spellout-cardinal-masculine=;</rbnfrule>
+                <rbnfrule value="100">→%%optional-e→=%spellout-cardinal-masculine=;</rbnfrule>
+            </ruleset>
             <ruleset type="spellout-cardinal-masculine">
                 <rbnfrule value="-x">menos →→;</rbnfrule>
                 <rbnfrule value="x.x">←← vírgula →→;</rbnfrule>
@@ -64,13 +72,17 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="700">setecentos[ e →→];</rbnfrule>
                 <rbnfrule value="800">oitocentos[ e →→];</rbnfrule>
                 <rbnfrule value="900">novecentos[ e →→];</rbnfrule>
-                <rbnfrule value="1000">mil[ e →→];</rbnfrule>
-                <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">←← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">←← mil milhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">←← $(cardinal,one{bilião}other{biliões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">←← mil biliões[ e →→];</rbnfrule>
+                <rbnfrule value="1000">mil[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="2000">←← mil[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000">←← $(cardinal,one{milhão}other{milhões})$[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000">←← mil milhões[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000">←← $(cardinal,one{bilião}other{biliões})$[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←← mil biliões[→%%spellout-cardinal-masculine-with-e→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-feminine-with-e" access="private">
+                <rbnfrule value="0">' e =%spellout-cardinal-feminine=;</rbnfrule>
+                <rbnfrule value="100">→%%optional-e→=%spellout-cardinal-feminine=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-feminine">
                 <rbnfrule value="-x">menos →→;</rbnfrule>
@@ -97,12 +109,12 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="700">setecentas[ e →→];</rbnfrule>
                 <rbnfrule value="800">oitocentas[ e →→];</rbnfrule>
                 <rbnfrule value="900">novecentas[ e →→];</rbnfrule>
-                <rbnfrule value="1000">mil[ e →→];</rbnfrule>
-                <rbnfrule value="2000">←← mil[ e →→];</rbnfrule>
-                <rbnfrule value="1000000">←%spellout-cardinal-masculine← $(cardinal,one{milhão}other{milhões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← mil milhões[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← $(cardinal,one{bilião}other{biliões})$[ e →→];</rbnfrule>
-                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← mil biliões[ e →→];</rbnfrule>
+                <rbnfrule value="1000">mil[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="2000">←← mil[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000">←%spellout-cardinal-masculine← $(cardinal,one{milhão}other{milhões})$[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000">←%spellout-cardinal-masculine← mil milhões[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← $(cardinal,one{bilião}other{biliões})$[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← mil biliões[→%%spellout-cardinal-feminine-with-e→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-masculine">


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-9291
- [x] Updated PR title and link in previous line to include Issue number

I verified the following values.

- 12147889885678 → doze trilhões cento e quarenta e sete bilhões oitocentos e oitenta e nove milhões oitocentos e oitenta e cinco mil seiscentos e setenta e oito
- 100030 → cem mil e trinta
- 1000500 → um milhão e quinhentos
- 1100030 → um milhão cem mil e trinta
- 1100000 → um milhão e cem mil

The largest number was the reported value. The rest were added as test examples from Portuguese experts.