### PR TITLE
CLDR-14476 fa, remove explicit <LRM> or replace with \u200E; ko, remove a bogus <

### DIFF
--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -8736,13 +8736,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>گرانش</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;G</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;G</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>متر/مجذور ثانیه</displayName>
-				<unitPattern count="one">{0}&lt;LRM&gt; m/s²</unitPattern>
-				<unitPattern count="other">{0}&lt;LRM&gt; m/s²</unitPattern>
+				<unitPattern count="one">{0}‎ m/s²</unitPattern>
+				<unitPattern count="other">{0}‎ m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>دور</displayName>
@@ -8778,25 +8778,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-hectare">
 				<displayName>هکتار</displayName>
 				<unitPattern count="one">{0} هک</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>متر مربع</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;m²</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;m²</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/m²</perUnitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}‎/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0}‎ cm²</unitPattern>
 				<unitPattern count="other">{0}‎ cm²</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/cm²</perUnitPattern>
+				<perUnitPattern>{0}‎/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>مایل مربع</displayName>
 				<unitPattern count="one">{0} مایل مربع</unitPattern>
 				<unitPattern count="other">{0} مایل مربع</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/mi²</perUnitPattern>
+				<perUnitPattern>{0}‎/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>جریب</displayName>
@@ -8805,8 +8805,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>یارد مربع</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;yd²</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;yd²</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>فوت مربع</displayName>
@@ -8815,9 +8815,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>اینچ مربع</displayName>
-				<unitPattern count="one">{0}&lt;LRM&gt;/in²</unitPattern>
-				<unitPattern count="other">{0}&lt;LRM&gt;/in²</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/in²</perUnitPattern>
+				<unitPattern count="one">{0}‎/in²</unitPattern>
+				<unitPattern count="other">{0}‎/in²</unitPattern>
+				<perUnitPattern>{0}‎/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>دونوم</displayName>
@@ -8886,48 +8886,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>پتابایت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;PB</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;PB</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>ترابایت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;TB</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;TB</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>ترابیت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;Tb</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;Tb</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GB</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;GB</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;GB</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>گیگابیت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;Gb</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;Gb</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MB</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;MB</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;MB</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>مگابیت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;Mb</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;Mb</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>کیلوبایت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;kB</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;kB</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>کیلوبیت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;kb</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;kb</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>بایت</displayName>
@@ -8999,12 +8999,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-microsecond">
 				<displayName>میکروثانیه</displayName>
 				<unitPattern count="one">{0} میکروثانیه</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>نانوثانیه</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ns</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ns</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>آمپر</displayName>
@@ -9103,38 +9103,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;em</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;px</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;MP</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;MP</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ppcm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ppi</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;dpcm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;dpcm</unitPattern>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;dpi</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;dpi</unitPattern>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>نقطه</displayName>
@@ -9143,103 +9143,103 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>R⊕</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;R⊕</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;R⊕</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>کیلومتر</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;km</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;km</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/km</perUnitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}‎/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>متر</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;m</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;m</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/m</perUnitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}‎/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;dm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;dm</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;cm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;cm</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/cm</perUnitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}‎/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;mm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;mm</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>میکرومتر</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;μm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;μm</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;nm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;nm</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>pm</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;pm</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;pm</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>مایل</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;mi</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;mi</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>یارد</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;yd</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;yd</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>فوت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ft</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ft</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/ft</perUnitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}‎/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>اینچ</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;in</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;in</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/in</perUnitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}‎/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>پارسک</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;pc</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;pc</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>سال نوری</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ly</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ly</unitPattern>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;au</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;au</unitPattern>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>فرلانگ</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;fur</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;fur</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>فاتوم</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;fth</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;fth</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;nmi</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;nmi</unitPattern>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
@@ -9248,13 +9248,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-point">
 				<displayName>پوینت</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;pt</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;pt</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>شعاع خورشید</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;R☉</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;R☉</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>لوکس</displayName>
@@ -9278,14 +9278,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-metric-ton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;t</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;t</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>کیلوگرم</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;kg</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} کیلوگرم</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/kg</perUnitPattern>
+				<perUnitPattern>{0}‎/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>گرم</displayName>
@@ -9295,13 +9295,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;mg</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;mg</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;μg</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;μg</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>تن</displayName>
@@ -9417,8 +9417,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;Pa</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;Pa</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>هکتوپاسکال</displayName>
@@ -9442,8 +9442,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>متر در ثانیه</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;m/s</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;m/s</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>مایل در ساعت</displayName>
@@ -9492,9 +9492,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>متر مکعب</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;m³</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;m³</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/m³</perUnitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}‎/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
@@ -9504,49 +9504,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;mi³</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;mi³</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>یارد مکعب</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;yd³</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;yd³</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>فوت مکعب</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ft³</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ft³</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>اینچ مکعب</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;in³</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;in³</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>مگالیتر</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;ML</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;ML</unitPattern>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;hL</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;hL</unitPattern>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>لیتر</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;L</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;L</unitPattern>
-				<perUnitPattern>{0}&lt;LRM&gt;/L</perUnitPattern>
+				<unitPattern count="one">{0} L</unitPattern>
+				<unitPattern count="other">{0} L</unitPattern>
+				<perUnitPattern>{0}‎/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;dL</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;dL</unitPattern>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} &lt;LRM&gt;cL</unitPattern>
-				<unitPattern count="other">{0} &lt;LRM&gt;cL</unitPattern>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>میلی‌لیتر</displayName>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -3422,7 +3422,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="180">분쇼 (1466 ~ 1467)</era>
 						<era type="181">오닌 (1467 ~ 1469)</era>
 						<era type="182">분메이 (1469 ~ 1487)</era>
-						<era type="183">조쿄 (1487 ~ 1489)&lt;</era>
+						<era type="183">조쿄 (1487 ~ 1489)</era>
 						<era type="184">엔토쿠 (1489 ~ 1492)</era>
 						<era type="185">메이오 (1492 ~ 1501)</era>
 						<era type="186">분키 (1501 ~ 1504)</era>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14476
- [x] Updated PR title and link in previous line to include Issue number

In fa, which has a bunch of ASCII &lt;LRM&gt; which were probably intended to be actual \u200E characters:
- If the  &lt;LRM&gt; immediately precedes a strong L character (ASCII letter or µ), then just remove it, it would have zero effect if converted to \u200E
- In the other cases, convert the &lt;LRM&gt; to an actual  \u200E character. Most of these are before a / in a per pattern, which makes sense. Two of them precede a space which is followed by a strong L character; these are probably mistakes but they would have an effect in a R-L context so I did convert them.

In ko, there was one bogus &lt; in Japanese era name, removed it.

I will split off a separate ticket to add tests for a future Survey Tool phase.