### PR TITLE
CLDR-10831 megabyte gigabyte ka

### DIFF
--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -6850,7 +6850,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ტერაბიტი</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>GB</displayName>
+				<displayName>გიგაბაიტი</displayName>
 				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
@@ -6860,7 +6860,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} გიგაბიტი</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>MB</displayName>
+				<displayName>მეგაბაიტი</displayName>
 				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -6850,9 +6850,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ტერაბიტი</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>გიგაბაიტი</displayName>
-				<unitPattern count="one">{0} გიგაბაიტი</unitPattern>
-				<unitPattern count="other">{0} გიგაბაიტი</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>გიგაბიტი</displayName>
@@ -6860,9 +6860,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} გიგაბიტი</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>მეგაბაიტი</displayName>
-				<unitPattern count="one">{0} მეგაბაიტი</unitPattern>
-				<unitPattern count="other">{0} მეგაბაიტი</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>მეგაბიტი</displayName>


### PR DESCRIPTION
Updated the ka form of gigabyte and megabyte to the non-localized version

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10831
- [ ] Updated PR title and link in previous line to include Issue number

