### PR TITLE
CLDR-14395 fix /v to accept POST

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -124,6 +124,14 @@ public class SurveyTool extends HttpServlet {
         }
     }
 
+    /**
+     * Allow POST as well, used for login
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        doGet(request, response);
+    }
+
     private void serveBustedPage(HttpServletRequest request, PrintWriter out) {
         out.write("<html>\n<head>\n");
         out.write("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>\n");


### PR DESCRIPTION
CLDR-14395

in e35a0992b2ffb032c90eb53e9d8b1cceb28cf710 I moved SurveyTool.service() to doGet()
service() was not the right override, but this disabled POST which seems to be used by
the login form.
