### PR TITLE
CLDR-14461 update localeCanonicalization.txt for using no instead of nb

### DIFF
--- a/common/testData/localeIdentifiers/localeCanonicalization.txt
+++ b/common/testData/localeIdentifiers/localeCanonicalization.txt
@@ -35,8 +35,8 @@ hy_arevela	;	hy
 hy_arevmda	;	hyw
 hy_arevmda_arevela	;	hyw
 hye_arevmda	;	hyw
-no_bokmal_nynorsk	;	nb
-no_nynorsk_bokmal	;	nb
+no_bokmal_nynorsk	;	nn
+no_nynorsk_bokmal	;	nn
 zh_guoyu_hakka_xiang	;	hak
 zh_hakka_xiang	;	hak
 
@@ -274,11 +274,11 @@ nld	;	nl
 nno	;	nn
 nns	;	nbr
 nnx	;	ngv
-no	;	nb
-no_bokmal	;	nb
+no	;	no
+no_bokmal	;	no
 no_nynorsk	;	nn
-nob	;	nb
-nor	;	nb
+nob	;	no
+nor	;	no
 npi	;	ne
 nts	;	pij
 nya	;	ny
@@ -1459,12 +1459,12 @@ nld_Adlm_AC_fonipa	;	nl_Adlm_AC_fonipa
 nno_Adlm_AC_fonipa	;	nn_Adlm_AC_fonipa
 nns_Adlm_AC_fonipa	;	nbr_Adlm_AC_fonipa
 nnx_Adlm_AC_fonipa	;	ngv_Adlm_AC_fonipa
-no_Adlm_AC_bokmal_fonipa	;	nb_Adlm_AC_fonipa
-no_Adlm_AC_bokmal_fonipa_nynorsk	;	nb_Adlm_AC_fonipa
-no_Adlm_AC_fonipa	;	nb_Adlm_AC_fonipa
+no_Adlm_AC_bokmal_fonipa	;	no_Adlm_AC_fonipa
+no_Adlm_AC_bokmal_fonipa_nynorsk	;	nn_Adlm_AC_fonipa
+no_Adlm_AC_fonipa	;	no_Adlm_AC_fonipa
 no_Adlm_AC_fonipa_nynorsk	;	nn_Adlm_AC_fonipa
-nob_Adlm_AC_fonipa	;	nb_Adlm_AC_fonipa
-nor_Adlm_AC_fonipa	;	nb_Adlm_AC_fonipa
+nob_Adlm_AC_fonipa	;	no_Adlm_AC_fonipa
+nor_Adlm_AC_fonipa	;	no_Adlm_AC_fonipa
 npi_Adlm_AC_fonipa	;	ne_Adlm_AC_fonipa
 nts_Adlm_AC_fonipa	;	pij_Adlm_AC_fonipa
 nya_Adlm_AC_fonipa	;	ny_Adlm_AC_fonipa


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14461
- [x] Updated PR title and link in previous line to include Issue number

Issue found during integration of CLDR alpha0 with ICU: Needed to update the CLDR file localeCanonicalization.txt (which is used in ICU testing) to account for the change to use no instead of nb, per [CLDR-2698](https://unicode-org.atlassian.net/browse/CLDR-2698; this PR is really a follow-on to [PR-964](https://github.com/unicode-org/cldr/pull/964) for that ticket.
