### PR TITLE
CLDR-14232 fix MapComparator to not regress w/ 38.1

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1276,6 +1276,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         "area-square-mile", "area-acre", "area-square-yard", "area-square-foot", "area-square-inch",
         "area-dunam",
         "concentr-karat",
+        "concentr-milligram-per-deciliter", "concentr-millimole-per-liter", // Compatibility with CLDR ≤38.1
         "concentr-milligram-ofglucose-per-deciliter",
         "concentr-millimole-per-liter",
         "concentr-item",


### PR DESCRIPTION
CLDR-14232


Without the DtdData change, CLDR 39 is unable to read CLDR 38.1 staging data,
CLDRFile.iterator() crashes with "Missing Map Comparator Values … concentr-milligram-per-deciliter…"
