### PR TITLE
CLDR-14485 add top level maven project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 # Maven output directories
+/target
 /tools/target
 /tools/*/target
 
@@ -84,3 +85,5 @@
 
 
 org.eclipse.wst.common.project.facet.core.xml
+/.settings
+/tools/cldr-rdf/.settings/org.eclipse.m2e.core.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.unicode.cldr</groupId>
+	<artifactId>cldr-data</artifactId>
+	<version>39.0-SNAPSHOT</version>
+	<name>CLDR Top Level and Data</name>
+	<packaging>pom</packaging>
+	<licenses>
+		<license>
+			<name>Unicode-DFS-2016</name>
+		</license>
+	</licenses>
+	<properties>
+	</properties>
+
+	<modules>
+		<module>tools</module>
+	</modules>
+
+	<distributionManagement>
+		<repository>
+			<id>githubcldr</id>
+			<name>Maven@unicode-org/cldr</name>
+			<url>https://maven.pkg.github.com/unicode-org/cldr</url>
+		</repository>
+	</distributionManagement>
+</project>

--- a/tools/cldr-rdf/.settings/org.eclipse.core.resources.prefs
+++ b/tools/cldr-rdf/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,5 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
 encoding//src/test/java=UTF-8
 encoding/<project>=UTF-8

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>org.unicode.cldr</groupId>
 	<artifactId>cldr-all</artifactId>
 	<version>39.0-SNAPSHOT</version>
-	<name>CLDR Parent</name>
+	<name>CLDR All Tools</name>
 	<packaging>pom</packaging>
 	<licenses>
 		<license>
@@ -20,7 +20,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions 
+		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
 		<icu4j.version>68.1-release-68-1</icu4j.version>
 		<junit.version>4.13.1</junit.version>
@@ -116,7 +116,7 @@
 				<artifactId>commons-io</artifactId>
 				<version>2.4</version>
 			</dependency>
-			
+
 			<!-- mail / rss -->
 
 			<dependency>


### PR DESCRIPTION
CLDR-14485
It is optional to use, and for the convenience of Eclipse use

-----

- so with this change, i just run the same maven import at the /cldr level. 
 
<img width="495" alt="ImagenPegada-1" src="https://user-images.githubusercontent.com/855219/107524669-a6e35d80-6b7b-11eb-828f-ca02857c75c6.png">

- Seems to work for editing in Eclipse…

<img width="659" alt="ImagenPegada-2" src="https://user-images.githubusercontent.com/855219/107524733-b793d380-6b7b-11eb-9a86-397e6632cc54.png">

Command line building from the tools directory down is unaffected, no files changed there. (I’m not going to rev all of the docs, but `—file=tools/pom.xml` is now optional.)

I don’t want to *require* building from / using the new top level directory, that would break workspaces, build scripts, processes, etc.  for no real benefit at this point. 

You can build from the top level:

```shell
~/src/cldr:$ mvn package -DskipTests=true
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] CLDR All Tools                                                     [pom]
[INFO] CLDR Java Tools                                                    [jar]
[INFO] CLDR RDF Tools                                                     [jar]
[INFO] CLDR Survey Tool                                                   [war]
[INFO] CLDR Top Level and Data                                            [pom]
```

- I named `/pom.xml` **cldr-data** and call it “CLDR Top Level and Data”

- the `/tools/pom.xml` is still called **cldr-all** but I changed the description to “CLDR All Tools” (since it is no longer the top level).
