### PR TITLE
CLDR-14557 Modernize look up code or xpath (browse)

### DIFF
--- a/tools/cldr-apps/js/src/specialToComponentMap.js
+++ b/tools/cldr-apps/js/src/specialToComponentMap.js
@@ -1,4 +1,5 @@
 import AboutPanel from "./views/AboutPanel.vue";
+import LookUp from "./views/LookUp.vue";
 import DashboardPanel from "./views/DashboardPanel.vue";
 import UnknownPanel from "./views/UnknownPanel.vue";
 import VettingSummary from "./views/VettingSummary.vue";
@@ -9,6 +10,7 @@ import WaitingPanel from "./views/WaitingPanel.vue";
  */
 const specialToComponentMap = {
   about: AboutPanel,
+  lookup: LookUp,
   retry: WaitingPanel,
   vsummary: VettingSummary,
   r_vetting_json: DashboardPanel,

--- a/tools/cldr-apps/js/src/views/LookUp.vue
+++ b/tools/cldr-apps/js/src/views/LookUp.vue
@@ -1,0 +1,140 @@
+<template>
+  <h2>XPath Calculator</h2>
+  <p class="helpHtml">
+    <em>Instructions:</em> Enter an XPath, such as
+    <kbd>//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator</kbd>
+    into the "XPath string" field, or, enter a hex or decimal XPath id, such as
+    <kbd>1d142c4be7841aa7</kbd> or <kbd>15305</kbd> into the corresponding
+    field. Then press the <kbd>Tab</kbd> key. The other fields will be filled
+    in.
+  </p>
+  <label for="str">XPath string: </label
+  ><input id="str" v-model="str" v-on:change="lookupPath" size="160" />
+  <br />
+  <label for="hex">XPath hex id: </label
+  ><input id="hex" v-model="hex" v-on:change="lookupPath" size="32" />
+  <br />
+  <label for="dec">XPath decimal id: </label
+  ><input id="dec" v-model="dec" v-on:change="lookupPath" size="8" />
+  <div id="xpathStatus">
+    {{ xpathStatus }}
+  </div>
+
+  <h2>What Is...</h2>
+  <p class="helpHtml">
+    <em>Instructions:</em> Enter a code or a portion of a name in the "What is"
+    field, such as <kbd>jgo</kbd> or <kbd>English</kbd>, and press the
+    <kbd>Tab</kbd> key. A list of matching codes will be shown.
+  </p>
+  <label for="whatis">What is: </label>
+  <input id="whatis" v-model="whatis" v-on:change="lookupWhatis" />
+  <label for="loc">Base Locale: </label>
+  <input id="loc" name="loc" v-model="baseLocale" />
+  <div id="whatisAnswer">{{ whatisAnswer }}</div>
+</template>
+
+<script>
+import * as cldrAjax from "../../../src/main/webapp/js/esm/cldrAjax.js";
+
+export default {
+  data() {
+    return {
+      baseLocale: "en_US",
+      dec: "",
+      hex: "",
+      str: "",
+      whatis: "",
+      whatisAnswer: "",
+      xpathStatus: "",
+    };
+  },
+
+  methods: {
+    /**
+     * Look up the entered xpath string, hex code, or decimal code
+     */
+    lookupPath(event) {
+      const el = event.target;
+      const from = el.id; // str, hex, or dec
+      const v = el.value;
+      if (v.length == 0) {
+        return;
+      }
+      this.xpathStatus = "Looking up " + from + " " + v + "...";
+      const xhrArgs = {
+        url: this.getLookupPathAjaxUrl(from, v),
+        postData: from === "str" ? { str: v } : null,
+        handleAs: "json",
+        load: this.pathLoadHandler,
+        error: (err) => (this.xpathStatus = "❌  " + err),
+      };
+      cldrAjax.sendXhr(xhrArgs);
+    },
+
+    pathLoadHandler(json) {
+      if (json.err) {
+        // TODO: given "12345678", don't report "Status 500 Internal Server Error; URL: api/xpath/dec/12345678"!
+        // Caused by: java.lang.InternalError: Exceeded max 768000 @ 12345678
+	      // at org.unicode.cldr.web.IntHash.get(IntHash.java:61)
+        // The server should be more robust, and catch such exceptions, or not throw them in the first place
+        this.xpathStatus = "❌  " + json.message;
+      } else {
+        this.str = json.xpath;
+        this.hex = json.hexId;
+        this.dec = json.decimalId;
+        this.xpathStatus = "✅";
+      }
+    },
+
+    /**
+     * Look up the entered "What is" string
+     */
+    lookupWhatis() {
+      if (!this.whatis) {
+        this.whatisAnswer = "";
+        return;
+      }
+      this.whatisAnswer = "Looking up " + this.whatis + "...";
+      const xhrArgs = {
+        url: this.getWhatisAjaxUrl(),
+        // TODO: the back end should return json, not text (html)
+        handleAs: "text",
+        load: (answer) => (this.whatisAnswer = answer),
+        error: (err) => (this.whatisAnswer = "Error: " + err),
+      };
+      cldrAjax.sendXhr(xhrArgs);
+    },
+
+    getLookupPathAjaxUrl(from, v) {
+      if (from === "str") {
+        // request will be post; v will be in body
+        return "api/xpath/str";
+      } else {
+        // request will be get
+        return "api/xpath/" + from + "/" + v;
+      }
+    },
+
+    getWhatisAjaxUrl() {
+      const p = new URLSearchParams();
+      p.append("loc", this.baseLocale);
+      p.append("q", this.whatis);
+      // TODO: not jsp! Maybe api/whatis
+      return "browse_results.jsp?" + p.toString();
+    },
+  },
+
+  computed: {
+    console: () => console,
+  },
+};
+</script>
+
+<style scoped>
+#whatis {
+  font-size: x-large;
+}
+.helpHtml {
+  margin: 1em;
+}
+</style>

