### PR TITLE
CLDR-14461 update ICU4J libs to version of 2021-03-09 with fix for compact dec e,c; update readme

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -12,15 +12,15 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 39</h3>
-    <p>Last updated: 2021-Feb-17</p>
+    <p>Last updated: 2021-Mar-09</p>
 
     <!--<p><b>Note:</b> CLDR 39 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 39, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <p><b>Note:</b> This is a preliminary version of CLDR 39, intended for those wishing to do pre-release testing.
-    It is not recommended for production use.</p>
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 39, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
+    <p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
+    It is not recommended for production use.</p>
     <!--<p>This is the final release version of CLDR 39.</p>-->
     
     <p><strong>Important notes for CLDR 36 and later:</strong></p>

--- a/tools/cldr-code/src/license/THIRD-PARTY.properties
+++ b/tools/cldr-code/src/license/THIRD-PARTY.properties
@@ -11,6 +11,6 @@
 # Please fill the missing licenses for dependencies :
 #
 #
-#Fri Feb 19 13:26:13 EST 2021
-com.ibm.icu--utilities-for-cldr--69.1-SNAPSHOT-cldr-2021-02-17=
-com.ibm.icu--icu4j-for-cldr--69.1-SNAPSHOT-cldr-2021-02-17=
+#Tue Mar 09 21:33:58 PST 2021
+com.ibm.icu--icu4j-for-cldr--69.1-SNAPSHOT-cldr-2021-03-09=
+com.ibm.icu--utilities-for-cldr--69.1-SNAPSHOT-cldr-2021-03-09=

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-SNAPSHOT-cldr-2021-02-17</icu4j.version>
+		<icu4j.version>69.1-SNAPSHOT-cldr-2021-03-09</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14461
- [x] Updated PR title and link in previous line to include Issue number

Update the ICU4J libs in CLDR to the version from ICU main branch as of 2021-03-09, including Elango's fix [ICU-PR-1624](https://github.com/unicode-org/icu/pull/1624) to make compact notation 'c' behave like 'e' in FixedDecimal.

Also update the readme for beta.
