### PR TITLE
CLDR-10831 Non-localized version of MB GB ka

### DIFF
--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -7885,9 +7885,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ტბიტი</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>გბაიტი</displayName>
-				<unitPattern count="one">{0} გბაიტი</unitPattern>
-				<unitPattern count="other">{0} გბაიტი</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>გბიტი</displayName>
@@ -7895,9 +7895,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} გბიტი</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>მბაიტი</displayName>
-				<unitPattern count="one">{0} მბაიტი</unitPattern>
-				<unitPattern count="other">{0} მბაიტი</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>მბიტი</displayName>


### PR DESCRIPTION
Updated lines 7887-7890 and 7898-7900. Updated this lines to "MB" and "GB"

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10831
- [ ] Updated PR title and link in previous line to include Issue number

