### PR TITLE
CLDR-14410 clean up ordering and add test

### DIFF
--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -23,60 +23,70 @@ For terms of use, see http://www.unicode.org/copyright.html
     </unitConstants>
     <unitQuantities> 
         <!-- NB: quantity ordering is used in canonical order of derived units. -->
-        <!--  SI Base Units -->
+        
+        <!-- SI Base Units -->
+        
         <unitQuantity baseUnit='candela' quantity='luminous-intensity' status='simple'/>
-        <unitQuantity baseUnit='kilogram' quantity='mass' status='simple'/>
-        <unitQuantity baseUnit='meter' quantity='length' status='simple'/>
-        <unitQuantity baseUnit='second' quantity='duration' status='simple'/> <!-- use duration because 'time' can mean absolute time -->
-        <unitQuantity baseUnit='year' quantity='year-duration' status='simple'/> <!-- non-SI but here for ordering -->
-        <unitQuantity baseUnit='ampere' quantity='electric-current' status='simple'/>
-        <unitQuantity baseUnit='kelvin' quantity='temperature' status='simple'/>
-        
-        <!-- Additional base units -->
-        
-        <unitQuantity baseUnit='revolution' quantity='angle' status='simple'/> <!-- = circle, cycle for base -->
-        <unitQuantity baseUnit='item' quantity='substance-amount' status='simple'/> <!-- use instead of mole -->
-        <unitQuantity baseUnit='portion' quantity='portion' status='simple'/>
-        <unitQuantity baseUnit='bit' quantity='digital' status='simple'/>
-        <unitQuantity baseUnit='pixel' quantity='graphics' status='simple'/>
-        <unitQuantity baseUnit='em' quantity='typewidth' status='simple'/>
-        
-        <!--  SI Derived Units -->
-        
-        <unitQuantity baseUnit='revolution-per-second' quantity='frequency'/>
-        <unitQuantity baseUnit='square-revolution' quantity='solid-angle'/>
-        <unitQuantity baseUnit='kilogram-meter-per-square-second' quantity='force'/>
-        <unitQuantity baseUnit='kilogram-per-meter-square-second' quantity='pressure'/>
-        <unitQuantity baseUnit='kilogram-per-square-meter-square-second' quantity='pressure-per-length'/>
-        <unitQuantity baseUnit='kilogram-square-meter-per-square-second' quantity='energy'/>
-        <unitQuantity baseUnit='kilogram-square-meter-per-cubic-second' quantity='power'/>
-        <unitQuantity baseUnit='second-ampere' quantity='electric-charge'/>
-        <unitQuantity baseUnit='kilogram-square-meter-per-cubic-second-ampere' quantity='voltage'/>
-        <unitQuantity baseUnit='pow4-second-square-ampere-per-kilogram-square-meter' quantity='electric-capacitance'/>
-        <unitQuantity baseUnit='kilogram-square-meter-per-cubic-second-square-ampere' quantity='electric-resistance'/>
-        <unitQuantity baseUnit='cubic-second-square-ampere-per-kilogram-square-meter' quantity='electric-conductance'/>
-        <unitQuantity baseUnit='kilogram-square-meter-per-square-second-ampere' quantity='magnetic-flux'/>
-        <unitQuantity baseUnit='kilogram-per-square-second-ampere' quantity='magnetic-induction'/>
-        <unitQuantity baseUnit='kilogram-square-meter-per-square-second-square-ampere' quantity='electric-inductance'/>
-        <unitQuantity baseUnit='square-meter-per-square-second' quantity='dose'/>
-        <unitQuantity baseUnit='square-meter' quantity='area'/>
-        <unitQuantity baseUnit='cubic-meter' quantity='volume'/>
-        <unitQuantity baseUnit='meter-per-second' quantity='speed'/>
-        <unitQuantity baseUnit='meter-per-square-second' quantity='acceleration'/>
-        <unitQuantity baseUnit='revolution-per-meter' quantity='wave-number'/>
-        <unitQuantity baseUnit='kilogram-per-cubic-meter' quantity='mass-density'/>
-        <unitQuantity baseUnit='cubic-meter-per-kilogram' quantity='specific-volume'/>
-        <unitQuantity baseUnit='ampere-per-square-meter' quantity='current-density'/>
-        <unitQuantity baseUnit='ampere-per-meter' quantity='magnetic-field-strength'/>
-        <unitQuantity baseUnit='item-per-cubic-meter' quantity='concentration'/>
         <unitQuantity baseUnit='candela-per-square-meter' quantity='illuminance'/>
         <unitQuantity baseUnit='candela-square-meter-per-square-meter' quantity='luminous-flux'/>
