### PR TITLE
CLDR-14159 DAIP should trim all whitespace

### DIFF
--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2020 Unicode, Inc.
+<!-- Copyright © 1991-2021 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4934,10 +4934,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000" count="few">000 млн ¤</pattern>
 					<pattern type="100000000" count="many">000 млн ¤</pattern>
 					<pattern type="100000000" count="other">000 млн ¤</pattern>
-					<pattern type="1000000000" count="one">0 млрд ¤ </pattern>
-					<pattern type="1000000000" count="few">0 млрд ¤ </pattern>
-					<pattern type="1000000000" count="many">0 млрд ¤ </pattern>
-					<pattern type="1000000000" count="other">0 млрд ¤ </pattern>
+					<pattern type="1000000000" count="one">0 млрд ¤</pattern>
+					<pattern type="1000000000" count="few">0 млрд ¤</pattern>
+					<pattern type="1000000000" count="many">0 млрд ¤</pattern>
+					<pattern type="1000000000" count="other">0 млрд ¤</pattern>
 					<pattern type="10000000000" count="one">00 млрд ¤</pattern>
 					<pattern type="10000000000" count="few">00 млрд ¤</pattern>
 					<pattern type="10000000000" count="many">00 млрд ¤</pattern>

--- a/common/main/dz.xml
+++ b/common/main/dz.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2020 Unicode, Inc.
+<!-- Copyright © 1991-2021 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2630,7 +2630,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 		</currencies>
 		<minimalPairs>
-			<pluralMinimalPairs count="other">ཉིནམ་ {0} </pluralMinimalPairs>
+			<pluralMinimalPairs count="other">ཉིནམ་ {0}</pluralMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/main/es_GT.xml
+++ b/common/main/es_GT.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2020 Unicode, Inc.
+<!-- Copyright © 1991-2021 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -240,10 +240,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="other" draft="contributed">¤000M</pattern>
 					<pattern type="1000000000" count="one" draft="contributed">¤0000M</pattern>
 					<pattern type="1000000000" count="other" draft="contributed">¤0000M</pattern>
-					<pattern type="10000000000" count="one" draft="contributed">¤00MRD </pattern>
-					<pattern type="10000000000" count="other" draft="contributed">¤00MRD </pattern>
-					<pattern type="100000000000" count="one" draft="contributed">¤000MRD </pattern>
-					<pattern type="100000000000" count="other" draft="contributed">¤000MRD </pattern>
+					<pattern type="10000000000" count="one" draft="contributed">¤00MRD</pattern>
+					<pattern type="10000000000" count="other" draft="contributed">¤00MRD</pattern>
+					<pattern type="100000000000" count="one" draft="contributed">¤000MRD</pattern>
+					<pattern type="100000000000" count="other" draft="contributed">¤000MRD</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">{1} {0}</unitPattern>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -10119,7 +10119,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} bhròg</pluralMinimalPairs>
-			<pluralMinimalPairs count="two">{0}  bhròig</pluralMinimalPairs>
+			<pluralMinimalPairs count="two">{0} bhròig</pluralMinimalPairs>
 			<pluralMinimalPairs count="few">{0} brògan</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">{0} bròg</pluralMinimalPairs>
 		</minimalPairs>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -7125,7 +7125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign>約 </approximatelySign>
+			<approximatelySign>約</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -5905,12 +5905,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">0 илј'.' ¤ </pattern>
-					<pattern type="1000" count="other">0 илј'.' ¤ </pattern>
-					<pattern type="10000" count="one">00 илј'.' ¤ </pattern>
-					<pattern type="10000" count="other">00 илј'.' ¤ </pattern>
-					<pattern type="100000" count="one">000 илј'.' ¤ </pattern>
-					<pattern type="100000" count="other">000 илј'.' ¤ </pattern>
+					<pattern type="1000" count="one">0 илј'.' ¤</pattern>
+					<pattern type="1000" count="other">0 илј'.' ¤</pattern>
+					<pattern type="10000" count="one">00 илј'.' ¤</pattern>
+					<pattern type="10000" count="other">00 илј'.' ¤</pattern>
+					<pattern type="100000" count="one">000 илј'.' ¤</pattern>
+					<pattern type="100000" count="other">000 илј'.' ¤</pattern>
 					<pattern type="1000000" count="one">0 мил'.' ¤</pattern>
 					<pattern type="1000000" count="other">0 мил'.' ¤</pattern>
 					<pattern type="10000000" count="one">00 мил'.' ¤</pattern>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -1621,9 +1621,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">G y – y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM   </greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
 							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
