### PR TITLE
CLDR-11407 Spelt out date past 1999 should use multiples of a thousand

### DIFF
--- a/common/rbnf/fr.xml
+++ b/common/rbnf/fr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -20,7 +20,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="x.x">=0.0=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
                 <rbnfrule value="1100" radix="100">←%spellout-cardinal-masculine←-cent→%%cents-m→;</rbnfrule>
-                <rbnfrule value="10000">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="2000">=%spellout-numbering=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>

--- a/common/rbnf/fr_BE.xml
+++ b/common/rbnf/fr_BE.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -21,7 +21,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="x.x">=0.0=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
                 <rbnfrule value="1100" radix="100">←%spellout-cardinal-masculine←-cent→%%cents-m→;</rbnfrule>
-                <rbnfrule value="10000">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="2000">=%spellout-numbering=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>

--- a/common/rbnf/fr_CH.xml
+++ b/common/rbnf/fr_CH.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -21,7 +21,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="x.x">=0.0=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
                 <rbnfrule value="1100" radix="100">←%spellout-cardinal-masculine←-cent→%%cents-m→;</rbnfrule>
-                <rbnfrule value="10000">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="2000">=%spellout-numbering=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering">
                 <rbnfrule value="0">=%spellout-cardinal-masculine=;</rbnfrule>


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11407
- [x] Updated PR title and link in previous line to include Issue number