-        <!--  <unitQuantity baseUnit='candela-square-meter' quantity='luminence'/> -->
-        <unitQuantity baseUnit='kilogram-per-kilogram' quantity='mass-fraction'/>
         
-        <!-- Additional derived units -->
+        <unitQuantity baseUnit='kilogram' quantity='mass' status='simple'/>
+        <unitQuantity baseUnit='kilogram-per-kilogram' quantity='mass-fraction'/>
+        <unitQuantity baseUnit='kilogram-per-cubic-meter' quantity='mass-density'/>
+        <unitQuantity baseUnit='kilogram-per-meter-square-second' quantity='pressure'/>
+        <unitQuantity baseUnit='kilogram-per-square-second-ampere' quantity='magnetic-induction'/>
+        <unitQuantity baseUnit='kilogram-meter-per-square-second' quantity='force'/>
+        <unitQuantity baseUnit='kilogram-square-meter-per-cubic-second' quantity='power'/>
+        <unitQuantity baseUnit='kilogram-square-meter-per-cubic-second-ampere' quantity='voltage'/>
+        <unitQuantity baseUnit='kilogram-square-meter-per-cubic-second-square-ampere' quantity='electric-resistance'/>
+        <unitQuantity baseUnit='kilogram-square-meter-per-square-second' quantity='energy'/>
+        <unitQuantity baseUnit='kilogram-square-meter-per-square-second-ampere' quantity='magnetic-flux'/>
+        <unitQuantity baseUnit='kilogram-square-meter-per-square-second-square-ampere' quantity='electric-inductance'/>
+        
+        <unitQuantity baseUnit='cubic-meter' quantity='volume'/>
+        <unitQuantity baseUnit='cubic-meter-per-kilogram' quantity='specific-volume'/>
         <unitQuantity baseUnit='cubic-meter-per-meter' quantity='consumption'/>
+        <unitQuantity baseUnit='square-meter' quantity='area'/>
+        <unitQuantity baseUnit='square-meter-per-square-second' quantity='dose'/>
+        <unitQuantity baseUnit='meter' quantity='length' status='simple'/>
+        <unitQuantity baseUnit='meter-per-second' quantity='speed'/>
+        <unitQuantity baseUnit='meter-per-square-second' quantity='acceleration'/>
+        
+        <unitQuantity baseUnit='kilogram-per-square-meter-square-second' quantity='pressure-per-length'/> <!-- special ordering for ofhg -->
+        
+        <unitQuantity baseUnit='pow4-second-square-ampere-per-kilogram-square-meter' quantity='electric-capacitance'/>
+        <unitQuantity baseUnit='cubic-second-square-ampere-per-kilogram-square-meter' quantity='electric-conductance'/>
+        <unitQuantity baseUnit='second' quantity='duration' status='simple'/> <!-- use duration because 'time' can mean absolute time -->
+        <unitQuantity baseUnit='second-ampere' quantity='electric-charge'/>
+
+        <unitQuantity baseUnit='year' quantity='year-duration' status='simple'/> <!-- non-SI but here for ordering -->
+        
+        <unitQuantity baseUnit='ampere' quantity='electric-current' status='simple'/>
+        <unitQuantity baseUnit='ampere-per-square-meter' quantity='current-density'/>
+        <unitQuantity baseUnit='ampere-per-meter' quantity='magnetic-field-strength'/>
+
+        <unitQuantity baseUnit='kelvin' quantity='temperature' status='simple'/>
+        
+        <!-- Non-SI base units -->
+        
+        <unitQuantity baseUnit='square-revolution' quantity='solid-angle'/>
+        <unitQuantity baseUnit='revolution' quantity='angle' status='simple'/> <!-- = circle, cycle for base instead of radian -->
+        <unitQuantity baseUnit='revolution-per-meter' quantity='wave-number'/>
+        <unitQuantity baseUnit='revolution-per-second' quantity='frequency'/>
+
+        <unitQuantity baseUnit='item' quantity='substance-amount' status='simple'/> <!-- use instead of mole -->
+        <unitQuantity baseUnit='item-per-cubic-meter' quantity='concentration'/>
+
+        <unitQuantity baseUnit='portion' quantity='portion' status='simple'/>
+        
+        <unitQuantity baseUnit='bit' quantity='digital' status='simple'/>
+        
+        <unitQuantity baseUnit='pixel' quantity='graphics' status='simple'/>
+
         <unitQuantity baseUnit='pixel-per-meter' quantity='resolution'/>
