### PR TITLE
CLDR-14460 XPathParts remove synchronized block

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
@@ -1293,12 +1293,9 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
         return xppClone;
     }
 
-    public static synchronized XPathParts getFrozenInstance(String path) {
-        XPathParts result = cache.get(path);
-        if (result == null) {
-            result = new XPathParts().addInternal(path, true).freeze();
-            cache.put(path, result);
-        }
+    public static XPathParts getFrozenInstance(String path) {
+        XPathParts result = cache.computeIfAbsent(path,
+            (String forPath) -> new XPathParts().addInternal(forPath, true).freeze());
         return result;
     }
 


### PR DESCRIPTION
CLDR-14460

On a quick test, seems to give about a 50% speedup in JSON generation. 