### PR TITLE
CLDR-14269 add nasal Yoruba exemplar characters

### DIFF
--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -716,7 +716,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[a á à b d e é è ẹ {ẹ\u0301} {ẹ\u0300} f g {gb} h i í ì j k l m n ń o ó ò ọ {ọ\u0301} {ọ\u0300} p r s ṣ t u ú ù w y]</exemplarCharacters>
+		<exemplarCharacters>[a á à b d e é è ẹ {ẹ\u0301} {ẹ\u0300} f g {gb} h i í ì j k l m ḿ {m\u0300} n ń ǹ o ó ò ọ {ọ\u0301} {ọ\u0300} p r s ṣ t u ú ù w y]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[c q v x z]</exemplarCharacters>
 		<exemplarCharacters type="index">[A B D E F G H I J K L M N O P R S T U W Y]</exemplarCharacters>
 		<exemplarCharacters type="numbers" draft="contributed">↑↑↑</exemplarCharacters>


### PR DESCRIPTION
CLDR-14269 Add missing additional nasal Yoruba exemplar characters: “ǹ, ḿ, m̀”

Syllabic nasals can have either a high tone, a mid tone or a low tone. They are written as a 'n' except before 'b' where they are written as a 'm'.
- High tone is marked with an acute accent 
- Mid is unmarked
- Low is marked with a grave accent

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14269
- [X] Updated PR title and link in previous line to include Issue number

