### PR TITLE
CLDR-14322 A de_CH unit binary prefixes have incorrect capitalization

### DIFF
--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -193,28 +193,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>kibi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Kibi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>mebi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Mebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>gibi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Gibi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>tebi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Tebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>pebi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Pebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>exbi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Exbi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>zebi{0}</unitPrefixPattern>
+				<unitPrefixPattern>Zebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>yobe{0}</unitPrefixPattern>
+				<unitPrefixPattern>Yobi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<unit type="area-square-foot">
 				<displayName>Quadratfuss</displayName>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14322
- [x] Updated PR title and link in previous line to include Issue number