+
+        <unitQuantity baseUnit='em' quantity='typewidth' status='simple'/>
+        
     </unitQuantities>    
     <convertUnits>
         <!-- Values where possible from:
@@ -102,6 +112,34 @@ For terms of use, see http://www.unicode.org/copyright.html
         <convertUnit source='metric-ton' baseUnit='kilogram' factor='1000'/>
         <convertUnit source='earth-mass' baseUnit='kilogram' factor='5.9722E+24'/>
         <convertUnit source='solar-mass' baseUnit='kilogram' factor='1.98847E+30'/>
+        
+        <!-- volume -->
+        <convertUnit source='drop' baseUnit='cubic-meter' factor='gal_to_m3/128*576' systems="ussystem"/>
+        <convertUnit source='pinch' baseUnit='cubic-meter' factor='gal_to_m3/128*128' systems="ussystem"/>
+        <convertUnit source='dessert-spoon' baseUnit='cubic-meter' factor='gal_to_m3/16*128' systems="ussystem"/>
+        <convertUnit source='dessert-spoon-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3/16*128' systems="uksystem"/>
+        <convertUnit source='dram' baseUnit='cubic-meter' factor='gal_to_m3/128*8' systems="ussystem"/>
+        <convertUnit source='teaspoon' baseUnit='cubic-meter' factor='gal_to_m3/16*48' systems="ussystem"/>
+        <convertUnit source='tablespoon' baseUnit='cubic-meter' factor='gal_to_m3/256' systems="ussystem"/>
+        <convertUnit source='fluid-ounce-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3/160' systems="uksystem"/>
+        <convertUnit source='fluid-ounce' baseUnit='cubic-meter' factor='gal_to_m3/128' systems="ussystem"/>
+        <convertUnit source='jigger' baseUnit='cubic-meter' factor='gal_to_m3*3/128*2' systems="ussystem"/>
+        <convertUnit source='cup' baseUnit='cubic-meter' factor='gal_to_m3/16' systems="ussystem"/>
+        <convertUnit source='cup-metric' baseUnit='cubic-meter' factor='0.00025'/>
+        <convertUnit source='pint' baseUnit='cubic-meter' factor='gal_to_m3/8' systems="ussystem"/>
+        <convertUnit source='pint-metric' baseUnit='cubic-meter' factor='0.0005'/>
+        <convertUnit source='quart' baseUnit='cubic-meter' factor='gal_to_m3/4' systems="ussystem"/>
+        <convertUnit source='liter' baseUnit='cubic-meter' factor='0.001'/>
+        <convertUnit source='quart-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3/4' systems="uksystem"/>
+        <convertUnit source='gallon' baseUnit='cubic-meter' factor='gal_to_m3' systems="ussystem"/>
+        <convertUnit source='gallon-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3' systems="uksystem"/>
+        <convertUnit source='bushel' baseUnit='cubic-meter' factor='2150.42*in3_to_m3' systems="ussystem"/>
+        <convertUnit source='barrel' baseUnit='cubic-meter' factor='42*gal_to_m3' systems="ussystem"/> <!-- oil -->
+        
+        <!-- area -->
+        <convertUnit source='dunam' baseUnit='square-meter' factor='1000'/>
+        <convertUnit source='acre' baseUnit='square-meter' factor='ft2_to_m2 * 43560' systems="ussystem uksystem"/>
+        <convertUnit source='hectare' baseUnit='square-meter' factor='10000'/>
         
         <!-- length -->
         <convertUnit source='point' baseUnit='meter' factor='ft_to_m/864' systems="ussystem uksystem"/>