-							<greatestDifference id="y">GGGGG y-MM – y-MM </greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
@@ -1644,7 +1644,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
 							<greatestDifference id="d">G y MMM d – d</greatestDifference>
-							<greatestDifference id="G">G y MMM d – G y MMM d   </greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
 							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
 							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -2772,10 +2772,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>deň týždňa v mesiaci</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>d.  týž. v mes.</displayName>
+				<displayName>d. týž. v mes.</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>d.  týž. v mes.</displayName>
+				<displayName>d. týž. v mes.</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">minulú nedeľu</relative>

--- a/common/main/ug.xml
+++ b/common/main/ug.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2020 Unicode, Inc.
+<!-- Copyright © 1991-2021 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4730,7 +4730,7 @@ Reviewed by Waris Abdukerim Janbaz <oyghan@gmail.com> of the Uyghur Computer Sci
 			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="one">{0}  كىتاب</pluralMinimalPairs>
+			<pluralMinimalPairs count="one">{0} كىتاب</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">{0} بېلىق كۆردۈم ۋە ئۇنى يەۋەتتىم.</pluralMinimalPairs>
 		</minimalPairs>
 	</numbers>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -81,14 +81,31 @@ public class DisplayAndInputProcessor {
         + "numbers/(decimal|currency|percent|scientific)Formats.+/(decimal|currency|percent|scientific)Format.*)");
     private static final Pattern INTERVAL_FORMAT_PATHS = PatternCache.get("//ldml/dates/.+/intervalFormatItem.*");
     private static final Pattern NON_DECIMAL_PERIOD = PatternCache.get("(?<![0#'])\\.(?![0#'])");
-    private static final Pattern WHITESPACE_NO_NBSP_TO_NORMALIZE = PatternCache.get("\\s+"); // string of whitespace not
-    // including NBSP, i.e. [
-    // \t\n\r]+
-    private static final Pattern WHITESPACE_AND_NBSP_TO_NORMALIZE = PatternCache.get("[\\s\\u00A0]+"); // string of
-    // whitespace
-    // including NBSP,
-    // i.e. [
-    // \u00A0\t\n\r]+
+
+    /**
+     * string of whitespace not including NBSP, i.e. [\t\n\r]+
+     */
+    private static final Pattern WHITESPACE_NO_NBSP_TO_NORMALIZE = PatternCache.get("\\s+"); //
+
+    /**
+     * string of whitespace including NBSP, i.e. [\u00A0\t\n\r]+
+     */
+    private static final Pattern WHITESPACE_AND_NBSP_TO_NORMALIZE = PatternCache.get("[\\s\\u00A0]+");
+
+    /**
+     * one or more NBSP followed by one or more regular spaces
+     */
+    private static final Pattern NBSP_PLUS_SPACE_TO_NORMALIZE = PatternCache.get("\\u00A0+\\u0020+");
+
+    /**
+     * one or more regular spaces followed by one or more NBSP
+     */
+    private static final Pattern SPACE_PLUS_NBSP_TO_NORMALIZE = PatternCache.get("\\u0020+\\u00A0+");
+
+    private static final Pattern INITIAL_NBSP = PatternCache.get("^\\u00A0+");
+    private static final Pattern FINAL_NBSP = PatternCache.get("\\u00A0+$");
+    private static final Pattern MULTIPLE_NBSP = PatternCache.get("\\u00A0\\u00A0+");
+
     private static final UnicodeSet UNICODE_WHITESPACE = new UnicodeSet("[:whitespace:]").freeze();
 
     private static final CLDRLocale MALAYALAM = CLDRLocale.getInstance("ml");
@@ -583,37 +600,6 @@ public class DisplayAndInputProcessor {
         return value;
     }
 
