### PR TITLE
CLDR-13759 copy compact currency formats to compact decimal (without ¤)

### DIFF
--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -5203,30 +5203,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="one" draft="contributed">0T</pattern>
+					<pattern type="1000" count="other" draft="contributed">0T</pattern>
+					<pattern type="10000" count="one" draft="contributed">00T</pattern>
+					<pattern type="10000" count="other" draft="contributed">00T</pattern>
+					<pattern type="100000" count="one" draft="contributed">0L</pattern>
+					<pattern type="100000" count="other" draft="contributed">0L</pattern>
+					<pattern type="1000000" count="one" draft="contributed">00L</pattern>
+					<pattern type="1000000" count="other" draft="contributed">00L</pattern>
+					<pattern type="10000000" count="one" draft="contributed">0Cr</pattern>
+					<pattern type="10000000" count="other" draft="contributed">0Cr</pattern>
+					<pattern type="100000000" count="one" draft="contributed">00Cr</pattern>
+					<pattern type="100000000" count="other" draft="contributed">00Cr</pattern>
+					<pattern type="1000000000" count="one" draft="contributed">000Cr</pattern>
+					<pattern type="1000000000" count="other" draft="contributed">000Cr</pattern>
+					<pattern type="10000000000" count="one" draft="contributed">0TCr</pattern>
+					<pattern type="10000000000" count="other" draft="contributed">0TCr</pattern>
+					<pattern type="100000000000" count="one" draft="contributed">00TCr</pattern>
+					<pattern type="100000000000" count="other" draft="contributed">00TCr</pattern>
+					<pattern type="1000000000000" count="one" draft="contributed">0LCr</pattern>
+					<pattern type="1000000000000" count="other" draft="contributed">0LCr</pattern>
+					<pattern type="10000000000000" count="one" draft="contributed">00LCr</pattern>
+					<pattern type="10000000000000" count="other" draft="contributed">00LCr</pattern>
+					<pattern type="100000000000000" count="one" draft="contributed">000LCr</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13759
- [x] Updated PR title and link in previous line to include Issue number

For en_IN, make the compact **decimal** formats match the compact **currency** formats (but without the ¤), this achieves the desired result.

Note that in Apple ICU, en_IN has compact currency and decimal formats equal to the result of this, except that Apple ICU en_IN uses 'K' instead of 'T' to indicate thousands (the result of some internal discussion). But the CLDR vetters chose T for the compact currency formats so in CLDR we use that for the compact decimal formats too.
