### PR TITLE
CLDR-14428 ZoneParser failures

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneParser.java
@@ -585,12 +585,11 @@ public class ZoneParser {
         private List<String> getData(String s) {
             List<String> d = data.get(s);
             if (d == null) {
-                if ("Australia/Currie".equals(s)) {
-                    // 39°55′52″S 143°51′02″E per https://en.wikipedia.org/wiki/Currie,_Tasmania
-                    // Converted with https://www.latlong.net/degrees-minutes-seconds-to-decimal-degrees
-                    d = Arrays.asList("-39.93", "143.85", "AU", "Currie");
-                } else {
-                    // TODO: "America/Santa_Isabel", "Pacific/Honolulu"?
+                String sNew = linkold_new.get(s);
+                if (sNew != null) {
+                    d = data.get(sNew);
+                }
+                if (d == null) {
                     d = errorData;
                 }
             }


### PR DESCRIPTION
-Use the existing linkold_new in getData in ZoneParser.java

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14428
- [x] Updated PR title and link in previous line to include Issue number

