### PR TITLE
CLDR-13952 change root symbol for PHP to match narrow = ₱

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3996,6 +3996,7 @@ for derived annotations.
 				<symbol alt="narrow">$</symbol>
 			</currency>
 			<currency type="PHP">
+				<symbol>₱</symbol>
 				<symbol alt="narrow">₱</symbol>
 			</currency>
 			<currency type="PKR">


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13952
- [x] Updated PR title and link in previous line to include Issue number

change root symbol for PHP to match narrow = ₱