### PR TITLE
CLDR-10831 Updated MB and GB to non-localized form

### DIFF
--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -10722,16 +10722,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}太比特</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>吉字节</displayName>
-				<unitPattern count="other">{0}吉字节</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>吉比特</displayName>
 				<unitPattern count="other">{0}吉比特</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>兆字节</displayName>
-				<unitPattern count="other">{0}兆字节</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>兆比特</displayName>


### PR DESCRIPTION
On line 10725, updated "吉字节" to "GB" and "兆字节" to "MB"

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10831
- [ ] Updated PR title and link in previous line to include Issue number