@@ -210,34 +248,6 @@ For terms of use, see http://www.unicode.org/copyright.html
         
         <!-- electric-resistance -->
         <convertUnit source='ohm' baseUnit='kilogram-square-meter-per-cubic-second-square-ampere'/>
-        
-        <!-- area -->
-        <convertUnit source='dunam' baseUnit='square-meter' factor='1000'/>
-        <convertUnit source='acre' baseUnit='square-meter' factor='ft2_to_m2 * 43560' systems="ussystem uksystem"/>
-        <convertUnit source='hectare' baseUnit='square-meter' factor='10000'/>
-        
-        <!-- volume -->
-        <convertUnit source='drop' baseUnit='cubic-meter' factor='gal_to_m3/128*576' systems="ussystem"/>
-        <convertUnit source='pinch' baseUnit='cubic-meter' factor='gal_to_m3/128*128' systems="ussystem"/>
-        <convertUnit source='dessert-spoon' baseUnit='cubic-meter' factor='gal_to_m3/16*128' systems="ussystem"/>
-        <convertUnit source='dessert-spoon-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3/16*128' systems="uksystem"/>
-        <convertUnit source='dram' baseUnit='cubic-meter' factor='gal_to_m3/128*8' systems="ussystem"/>
-        <convertUnit source='teaspoon' baseUnit='cubic-meter' factor='gal_to_m3/16*48' systems="ussystem"/>
-        <convertUnit source='tablespoon' baseUnit='cubic-meter' factor='gal_to_m3/256' systems="ussystem"/>
-        <convertUnit source='fluid-ounce-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3/160' systems="uksystem"/>
-        <convertUnit source='fluid-ounce' baseUnit='cubic-meter' factor='gal_to_m3/128' systems="ussystem"/>
-        <convertUnit source='jigger' baseUnit='cubic-meter' factor='gal_to_m3*3/128*2' systems="ussystem"/>
-        <convertUnit source='cup' baseUnit='cubic-meter' factor='gal_to_m3/16' systems="ussystem"/>
-        <convertUnit source='cup-metric' baseUnit='cubic-meter' factor='0.00025'/>
-        <convertUnit source='pint' baseUnit='cubic-meter' factor='gal_to_m3/8' systems="ussystem"/>
-        <convertUnit source='pint-metric' baseUnit='cubic-meter' factor='0.0005'/>
-        <convertUnit source='quart' baseUnit='cubic-meter' factor='gal_to_m3/4' systems="ussystem"/>
-        <convertUnit source='liter' baseUnit='cubic-meter' factor='0.001'/>
-        <convertUnit source='quart-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3/4' systems="uksystem"/>
-        <convertUnit source='gallon' baseUnit='cubic-meter' factor='gal_to_m3' systems="ussystem"/>
-        <convertUnit source='gallon-imperial' baseUnit='cubic-meter' factor='gal_imp_to_m3' systems="uksystem"/>
-        <convertUnit source='bushel' baseUnit='cubic-meter' factor='2150.42*in3_to_m3' systems="ussystem"/>
-        <convertUnit source='barrel' baseUnit='cubic-meter' factor='42*gal_to_m3' systems="ussystem"/> <!-- oil -->
         
         <!-- speed -->
         <convertUnit source='knot' baseUnit='meter-per-second' factor='1852/3600' systems="ussystem uksystem"/>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/nistConversions.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/nistConversions.txt
@@ -1,4 +1,5 @@
 #From https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9