--- a/tools/cldr-apps/js/src/views/WaitingPanel.vue
+++ b/tools/cldr-apps/js/src/views/WaitingPanel.vue
@@ -3,7 +3,7 @@
         <h1 class='hang'>
             Waiting for the SurveyTool to startup…
         </h1>
-        <h1><tt>{{ /* little spinner */ "/|\\-".charAt(fetchCount % 4) }}</tt></h1>
+        <h1><kbd>{{ /* little spinner */ "/|\\-".charAt(fetchCount % 4) }}</kbd></h1>
         <!-- todo: spinner -->
         <ol>
             <li v-if="!statusData">Checking…</li><!-- this shows while we are waiting for status data -->

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
@@ -1,6 +1,8 @@
 package org.unicode.cldr.web.api;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -32,31 +34,56 @@ public class XPathAPI {
         public String getXpath() {
             return xpath;
         }
+
         public XPathInfo setXpath(String xpath) {
             this.xpath = xpath;
             return this;
         }
+
         public Integer getDecimalId() {
             return decimalId;
         }
+
         public XPathInfo setDecimalId(Integer decimalId) {
             this.decimalId = decimalId;
             return this;
         }
+
         public String getHexId() {
             return hexId;
         }
+
         public XPathInfo setHexId(String hexId) {
             this.hexId = hexId;
             return this;
         }
     }
 
-    private final XPathTable getXPathTable() {
-        return CookieSession.sm.xpt;
+    @POST
+    @Path("/str")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Fetch hex and decimal id from XPath string",
+        description = "Looks up the ids for a specific XPath string.")
+    public Response getByString(XPathRequest request) {
+        final String xpath = request.str;
+        final XPathTable xpt = getXPathTable();
+        final int decId = xpt.peekByXpath(xpath);
+        if (decId == XPathTable.NO_XPATH) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity(new STError("XPath " + xpath + " not found"))
+                .build();
+        }
+        final String hexId = xpt.getStringIDString(decId);
+        return Response.ok(new XPathInfo()
+            .setDecimalId(decId)
+            .setHexId(hexId)
+            .setXpath(xpath)).build();
     }
 
