### PR TITLE
CLDR-14484 fix typo in server config

### DIFF
--- a/tools/cldr-apps/src/main/liberty/config/server.xml
+++ b/tools/cldr-apps/src/main/liberty/config/server.xml
@@ -7,7 +7,7 @@
 		<feature>jndi-1.0</feature>
 		<feature>mpOpenAPI-1.1</feature>
 		<feature>mpConfig-1.4</feature>
-		<feature>localconnector-1.0</feature>
+		<feature>localConnector-1.0</feature>
 	</featureManager>
 	<!-- end::featureManager[] -->
 


### PR DESCRIPTION
CLDR-14484

should be capital C per https://openliberty.io/docs/20.0.0.12/reference/feature/localConnector-1.0.html