+#Fixed perm from (Pa · s · m2) to (Pa · m2 · s)
 ACCELERATION
 To convert from	to	Multiply by
 acceleration of free fall, standard (gn)	meter per second squared (m/s2)	9.806 65	E+00
@@ -414,10 +415,10 @@ Return to top
 PERMEABILITY
 To convert from	to	Multiply by
 darcy 14	meter squared (m2)	9.869 233	E-13
-perm (0 °C)	kilogram per pascal second square meter [kg/(Pa · s · m2)]	5.721 35	E-11
-perm (23 °C)	kilogram per pascal second square meter [kg/(Pa · s · m2)]	5.745 25	E-11
-perm inch (0 °C)	kilogram per pascal second meter [kg/(Pa · s · m)]	1.453 22	E-12
-perm inch (23 °C)	kilogram per pascal second meter [kg/(Pa · s · m)]	1.459 29	E-12
+perm (0 °C)	kilogram per pascal square meter second [kg/(Pa · m2 · s)]	5.721 35	E-11
+perm (23 °C)	kilogram per pascal square meter second [kg/(Pa · m2 · s)]	5.745 25	E-11
+perm inch (0 °C)	kilogram per pascal meter second [kg/(Pa · m · s)]	1.453 22	E-12
+perm inch (23 °C)	kilogram per pascal meter second [kg/(Pa · m · s)]	1.459 29	E-12
 Return to top
 
 POWER

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/nistDerivedUnits.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/nistDerivedUnits.txt
@@ -1,22 +1,24 @@
 # From https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes
 #Quantity	Special Name	Special symbol	Expression in terms of other SI units	Expression in terms of SI base units
+# Fixed newton, etc to have consistent unit ordering, kg · m
+# Fixed Cd to be cd
 plane angle          	radian(b)	rad	1(b)	m/m
 solid angle	steradian(b)	sr(c)	1(b)	m2/m2
 frequency	hertz(d)	Hz	 	s-1
-force	newton	N	 	m · kg · s-2
+force	newton	N	 	kg · m · s-2
 pressure, stress	pascal	Pa	N/m2	m-1 · kg · s-2
-energy, work, amount of heat	joule	J	N · m	m2 · kg · s-2
-power, radiant flux	watt	W	J/s	m2 · kg · s-3
+energy, work, amount of heat	joule	J	N · m	kg · m2 · s-2
+power, radiant flux	watt	W	J/s	kg · m2 · s-3
 electric charge, amount of electricity	coulomb	C	 	s · A
-electric potential difference(e), electromotive force	volt	V	W/A	m2 · kg · s-3 · A-1
-capacitance	farad	F	C/V	m-2 · kg-1 · s4 · A2
-electric resistance	ohm	Ω	V/A	m2 · kg · s-3 · A-2
-electric conductance	siemens	S	A/V	m-2 · kg-1 · s3 · A2
-magnetic flux	weber	Wb	V · s	m2 · kg · s-2 · A-1
+electric potential difference(e), electromotive force	volt	V	W/A	kg · m2 · s-3 · A-1
+capacitance	farad	F	C/V	kg-1 · m-2 · s4 · A2
+electric resistance	ohm	Ω	V/A	kg · m2 · s-3 · A-2
+electric conductance	siemens	S	A/V	kg-1 · m-2 · s3 · A2
+magnetic flux	weber	Wb	V · s	kg · m2 · s-2 · A-1
 magnetic flux density	tesla	T	Wb/m2	kg · s-2 · A-1
-inductance	henry	H	Wb/A	m2 · kg· s-2 · A-2
+inductance	henry	H	Wb/A	kg · m2 · s-2 · A-2
 Celsius temperature	degree Celsius (f)	°C	 	K