-    @GET @Path("/hex/{hexId}")
+    @GET
+    @Path("/hex/{hexId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
         summary = "Fetch XPath string from hex id",
@@ -66,21 +93,20 @@ public class XPathAPI {
             @APIResponse(
                 responseCode = "404",
                 description = "XPath not found",
-                content =  @Content(mediaType = "application/json",
-                schema = @Schema(implementation = STError.class))),
+                content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = STError.class))),
             @APIResponse(
                 responseCode = "200",
                 description = "Details about a given XPath",
-                content =  @Content(mediaType = "application/json",
-                schema = @Schema(implementation = XPathInfo.class))) })
+                content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = XPathInfo.class))) })
     public Response getByHex(
-        @Parameter(required = true, example = "1234abcd", schema = @Schema(type = SchemaType.STRING))
-        @PathParam("hexId") String hexId) {
+        @Parameter(required = true, example = "1234abcd", schema = @Schema(type = SchemaType.STRING)) @PathParam("hexId") String hexId) {
 
         // the actual implementation
         XPathTable xpt = getXPathTable();
         final String xpath = xpt.getByStringID(hexId);
-        if(xpath == null) {
+        if (xpath == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity(new STError("XPath " + hexId + " not found"))
                 .build();
@@ -91,7 +117,8 @@ public class XPathAPI {
             .setXpath(xpath)).build();
     }
 
-    @GET @Path("/dec/{decId}")
+    @GET
+    @Path("/dec/{decId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
         summary = "Fetch XPath string from decimal id",
@@ -101,21 +128,20 @@ public class XPathAPI {
             @APIResponse(
                 responseCode = "404",
                 description = "XPath not found",
-                content =  @Content(mediaType = "application/json",
-                schema = @Schema(implementation = STError.class))),
+                content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = STError.class))),
             @APIResponse(
                 responseCode = "200",
                 description = "Details about a given XPath",
-                content =  @Content(mediaType = "application/json",
-                schema = @Schema(implementation = XPathInfo.class))) })
+                content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = XPathInfo.class))) })
     public Response getByDecimal(
-        @Parameter(required = true, example = "5678", schema = @Schema(type = SchemaType.INTEGER))
-        @PathParam("decId") int decId) {
+        @Parameter(required = true, example = "5678", schema = @Schema(type = SchemaType.INTEGER)) @PathParam("decId") int decId) {
 
         // the actual implementation
         XPathTable xpt = getXPathTable();
         final String xpath = xpt.getById(decId);
-        if(xpath == null) {
+        if (xpath == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity(new STError("XPath #" + decId + " not found"))
                 .build();
@@ -124,5 +150,9 @@ public class XPathAPI {
             .setDecimalId(decId)
             .setHexId(xpt.getStringIDString(decId))
             .setXpath(xpath)).build();
+    }
+
+    private final XPathTable getXPathTable() {
+        return CookieSession.sm.xpt;
     }
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathRequest.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathRequest.java
@@ -1,0 +1,12 @@
+package org.unicode.cldr.web.api;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public class XPathRequest {
+
+    @Schema(required = true, description = "XPath string") public String str;
+
+    public XPathRequest() {
+
+    }
+}

--- a/tools/cldr-apps/src/main/webapp/js/esm/cldrAjax.js
+++ b/tools/cldr-apps/src/main/webapp/js/esm/cldrAjax.js
@@ -145,14 +145,14 @@ function sendXhr(xhrArgs) {
   if (xhrArgs.postData || xhrArgs.content) {
     options.method = "POST";
     options.data = xhrArgs.postData ? xhrArgs.postData : xhrArgs.content;
-    if (typeof options.data === "object" && xhrArgs.url.includes("/api/")) {
+    if (typeof options.data === "object" && xhrArgs.url.includes("api/")) {
       options.makeJsonPost = true;
     }
   } else {
     options.method = "GET";
   }
   const request = new XMLHttpRequest();
-  if (typeof USE_DOJO !== "undefined") {
+  if (typeof USE_DOJO !== "undefined" && !xhrArgs.url.includes("api/")) {
     if (xhrArgs.url.indexOf("?") == -1) {
       xhrArgs.url += "?USE_DOJO=" + USE_DOJO;
     } else {

--- a/tools/cldr-apps/src/main/webapp/js/esm/cldrGear.js
+++ b/tools/cldr-apps/src/main/webapp/js/esm/cldrGear.js
@@ -30,7 +30,6 @@ function getItems() {
     disableMyAccount: "lock.jsp",
     xmlUpload: "upload.jsp?a=/cldr-apps/survey&s=" + sessionId,
     flag: "tc-flagged.jsp?s=" + sessionId,
-    browse: "browse.jsp",
   };
   return [
     {
@@ -161,9 +160,8 @@ function getItems() {
     aboutMenu,
 
     {
-      title: "Lookup a code or xpath",
+      special: "lookup",
       level: 2,
-      url: surveyUserURL.browse,
     },
     {
       special: "error_subtypes",

--- a/tools/cldr-apps/src/main/webapp/js/esm/cldrLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/esm/cldrLoad.js
@@ -619,6 +619,7 @@ function getSpecial(str) {
   const specials = {
     // These are handled by Vue.
     about: cldrGenericVue,
+    lookup: cldrGenericVue,
     vsummary: cldrGenericVue,
     r_vetting_json: cldrGenericVue,
     default: cldrGenericVue, // Add this here for testing the '/v#default' page.

--- a/tools/cldr-apps/src/main/webapp/js/esm/cldrText.js
+++ b/tools/cldr-apps/src/main/webapp/js/esm/cldrText.js
@@ -440,6 +440,7 @@ const strings = {
   special_list_emails: "List Email Addresses",
   special_list_users: "List Users",
   special_locales: "Locale List",
+  special_lookup: "Look up a code or xpath",
   special_mail: "Notifications (SMOKETEST ONLY)",
   special_oldvotes: "Import Old Votes",
   special_r_compact: "Numbers",


### PR DESCRIPTION
-New LookUp.vue partly working; revise layout; base locale only affects whatis

-Extend XPathAPI.java with api/xpath/str getByString to convert string to hex and dec id

-Move subroutine getXPathTable to bottom of XPathAPI.java

-Format XPathAPI.java with Eclipse

-New XPathRequest.java to enable POST request for api/xpath/str

-Change tt (obsolete html, triggered vue warning) to kbd

-Prevent addition of USE_DOJO to api/ requests

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14557
- [x] Updated PR title and link in previous line to include Issue number

