### PR TITLE
CLDR-14477 nn, delete <miscPatterns numberSystem="latn"> to inherit from no

### DIFF
--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -6505,12 +6505,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other" draft="unconfirmed">Zimbabwe-dollar (2009)</displayName>
 			</currency>
 		</currencies>
-		<miscPatterns numberSystem="latn">
-			<pattern type="approximately">ca. {0}</pattern>
-			<pattern type="atLeast">≥{0}</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">{0}‒{1}</pattern>
-		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} dag</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">{0} dagar</pluralMinimalPairs>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14477
- [x] Updated PR title and link in previous line to include Issue number

In _nn_, delete <miscPatterns numberSystem="latn"> (inconsistent with _no_) to inherit from _no_