### PR TITLE
CLDR-14054 minimumdigitgrouping for es-419, es-US & es-MX 

### DIFF
--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -5052,7 +5052,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<otherNumberingSystems>
 			<native draft="contributed">latn</native>
 		</otherNumberingSystems>
-		<minimumGroupingDigits draft="contributed">2</minimumGroupingDigits>
+		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
 			<group>,</group>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -4674,7 +4674,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<otherNumberingSystems>
 			<native draft="contributed">↑↑↑</native>
 		</otherNumberingSystems>
-		<minimumGroupingDigits draft="contributed">2</minimumGroupingDigits>
+		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
 			<group>↑↑↑</group>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -4741,7 +4741,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<otherNumberingSystems>
 			<native draft="contributed">↑↑↑</native>
 		</otherNumberingSystems>
-		<minimumGroupingDigits draft="contributed">2</minimumGroupingDigits>
+		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
 			<group>↑↑↑</group>


### PR DESCRIPTION
Update minimumdigitgrouping for es-419, es-US & es-MX per language specialist feedback that Spanish in Latin America uses minimum digit grouping of 1.

I have updated the two other Latin America Spanish variants since our language specialist confirmed that minimum grouping should be 1 for all Latin American Spanish locales, but let me know if you are concerned and I can update the PR. I will update the ticket with sources for each country to demonstrate usage.

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14054
- [X] Updated PR title and link in previous line to include Issue number