-    private String normalizeWhitespace(String path, String value) {
-        // turn all whitespace sequences (including tab and newline, and NBSP for certain paths)
-        // into a single space or a single NBSP depending on path.
-        if ((path.contains("/dateFormatLength") && path.contains("/pattern")) ||
-            path.contains("/availableFormats/dateFormatItem") ||
-            (path.startsWith("//ldml/dates/timeZoneNames/metazone") && path.contains("/long")) ||
-            path.startsWith("//ldml/dates/timeZoneNames/regionFormat") ||
-            path.startsWith("//ldml/localeDisplayNames/codePatterns/codePattern") ||
-            path.startsWith("//ldml/localeDisplayNames/languages/language") ||
-            path.startsWith("//ldml/localeDisplayNames/territories/territory") ||
-            path.startsWith("//ldml/localeDisplayNames/types/type") ||
-            (path.startsWith("//ldml/numbers/currencies/currency") && path.contains("/displayName")) ||
-            (path.contains("/decimalFormatLength[@type=\"long\"]") && path.contains("/pattern")) ||
-            path.startsWith("//ldml/posix/messages") ||
-            (path.startsWith("//ldml/units/uni") && path.contains("/unitPattern "))) {
-            value = WHITESPACE_AND_NBSP_TO_NORMALIZE.matcher(value).replaceAll(" "); // replace with regular space
-        } else if ((path.contains("/currencies/currency") && (path.contains("/group") || path.contains("/pattern")))
-            ||
-            (path.contains("/currencyFormatLength") && path.contains("/pattern")) ||
-            (path.contains("/currencySpacing") && path.contains("/insertBetween")) ||
-            (path.contains("/decimalFormatLength") && path.contains("/pattern")) || // i.e. the non-long ones
-            (path.contains("/percentFormatLength") && path.contains("/pattern")) ||
-            (path.startsWith("//ldml/numbers/symbols") && (path.contains("/group") || path.contains("/nan")))) {
-            value = WHITESPACE_AND_NBSP_TO_NORMALIZE.matcher(value).replaceAll("\u00A0"); // replace with NBSP
-        } else {
-            // in this case don't normalize away NBSP
-            value = WHITESPACE_NO_NBSP_TO_NORMALIZE.matcher(value).replaceAll(" "); // replace with regular space
-        }
-        return value;
-    }
-
     private String normalizeCurrencyDisplayName(String value) {
         StringBuilder result = new StringBuilder();
         boolean inParentheses = false;
@@ -1013,6 +999,101 @@ public class DisplayAndInputProcessor {
 
         public int[] getPosixDigitCount() {
             return posixDigitCount;
+        }
+    }
+
+    /**
+     * Turn all whitespace sequences (including tab and newline, and NBSP for certain paths)
+     * into a single space or a single NBSP depending on path.
+     * Also trim initial/final NBSP, unless the value is only the one character, "\u00A0"
+     *
+     * @param path
+     * @param value
+     * @return the normalized value
+     */
+    private String normalizeWhitespace(String path, String value) {
+        PathSpaceType pst = PathSpaceType.get(path);
+        if (pst == PathSpaceType.allowSp) {
+            value = WHITESPACE_AND_NBSP_TO_NORMALIZE.matcher(value).replaceAll(" "); // replace with regular space
+        } else if (pst == PathSpaceType.allowNbsp) {
+            value = WHITESPACE_AND_NBSP_TO_NORMALIZE.matcher(value).replaceAll("\u00A0"); // replace with NBSP
+            value = trimNBSP(value);
+        } else if (pst == PathSpaceType.allowSpOrNbsp) {
+            /*
+             * in this case don't normalize away NBSP
+             */
+            value = WHITESPACE_NO_NBSP_TO_NORMALIZE.matcher(value).replaceAll(" "); // replace with regular space
+            /*
+             * if any NBSP and regular space are adjacent, replace with NBSP
+             */
+            value = NBSP_PLUS_SPACE_TO_NORMALIZE.matcher(value).replaceAll("\u00A0");
+            value = SPACE_PLUS_NBSP_TO_NORMALIZE.matcher(value).replaceAll("\u00A0");
+            value = MULTIPLE_NBSP.matcher(value).replaceAll("\u00A0");
+            value = trimNBSP(value);
+        } else {
+            throw new IllegalArgumentException("Unknown PathSpaceType " + pst);
+        }
+        return value;
+    }
+
+    /**
+     * Delete any initial or final NBSP, unless the value is just NBSP
+     *
+     * @param value
+     * @return the trimmed value
+     */
+    private String trimNBSP(String value) {
+        if (!"\u00A0".equals(value)) {
+            value = INITIAL_NBSP.matcher(value).replaceAll("");
+            value = FINAL_NBSP.matcher(value).replaceAll("");
+        }
+        return value;
+    }
+
+    /**
+     * Categorize xpaths according to whether they allow space, NBSP, or both
+     */
+    public enum PathSpaceType {
+        allowSp, allowNbsp, allowSpOrNbsp;
+
+        public static PathSpaceType get(String path) {
+            if (wantsRegularSpace(path)) {
+                return allowSp;
+            } else if (wantsNBSP(path)) {
+                return allowNbsp;
+            } else {
+                return allowSpOrNbsp;
+            }
+        }
+
+        private static boolean wantsRegularSpace(String path) {
+            if ((path.contains("/dateFormatLength") && path.contains("/pattern")) ||
+                path.contains("/availableFormats/dateFormatItem") ||
+                (path.startsWith("//ldml/dates/timeZoneNames/metazone") && path.contains("/long")) ||
+                path.startsWith("//ldml/dates/timeZoneNames/regionFormat") ||
+                path.startsWith("//ldml/localeDisplayNames/codePatterns/codePattern") ||
+                path.startsWith("//ldml/localeDisplayNames/languages/language") ||
+                path.startsWith("//ldml/localeDisplayNames/territories/territory") ||
+                path.startsWith("//ldml/localeDisplayNames/types/type") ||
+                (path.startsWith("//ldml/numbers/currencies/currency") && path.contains("/displayName")) ||
+                (path.contains("/decimalFormatLength[@type=\"long\"]") && path.contains("/pattern")) ||
+                path.startsWith("//ldml/posix/messages") ||
+                (path.startsWith("//ldml/units/uni") && path.contains("/unitPattern "))) {
+                return true;
+            }
+            return false;
+        }
+
+        private static boolean wantsNBSP(String path) {
+            if ((path.contains("/currencies/currency") && (path.contains("/group") || path.contains("/pattern"))) ||
+                (path.contains("/currencyFormatLength") && path.contains("/pattern")) ||
+                (path.contains("/currencySpacing") && path.contains("/insertBetween")) ||
+                (path.contains("/decimalFormatLength") && path.contains("/pattern")) || // i.e. the non-long ones
+                (path.contains("/percentFormatLength") && path.contains("/pattern")) ||
+                (path.startsWith("//ldml/numbers/symbols") && (path.contains("/group") || path.contains("/nan")))) {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.unittest;
 import java.util.Set;
 
 import org.unicode.cldr.test.DisplayAndInputProcessor;
+import org.unicode.cldr.test.DisplayAndInputProcessor.PathSpaceType;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.ExemplarType;
@@ -391,5 +392,85 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         String xpath = "//ldml/localeDisplayNames/languages/language[@type=\"fr\"]";
         String value = daip.processInput(xpath, "\btest\bTEST\b", null);
         assertEquals("Backspaces are filtered out", "testTEST", value);
+    }
+
+    /**
+     * Test whether DisplayAndInputProcessor.processInput normalizes whitespace.
+     * This depends very much on the xpath, since for most xpaths NBSP is normalized to
+     * ordinary space which, if initial or final, is then removed by trim(). But for some
+     * xpaths, NBSP is retained and then the standard trim() function doesn't apply.
++     *
++     * Each of the 3 types of paths, and for each, samples with
++     * A0 20
++     * 20 A0
++     * 20 A0 20
++     * 20 20
+     */
+    public void TestWhitespaceNormalization() {
+       DisplayAndInputProcessor daip = new DisplayAndInputProcessor(info.getEnglish(), false);
+       PathSpaceData[] a = PathSpaceData.getArray();
+       for (int i = 0; i < a.length; i++) {
+           PathSpaceType pst = PathSpaceType.get(a[i].xpath);
+           assertEquals("Path has expected type for i = " + i, a[i].pst, pst);
+           String val = daip.processInput(a[i].xpath, a[i].rawValue, null);
+           assertEquals("Whitespace is normalized for i = " + i, a[i].normValue, val);
+       }
+    }
+
+    private static class PathSpaceData {
+        private String xpath;
+        private String rawValue, normValue;
+        private PathSpaceType pst;
+
+        public PathSpaceData(String xpath, String rawValue, String normValue, PathSpaceType pst) {
+            this.xpath = xpath;
+            this.rawValue = rawValue;
+            this.normValue = normValue;
+            this.pst = pst;
+        }
+
+        public static PathSpaceData[] getArray() {
+            PathSpaceData[] a = {
+                new PathSpaceData("//ldml/localeDisplayNames/types/type",
+                    " \u00A0  TEST \u00A0 ", "TEST", PathSpaceType.allowSp),
+                new PathSpaceData("//ldml/localeDisplayNames/languages/language[@type=\"ab\"]",
+                    "\u00A0  FOO \u00A0\u00A0 BAR \u00A0", "FOO BAR", PathSpaceType.allowSp),
+                new PathSpaceData("//ldml/dates/calendars/calendar[@type=\"generic\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"Bh\"]",
+                    "\u00A0  DUCK \u00A0  GOOSE \u00A0", "DUCK GOOSE", PathSpaceType.allowSp),
+
+                new PathSpaceData("//ldml/numbers/currencies/currency/group",
+                    " \u00A0  ፊደል \u00A0 ", "ፊደል", PathSpaceType.allowNbsp),
+                new PathSpaceData("//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/insertBetween",
+                    "\u00A0  ding \u00A0\u00A0 dong \u00A0", "ding\u00A0dong", PathSpaceType.allowNbsp),
+                new PathSpaceData("//ldml/numbers/symbols/nan",
+                    "\u00A0  HA   HU \u00A0", "HA\u00A0HU", PathSpaceType.allowNbsp),
+
+                new PathSpaceData("//ldml/numbers/symbols[@numberSystem=\"telu\"]/approximatelySign",
+                    " \u00A0  试 \u00A0 ", "试", PathSpaceType.allowSpOrNbsp),
+                new PathSpaceData(
+                    "//ldml/dates/calendars/calendar[@type=\"hebrew\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"yMMMM\"]/greatestDifference[@id=\"M\"]",
+                    "\u00A0  X \u00A0 Y \u00A0", "X\u00A0Y", PathSpaceType.allowSpOrNbsp),
+                new PathSpaceData(
+                    "//ldml/dates/calendars/calendar[@type=\"islamic-civil\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"MEd\"]/greatestDifference[@id=\"M\"]",
+                    "\u00A0  Marvin   Gaye \u00A0", "Marvin Gaye", PathSpaceType.allowSpOrNbsp),
+                new PathSpaceData(
+                    "//ldml/dates/calendars/calendar[@type=\"islamic-civil\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"MEd\"]/greatestDifference[@id=\"M\"]",
+                    "〖\u00A0\u00A0〗", "〖\u00A0〗", PathSpaceType.allowSpOrNbsp),
+                /*
+                 * The following path is an exception in which regular space is changed to NBSP
+                 * in spite of the path being allowSpOrNbsp; see comment "fix grouping separator if space"
+                 */
+                new PathSpaceData("//ldml/numbers/symbols[@numberSystem=\"telu\"]/approximatelySign",
+                    "\u00A0  P   Q \u00A0", "P\u00A0Q", PathSpaceType.allowSpOrNbsp),
+                /*
+                 * The following path is an exception in which NBSP is changed to regular space
+                 * in spite of the path being allowSpOrNbsp; see DisplayAndInputProcessor.annotationsForDisplay
+                 */
+                new PathSpaceData("//ldml/annotations/annotation[@cp=\"🍊\"]",
+                    "\u00A0  fruit   |   orange   | \u00A0  tangerine \u00A0", "fruit | orange | tangerine",
+                    PathSpaceType.allowSpOrNbsp),
+            };
+            return a;
+        }
     }
 }


### PR DESCRIPTION
-Revise normalizeWhitespace to call subroutines, including new trimNBSP

-Add new enum PathSpaceType

-Add new unit test TestDisplayAndInputProcessor.TestWhitespaceNormalization

-Update xml with changes from running CLDRModify -fp

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14159
- [x] Updated PR title and link in previous line to include Issue number

