### PR TITLE
CLDR-11581 Change symbol for XOF

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -5861,7 +5861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Wes-Afrikaanse CFA-frank</displayName>
 				<displayName count="one">Wes-Afrikaanse CFA-frank</displayName>
 				<displayName count="other">Wes-Afrikaanse CFA-frank</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP-frank</displayName>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -6479,7 +6479,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>የምዕራብ አፍሪካ ሴፋ ፍራንክ</displayName>
 				<displayName count="one">የምዕራብ አፍሪካ ሴፋ ፍራንክ</displayName>
 				<displayName count="other">የምዕራብ አፍሪካ ሴፋ ፍራንክ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>ሲ ኤፍ ፒ ፍራንክ</displayName>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -8427,7 +8427,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">فرنك غرب أفريقي</displayName>
 				<displayName count="many">فرنك غرب أفريقي</displayName>
 				<displayName count="other">فرنك غرب أفريقي</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>بالاديوم</displayName>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -5674,7 +5674,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>পশ্চিম আফ্ৰিকান CFA ফ্ৰেংক</displayName>
 				<displayName count="one">পশ্চিম আফ্ৰিকান CFA ফ্ৰেংক</displayName>
 				<displayName count="other">পশ্চিম আফ্ৰিকান CFA ফ্ৰেংক</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP ফ্ৰেংক</displayName>

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -8970,7 +8970,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>francu CFA BCEAO</displayName>
 				<displayName count="one">francu CFA BCEAO</displayName>
 				<displayName count="other">francos CFA BCEAO</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Paladiu</displayName>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -6559,7 +6559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Fil Dişi Sahili Frankı</displayName>
 				<displayName count="one">Fil Dişi Sahili frankı</displayName>
 				<displayName count="other">Fil Dişi Sahili frankı</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Palladium</displayName>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -6302,7 +6302,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">заходнеафрыканскія франкі КФА</displayName>
 				<displayName count="many">заходнеафрыканскіх франкаў КФА</displayName>
 				<displayName count="other">заходнеафрыканскага франка КФА</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>французскі ціхаакіянскі франк</displayName>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -6542,7 +6542,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Западноафрикански франк</displayName>
 				<displayName count="one">западноафрикански франк</displayName>
 				<displayName count="other">западноафрикански франка</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Паладий</displayName>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -7520,7 +7520,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>পশ্চিম আফ্রিকান [CFA] ফ্র্যাঙ্ক</displayName>
 				<displayName count="one">পশ্চিম আফ্রিকান [CFA] ফ্র্যাঙ্ক</displayName>
 				<displayName count="other">পশ্চিম আফ্রিকান [CFA] ফ্র্যাঙ্ক</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>প্যালেডিয়াম</displayName>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -12039,7 +12039,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="few">lur CFA BCEAO</displayName>
 				<displayName count="many">a lurioù CFA BCEAO</displayName>
 				<displayName count="other">lur CFA Afrika ar Cʼhornôg</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladiom</displayName>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -7351,7 +7351,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">zapadnoafrički franak (CFA)</displayName>
 				<displayName count="few">zapadnoafrička franka (CFA)</displayName>
 				<displayName count="other">zapadnoafričkih franaka (CFA)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Paladijum</displayName>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -7047,7 +7047,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>franc CFA BCEAO</displayName>
 				<displayName count="one">franc CFA BCEAO</displayName>
 				<displayName count="other">francs CFA BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>pal·ladi</displayName>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -6128,7 +6128,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>𑄛𑄧𑄎𑄨𑄟𑄴 𑄃𑄜𑄳𑄢𑄨𑄇𑄚𑄴 [CFA] 𑄜𑄳𑄢𑄳𑄠𑄋𑄳𑄇𑄴</displayName>
 				<displayName count="one">𑄛𑄧𑄎𑄨𑄟𑄴 𑄃𑄜𑄳𑄢𑄨𑄇𑄚𑄴 [CFA] 𑄜𑄳𑄢𑄳𑄠𑄋𑄳𑄇𑄴</displayName>
 				<displayName count="other">𑄛𑄧𑄎𑄨𑄟𑄴 𑄃𑄜𑄳𑄢𑄨𑄇𑄚𑄴 [CFA] 𑄜𑄳𑄢𑄳𑄠𑄋𑄳𑄇𑄴</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>𑄛𑄳𑄠𑄣𑄬𑄓𑄨𑄠𑄟𑄴</displayName>

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -4894,7 +4894,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Малхбузен Африкан КФА франк</displayName>
 				<displayName count="one">Малхбузен Африкан КФА франк</displayName>
 				<displayName count="other">Малхбузен Африкан КФА франк</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Французийн Тийна океанан франк</displayName>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -5677,7 +5677,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ᏭᏕᎵᎬ ᎬᎿᎨᏍᏛ CFA ᎠᏕᎳ</displayName>
 				<displayName count="one">ᏭᏕᎵᎬ ᎬᎿᎨᏍᏛ CFA ᎠᏕᎳ</displayName>
 				<displayName count="other">ᏭᏕᎵᎬ ᎬᎿᎨᏍᏛ CFA ᎠᏕᎳ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP ᎠᏕᎳ</displayName>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -12323,7 +12323,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">CFA/BCEAO franky</displayName>
 				<displayName count="many">CFA/BCEAO franku</displayName>
 				<displayName count="other">CFA/BCEAO franků</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladium</displayName>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -7974,7 +7974,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">ffranc CFA Gorllewin Affrica</displayName>
 				<displayName count="many">ffranc CFA Gorllewin Affrica</displayName>
 				<displayName count="other">ffranc CFA Gorllewin Affrica</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Paladiwm</displayName>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -7063,7 +7063,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>CFA-franc BCEAO</displayName>
 				<displayName count="one">CFA-franc BCEAO</displayName>
 				<displayName count="other">CFA-franc BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Palladium</displayName>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -7687,7 +7687,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>CFA-Franc (BCEAO)</displayName>
 				<displayName count="one">CFA-Franc (BCEAO)</displayName>
 				<displayName count="other">CFA-Francs (BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Unze Palladium</displayName>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -4555,7 +4555,7 @@ terms of use, see http://www.unicode.org/copyright.html
 				<displayName count="two">CFA-franka (BCEAO)</displayName>
 				<displayName count="few">CFA-franki (BCEAO)</displayName>
 				<displayName count="other">CFA-frankow (BCEAO)</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP-frank</displayName>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -7353,7 +7353,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Φράγκο CFA Δυτικής Αφρικής</displayName>
 				<displayName count="one">φράγκο CFA Δυτικής Αφρικής</displayName>
 				<displayName count="other">φράγκα CFA Δυτικής Αφρικής</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Φράγκο CFP</displayName>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -6833,7 +6833,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Lääne-Aafrika CFA frank</displayName>
 				<displayName count="one">Lääne-Aafrika CFA frank</displayName>
 				<displayName count="other">Lääne-Aafrika CFA franki</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>pallaadium</displayName>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -5867,7 +5867,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Afrika mendebaldeko CFA frankoa</displayName>
 				<displayName count="one">Afrika mendebaldeko CFA franko</displayName>
 				<displayName count="other">Afrika mendebaldeko CFA franko</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP frankoa</displayName>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -7521,7 +7521,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>فرانک CFA غرب افریقا</displayName>
 				<displayName count="one">فرانک CFA غرب افریقا</displayName>
 				<displayName count="other">فرانک CFA غرب افریقا</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>پالادیم</displayName>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -7824,7 +7824,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>CFA-frangi BCEAO</displayName>
 				<displayName count="one">CFA-frangi BCEAO</displayName>
 				<displayName count="other">CFA-frangia BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladium</displayName>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -7902,7 +7902,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>CFA Franc ng Kanlurang Africa</displayName>
 				<displayName count="one">CFA franc ng Kanlurang Africa</displayName>
 				<displayName count="other">CFA francs ng Kanlurang Africa</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP Franc</displayName>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -5708,7 +5708,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Vesturafrika CFA frankur</displayName>
 				<displayName count="one">Vesturafrika CFA frankur</displayName>
 				<displayName count="other">Vesturafrika CFA frankar</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">unse palladium</displayName>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -9575,7 +9575,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>franc CFA (BCEAO)</displayName>
 				<displayName count="one">franc CFA (BCEAO)</displayName>
 				<displayName count="other">francs CFA (BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladium</displayName>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -6112,7 +6112,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="contributed">CFA-franc BCEAO</displayName>
 				<displayName count="one" draft="contributed">CFA-franc BCEAO</displayName>
 				<displayName count="other" draft="contributed">CFA-franc BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">Palladium</displayName>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -9918,7 +9918,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="two">fhranc CFA Afraga an Iar</displayName>
 				<displayName count="few">franc CFA Afraga an Iar</displayName>
 				<displayName count="other">franc CFA Afraga an Iar</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Pallaideam</displayName>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -6023,7 +6023,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>franco CFA (BCEAO)</displayName>
 				<displayName count="one">franco CFA (BCEAO)</displayName>
 				<displayName count="other">francos CFA (BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">Paladio</displayName>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -6819,7 +6819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>પશ્ચિમી આફ્રિકન [CFA] ફ્રેંક</displayName>
 				<displayName count="one">પશ્ચિમી આફ્રિકન [CFA] ફ્રેંક</displayName>
 				<displayName count="other">પશ્ચિમી આફ્રિકન [CFA] ફ્રેંક્સ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>[CFP] ફ્રેંક</displayName>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -7673,7 +7673,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="two">פרנק CFA מערב אפריקני</displayName>
 				<displayName count="many">פרנק CFA מערב אפריקני</displayName>
 				<displayName count="other">פרנק CFA מערב אפריקני</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">פלדיום</displayName>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -7010,7 +7010,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>पश्चिमी अफ़्रीकी CFA फ़्रैंक</displayName>
 				<displayName count="one">पश्चिमी अफ़्रीकी CFA फ़्रैंक</displayName>
 				<displayName count="other">पश्चिमी अफ़्रीकी CFA फ़्रैंक</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>[CFP] फ़्रैंक</displayName>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -8128,7 +8128,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">CFA franak BCEAO</displayName>
 				<displayName count="few">CFA franka BCEAO</displayName>
 				<displayName count="other">CFA franaka BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>paladij</displayName>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -4546,7 +4546,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="two">CFA-frankaj (BCEAO)</displayName>
 				<displayName count="few">CFA-franki (BCEAO)</displayName>
 				<displayName count="other">CFA-frankow (BCEAO)</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP-frank</displayName>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -7319,7 +7319,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>CFA frank BCEAO</displayName>
 				<displayName count="one">CFA frank BCEAO</displayName>
 				<displayName count="other">CFA frank BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palládium</displayName>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -5799,7 +5799,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Արևմտյան Աֆրիկայի ԿՖԱ ֆրանկ</displayName>
 				<displayName count="one">Արևմտյան Աֆրիկայի ԿՖԱ ֆրանկ</displayName>
 				<displayName count="other">Արևմտյան Աֆրիկայի ԿՖԱ ֆրանկ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>ԿՊՖ ֆրանկ</displayName>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -7067,7 +7067,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>Franc CFA Afrika Barat</displayName>
 				<displayName count="other">Franc CFA Afrika Barat</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Palladium</displayName>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -8503,7 +8503,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>vesturafrískur franki</displayName>
 				<displayName count="one">vesturafrískur franki</displayName>
 				<displayName count="other">vesturafrískir frankar</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="unconfirmed">unse palladín</displayName>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -8706,7 +8706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>西アフリカ CFA フラン</displayName>
 				<displayName count="other">西アフリカ CFA フラン</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>パラジウム</displayName>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -6507,7 +6507,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>დასავლეთ აფრიკული CFA ფრანკი</displayName>
 				<displayName count="one">დასავლეთ აფრიკული CFA ფრანკი</displayName>
 				<displayName count="other">დასავლეთ აფრიკული CFA ფრანკი</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP ფრანკი</displayName>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -6279,7 +6279,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Afrank BCEAO CFA</displayName>
 				<displayName count="one" draft="unconfirmed">Afrank CFA (BCEAO)</displayName>
 				<displayName count="other" draft="unconfirmed">Ifranken CFA (BCEAO)</displayName>
-				<symbol draft="unconfirmed">CFA</symbol>
+				<symbol draft="unconfirmed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="unconfirmed">Palladium</displayName>

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -3180,7 +3180,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XOF">
 				<displayName>Franku CFA (BCEAO)</displayName>
 				<displayName count="other">Franku CFA (BCEAO)</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<symbol>CFPF</symbol>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -5753,7 +5753,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>КФА ВСЕАО франкі</displayName>
 				<displayName count="one">КФА ВСЕАО франкі</displayName>
 				<displayName count="other">КФА ВСЕАО франкі</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>КФП франкі</displayName>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -5451,7 +5451,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>ហ្វ្រង់ CFA អាហ្វ្រិកខាងលិច</displayName>
 				<displayName count="other">ហ្វ្រង់ CFA អាហ្វ្រិកខាងលិច</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>ហ្វ្រង់ CFP</displayName>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -6800,7 +6800,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ಪಶ್ಚಿಮ ಆಫ್ರಿಕಾದ CFA ಫ್ರಾಂಕ್</displayName>
 				<displayName count="one">ಪಶ್ಚಿಮ ಆಫ್ರಿಕಾದ CFA ಫ್ರಾಂಕ್</displayName>
 				<displayName count="other">ಪಶ್ಚಿಮ ಆಫ್ರಿಕಾದ CFA ಫ್ರಾಂಕ್‌ಗಳು</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>[CFP] ಫ್ರಾಂಕ್</displayName>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -7765,7 +7765,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>서아프리카 CFA 프랑</displayName>
 				<displayName count="other">서아프리카 CFA 프랑</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>팔라듐</displayName>

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -5350,7 +5350,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XOF">
 				<displayName>अस्तंत आफ्रिकी सीएफए फ्रँक</displayName>
 				<displayName count="other">अस्तंत आफ्रिकी सीएफए फ्रँक्स</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>सीएफपी फ्रँक</displayName>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -5731,7 +5731,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>КФА франкы</displayName>
 				<displayName count="one">КФА франкы</displayName>
 				<displayName count="other">КФА франкы</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>КФП франкы</displayName>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -5044,7 +5044,7 @@ terms of use, see http://www.unicode.org/copyright.html
 				<displayName>CFA-Frang (BCEAO)</displayName>
 				<displayName count="one">CFA-Frang (BCEAO)</displayName>
 				<displayName count="other">CFA-Frang (BCEAO)</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Onz Palladium</displayName>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -7309,7 +7309,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>ຟັງເຊຟານ ອາຟຣິກາຕາເວັນຕົກ</displayName>
 				<displayName count="other">ຟັງເຊຟານ ອາຟຣິກາຕາເວັນຕົກ</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>ແພເລດຽມ</displayName>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -6863,7 +6863,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="zero">Rietumāfrikas CFA franki</displayName>
 				<displayName count="one">Rietumāfrikas CFA franks</displayName>
 				<displayName count="other">Rietumāfrikas CFA franki</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>pallādijs</displayName>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -7158,7 +7158,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Западноафрикански франк</displayName>
 				<displayName count="one">Западноафрикански франк</displayName>
 				<displayName count="other">Западноафрикански франци</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>ЦФП франк</displayName>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -7370,7 +7370,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>പശ്ചിമ ആഫ്രിക്കൻ [CFA] ഫ്രാങ്ക്</displayName>
 				<displayName count="one">പശ്ചിമ ആഫ്രിക്കൻ [CFA] ഫ്രാങ്ക്</displayName>
 				<displayName count="other">പശ്ചിമ ആഫ്രിക്കൻ [CFA] ഫ്രാങ്ക്</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>പലാഡിയം</displayName>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -5721,7 +5721,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Баруун Африкийн франк</displayName>
 				<displayName count="one">Баруун Африкийн франк</displayName>
 				<displayName count="other">Баруун Африкийн франк</displayName>
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Францын колонийн франк</displayName>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -6810,7 +6810,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>पश्चिम आफ्रिकन [CFA] फ्रँक</displayName>
 				<displayName count="one">पश्चिम आफ्रिकन [CFA] फ्रँक</displayName>
 				<displayName count="other">पश्चिम आफ्रिकन [CFA] फ्रँक्स</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>[CFP] फ्रँक</displayName>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -7824,7 +7824,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>Franc CFA BCEAO</displayName>
 				<displayName count="other">Franc CFA BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<symbol draft="contributed">↑↑↑</symbol>

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -3886,7 +3886,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">$</symbol>
 			</currency>
 			<currency type="XOF">
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<symbol draft="contributed">CFPF</symbol>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -5592,7 +5592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>အနောက် အာဖရိက CFA ဖရန့်</displayName>
 				<displayName count="other">အနောက် အာဖရိက CFA ဖရန့်</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP ဖရန့်</displayName>

--- a/common/main/mzn.xml
+++ b/common/main/mzn.xml
@@ -1871,7 +1871,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XOF">
 				<displayName>غربی آفریقای ِسی‌اف‌ای فرانک</displayName>
 				<displayName count="other">غربی آفریقای ِسی‌اف‌ای فرانک</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="YER">
 				<displayName>یمن ِریال</displayName>

--- a/common/main/nb.xml
+++ b/common/main/nb.xml
@@ -13581,7 +13581,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>vestafrikanske CFA-franc</displayName>
 				<displayName count="one">vestafrikansk CFA-franc</displayName>
 				<displayName count="other">vestafrikanske CFA-franc</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladium</displayName>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -6012,7 +6012,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>सीएफ्‌ए फ्रान्क बीसीइएओ</displayName>
 				<displayName count="one">सीएफ्‌ए फ्रान्क बीसीइएओ</displayName>
 				<displayName count="other">सीऐफ्‌ए फ्रान्क्स बीसीइएओ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>सीएफ्‌पी फ्रान्क</displayName>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -15683,7 +15683,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>CFA-franc BCEAO</displayName>
 				<displayName count="one">CFA-franc BCEAO</displayName>
 				<displayName count="other">CFA-franc BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Palladium</displayName>

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -6412,7 +6412,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>vestafrikanske CFA-franc</displayName>
 				<displayName count="one">vestafrikansk CFA-franc</displayName>
 				<displayName count="other">vestafrikanske CFA-franc</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladium</displayName>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -5959,7 +5959,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ପଶ୍ଚିମ ଆଫ୍ରିକିୟ CFA ଫ୍ରାଙ୍କ୍</displayName>
 				<displayName count="one">ପଶ୍ଚିମ ଆଫ୍ରିକିୟ CFA ଫ୍ରାଙ୍କ୍</displayName>
 				<displayName count="other">ପଶ୍ଚିମ ଆଫ୍ରିକିୟ CFA ଫ୍ରାଙ୍କ୍</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP ଫ୍ରାଙ୍କ୍</displayName>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -6775,7 +6775,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ਪੱਛਮੀ ਅਫ਼ਰੀਕੀ (CFA) ਫ੍ਰੈਂਕ</displayName>
 				<displayName count="one">ਪੱਛਮੀ ਅਫ਼ਰੀਕੀ (CFA) ਫ੍ਰੈਂਕ</displayName>
 				<displayName count="other">ਪੱਛਮੀ ਅਫ਼ਰੀਕੀ (CFA) ਫ੍ਰੈਂਕ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>ਫ੍ਰੈਂਕ (CFP)</displayName>

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -5436,7 +5436,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Wẹ́st Afríká Sẹ́fa Frank</displayName>
 				<displayName count="one">Wẹ́st Afríká Sẹ́fa frank</displayName>
 				<displayName count="other">Wẹ́st Afríká Sẹ́fa franks</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Frẹ́nch Poliníshiá Frank</displayName>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -6951,7 +6951,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Franco CFA de BCEAO</displayName>
 				<displayName count="one">Franco CFA de BCEAO</displayName>
 				<displayName count="other">Francos CFA de BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Paládio</displayName>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -6361,7 +6361,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>franco CFA (BCEAO)</displayName>
 				<displayName count="one">franco CFA (BCEAO)</displayName>
 				<displayName count="other">francos CFA (BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>franco CFP</displayName>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -4206,7 +4206,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>franc CFA da l’Africa dal Vest</displayName>
 				<displayName count="one">franc CFA da l’Africa dal Vest</displayName>
 				<displayName count="other">francs CFA da l’Africa dal Vest</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">palladi</displayName>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -7655,7 +7655,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">franc CFA BCEAO</displayName>
 				<displayName count="few">franci CFA BCEAO</displayName>
 				<displayName count="other">franci CFA BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>paladiu</displayName>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -4085,7 +4085,7 @@ for derived annotations.
 				<symbol alt="narrow">$</symbol>
 			</currency>
 			<currency type="XOF">
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<symbol>CFPF</symbol>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -8192,7 +8192,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">франка КФА ВСЕАО</displayName>
 				<displayName count="many">франков КФА ВСЕАО</displayName>
 				<displayName count="other">франка КФА ВСЕАО</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Палладий</displayName>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -5948,7 +5948,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>اولهه آفريڪا فرينڪ</displayName>
 				<displayName count="one">اولهه آفريڪا فرينڪ</displayName>
 				<displayName count="other">اولهه آفريڪا فرينڪ</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP فرينڪ</displayName>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -8119,7 +8119,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">západoafrické franky</displayName>
 				<displayName count="many">západoafrického franku</displayName>
 				<displayName count="other">západoafrických frankov</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">paládium</displayName>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -7003,7 +7003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="two">zahodnoafriška franka CFA</displayName>
 				<displayName count="few">zahodnoafriški franki CFA</displayName>
 				<displayName count="other">zahodnoafriških frankov CFA</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>paladij</displayName>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -5830,7 +5830,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Franga e Bregut të Fildishtë</displayName>
 				<displayName count="one">frangë e Bregut të Fildishtë</displayName>
 				<displayName count="other">franga të Bregut të Fildishtë</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Franga franceze e Polinezisë</displayName>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -7592,7 +7592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">ЦФА франак БЦЕАО</displayName>
 				<displayName count="few">ЦФА франка БЦЕАО</displayName>
 				<displayName count="other">ЦФА франака БЦЕАО</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Паладијум</displayName>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -7467,7 +7467,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">CFA franak BCEAO</displayName>
 				<displayName count="few">CFA franka BCEAO</displayName>
 				<displayName count="other">CFA franaka BCEAO</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Paladijum</displayName>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -8573,7 +8573,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>västafrikansk franc</displayName>
 				<displayName count="one">västafrikansk franc</displayName>
 				<displayName count="other">västafrikanska franc</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>palladium</displayName>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -5864,7 +5864,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Faranga ya Afrika Magharibi CFA</displayName>
 				<displayName count="one">faranga ya Afrika Magharibi CFA</displayName>
 				<displayName count="other">faranga za Afrika Magharibi CFA</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Faranga ya CFP</displayName>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -6766,7 +6766,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>மேற்கு ஆப்பிரிக்க CFA ஃப்ராங்க்</displayName>
 				<displayName count="one">மேற்கு ஆப்பிரிக்க CFA ஃப்ராங்க்</displayName>
 				<displayName count="other">மேற்கு ஆப்பிரிக்க CFA ஃப்ராங்க்குகள்</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>ஃப்ராங்க் (CFP)</displayName>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -6815,7 +6815,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>పశ్చిమ ఆఫ్రికన్ సిఏఫ్ఏ ఫ్రాంక్</displayName>
 				<displayName count="one">పశ్చిమ ఆఫ్రికన్ సిఏఫ్ఏ ఫ్రాంక్</displayName>
 				<displayName count="other">పశ్చిమ ఆఫ్రికన్ సిఏఫ్ఏ ఫ్రాంక్‌లు</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>సిఎఫ్‌పి ఫ్రాంక్</displayName>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -8215,7 +8215,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>ฟรังก์เซฟาธนาคารกลางรัฐแอฟริกาตะวันตก</displayName>
 				<displayName count="other">ฟรังก์เซฟาธนาคารกลางรัฐแอฟริกาตะวันตก</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>พัลเลเดียม</displayName>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -5668,7 +5668,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>KFA BCEAO franky</displayName>
 				<displayName count="one">KFA BCEAO franky</displayName>
 				<displayName count="other">KFA BCEAO franky</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Fransuz ýuwaş umman franky</displayName>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -7483,7 +7483,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Batı Afrika CFA Frangı</displayName>
 				<displayName count="one">Batı Afrika CFA frangı</displayName>
 				<displayName count="other">Batı Afrika CFA frangı</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>Paladyum</displayName>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -7922,7 +7922,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">західноафриканські франки</displayName>
 				<displayName count="many">західноафриканських франків</displayName>
 				<displayName count="other">західноафриканського франка</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">паладій</displayName>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -6456,7 +6456,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>مغربی افریقی [CFA] فرانک</displayName>
 				<displayName count="one">مغربی افریقی [CFA] فرانک</displayName>
 				<displayName count="other">مغربی افریقی [CFA] فرانک</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>CFP فرانک</displayName>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -5871,7 +5871,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>G‘arbiy Afrika CFA franki</displayName>
 				<displayName count="one">G‘arbiy Afrika CFA franki</displayName>
 				<displayName count="other">G‘arbiy Afrika CFA franki</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>Fransuz Polineziyasi franki</displayName>

--- a/common/main/uz_Cyrl.xml
+++ b/common/main/uz_Cyrl.xml
@@ -2948,7 +2948,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol>EC$</symbol>
 			</currency>
 			<currency type="XOF">
-				<symbol>CFA</symbol>
+				<symbol>F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<symbol>CFPF</symbol>

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -1928,7 +1928,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XOF">
 				<displayName>Franc CFA bu Afrik Sowwu-jant</displayName>
 				<displayName count="other">Franc CFA yu Afrik Sowwu-jant</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XXX">
 				<displayName>Xaalis buñ Xamul</displayName>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -8370,7 +8370,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XOF">
 				<displayName>法郎 (CFA–BCEAO)</displayName>
 				<displayName count="other">法郎 (CFA–BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">帕拉狄昂</displayName>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -8307,7 +8307,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XOF">
 				<displayName>法郎 (CFA–BCEAO)</displayName>
 				<displayName count="other">法郎 (CFA–BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">帕拉狄昂</displayName>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -10195,7 +10195,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>西非法郎</displayName>
 				<displayName count="other">西非法郎</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName>钯</displayName>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -13692,7 +13692,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>法郎 (CFA–BCEAO)</displayName>
 				<displayName count="other">法郎 (CFA–BCEAO)</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPD">
 				<displayName draft="contributed">帕拉狄昂</displayName>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -6439,7 +6439,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>i-West African CFA Franc</displayName>
 				<displayName count="one">i-West African CFA Franc</displayName>
 				<displayName count="other">i-West African CFA francs</displayName>
-				<symbol draft="contributed">CFA</symbol>
+				<symbol draft="contributed">F\u202fCFA</symbol>
 			</currency>
 			<currency type="XPF">
 				<displayName>i-CFP Franc</displayName>

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/data/xmb/en.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/data/xmb/en.xml
@@ -7687,7 +7687,7 @@
 
 	<!-- //ldml/numbers/currencies/currency[@type="XOF"]/symbol -->
 	<msg id='7441741010095280916'
-		desc='The symbol for the currency with the ISO currency code = XOF. For more information, see http://cldr.org/translation/currency-names.'>CFA</msg>
+		desc='The symbol for the currency with the ISO currency code = XOF. For more information, see http://cldr.org/translation/currency-names.'>F\u202fCFA</msg>
 
 	<!-- //ldml/numbers/currencies/currency[@type="XPF"]/displayName -->
 	<msg id='6229334690374504108'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This pull request changes the `symbol` element value for XOF from `CFA` to `F\u202fCFA`. This includes 97 files in cldr/common/main plus 1 file in cldr/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/data/xmb

NB: No changes are needed for XAF entries nor for any elements other than `symbol` for XOF entries.

`\u202f` is used for a narrow no-break space.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11581
- [x] Updated PR title and link in previous line to include Issue number

