### PR TITLE
CLDR-14506 Updated Singaporean currency symbol

### DIFF
--- a/common/main/en_SG.xml
+++ b/common/main/en_SG.xml
@@ -148,7 +148,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<currencies>
 			<currency type="SGD">
-				<symbol>$</symbol>
+				<symbol>"S$"</symbol>
 			</currency>
 		</currencies>
 	</numbers>


### PR DESCRIPTION
Updated Singaporean currency symbol from $ to S$ on line 151

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14506
- [ ] Updated PR title and link in previous line to include Issue number

