### PR TITLE
CLDR-14428 ZoneParser failures; use linkold_new, remove SKIP_LINKS

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneParser.java
@@ -585,12 +585,11 @@ public class ZoneParser {
         private List<String> getData(String s) {
             List<String> d = data.get(s);
             if (d == null) {
-                if ("Australia/Currie".equals(s)) {
-                    // 39°55′52″S 143°51′02″E per https://en.wikipedia.org/wiki/Currie,_Tasmania
-                    // Converted with https://www.latlong.net/degrees-minutes-seconds-to-decimal-degrees
-                    d = Arrays.asList("-39.93", "143.85", "AU", "Currie");
-                } else {
-                    // TODO: "America/Santa_Isabel", "Pacific/Honolulu"?
+                String sNew = linkold_new.get(s);
+                if (sNew != null) {
+                    d = data.get(sNew);
+                }
+                if (d == null) {
                     d = errorData;
                 }
             }
@@ -618,11 +617,6 @@ public class ZoneParser {
         "southamerica" };
 
     private static Map<String, String> FIX_UNSTABLE_TZIDS;
-
-    private static Set<String> SKIP_LINKS = new HashSet<>(Arrays.asList(
-        new String[] {
-            "America/Montreal", "America/Toronto",
-            "America/Santa_Isabel", "America/Tijuana" }));
 
     private static Set<String> PREFERRED_BASES = new HashSet<>(Arrays.asList(new String[] { "Europe/London" }));
 
@@ -841,16 +835,7 @@ public class ZoneParser {
                     } else if (items[0].equals("Link")) {
                         String old = items[2];
                         String newOne = items[1];
-                        if (!(SKIP_LINKS.contains(old) && SKIP_LINKS.contains(newOne))) {
-                            //System.out.println("Original " + old + "\t=>\t" + newOne);
-                            linkedItems.add(old, newOne);
-                        }
-                        /*
-                         * String conflict = (String) linkold_new.get(old); if (conflict !=
-                         * null) { System.out.println("Conflict with old: " + old + " => " +
-                         * conflict + ", " + newOne); } System.out.println(old + "\t=>\t" +
-                         * newOne); linkold_new.put(old, newOne);
-                         */
+                        linkedItems.add(old, newOne);
                     } else {
                         if (DEBUG)
                             System.out.println("Unknown zone line: " + line);


### PR DESCRIPTION
-Use the existing linkold_new in getData in ZoneParser.java

-Remove SKIP_LINKS, so that Santa_Isabel is found in linkold_new and collates with Tijuana

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14428
- [x] Updated PR title and link in previous line to include Issue number

