### PR TITLE
CLDR-14508 Fix a link to BCP 47 Section 4.5 to link directly, not through an interstitial page

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3575,7 +3575,7 @@ To canonicalize a given _source_:
 1. Canonicalize the syntax of _source_ as per _Definition 5. Canonicalizing Syntax_.
 2. Where the _source_ could be an arbitrary BCP 47 language tag, first process as follows:
    1. If the source is identical to one of the types in the BCP47 LegacyRules, replace the entire source by the replacement value.
-   2. Else if there is an extlang subtag, then apply Step 3 of [https://tools.ietf.org/html/bcp47#section-4.5](https://www.google.com/url?q=https://tools.ietf.org/html/bcp47%23section-4.5&sa=D&ust=1600829915065000&usg=AOvVaw12vD5EzoVl3VFzEyrECMj-) to remove the extlang subtag (possibly adjusting the language subtag).
+   2. Else if there is an extlang subtag, then apply Step 3 of BCP 47 [Section 4.5](https://tools.ietf.org/html/bcp47#section-4.5) to remove the extlang subtag (possibly adjusting the language subtag).
       1. Don’t apply any of the other canonicalization steps in that section, however.
    3. Else if the first subtag is "x", prefix by "und-".
    4. **Note:** there are currently no valid 4-letter primary language subtags. While it is extremely unlikely that BCP47 would ever register them, if so then _languageAlias_ mappings will be supplied for them, mapping to defined CLDR language subtags (from the `idStatus="reserved"` set).


### PR DESCRIPTION
Having

> Step 3 of [https://tools.ietf.org/html/bcp47#section-4.5](https://www.google.com/url?q=https://tools.ietf.org/html/bcp47%23section-4.5&sa=D&ust=1600829915065000&usg=AOvVaw12vD5EzoVl3VFzEyrECMj-)

in the spec -- note the link goes through some Google interstitial -- doesn't make any sense.  Much better for it to be

> Step 3 of BCP 47 [Section 4.5](https://tools.ietf.org/html/bcp47#section-4.5)

which is consistent with the style elsewhere in the document.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14508
- [x] Updated PR title and link in previous line to include Issue number