-luminous flux	lumen	lm	cd · sr(c)	Cd
+luminous flux	lumen	lm	cd · sr(c)	cd
 illuminance	lux	lx	lm/m2	m-2· cd
 activity referred to a radionuclide(g)	becquerel(d)	Bq	 	s-1
 absorbed dose, specific energy (imparted), kerma	gray	Gy	J/kg	m2· s-2

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/ExternalUnitConversionData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/ExternalUnitConversionData.java
@@ -112,6 +112,9 @@ final class ExternalUnitConversionData {
         source = source.replace("inch to the fourth power", "pow4-inch");
         source = source.replace("meter to the fourth power", "pow4-meter");
 
+        source = source.replace("Britsh", "british");
+        source = source.replace("reciprocal", "per");
+
         source = replaceWhole(oldSource, source, changes);
 
         final Matcher match = firstPart.matcher(source);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NistUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NistUnits.java
@@ -31,6 +31,8 @@ import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.util.ICUUncheckedIOException;
 
 final class NistUnits {
+    private static final boolean DEBUG = false;
+
     final static Multimap<String,String> unitToQuantity;
     final static Map<String, TargetInfo> derivedUnitToConversion;
     final static List<ExternalUnitConversionData> externalConversionData;
@@ -54,7 +56,7 @@ final class NistUnits {
                 String quantity = null;
                 try (Stream<String> s = in.lines()) {
                     for (String line : (Iterable<String>) s::iterator) {
-                        if (line.startsWith("#") 
+                        if (line.startsWith("#")
                             || line.equals("To convert from\tto\tMultiply by")
                             || line.startsWith("degree Fahrenheit hour square foot per British thermal unitth inch") // bad NIST data
                             ) {
@@ -62,15 +64,15 @@ final class NistUnits {
                         }
                         List<String> parts = SPLIT_TABS.splitToList(line);
                         switch(parts.size()) {
-                        case 1: 
+                        case 1:
                             quantity = parts.get(0);
                             break;
-                        case 4: 
+                        case 4:
                             Rational factor = Rational.of((parts.get(2) + parts.get(3)).replace(" ", ""));
                             ExternalUnitConversionData data = new ExternalUnitConversionData(quantity, parts.get(0), parts.get(1), factor, line, _idChanges);
                             _externalConversionData.add(data);
                             break;
-                        default: 
+                        default:
                             _skipping.add(line);
                         }
                     }
@@ -109,36 +111,36 @@ final class NistUnits {
                         }
                         List<String> parts = SPLIT_TABS.splitToList(line);
                         // #Quantity   Special Name    Special symbol  Expression in terms of other SI units   Expression in terms of SI base units
-                        
+
                         String quantity = parts.get(0);
                         List<String> quantities = SPLIT_COMMAS.splitToList(quantity).stream()
                             .map(x ->  SPLIT_PARENS.split(parts.get(0)).iterator().next())
                             .collect(Collectors.toList());
                         quantity = Joiner.on(", ").join(quantities);
-                        
+
                         String name = SPLIT_PARENS.split(parts.get(1)).iterator().next();
                         if (name.equals("degree Celsius")) {
                             name = "celsius";
                         }
-                        
+
                         String symbol = parts.get(2);
                         String expressionInOtherSymbols = parts.get(4);
                         String expressionInBaseSymbols = parts.get(4);
                         _symbolToUnit.put(symbol, name);
                         _unitToQuantity.putAll(name, quantities);
-                        
+
                         final String targetUnit = getUnitFromSymbols(expressionInBaseSymbols, _symbolToUnit);
                         unitToTargetInfo.put(name, new TargetInfo(targetUnit, new ConversionInfo(Rational.ONE, Rational.ZERO), Collections.emptyMap()));
-                        
+
                         ExternalUnitConversionData data = new ExternalUnitConversionData(quantity, name, targetUnit, Rational.ONE, line, _idChanges);
                         _externalConversionData.add(data);
 
                     }
                 }
             }
-            
+
             // Protect everything
-            
+
             skipping = ImmutableSet.copyOf(_skipping);
             idChanges = ImmutableMultimap.copyOf(_idChanges);
             externalConversionData = ImmutableList.copyOf(_externalConversionData);
@@ -150,43 +152,49 @@ final class NistUnits {
     }
 
     public static String getUnitFromSymbols(String expressionInBaseSymbols, Map<String, String> symbolToUnit) {
-        // handle the irregualar formats
+        String result;
+        // handle the irregular formats
         if (expressionInBaseSymbols.equals("m/m")) {
-            return "meter-per-meter";
+            result = "meter-per-meter";
         } else if (expressionInBaseSymbols.equals("m2/m2")) {
-            return "square-meter-per-square-meter";
-        }
-        // m2 · kg · s-3 · A-1
-        StringBuilder numerator = new StringBuilder();
-        StringBuilder denominator = new StringBuilder();
-        for (String part : SPLIT_MIDDOT.split(expressionInBaseSymbols)) {
-            final Matcher parts = flatExponent.matcher(part);
-            if (!parts.matches()) {
-                throw new IllegalArgumentException("bad symbol: " + part);
-            }
-            String unit = symbolToUnit.get(parts.group(1));
-            String pow = null;
-            int power = 0;
-            final String exponent = parts.group(2);
-            if (exponent != null) {
-                power = Integer.parseInt(exponent);
-                switch(Math.abs(power)) {
-                case 0: case 1: break;// skip
-                case 2: pow = "square-"; break;
-                case 3: pow = "cubic-"; break;
-                default: pow = "pow" + Math.abs(power) + "-"; break;
+            result = "square-meter-per-square-meter";
+        } else {
+            // m2 · kg · s-3 · A-1
+            StringBuilder numerator = new StringBuilder();
+            StringBuilder denominator = new StringBuilder();
+            for (String part : SPLIT_MIDDOT.split(expressionInBaseSymbols)) {
+                final Matcher parts = flatExponent.matcher(part);
+                if (!parts.matches()) {
+                    throw new IllegalArgumentException("bad symbol: " + part);
                 }
+                String unit = symbolToUnit.get(parts.group(1));
+                String pow = null;
+                int power = 0;
+                final String exponent = parts.group(2);
+                if (exponent != null) {
+                    power = Integer.parseInt(exponent);
+                    switch(Math.abs(power)) {
+                    case 0: case 1: break;// skip
+                    case 2: pow = "square-"; break;
+                    case 3: pow = "cubic-"; break;
+                    default: pow = "pow" + Math.abs(power) + "-"; break;
+                    }
+                }
+                StringBuilder target = power >= 0 ? numerator : denominator;
+                if (target.length() != 0) {
+                    target.append('-');
+                }
+                if (pow != null) {
+                    target.append(pow);
+                }
+                target.append(unit);
             }
-            StringBuilder target = power >= 0 ? numerator : denominator;
-            if (target.length() != 0) {
-                target.append('-');
-            }
-            if (pow != null) {
-                target.append(pow);
-            }
-            target.append(unit);
+            result = (numerator.length() == 0 ? "" : numerator)
+                + (denominator.length() == 0 ? "" :
+                    (numerator.length() == 0 ? "per-" : "-per-") + denominator);
         }
-        return (numerator.length() == 0 ? "1" : numerator) + (denominator.length() == 0 ? "" : "-per-" + denominator);
+        if (DEBUG) System.out.println(expressionInBaseSymbols + " => " + result);
+        return result;
     }
 
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TotalOrderBuilder.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TotalOrderBuilder.java
@@ -1,0 +1,104 @@
+package org.unicode.cldr.unittest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Build a total order from a partial order.
+ * TODO optimize!
+ */
+public class TotalOrderBuilder<T> {
+    private boolean DEBUG = true;
+    private LinkedHashSet<List<T>> rows = new LinkedHashSet<>();
+    static final List<String> TEST = ImmutableList.of("meter", "kilogram");
+
+    public TotalOrderBuilder<T> add(List<T> items) {
+        if (TEST.equals(items)) {
+            int debug = 0;
+        }
+        LinkedHashSet<T> rowCheck = new LinkedHashSet<>(items);
+        if (rowCheck.size() != items.size()) {
+            throw new IllegalArgumentException("Duplicate items in input");
+        }
+        if (!items.isEmpty()) {
+            rows.add(new ArrayList<>(items));
+        }
+        return this;
+    }
+
+    public TotalOrderBuilder<T>  add(T... items) {
+        return add(Arrays.asList(items));
+    }
+
+    public List<T> build() {
+        List<T> result = new ArrayList<>();
+        // whenever a first item in a row is not in any other row (other than first position) put it into the result, and remove
+        main:
+        while (true) {
+            boolean failed = false;
+            if (rows.size() == 6) {
+                int debug = 0;
+            }
+
+            for (List<T> row : rows) {
+                if (row.isEmpty()) {
+                    continue;
+                }
+                T first = row.iterator().next();
+                if (inNonFirstPosition(first)) {
+                    failed = true;
+                    continue;
+                }
+                // got through the gauntlet
+                if (DEBUG) {
+                    System.out.println("Removing " + first);
+                }
+                result.add(first);
+                removeFromRows(first);
+                failed = false;
+                continue main;
+            }
+            if (failed) {
+                final String items = toString();
+                rows.clear();
+                throw new IllegalArgumentException("incompatible orderings, eg:\n" + items );
+            }
+            rows.clear();
+            return result;
+        }
+    }
+
+    private void removeFromRows(T first) {
+        for (List<T> row : rows) {
+            if (DEBUG && row.contains("kilogram")) {
+                int debug = 0;
+            }
+            row.remove(first);
+        }
+        rows = new LinkedHashSet<>(rows); // consolidate
+    }
+
+    private boolean inNonFirstPosition(T item) {
+        for (List<T> row : rows) {
+            if (DEBUG && row.contains("kilogram")) {
+                int debug = 0;
+            }
+            if (!row.isEmpty()
+                && row.contains(item)
+                && !row.iterator().next().equals(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return Joiner.on('\n').join(new LinkedHashSet<>(rows));
+    }
+}


### PR DESCRIPTION
This looked like a spec bug, but turned out to be an error in the data.

https://unicode.org/reports/tr35/tr35-info.html#Unit_Identifier_Normalization

Problems. 

- #4,  the ordering algorithm for units within the numerator or denominator, doesn’t handle derived units like newton in the way the user would expect.
- We need to also mention the powers, in a step either before or after #5.
- 
I looked into this, and wrote a module to walk though our data plus the NIST data to pick up the ordering of units within the denominators and numerators. This results in a partial order which I then used a simple algorithm to produce a total order among base and derived units. (NOTE there are multiple orders that would satisfy the partial order; I used an algorithm that favors lexicographic order, just for stability).

common/supplemental/units.xml 

I then ordered the base and derived units in with that order within this file.

The order among the base elements matches that which is in common use, eg much of https://en.wikipedia.org/wiki/International_System_of_Units. There are however inconsistencies; I think where people are thinking of the unit as being composed of other pieces. Anyway, the order is:

candela, kilogram, meter, second (year), ampere, kelvin

NOTE: the NIST data used for testing deviates from this, and cannot be used for a total order, because it has cycles if you try. I fixed that in the data, and put comments at the top. That is in:

tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/nistConversions.txt

tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/nistDerivedUnits.txt

This can be used not only to order simple units within a compound, but also units against one another (lexicographically)

NOTE: There is one special order for ofhg, because we want millimeter-ofhg instead of the reverse.

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java

There are a number of changes to this file. Some were changes to make debugging easier. The significant change was to getQuantityComparator, which can use a much simpler algorithm now. I'm leaving in the old code for comparison, under a flag.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/ExternalUnitConversionData.java

Found two problems in the NIST data that needed fixing in the converter (another misspelling, and use of reciprocal instead of per).

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NistUnits.java

Fixed a problem in the conversion, where it was producing 1-per-... instead of per-...

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java

There were a number of cleanups to the tests to stop printing extra lines.

The biggest change was the addition of TestUnitOrder(), which does a number of checks on the order of simple units. As part of those changes, it also parses more of the NIST file.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TotalOrderBuilder.java

This is a very simple implementation to build a total order from a partial order. A not-very-efficient algorithm, but is fast enough for this test.

BTW, also filed https://unicode-org.atlassian.net/browse/CLDR-14421 for future consideration.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14410
- [ ] Updated PR title and link in previous line to include Issue number

