### PR TITLE
CLDR-14461 update localeCanonicalization.txt for nb as child of no

### DIFF
--- a/common/rbnf/nb.xml
+++ b/common/rbnf/nb.xml
@@ -6,8 +6,8 @@ Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <ldml>
-	<identity>
-		<version number="$Revision$"/>
-		<language type="nb"/>
-	</identity>
+    <identity>
+        <version number="$Revision$"/>
+        <language type="nb"/>
+    </identity>
 </ldml>

--- a/common/testData/localeIdentifiers/localeCanonicalization.txt
+++ b/common/testData/localeIdentifiers/localeCanonicalization.txt
@@ -35,8 +35,8 @@ hy_arevela	;	hy
 hy_arevmda	;	hyw
 hy_arevmda_arevela	;	hyw
 hye_arevmda	;	hyw
-no_bokmal_nynorsk	;	nn
-no_nynorsk_bokmal	;	nn
+no_bokmal_nynorsk	;	nb
+no_nynorsk_bokmal	;	nb
 zh_guoyu_hakka_xiang	;	hak
 zh_hakka_xiang	;	hak
 
@@ -275,9 +275,9 @@ nno	;	nn
 nns	;	nbr
 nnx	;	ngv
 no	;	no
-no_bokmal	;	no
+no_bokmal	;	nb
 no_nynorsk	;	nn
-nob	;	no
+nob	;	nb
 nor	;	no
 npi	;	ne
 nts	;	pij
@@ -1459,11 +1459,11 @@ nld_Adlm_AC_fonipa	;	nl_Adlm_AC_fonipa
 nno_Adlm_AC_fonipa	;	nn_Adlm_AC_fonipa
 nns_Adlm_AC_fonipa	;	nbr_Adlm_AC_fonipa
 nnx_Adlm_AC_fonipa	;	ngv_Adlm_AC_fonipa
-no_Adlm_AC_bokmal_fonipa	;	no_Adlm_AC_fonipa
-no_Adlm_AC_bokmal_fonipa_nynorsk	;	nn_Adlm_AC_fonipa
+no_Adlm_AC_bokmal_fonipa	;	nb_Adlm_AC_fonipa
+no_Adlm_AC_bokmal_fonipa_nynorsk	;	nb_Adlm_AC_fonipa
 no_Adlm_AC_fonipa	;	no_Adlm_AC_fonipa
 no_Adlm_AC_fonipa_nynorsk	;	nn_Adlm_AC_fonipa
-nob_Adlm_AC_fonipa	;	no_Adlm_AC_fonipa
+nob_Adlm_AC_fonipa	;	nb_Adlm_AC_fonipa
 nor_Adlm_AC_fonipa	;	no_Adlm_AC_fonipa
 npi_Adlm_AC_fonipa	;	ne_Adlm_AC_fonipa
 nts_Adlm_AC_fonipa	;	pij_Adlm_AC_fonipa


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14461
- [x] Updated PR title and link in previous line to include Issue number

Fixes from integrating CLDR alpha1 (with changes so nb is a child of no, not an alias to it) into ICU.
- Mainly this is just an update to the localeCanonicalization.txt test file, which comes from CLDR but is only used in ICU tests.
- I also cleaned up some spacing in rbnf/nb.xml to be consistent with ofher rbnf files.
