### PR TITLE
CLDR-10831 Non-localize MB GB fa

### DIFF
--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -8900,7 +8900,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} &lt;LRM&gt;Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>گیگابایت</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0} &lt;LRM&gt;GB</unitPattern>
 				<unitPattern count="other">{0} &lt;LRM&gt;GB</unitPattern>
 			</unit>
@@ -8910,7 +8910,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} &lt;LRM&gt;Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>مگابایت</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0} &lt;LRM&gt;MB</unitPattern>
 				<unitPattern count="other">{0} &lt;LRM&gt;MB</unitPattern>
 			</unit>


### PR DESCRIPTION
Updated lines 8903 and 8913 to the non-localized versions of GB and MB for fa

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-10831
- [ ] Updated PR title and link in previous line to include Issue number

