### PR TITLE
CLDR-14054 change minimumGroupingDigits from 2 to 1 for es_419,es_MX,es_US

### DIFF
--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -5052,7 +5052,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<otherNumberingSystems>
 			<native draft="contributed">latn</native>
 		</otherNumberingSystems>
-		<minimumGroupingDigits draft="contributed">2</minimumGroupingDigits>
+		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
 			<group>,</group>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -4674,7 +4674,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<otherNumberingSystems>
 			<native draft="contributed">↑↑↑</native>
 		</otherNumberingSystems>
-		<minimumGroupingDigits draft="contributed">2</minimumGroupingDigits>
+		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
 			<group>↑↑↑</group>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -4741,7 +4741,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<otherNumberingSystems>
 			<native draft="contributed">↑↑↑</native>
 		</otherNumberingSystems>
-		<minimumGroupingDigits draft="contributed">2</minimumGroupingDigits>
+		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
 			<group>↑↑↑</group>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14054
- [x] Updated PR title and link in previous line to include Issue number

Update minimumdigitgrouping for es-419, es-US & es-MX per language specialist feedback that Spanish in Latin America uses minimum digit grouping of 1.

This is a replacement for [PR-1008](https://github.com/unicode-org/cldr/pull/1008) since that one needed to be rebased on master and squashed to fix reported errors, faster this way.
