### PR TITLE
CLDR-14457 Revert space removal in zh date format

### DIFF
--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -3329,7 +3329,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>{1}{0}</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -3339,7 +3339,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>{1}{0}</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">


### PR DESCRIPTION
Fix zh date time format by returning the spaces in the full and medium forms that were removed in v38.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14457
- [x] Updated PR title and link in previous line to include Issue number

