### PR TITLE
CLDR-11581 Allow U+202F to distinguish collisions

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -168,7 +168,7 @@ public class SimpleXMLSource extends XMLSource {
     static final Normalizer2 NFKC = Normalizer2.getNFKCInstance();
 
     // The following includes letters, marks, numbers, currencies, and *selected* symbols/punctuation
-    static final UnicodeSet NON_ALPHANUM = new UnicodeSet("[^[:L:][:M:][:N:][:Sc:][\\u202F\uFFFF _ ¡ « ( ) \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]").freeze();
+    static final UnicodeSet NON_ALPHANUM = new UnicodeSet("[^[:L:][:M:][:N:][:Sc:][\\u202F\uFFFF _ ¡ « ( ) \\- \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]").freeze();
 
     public static String normalize(String valueToMatch) {
         return normalize2(valueToMatch, NFKCCF);
@@ -181,7 +181,7 @@ public class SimpleXMLSource extends XMLSource {
     public static String normalize2(String valueToMatch, Normalizer2 normalizer2) {
         if (valueToMatch.indexOf('\u202F') >= 0) { // special hack to allow \u202f, which is otherwise removed by NFKC
             String temp = valueToMatch.replace('\u202F', '\uFFFF');
-            String result = replace(NON_ALPHANUM, NFKCCF.normalize(temp), "");
+            String result = replace(NON_ALPHANUM, normalizer2.normalize(temp), "");
             return result.replace('\uFFFF','\u202F');
         }
         return replace(NON_ALPHANUM, normalizer2.normalize(valueToMatch.replace('\u202F', '\u00A0')), "");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -168,9 +168,14 @@ public class SimpleXMLSource extends XMLSource {
     static final Normalizer2 NFKC = Normalizer2.getNFKCInstance();
 
     // The following includes letters, marks, numbers, currencies, and *selected* symbols/punctuation
-    static final UnicodeSet NON_ALPHANUM = new UnicodeSet("[^[:L:][:M:][:N:][:Sc:]/+\\-°′″%‰‱٪؉−⍰()⊕☉]").freeze();
+    static final UnicodeSet NON_ALPHANUM = new UnicodeSet("[^[:L:][:M:][:N:][:Sc:][\\u00A0\\u202F\\uFFFF _ ¡ « ( ) \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]").freeze();
 
     public static String normalize(String valueToMatch) {
+        if (valueToMatch.indexOf('\u202F') >= 0) { // special hack to allow \u202f, which is otherwise removed by NFKC
+            String temp = valueToMatch.replace('\u202F', '\uFFFF');
+            String result = replace(NON_ALPHANUM, NFKCCF.normalize(temp), "");
+            return result.replace('\uFFFF','\u202F');
+        }
         return replace(NON_ALPHANUM, NFKCCF.normalize(valueToMatch), "");
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -168,19 +168,23 @@ public class SimpleXMLSource extends XMLSource {
     static final Normalizer2 NFKC = Normalizer2.getNFKCInstance();
 
     // The following includes letters, marks, numbers, currencies, and *selected* symbols/punctuation
-    static final UnicodeSet NON_ALPHANUM = new UnicodeSet("[^[:L:][:M:][:N:][:Sc:][\\u00A0\\u202F\\uFFFF _ ¡ « ( ) \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]").freeze();
+    static final UnicodeSet NON_ALPHANUM = new UnicodeSet("[^[:L:][:M:][:N:][:Sc:][\\u202F\uFFFF _ ¡ « ( ) \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]").freeze();
 
     public static String normalize(String valueToMatch) {
+        return normalize2(valueToMatch, NFKCCF);
+    }
+
+    public static String normalizeCaseSensitive(String valueToMatch) {
+        return normalize2(valueToMatch, NFKC);
+    }
+
+    public static String normalize2(String valueToMatch, Normalizer2 normalizer2) {
         if (valueToMatch.indexOf('\u202F') >= 0) { // special hack to allow \u202f, which is otherwise removed by NFKC
             String temp = valueToMatch.replace('\u202F', '\uFFFF');
             String result = replace(NON_ALPHANUM, NFKCCF.normalize(temp), "");
             return result.replace('\uFFFF','\u202F');
         }
-        return replace(NON_ALPHANUM, NFKCCF.normalize(valueToMatch), "");
-    }
-
-    public static String normalizeCaseSensitive(String valueToMatch) {
-        return replace(NON_ALPHANUM, NFKC.normalize(valueToMatch), "");
+        return replace(NON_ALPHANUM, normalizer2.normalize(valueToMatch.replace('\u202F', '\u00A0')), "");
     }
 
     public static String replace(UnicodeSet unicodeSet, String valueToMatch, String substitute) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -184,7 +184,7 @@ public class SimpleXMLSource extends XMLSource {
             String result = replace(NON_ALPHANUM, normalizer2.normalize(temp), "");
             return result.replace('\uFFFF','\u202F');
         }
-        return replace(NON_ALPHANUM, normalizer2.normalize(valueToMatch.replace('\u202F', '\u00A0')), "");
+        return replace(NON_ALPHANUM, normalizer2.normalize(valueToMatch), "");
     }
 
     public static String replace(UnicodeSet unicodeSet, String valueToMatch, String substitute) {


### PR DESCRIPTION
The goal is to allow 202F to distinguish collisions. 
- fix the set of characters that are distinguished to add 202F (also removed some CO controls and reformatted for clarity
- add hack to get around the NFKC normalization for this character. 

CLDR-11581

ALLOW_MANY_COMMITS=true