### PR TITLE
CLDR-14578 Fix and improve comments in grammaticalFeatures.xml

### DIFF
--- a/common/supplemental/grammaticalFeatures.xml
+++ b/common/supplemental/grammaticalFeatures.xml
@@ -13,10 +13,10 @@ These are the grammatical features that are used in each locale to mark inflecte
 CLDR textual items may be tagged with grammatical features when these are needed to ensure that the
 correct forms are used in context.
 
-For instance, in Russian "Уменьши яркость света до 10 процентов" ("dim the light to 10 percent"),
+For instance, in Russian "Уменьши яркость света до 33 процентов" ("dim the light to 33 percent"),
 the 'percent' unit must be expressed in plural and in the genitive case, whereas "1%" would be
 expressed in different cases depending on the context. The case usage is implicit in short form
-"10%", but the full form requires the grammatical variant marked by case and number to be expressed
+"33%", but the full form requires the grammatical variant marked by case and number to be expressed
 correctly.
 
 In romance languages, nouns such as unit names have an intrinsic grammatical gender, which
@@ -241,7 +241,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
 	<!-- from the grammatical case of the compound unit, determine the grammatical case of its components -->
 	<!-- The attributeValues of value0 and value1 are: compound (=the grammatical case of the compound),  or one of the valid grammatical case values for the language -->
 
-	  <deriveComponent feature="case" structure="per" value0="compound" value1="nominative"/> <!-- compound(gram-per-meter) ⇒ compound(gram) “per" accusative(meter) -->
+	  <deriveComponent feature="case" structure="per" value0="compound" value1="nominative"/> <!-- compound(gram-per-meter) ⇒ compound(gram) “per" nominative(meter) -->
 	  <deriveComponent feature="case" structure="times" value0="nominative"  value1="compound"/> <!-- compound(newton-meter) ⇒  nominative(newton) “-" compound(meter) -->
 	  <deriveComponent feature="case" structure="power" value0="nominative"  value1="compound"/> <!-- compound(square-meter) ⇒  nominative(square) compound(meter) -->
 	  <deriveComponent feature="case" structure="prefix" value0="nominative"  value1="compound"/><!--compound(kilometer) ⇒  nominative(kilo) compound(meter) -->
@@ -276,7 +276,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
 	<!-- The attributeValues of value are: 0 (=gender of the first element), 1 (=gender of second element), or one of the valid gender values for the language -->
 	
 	  <deriveCompound feature="gender" structure="per" value="0"/> <!-- gender(gram-per-meter) ←  gender(gram) --> 
-	  <deriveCompound feature="gender" structure="times" value="0"/> <!-- gender(newton-meter) ←  gender(meter) --> 
+	  <deriveCompound feature="gender" structure="times" value="0"/> <!-- gender(newton-meter) ←  gender(newton) --> 
 	  <deriveCompound feature="gender" structure="power" value="0"/> <!-- gender(square-meter) ←  gender(meter) --> 
 	  <deriveCompound feature="gender" structure="prefix" value="0"/> <!-- gender(kilometer) ←  gender(meter)--> 
 	
@@ -284,8 +284,8 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
 	<!-- The attributeValues of value0 and value1 are: compound (=the pluralCategory of the compound),  or one of the valid plural category values for the language -->
 	
 	  <deriveComponent feature="plural" structure="per" value0="compound" value1="one"/> <!-- compound(gram-per-meter) ⇒  compound(gram) “per" singular(meter) -->
-	  <deriveComponent feature="plural" structure="times" value0="compound"  value1="compound"/>  <!-- compound(newton-meter) ⇒  singular(newton) “-" compound(meter) -->
-	  <deriveComponent feature="plural" structure="power" value0="compound"  value1="compound"/>  <!-- compound(square-meter) ⇒  singular(square) compound(meter) -->
+	  <deriveComponent feature="plural" structure="times" value0="compound"  value1="compound"/>  <!-- compound(newton-meter) ⇒  compound(newton) “-" compound(meter) -->
+	  <deriveComponent feature="plural" structure="power" value0="compound"  value1="compound"/>  <!-- compound(square-meter) ⇒  compound(square) compound(meter) -->
 	  <deriveComponent feature="plural" structure="prefix" value0="one"  value1="compound"/> <!-- compound(kilometer) ⇒  singular(kilo) compound(meter) -->
 	
 	</grammaticalDerivations>


### PR DESCRIPTION
Rationale for the first change: "use a number for which nominative and genitive forms are distinct":
to make the example clear, we need a plural falling in the "few" or "one" categories, since these have distinctions between "nominative" and "genitive". The plural rule for "few" looks as follows:

```
    few{
        "v = 0 and i % 10 = 2..4 and i % 100 != 12..14 @integer 2~4, 22~24, 3"
        "2~34, 42~44, 52~54, 62, 102, 1002, …"
    }
```

33% seems like a more reasonable number than 2%, based on my lights for example - but 1% could also work.

The data for "percent" for "ru" shows no distinction between nominative and genitive for the "many" and "other" plural categories:

```
    genitive{
        few{"{0} процентов"}
        many{"{0} процентов"}
        one{"{0} процента"}
        other{"{0} процента"}
    }
```

Data for ru nominative:

```
    few{"{0} процента"}
    many{"{0} процентов"}
    one{"{0} процент"}
    other{"{0} процента"}
```

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14578
- [X] Updated PR title and link in previous line to include Issue number

