### PR TITLE
CLDR-14572 remove fr names for short en_GB/US; fix TestMissingStatus to use non-↑↑↑ value

### DIFF
--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -169,9 +169,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="en_AU">anglais australien</language>
 			<language type="en_CA">anglais canadien</language>
 			<language type="en_GB">anglais britannique</language>
-			<language type="en_GB" alt="short">anglais (R.-U.)</language>
 			<language type="en_US">anglais américain</language>
-			<language type="en_US" alt="short">anglais (É.-U.)</language>
 			<language type="enm">moyen anglais</language>
 			<language type="eo">espéranto</language>
 			<language type="es">espagnol</language>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1280,7 +1280,9 @@ public class VettingViewer<T> {
             String localeFound = sourceFile.getSourceLocaleIdExtended(path, status, false /* skipInheritanceMarker */);
             /*
              * Only count it as missing IF the (localeFound is root or codeFallback)
-             * AND the aliasing didn't change the path
+             * AND the aliasing didn't change the path.
+             * Note that localeFound will be where an item with ↑↑↑ was found even though
+             * the value is actually inherited from somewhere else.
              */
             if (localeFound.equals("root") || localeFound.equals(XMLSource.CODE_FALLBACK_ID)) {
                 result = ValuePathStatus.isMissingOk(sourceFile, path, latin, isAliased)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -68,7 +68,7 @@ public class TestCLDRUtils extends TestFmwk {
             .make("fr", true);
 
         checkNames(french, "en_US_POSIX", "anglais américain (informatique)",
-            "anglais [É.-U.] (informatique)",
+            "anglais américain (informatique)", // or "anglais (É.-U., informatique)" if short has priority over dialect
             "anglais (États-Unis, informatique)",
             "anglais (É.-U., informatique)");
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -1379,10 +1379,14 @@ public class TestUtilities extends TestFmwkPlus {
      * Ideally we should also test for MissingStatus.DISPUTED, etc.; that's more difficult
      */
     public void TestMissingStatus() {
-        final String path = "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"volume-barrel\"]/displayName";
+        final String path = "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"volume-cup\"]/displayName";
         final String locale = "fr";
         final CLDRFile cldrFile = testInfo.getCLDRFile(locale, true);
         final MissingStatus expected = MissingStatus.PRESENT;
+        // Note: VettingViewer.getMissingStatus reports PRESENT for items with ↑↑↑ and absent if the item
+        // is removed to inherit from root, even though the value obtained is the same in either case;
+        // so for path pick an item that does not have ↑↑↑, otherwise when that item is stripped for
+        // production data the test will fail.
         final MissingStatus status = VettingViewer.getMissingStatus(cldrFile, path, true /* latin */);
         if (status != expected) {
             errln("Got getMissingStatus = " + status.toString() + "; expected " + expected.toString());


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14572
- [x] Updated PR title and link in previous line to include Issue number

Two fixes to make test pass on both the main cldr repo and  on the production data in cldr-staging. The first actualy fixes a problem in the French data.

1. The first issue has to do with how to handle requests for display names that are both short and dialect-style (non-compound); the CLDR spec does not say which to give priority. The fr data in the main CLDR repo was as below, with the items removed as redundant for production data marked with '-':
```
   <languages>
     <language type="en">anglais</language>
     <language type="en_GB">anglais britannique</language>
-    <language type="en_GB" alt="short">anglais (R.-U.)</language>
     <language type="en_US">anglais américain</language>
-    <language type="en_US" alt="short">anglais (É.-U.)</language>
 
   <territories>
     <territory type="GB">Royaume-Uni</territory>
     <territory type="GB" alt="short">R.-U.</territory>
     <territory type="US">États-Unis</territory>
     <territory type="US" alt="short">É.-U.</territory>
```
If we are just asking for the short dialect names for en_US or en_GB there is no issue, and the short names for en_GB/US are redundant. But if we ask for the name of something like "en_US_POSIX", they are not only non-redundant but actually harmful. We first get the dialect name for e.g. "anglais (É.-U.)", then convert parens to square brackets, and append other variant names using the standard localeDisplayPattern.

With data in the main repo, we were getting:
```
standard long:  "anglais (États-Unis, informatique)"
standard short: "anglais (É.-U., informatique)"
dialect long:   "anglais américain (informatique)"
dialect short:  "anglais [É.-U.] (informatique)"  ** bad **
```

So I decided to remove the “short” entries for en_US/en_GNB in the main repo (they get stripped for production data anyway). With removal we get this, same as what we were getting with production data, which is better:
```
dialect short:  "anglais américain (informatique)"  ** better ** 
```

However for this particular case we might prefer the following, which would require a spec change to favor the request for short over the request for dialect-style (though that behavior might not be desired for all dialect-style names):
```
dialect short:  "anglais (É.-U., informatique)"   ** best for this case, maybe not others **
```

2. The second is more of an issue with the TestMissingStatus test. It was calling VettingViewer.getMissingStatus to verify that a particular unit display name was PRESENT. However, in French, that name currently has ↑↑↑ and gets stripped for production. But even though the value ultimately comes from root in either case, VettingViewer.getMissingStatus reports PRESENT if the item is present with ↑↑↑ and ABSENT if the item is stripped. So for the test, choose another unit display item that does not have ↑↑↑.