### PR TITLE
CLDR-13787 Try merging consumption preferences together. 

### DIFF
--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -301,12 +301,6 @@ For terms of use, see http://www.unicode.org/copyright.html
         <unitPreferences category="consumption" usage="vehicle-fuel">
             <unitPreference regions="001">liter-per-100-kilometer</unitPreference>
             <unitPreference regions="BR IT JP KR MX MY NL TH TR">liter-per-kilometer</unitPreference>
-        </unitPreferences>
-        <unitPreferences category="consumption-inverse" usage="default">
-            <unitPreference regions="001">kilometer-per-centiliter</unitPreference>
-        </unitPreferences>
-        <unitPreferences category="consumption-inverse" usage="vehicle-fuel">
-            <unitPreference regions="001">kilometer-per-centiliter</unitPreference>
             <unitPreference regions="US">mile-per-gallon</unitPreference>
             <unitPreference regions="CA GB">mile-per-gallon-imperial</unitPreference>
         </unitPreferences>


### PR DESCRIPTION
We would also need to change the spec so that the category means 'units that are convertible to this quantity', thus "consumption' can include liters per kilometer and kilometers per meter (and anything convertible to those).

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-13787
- [x] Updated PR title and link in previous line to include Issue number

