### PR TITLE
Changing Kurdish to Northern Kurdish or Kurdish (Kurmanji) in CLDR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ If a test or status check does not pass, see [Running Tests][] on the CLDR devel
 
 ## Copyright
 
-Copyright &copy; 1991-2020 Unicode, Inc.
+Copyright &copy; 1991-2021 Unicode, Inc.
 All rights reserved. [Terms of use][]
 
 [Survey Tool]: http://cldr.unicode.org/index/survey-tool

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unicode CLDR Project
 
-Latest Release: [v39.0](http://cldr.unicode.org/index/downloads/cldr-39) published 2021-03-31
+Latest Release: [v39.0](http://cldr.unicode.org/index/downloads/cldr-39) published 2021-04-07
 
 ## Build Status
 

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -169,9 +169,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="en_AU">anglais australien</language>
 			<language type="en_CA">anglais canadien</language>
 			<language type="en_GB">anglais britannique</language>
-			<language type="en_GB" alt="short">anglais (R.-U.)</language>
 			<language type="en_US">anglais américain</language>
-			<language type="en_US" alt="short">anglais (É.-U.)</language>
 			<language type="enm">moyen anglais</language>
 			<language type="eo">espéranto</language>
 			<language type="es">espagnol</language>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -4126,7 +4126,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>चोइबालसन</exemplarCity>
 			</zone>
 			<zone type="Asia/Macau">
-				<exemplarCity>मकाउ</exemplarCity>
+				<exemplarCity>मकाऊ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Saipan">
 				<exemplarCity>सायपान</exemplarCity>

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -115,8 +115,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <pluralRules locales="fr">
             <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
-            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1e6, 2e6, 3e6, 4e6, 5e6, 6e6, … @decimal 1.0000001e6, 1.1e6, 2.0000001e6, 2.1e6, 3.0000001e6, 3.1e6, …</pluralRule>
-            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1e3, 2e3, 3e3, 4e3, 5e3, 6e3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001e3, 1.1e3, 2.0001e3, 2.1e3, 3.0001e3, 3.1e3, …</pluralRule>
+            <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
+            <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>
         </pluralRules>
 
         <!-- 4: one,two,few,other -->

--- a/common/supplemental/windowsZones.xml
+++ b/common/supplemental/windowsZones.xml
@@ -267,9 +267,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="Cape Verde Standard Time" territory="ZZ" type="Etc/GMT+1"/>
 
 			<!-- (UTC) Coordinated Universal Time -->
-			<mapZone other="UTC" territory="001" type="Etc/GMT"/>
-			<mapZone other="UTC" territory="GL" type="America/Danmarkshavn"/>
-			<mapZone other="UTC" territory="ZZ" type="Etc/GMT Etc/UTC"/>
+			<mapZone other="UTC" territory="001" type="Etc/UTC"/>
+			<mapZone other="UTC" territory="ZZ" type="Etc/UTC Etc/GMT"/>
 
 			<!-- (UTC+00:00) Dublin, Edinburgh, Lisbon, London -->
 			<mapZone other="GMT Standard Time" territory="001" type="Europe/London"/>
@@ -287,6 +286,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="Greenwich Standard Time" territory="BF" type="Africa/Ouagadougou"/>
 			<mapZone other="Greenwich Standard Time" territory="CI" type="Africa/Abidjan"/>
 			<mapZone other="Greenwich Standard Time" territory="GH" type="Africa/Accra"/>
+			<mapZone other="Greenwich Standard Time" territory="GL" type="America/Danmarkshavn"/>
 			<mapZone other="Greenwich Standard Time" territory="GM" type="Africa/Banjul"/>
 			<mapZone other="Greenwich Standard Time" territory="GN" type="Africa/Conakry"/>
 			<mapZone other="Greenwich Standard Time" territory="GW" type="Africa/Bissau"/>

--- a/docs/ldml/tr35-collation.md
+++ b/docs/ldml/tr35-collation.md
@@ -18,7 +18,7 @@ This is a partial document, describing only those parts of the LDML that are rel
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -18,7 +18,7 @@ This is a partial document, describing only those parts of the LDML that are rel
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -57,6 +57,7 @@ The LDML specification is divided into the following parts:
     *   4.1 [Calendar Data](#Calendar_Data)
     *   4.2 [Calendar Preference Data](#Calendar_Preference_Data)
     *   4.3 [Week Data](#Week_Data)
+        *   Table: [Week Designation Types](#Week_Designation_Types)
     *   4.4 [Time Data](#Time_Data)
     *   4.5 [Day Period Rule Sets](#Day_Period_Rule_Sets)
         *   4.5.1 [Day Period Rules](#Day_Period_Rules)
@@ -1196,7 +1197,7 @@ For examples, see [Day Periods Chart](https://unicode-org.github.io/cldr-staging
 
 The time zone IDs (tzid) are language-independent, and follow the _TZ time zone database_ [[Olson](tr35.md#Olson)] and naming conventions. However, the display names for those IDs can vary by locale. The generic time is so-called _wall-time_; what clocks use when they are correctly switched from standard to daylight time at the mandated time of the year.
 
-Unfortunately, the canonical tzid's (those in zone.tab) are not stable: may change in each release of the _TZ_ Time Zone database. In CLDR, however, stability of identifiers is very important. So the canonical IDs in CLDR are kept stable as described in [Canonical Form](tr35.md#Canonical_Form).
+Unfortunately, the canonical tzid's (those in zone.tab) are not stable: they may change in each release of the _TZ_ Time Zone database. In CLDR, however, stability of identifiers is very important. So the canonical IDs in CLDR are kept stable as described in [Canonical Form](tr35.md#Canonical_Form).
 
 The _TZ time zone database_ can have multiple IDs that refer to the same entity. It does contain information on equivalence relationships between these IDs, such as "Asia/Calcutta" and "Asia/Kolkata". It does not remove IDs (with a few known exceptions), but it may change the "canonical" ID which is in the file zone.tab.
 

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -52,6 +52,7 @@ The LDML specification is divided into the following parts:
     *   3.5 [More Information](#Character_More_Info)
     *   3.6 [Parse Lenient](#Character_Parse_Lenient)
 *   4 [Delimiter Elements](#Delimiter_Elements)
+    *   4.1 [Tailoring Linebreak Using Delimiters](#Tailor_Linebreak_With_Delimiters)
 *   5 [Measurement System Data](#Measurement_System_Data)
     *   5.1 [Measurement Elements (deprecated)](#Measurement_Elements)
 *   6 [Unit Elements](#Unit_Elements)
@@ -641,6 +642,23 @@ When quotations are nested, the quotation marks and alternate marks are used in 
 <alternateQuotationStart>‘</alternateQuotationStart>  
 <alternateQuotationEnd>’</alternateQuotationEnd>
 ```
+
+### 4.1 <a name="Tailor_Linebreak_With_Delimiters" href="#Tailor_Linebreak_With_Delimiters">Tailoring Linebreak Using Delimiters</a>
+
+The delimiter data can be used for language-specific tailoring of linebreak behavior, as suggested
+in the [description of linebreak class QU: Quotation](https://www.unicode.org/reports/tr14/#QU)
+in [[UAX14](https://www.unicode.org/reports/tr41/#UAX14)]. This is an example of
+[tailoring type](https://www.unicode.org/reports/tr14/#Tailoring) 1 (from that same document),
+changing the line breaking class assignment for some characters.
+
+If the values of `<quotationStart>` and `<quotationEnd>` are different, then:
+* if the value of `<quotationStart>` is a single character with linebreak class QU: Quotation, change its class to OP: Open Punctuation.
+* if the value of `<quotationEnd>` is a single character with linebreak class QU: Quotation, change its class to CL: Close Punctuation.
+Similarly for `<alternateQuotationStart>` and `<alternateQuotationEnd>`.
+
+Some characters with multiple uses should generally be excluded from this linebreak class remapping, such as:
+* U+2019 RIGHT SINGLE QUOTATION MARK, often used as apostrophe, should not be changed from QU; otherwise it will introduce breaks after apostrophe.
+* Several locales (mostly for central and eastern Europe) have U+201C LEFT DOUBLE QUOTATION MARK as `<quotationEnd>` or `<alternateQuotationEnd>`. However users in these locales may also encounter English text in which U+201C is used as `<quotationStart>`. In order to prevent improper breaks for English text, in these locales U+201C should not be changed from QU.
 
 ## 5 <a name="Measurement_System_Data" href="#Measurement_System_Data">Measurement System Data</a>
 

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -97,7 +97,7 @@ The LDML specification is divided into the following parts:
     *   15.1 [Gender](#Gender)
     *   15.2 [Case](#Case)
 *   16 [Grammatical Derivations](#Grammatical_Derivations)
-    *   16.1[Deriving the Gender of Compound Units](#gender_compound_units)
+    *   16.1 [Deriving the Gender of Compound Units](#gender_compound_units)
     *   16.2 [Deriving the Plural Category of Unit Components](#plural_compound_units)
     *   16.3 [Deriving the Case of Unit Components](#case_compound_units)
 
@@ -175,7 +175,7 @@ When the display name contains "(" or ")" characters (or full-width equivalents)
 1.  **Language.** Match the L subtags against the type values in the `<language>` elements. Pick the element with the most subtags matching. If there is more than one such element, pick the one that has subtypes matching earlier. If there are two such elements, pick the one that is alphabetically less. Set LBN to that value. Disregard any of the matching subtags in the following processing.
     *   If CombineLanguage is false, only choose matches with the language subtag matching.
 2.  **Script, Region, Variants.** Where any of these subtags are in L, append the matching element value to LQS.
-3.  **T extensions.** Get the value of the `key="h0" type="hybrid"` element, if there is one; otherwise the value of the `<key type="t">` element. Next get the locale display name of the tlang. Join the pair using localePattern> and append to the LQS. Then format and add display names to LQS for any of the remaining tkey-tvalue pairs as described below.
+3.  **T extensions.** Get the value of the `key="h0" type="hybrid"` element, if there is one; otherwise the value of the `<key type="t">` element. Next get the locale display name of the tlang. Join the pair using `<localePattern>` and append to the LQS. Then format and add display names to LQS for any of the remaining tkey-tvalue pairs as described below.
 4.  **U extensions.** If there is an attribute value A, process the key-value pair <"u", A> as below and append to LQS. Then format and add display names for each of the remaining key-type pairs as described below.
 5.  **Other extensions.** There are currently no such extensions defined. Until such time as there are formats defined for them, append each of the extensions’s subtags to LQS.
 6.  **Private Use extensions.** Get the value
@@ -461,7 +461,7 @@ indicates that language names embedded in text are normally written in lower cas
 *   titlecase-words : all words in the phrase should be title case
 *   titlecase-firstword : the first word should be title case
 *   lowercase-words : all words in the phrase should be lower case
-*   mixed : a mixture of upper and lower case is permitted. generally used when the correct value is unknown.
+*   mixed : a mixture of upper and lower case is permitted, generally used when the correct value is unknown
 
 ## 3 <a name="Character_Elements" href="#Character_Elements">Character Elements</a>
 
@@ -552,7 +552,7 @@ The ordering of the characters in the set is irrelevant, but for readability in 
 1.  The main, auxiliary and index sets are normally restricted to those letters with a specific [Script](https://unicode.org/Public/UNIDATA/Scripts.txt) character property (that is, not the values Common or Inherited) or required [Default_Ignorable_Code_Point](https://unicode.org/Public/UNIDATA/DerivedCoreProperties.txt) characters (such as a non-joiner), or combining marks, or the [Word_Break](https://www.unicode.org/Public/UNIDATA/auxiliary/WordBreakProperty.txt) properties [Katakana](#Katakana), [ALetter](#ALetter), or [MidLetter](#MidLetter).
 2.  The auxiliary set should not overlap with the main set. There is one exception to this: Hangul Syllables and CJK Ideographs can overlap between the sets.
 3.  Any [Default_Ignorable_Code_Point](https://unicode.org/Public/UNIDATA/DerivedCoreProperties.txt)s should be in the auxiliary set , or, if they are only needed for currency formatting, in the currency set. These can include characters such as U+200E LEFT-TO-RIGHT MARK and U+200F RIGHT-TO-LEFT MARK which may be needed in bidirectional text in order for date, currency or other formats to display correctly.
-4.  For exemplar characters the [Unicode Set](tr35.md#Unicode_Sets) format is restricted so as to not use properties or boolean combinations .
+4.  For exemplar characters the [Unicode Set](tr35.md#Unicode_Sets) format is restricted so as to not use properties or boolean combinations.
 
 ### 3.2 ~~<a name="Character_Mapping" href="#Character_Mapping">Mapping</a>~~
 
@@ -746,7 +746,7 @@ These elements specify the localized way of formatting quantities of units such 
 </unit>
 ```
 
-The german rules are more complicated, because German has both gender and case. They thus have additional information, as illustrated below. Note that if there is no `@case` attribute, for backwards compatibility the implied case is nominative. The possible values for @case are listed in the `grammaticalFeatures` element. These follow the inheritance specified in Part 1, Section [4.1.2 Lateral Inheritance](tr35.md#Lateral_Inheritance). Note that the additional grammar elements are only present in the `<unitLength type='long'>` form.
+The German rules are more complicated, because German has both gender and case. They thus have additional information, as illustrated below. Note that if there is no `@case` attribute, for backwards compatibility the implied case is nominative. The possible values for @case are listed in the `grammaticalFeatures` element. These follow the inheritance specified in Part 1, Section [4.1.2 Lateral Inheritance](tr35.md#Lateral_Inheritance). Note that the additional grammar elements are only present in the `<unitLength type='long'>` form.
 
 ```xml
 <unit type="duration-day">
@@ -764,7 +764,7 @@ The german rules are more complicated, because German has both gender and case. 
 </unit>
 ```
 
-These follow the inheritance specified in Part 1, Section [4.1.2 Lateral Inheritance](tr35.md#Lateral_Inheritance).In addition to supporting language-specific plural cases such as “one” and “other”, unitPatterns support the language-independent explicit cases “0” and “1” for special handling of numeric values that are exactly 0 or 1; see [Explicit 0 and 1 rules](tr35-numbers.md#Explicit_0_1_rules).
+These follow the inheritance specified in Part 1, Section [4.1.2 Lateral Inheritance](tr35.md#Lateral_Inheritance). In addition to supporting language-specific plural cases such as “one” and “other”, unitPatterns support the language-independent explicit cases “0” and “1” for special handling of numeric values that are exactly 0 or 1; see [Explicit 0 and 1 rules](tr35-numbers.md#Explicit_0_1_rules).
 
 The `<unitPattern>` elements may be used to format quantities with decimal values; in such cases the choice of plural form will depend not only on the numeric value, but also on its formatting (see [Language Plural Rules](tr35-numbers.md#Language_Plural_Rules)). In addition to formatting units for stand-alone use, `<unitPattern>` elements are increasingly being used to format units for use in running text; for such usages, the developing [Grammatical Features](#Grammatical_Features) information will be very useful.
 
@@ -1681,7 +1681,7 @@ ss → z ;
 
 This conversion rule transforms "bass school" into "baz shool". The transform walks through the string from start to finish. Thus given the rules above "bassch" will convert to "bazch", because the "ss" rule is found before the "sch" rule in the string (later, we'll see a way to override this behavior). If two rules can both apply at a given point in the string, then the transform applies the first rule in the list.
 
-All of the ASCII characters except numbers and letters are reserved for use in the rule syntax, as are the characters →, ←, ↔. Normally, these characters do not need to be converted. However, to convert them use either a pair of single quotes or a slash. The pair of single quotes can be used to surround a whole string of text. The slash affects only the character immediately after it. For example, to convert from a U+2190 ( ← ) LEFTWARDS ARROW to the string "arrow sign" (with a space), use one of the following rules:
+All of the ASCII characters except numbers and letters are reserved for use in the rule syntax, as are the characters `→`, `←`, `↔`. Normally, these characters do not need to be converted. However, to convert them use either a pair of single quotes or a slash. The pair of single quotes can be used to surround a whole string of text. The slash affects only the character immediately after it. For example, to convert from a U+2190 ( ← ) LEFTWARDS ARROW to the string "arrow sign" (with a space), use one of the following rules:
 
 ```
 \←    → arrow\ sign ;
@@ -1725,7 +1725,7 @@ Rules can also specify what happens when an inverse transform is formed. To do t
 $pi ← p ;
 ```
 
-With the inverse transform, "p" will convert to the Greek p. These two directions can be combined together into a dual conversion rule by using the "↔" operator, yielding:
+With the inverse transform, "p" will convert to the Greek p. These two directions can be combined together into a dual conversion rule by using the `↔` operator, yielding:
 
 ```
 $pi ↔ p ;
@@ -2491,7 +2491,7 @@ The identifers (types) use the tags from the OpenType Feature Tag Registry. Give
 
 To find a localized subfamily name such as “Extraleicht Schmal” for a font called “Extralight Condensed”, a system or application library might do the following:
 
-1. Determine the set of languages in which the subfamily name can potentially be returned.This is the union of the languages for which the font contains ‘name’ table entries with ID 2 or 17, plus the languages for which CLDR supplies typographic names.
+1. Determine the set of languages in which the subfamily name can potentially be returned. This is the union of the languages for which the font contains ‘name’ table entries with ID 2 or 17, plus the languages for which CLDR supplies typographic names.
    
 2. Use a language matching algorithm such as in ICU to find the best available language given the user preferences. The resulting subfamily name will be localized to this language.
    

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -138,7 +138,7 @@ For example, for the locale identifier zh_Hant_CN_co_pinyin_cu_USD, the display 
 
 ### 1.1 <a name="locale_display_name_algorithm" href="#locale_display_name_algorithm">Locale Display Name Algorithm</a>
 
-A locale display name LDN is generated for a locale identifer L in the following way. First, canonicalize the locale identifier as per **[Part 1, Section 3.2.1 Canonical Unicode Locale Identifiers](tr35.md#Canonical_Unicode_Locale_Identifiers)**. That will put the subtags in a defined order, and replace aliases by their canonical counterparts. (That defined order is followed in the processing below.)
+A locale display name LDN is generated for a locale identifer L in the following way. First, convert the locale identifier to *canonical syntax* per **[Part 1, Section 3.2.1 Canonical Unicode Locale Identifiers](tr35.md#Canonical_Unicode_Locale_Identifiers)**. That will put the subtags in a defined order, and replace aliases by their canonical counterparts. (That defined order is followed in the processing below.)
 
 Then follow each of the following steps for the subtags in L, building a base name LDN and a list of qualifying strings LQS.
 
@@ -153,7 +153,7 @@ Once LDN and LQS are built, return the following based on the length of LQS.
 <tr><td>&gt;1</td><td>use the &lt;localeSeparator&gt; element value to join the elements of the list into LDN2, then use the &lt;localePattern&gt; to compose the result LDN from LDN and LDN2, and return it.</td></tr>
 </tbody></table>
 
-The processing can be controled via the following parameters.
+The processing can be controlled via the following parameters.
 
 *   `CombineLanguage`: boolean
     *   Example: the `CombineLanguage = true`, picking the bold value below.
@@ -172,7 +172,7 @@ In addition, the input locale display name could be minimized (see [Part 1: Sect
 
 When the display name contains "(" or ")" characters (or full-width equivalents), replace them "\[", "\]" (or full-width equivalents) before adding.
 
-1.  **Language.** Match the L subtags against the type values in the `<language>` elements. Pick the element with the most subtags matching. If there is more than one such element, pick the one that has subtypes matching earlier. If there are two such elements, pick the one that is alphabetically less. Set LBN to that value. Disregard any of the matching subtags in the following processing.
+1.  **Language.** Match the L subtags against the type values in the `<language>` elements. Pick the element with the most subtags matching. If there is more than one such element, pick the one that has subtypes matching earlier. If there are two such elements, pick the one that is alphabetically less. If there is no match, then further convert L to *canonical form* per **[Part 1, Section 3.2.1 Canonical Unicode Locale Identifiers](tr35.md#Canonical_Unicode_Locale_Identifiers)** and try the preceding steps again. Set LBN to the selected value. Disregard any of the matching subtags in the following processing.
     *   If CombineLanguage is false, only choose matches with the language subtag matching.
 2.  **Script, Region, Variants.** Where any of these subtags are in L, append the matching element value to LQS.
 3.  **T extensions.** Get the value of the `key="h0" type="hybrid"` element, if there is one; otherwise the value of the `<key type="t">` element. Next get the locale display name of the tlang. Join the pair using `<localePattern>` and append to the LQS. Then format and add display names to LQS for any of the remaining tkey-tvalue pairs as described below.

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -1151,9 +1151,9 @@ If there is no precomputed form, the following process in pseudocode is used to 
 5.  Set both globalPlaceholder and globalPlaceholderPosition to be empty
 6.  Set numeratorUnitString to patternTimes(numerator, length, per0(pluralCategory), per0(caseVariant))
 7.  Set denominatorUnitString to patternTimes(denominator, length, per1(pluralCategory), per1(caseVariant))
-8.  Set perPattern to be getValue(times, locale, length)
-9.  If the denominatorString is empty, set result to denominatorString, otherwise set result to format(perPattern, numeratorString, denominatorString)
-10. return format(result, globalPlacholder, globalPlaceholderPosition)
+8.  Set perPattern to be getValue(per, locale, length)
+9.  If the denominatorString is empty, set result to numeratorString, otherwise set result to format(perPattern, numeratorUnitString, denominatorUnitString)
+10. return format(result, globalPlaceholder, globalPlaceholderPosition)
 
 **patternTimes(product_unit, locale, length, pluralCategory, caseVariant)**
 
@@ -1204,15 +1204,15 @@ If there is no precomputed form, the following process in pseudocode is used to 
 
 1. return the element value in the locale for the path corresponding to the key, locale, length, and variants — using normal inheritance including [Lateral Inheritance](https://unicode-org.github.io/cldr/ldml/tr35.md#Multiple_Inheritance) and [Parent Locales](https://unicode-org.github.io/cldr/ldml/tr35.md#Parent_Locales).
 
-**Extract(corePattern, coreUnit, placeHolder, placeholderPosition)**
+**Extract(corePattern, coreUnit, placeholder, placeholderPosition)**
 
-1. Find the position of the **placeHolder** in the core pattern
-2. Set **placeHolderPosition** to that postion (start, middle, or end)
-3. Remove the **placeHolder** from the **corePattern** and set **coreUnit** to that result
+1. Find the position of the **placeholder** in the core pattern
+2. Set **placeholderPosition** to that position (start, middle, or end)
+3. Remove the **placeholder** from the **corePattern** and set **coreUnit** to that result
 
 **per0(...), times0(...), etc.**
 
-1. These represent the **deriveCompound** data values from **Section 16 [Grammatical Derivations](#Grammatical_Derivations)**, where value0 of the per-structure is given as per0(...), and so on.
+1. These represent the **deriveComponent** data values from **Section 16 [Grammatical Derivations](#Grammatical_Derivations)**, where value0 of the per-structure is given as per0(...), and so on.
 2. "power" corresponds to dimensionality_prefix, while "prefix" corresponds to si_prefix.
 
 If the locale does not provide full modern coverage, the process could fall back to root locale for some localized patterns. That may give a "ransom-note" effect for the user. To avoid that, it may be preferable to abort the process at that point, and then localize the unitId for the root locale.

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -294,6 +294,12 @@ This contains a list of elements that provide the user-translated names for terr
 <territory type="US" alt="short">U.S.</territory>
 ```
 
+Notes:
+* Territory names may not match the official name of the territory, and the English or French names may not match those in ISO 3166. Reasons for this include:
+    * CLDR favors customary names in common parlance, not necessarily the official names.
+    * CLDR endeavors to provide names that are not too long, in order to avoid problems with truncation or overflow in user interfaces.
+* In general the territory names should also match those used in currency names, see **Part 3** _Section 4 [Currencies](tr35-numbers.md#Currencies)_.
+
 * * *
 
 ```xml

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -2521,17 +2521,28 @@ Note that the CLDR plural categories overlap some of these features, since some 
 <!ATTLIST grammaticalFeatures locales NMTOKENS #REQUIRED >
 
 <!ELEMENT grammaticalCase EMPTY>
-
+<!ATTLIST grammaticalCase scope NMTOKENS #IMPLIED >
 <!ATTLIST grammaticalCase values NMTOKENS #REQUIRED >
 
 <!ELEMENT grammaticalGender EMPTY>
-
+<!ATTLIST grammaticalGender scope NMTOKENS #IMPLIED >
 <!ATTLIST grammaticalGender values NMTOKENS #REQUIRED >
 
 <!ELEMENT grammaticalDefiniteness EMPTY>
-
+<!ATTLIST grammaticalDefiniteness scope NMTOKENS #IMPLIED >
 <!ATTLIST grammaticalDefiniteness values NMTOKENS #REQUIRED >
 ```
+
+The @targets attribute contains the specific grammatical entities to which the features apply, such as ```nominal``` when they apply to nouns only. The @locales attribute contains the specific locales to which the features apply, such as ```de fr``` for German and French.
+
+The @scope attribute, if present, indicates that the values are limited to a specific subset for certain kinds of entities. For example, a particular language might have an animate gender for nouns, but no units of measurement ever have that case; in another language, the language might have a rich set of grammatical cases, but units are invariant. If the @scope attribute is not present, then that has the meaning of "everything else".
+
+The @scope attributes are targeted at messages created by computers, thus a feature may have a narrower scope if for all practical purposes the feature value is not used in messages created by computers. For example, it may be possible in theory for a kilogram to be in the vocative case (English poetry might have “O Captain! my Captain!/ our fearful trip is done”, but on computers you have little call to need the message “O kilogram! my kilogram! …”).
+
+**Constraints:**
+
+* a scope attribute is only used when there is a corresponding “general” element, one for the same language and target without a scope attribute.
+* the scope attribute values must be narrower (a proper subset, possibly empty) of those in the corresponding general element.
 
 ### 15.1 <a name="Gender" href="#Gender">Gender</a>
 

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -18,7 +18,7 @@ This is a partial document, describing general parts of the LDML: display names 
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -827,7 +827,7 @@ The identifiers and unit conversion data are built to handle arbitrary combinati
 
 For the US spelling, see the [Preface of the Guide for the Use of the International System of Units (SI), NIST special publication 811](https://www.nist.gov/pml/special-publication-811), which is explicit about the discrepancy with the English-language BIPM spellings:
 
-In keeping with U.S. and International practice (see Sec. C.2), this Guide uses the dot on the line as the decimal marker. In addition this Guide utilizes the American spellings “meter,” “liter,” and “deka” rather than “metre,” “litre,” and “deca,” and the name “metric ton” rather than “tonne.”
+> In keeping with U.S. and International practice (see Sec. C.2), this Guide uses the dot on the line as the decimal marker. In addition this Guide utilizes the American spellings “meter,” “liter,” and “deka” rather than “metre,” “litre,” and “deca,” and the name “metric ton” rather than “tonne.”
 
 #### Syntax
 
@@ -881,11 +881,18 @@ The formal syntax for identifiers is provided below.
         <ul><li><em>Note:</em> "pow2-" and "pow3-" canonicalize to "square-" and "cubic-"</li></ul></td></tr>
 
 <tr><td>prefixed_unit</td><td></td>
-    <td>(si_prefix)? simple_unit<ul><li><em>Example: </em>kilometer</li></ul></td></tr>
+    <td>(prefix)? simple_unit<ul><li><em>Example: </em>kilometer</li></ul></td></tr>
+
+<tr><td>prefix</td><td></td>
+    <td>si_prefix | binary_prefix</td></tr>
 
 <tr><td>si_prefix</td><td>:=</td>
     <td>"deka" | "hecto" | "kilo", …
         <ul><li><em>Note: </em>See full list at <a href="https://www.nist.gov/pml/special-publication-811">NIST special publication 811</a></li></ul></td></tr>
+
+<tr><td>binary_prefix</td><td>:=</td>
+    <td>"kibi", "mebi", …
+        <ul><li><em>Note: </em>See full list at <a href="https://physics.nist.gov/cuu/Units/binary.html">Prefixes for binary multiples</a></li></ul></td></tr>
 
 <tr><td>simple_unit</td><td>:=</td>
     <td>unit_component ("-" unit_component)*<br/>
@@ -2576,8 +2583,8 @@ Feature that encodes the syntactic (and sometimes semantic) relationship of a no
 ##### Example
 
 ```xml
-<grammaticalFeatures targets="nominal" locales="es fr it pt">
-   <grammaticalGender values="masculine feminine"/>
+<grammaticalFeatures targets="nominal" locales="de">
+   <grammaticalCase values="nominative accusative genitive dative"/>
 ```
 
 ##### Values
@@ -2685,7 +2692,7 @@ For a description of how to use these fields to construct a localized name, see 
 
 ### 16.1 <a name="gender_compound_units" href="#gender_compound_units">Deriving the Gender of Compound Units</a>
 
-The **deriveCompound\[@feature="gender"\]** data provides information for how to derive the gender of the whole compound from the gender of its atomic units and structure. The `attributeValues` of value are: `0` (=gender of the first element), `1` (=gender of second element), or one of the valid gender values for the language:
+The **deriveCompound\[@feature="gender"\]** data provides information for how to derive the gender of the whole compound from the gender of its atomic units and structure. The `attributeValues` of value are: **`0` (=gender of the first element), `1` (=gender of second element), or one of the valid gender values for the language.** In the unusual case that the 'per' compound has no first element and 0 is supplied, then the value is 1.  
 
 Example:
 
@@ -2721,7 +2728,7 @@ For example, for gram-per-meter, the first line above means:
 
 ### 16.3 <a name="case_compound_units" href="#case_compound_units">Deriving the Case of Unit Components</a>
 
-The `deriveComponent[@feature="plural"]` data provides information for how to derive the plural category for each of the atomic units, from the plural category of the whole compound and the structure of the compound. The `attributeValues` of value0 and value1 are: `compound` (=the grammatical case of the compound), or one of the valid grammatical case values for the language.
+The `deriveComponent[@feature="case"]` data provides information for how to derive the grammatical case for each of the atomic units, from the grammatical case of the whole compound and the structure of the compound. The `attributeValues` of value0 and value1 are: `compound` (=the grammatical case of the compound), or one of the valid grammatical case values for the language.
 
 Example:
 

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -18,7 +18,7 @@ This is a partial document, describing only those parts of the LDML that are rel
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -1001,10 +1001,10 @@ There are many possible ways to construct complex units. For comparison of unit 
 3. Convert multiple instances of a unit into the appropriate power.
    * foot-per-second-second ⇒ foot-per-square-second
    * kilogram-meter-kilogram ⇒ meter-square-kilogram
-4. For each single unit, disregarding prefixes and powers, find its base unit using `<convertUnit>`, then get the order of that base unit among the `unitQuantity` elements in the [units.xml](https://github.com/unicode-org/cldr/blob/master/common/supplemental/units.xml). Then sort the single units by that order.
+4. For each single unit, disregarding prefixes and powers, get the order of the _simple_ unit among the `unitQuantity` elements in the [units.xml](https://github.com/unicode-org/cldr/blob/master/common/supplemental/units.xml). Sort the single units by that order, using a stable sort. If there are private-use single units, sort them after all the non-private use single units.
    * meter-square-kilogram => square-kilogram-meter
    * meter-square-gram ⇒ square-gram-meter
-5. If two single units have the same simple unit but different SI prefixes, such as "kilometer-meter", sort the higher-power SI prefixes first.
+5. As an edge case, there could be two adjacent single units with the same _simple_ unit but different prefixes, such as _meter-kilometer_. In that case, sort the larger prefixes first, such as _kilometer-meter_ or _kibibyte-kilobyte_
 6. Within private-use single units, sort by the simple unit alphabetically.
 
 The examples in #4 are due to the following ordering of the `unitQuantity` elements:

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -759,6 +759,12 @@ The parentLocales data is supplemental data, but is described in detail in the [
 
 The unit conversion data ([units.xml](https://github.com/unicode-org/cldr/blob/master/common/supplemental/units.xml)) provides the data for converting all of the cldr unit identifiers to base units, and back. That allows conversion between any two convertible units, such as two units of length. For any two convertible units (such as acre and dunum) the first can be converted to the base unit (square-meter), then that base unit can be converted to the second unit.
 
+Many of the elements allow for a common @description attribute, to disambiguate the main attribute value or to explain the choice of other values. For example:
+```xml
+<unitConstant constant="glucose_molar_mass" value="180.1557" 
+  description="derivation from the mean atomic weights according to STANDARD ATOMIC WEIGHTS 2019 on https://ciaaw.org/atomic-weights.htm"/>
+```
+
 ```xml
 <!ELEMENT unitConstants ( unitConstant* ) >
 
@@ -769,6 +775,8 @@ The unit conversion data ([units.xml](https://github.com/unicode-org/cldr/blob/m
 <!ATTLIST unitConstant value CDATA #REQUIRED >
 
 <!ATTLIST unitConstant status NMTOKEN #IMPLIED >
+
+<!ATTLIST unitConstant description CDATA #IMPLIED >
 ```
 
 ### Constants
@@ -807,6 +815,8 @@ An implementation need not use rationals directly for conversion; it could use d
 <!ATTLIST convertUnit factor CDATA #IMPLIED >
 
 <!ATTLIST convertUnit offset CDATA #IMPLIED >
+
+<!ATTLIST convertUnit description CDATA #IMPLIED >
 ```
 
 The conversion data provides the data for converting all of the cldr unit identifiers to base units, and back. That allows conversion between any two convertible units, such as two units of length. For any two convertible units (such as acre and dunum) the first can be converted to the base unit (square-meter), then that base unit can be converted to the second unit.
@@ -837,7 +847,22 @@ The conversion may also require an offset, such as the following:
 
 The factor and offset can be simple expressions, just like the values in the unitConstants.
 
-Where a factor is not present, the value is 1; where an offset is not present, the value is 0. The `systems` attribute indicates where the value is not metric; currently the attribute values just include the _ussystem_ and _uksystem_ systems. The term _metric_ is used in a broad sense, and includes units that are simple multiples of metric units, such as pound-metric (= ½ kilogram).
+Where a factor is not present, the value is 1; where an offset is not present, the value is 0. 
+
+The `systems` attribute indicates the measurement system(s). Multiple values may be given; for example, _minute_ is marked as systems="metric ussystem uksystem" 
+
+Attribute Value | Description
+------------ | -------------
+_si_ | the _International System of Units (SI)_
+_metric_ | a superset of the _si_ units, with some non-SI units accepted for use with the SI or simple multiples of metric units, such as pound-metric (= ½ kilogram)
+_ussystem_ | the inch-pound system as used in the US, also called _US Customary Units_
+_uksystem_ | the inch-pound system as used in the UK, also called _British Imperial Units_, differing mostly in units of volume
+
+CLDR follows conversion values where possible from:
+* [NIST Special Publication 1038](https://www.govinfo.gov/content/pkg/GOVPUB-C13-f10c2ff9e7af2091314396a2d53213e4/pdf/GOVPUB-C13-f10c2ff9e7af2091314396a2d53213e4.pdf)
+* [International Astronomical Union General Assembly](https://arxiv.org/pdf/1510.07674.pdf)
+ 
+See also [NIST Guide to the SI, Chapter 4: The Two Classes of SI Units and the SI Prefixes](https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes)
 
 For complex units, such as _pound-force-per-square-inch_, the conversions are computed by combining the conversions of each of the simple units: _pound-force_ and _inch_. Because the conversions in convertUnit are reversible, the computation can go from complex source unit to complex base unit to complex target units.
 
@@ -937,6 +962,8 @@ However, in conversion, it may be necessary to resolve them in order to find a m
 <!ATTLIST unitQuantity quantity NMTOKENS #REQUIRED >
 
 <!ATTLIST unitQuantity status NMTOKEN #IMPLIED >
+
+<!ATTLIST unitQuantity description CDATA #IMPLIED >
 ```
 
 Conversion is supported between comparable units. Those can be simple units, such as length, or more complex ‘derived’ units that are built up from _base units_. The `<unitQuantities>` element provides information on the base units used for conversion. It also supplies information about their _quantity_: mass, length, time, etc., and whether they are simple or not.

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -45,7 +45,7 @@ The LDML specification is divided into the following parts:
     *   2.3 [Supplemental Territory Information](#Supplemental_Territory_Information)
     *   2.4 [Territory-Based Preferences](#Territory_Based_Preferences)
         *   2.4.1 [Preferred Units for Specific Usages](#Preferred_Units_For_Usage)
-            *   Table: [Unit Preference Categories](#Unit_Preferences)
+            *   Table: [Unit Preference](#Unit_Preferences)
     *   2.5 [\<rgScope>: Scope of the “rg” Locale Key](#rgScope)
 *   3 [Supplemental Language Data](#Supplemental_Language_Data)
     *   3.1 [Supplemental Language Grouping](#Supplemental_Language_Grouping)
@@ -681,7 +681,7 @@ Attribute values for the \*Alias values include the following:
 | replacement | NMTOKEN       | The code(s) to replace it, space-delimited. |
 | reason      | deprecated    | The code in type is deprecated, such as 'iw' by 'he', or 'CS' by 'RS ME'. |
 |             | overlong      | The code in type is too long, such as 'eng' by 'en' or 'USA' or '840' by 'US' |
-|             | macrolanguage | The code in type is an encompassed languagethat is replaced by a macrolanguage, such as '[arb'](https://www.sil.org/iso639-3/documentation.asp?id=arb) by 'ar'. |
+|             | macrolanguage | The code in type is an encompassed language that is replaced by a macrolanguage, such as '[arb'](https://www.sil.org/iso639-3/documentation.asp?id=arb) by 'ar'. |
 |             | legacy        | The code in type is a legacy code that is replaced by another code for compatiblity with established legacy usage, such as 'sh' by 'sr_Latn' |
 |             | bibliographic | The code in type is a [bibliographic code](https://www.loc.gov/standards/iso639-2/langhome.html), which is replaced by a terminology code, such as 'alb' by 'sq'. |
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -18,7 +18,7 @@ This is a partial document, describing keyboard mappings. For the other parts of
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -18,7 +18,7 @@ This is a partial document, describing only those parts of the LDML that are rel
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -578,6 +578,14 @@ If there is an explicit negative subpattern, it serves only to specify the negat
 
 > **Note:** The thousands separator and decimal separator in patterns are always ASCII ',' and '.'. They are substituted by the code with the correct local values according to other fields in CLDR. The same is true of the - (ASCII minus sign) and other special characters listed above.
 
+A currency decimal pattern normally contains a currency symbol placeholder (¤, ¤¤, ¤¤¤, or ¤¤¤¤¤). The currency symbol placeholder may occur before the first digit, after the last digit symbol, or where the decimal symbol would otherwise be placed (for formats such as "12€50", as in "12€50 pour une omelette").
+
+Placement | Examples
+-------|-------
+Before|"¤#,##0.00" "¤ #,##0.00" "¤-#,##0.00" "¤ -#,##0.00" "-¤#,##0.00" "-¤ #,##0.00" …
+After|"#,##0.00¤" "#,##0.00 ¤" "#,##0.00-¤" "#,##0.00- ¤" "#,##0.00¤-" "#,##0.00 ¤-" …
+Decimal|"#,##0¤00"
+
 Below is a sample of patterns, special characters, and results:
 
 ##### <a name="Sample_Patterns_and_Results" href="#Sample_Patterns_and_Results">Sample Patterns and Results</a>

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -783,6 +783,10 @@ The `count` attribute distinguishes the different plural forms, such as in the f
 </currency>
 ```
 
+Note on displayNames:
+* In general the region portion of the displayName should match the territory name, see **Part 2** _Section 1.2 [Locale Display Name Fields](tr35-general.md#locale_display_name_fields)_.
+* As a result, the English currency displayName in CLDR may not match the name in ISO 4217.
+
 To format a particular currency value "ZWD" for a particular numeric value _n_ using the (long) display name:
 
 1. If the numeric value is exactly 0 or 1, first see if there is a count with a matching explicit number (0 or 1). If so, use that string (see [Explicit 0 and 1 rules](#Explicit_0_1_rules)).

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -238,9 +238,9 @@ The BCP 47 extensions (-u- and -t-) are described in _Section 3.6 [Unicode BCP 4
 
 A _Unicode language identifier_ has the following structure (provided in EBNF (Perl-based)). The following table defines syntactically well-formed identifiers: they are not necessarily valid identifiers. For additional validity criteria, see the links on the right.
 
-<table><thead>
-<th></th><th>EBNF</th><th>Validity / Comments</th>
-</thead><tbody>
+<table>
+<tbody>
+   <tr><th></th><th>EBNF</th><th>Validity / Comments</th></tr>
 <tr>
     <td><a name="unicode_language_id" href="#unicode_language_id"><code>unicode_language_id</code></a></td>
     <td><pre><code>= "root"

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3507,16 +3507,6 @@ _Example:_
 
 If the field = territory, and the replacement.field has more than one value, then look up the most likely territory\* for the base language code (and script, if there is one). If that likely territory is in the list of replacements, use it. Otherwise, use the first territory in the list.
 
-_Example:_
-
-> source=ja-Latn-fonipa-hepburn-heploc
-> 
-> rule  =”\<languageAlias type="und-hepburn-heploc"
-> 
-> replacement="und-alalc97">”
-> 
-> result=”ja-Latn-alalc97-fonipa” _// note that CLDR canonical order of variants is alphabetical_
-
 #### 5. Canonicalizing Syntax
 
 To canonicalize the syntax of _source_:

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3584,7 +3584,11 @@ The canonicalization of localeIds is done by first canonicalizing the languageId
       `<key name="ms"…>…<type name="uksystem" … alias="imperial" … />…</key>`
    2. We get the following transformation:  
       `en-u-ms-imperial ⇒ en-u-ms-uksystem`
-3. If there is an 'sd' or 'rg' key, replace any subdivision alias in its value in the same way, using subdivisionAlias data.
+3. Replace any unicode_subdivision_id that is a subdivision alias by its replacement value in the same way, using subdivisionAlias data. This applies, for example, to the values for the 'sd' and 'rg' keys. However, where the replacement value is a two-letter region code, also append zzzz so that the result is syntactically correct. For example:
+   1. Because of the following bcp47 data:  
+      `<subdivisionAlias type="fi01" replacement="AX"…`
+   2. We get the following transformation:  
+      `en-u-rg-fi01 ⇒ en-u-rg-axzzzz`
 
 ## Optimizations
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -291,13 +291,13 @@ As is often the case, the complete syntactic constraints are not easily captured
 
 |                                                                                                       | EBNF                                            | Validity / Comments |
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------- |
-| <a name="unicode_locale_id" href="#unicode_locale_id">`unicode_locale_id`</a>                         | `= unicode_language_id`<br/>`  extensions*`<br/>`  pu_extensions? ;` |
+| <a name="unicode_locale_id" href="#unicode_locale_id">`unicode_locale_id`</a>                         | `= unicode_language_id`<br/>  `extensions*`<br/>  `pu_extensions? ;` |
 | <a name="extensions" href="#extensions">`extensions`</a>                                              | `= unicode_locale_extensions`<br/>`\| transformed_extensions`<br/>` \| other_extensions ;` |
-| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>`  ((sep keyword)+`<br/>`  \|(sep attribute)+ (sep keyword)*) ;` |
-| <a name="transformed_extensions" href="#transformed_extensions">`transformed_extensions`</a>          | `= sep [tT]`<br/>`  ((sep tlang (sep tfield)*)`<br/>`  \| (sep tfield)+) ;` |
+| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>  `((sep keyword)+`<br/>  `\|(sep attribute)+ (sep keyword)*) ;` |
+| <a name="transformed_extensions" href="#transformed_extensions">`transformed_extensions`</a>          | `= sep [tT]`<br/>  `((sep tlang (sep tfield)*)`<br/>  `\| (sep tfield)+) ;` |
 | <a name="pu_extensions" href="#pu_extensions">`pu_extensions`</a>                                     | `= sep [xX]`<br/>`  (sep alphanum{1,8})+ ;` |
 | <a name="other_extensions" href="#other_extensions">`other_extensions`</a>                            | `= sep [alphanum-[tTuUxX]]`<br/>`  (sep alphanum{2,8})+ ;` |
-| `keyword`<br/>(Also known as `uvalue`)                                                                | `= key (sep type)? ;` |
+| `keyword`<br/>(Also known as `ufield`)                                                                | `= key (sep type)? ;` |
 | `key`<br/>(Also known as `ukey`)                                                                      | `= alphanum alpha ;`<br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with tkey.) | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47) |
 | `type`<br/>(Also known as `uvalue`)                                                                   | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47) |
 | `attribute`                                                                                           | `= alphanum{3,8} ;` |
@@ -3529,8 +3529,8 @@ To canonicalize the syntax of _source_:
   * Put any variants into alphabetical order (eg, en-fonipa-scouse, not en-scouse-fonipa)
   * Put any extensions into alphabetical order by their singleton (eg, en-t-xxx-u-yyy, not en-u-yyy-t-xxx)
   * Put all attributes into alphabetical order.
-  * Put all <keywords, tfields> pairs into alphabetical order of their keys, within their respective extensions.
-  * Remove any type or tfield value of "true"
+  * Put all ufields (<ukey, uvalue>) and tfields (<tkey, tvalue>) into alphabetical order according to their keys (ukey or tkey), within their respective extensions.
+  * Remove any uvalue (aka type) equal to "true". Note that "true" values cannot be removed from tvalues.
 * Separator
   * Replace '\_' by '-'
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3688,41 +3688,33 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
 **Revision 62**
-> TBD: Modify the following to show the v39 changes instead of v38 changes. That will incorporate the following, but with section locations instead of bug tickets.
-> Locales
->  *the modified use of the language codes 'no' and 'nb' is documented https://unicode-org.atlassian.net/browse/CLDR-2698
->  *the algorithm for generating display names for locales has been modified to handle aliased subtags https://unicode-org.atlassian.net/browse/CLDR-14490
->  *tvalues of true are not removed in canonicalization https://unicode-org.atlassian.net/browse/CLDR-14318
->  *variantAlias replacements that are region codes are converted to subdivision codes in rg and sd kvalues (by appending "zzzz") https://unicode-org.atlassian.net/browse/CLDR-14312
->  *the status of the kvalues of true and missing kvalues is clarified https://unicode-org.atlassian.net/browse/CLDR-14330
->  *a duplicate example was removed below "Territory Exception" in Appendix A https://unicode-org.atlassian.net/browse/CLDR-14319
->  *the text for keyword and tfield ordering in canonicalization has been clarified https://unicode-org.atlassian.net/browse/CLDR-14320
->  *duplicate variants in tlang fields are clearly disallowed https://unicode-org.atlassian.net/browse/CLDR-14329
->  *the use of uppercase letters in the canonical syntax of locales is now consistent (as only used in the Unicode language identifier) https://unicode-org.atlassian.net/browse/CLDR-14330
->  *a link in Annex C is fixed https://unicode-org.atlassian.net/browse/CLDR-14508
-> Units
->  *the text for inverse unit handling has been clarified https://unicode-org.atlassian.net/browse/CLDR-13787
->  *the ordering of units in a normalized unit identifier has been fixed to correspond to data ordering changes https://unicode-org.atlassian.net/browse/CLDR-14410
->  *the EBNF for unit identifiers is expanded for binary prefixes, https://unicode-org.atlassian.net/browse/CLDR-14253
->  *the new description attribute and unit systems attribute values (metric, si, other) are documented https://unicode-org.atlassian.net/browse/CLDR-14209
-> Currency
->  *policies for use of region names and region names in currency names are included https://unicode-org.atlassian.net/browse/CLDR-14209
-> Linebreak
->  *a description is provided for using delimiter information in linebreaking https://unicode-org.atlassian.net/browse/CLDR-14221
-> Inheritance
->  *the special behavior of the 'alt' value in inheritance is described https://unicode-org.atlassian.net/browse/CLDR-14244
-> Numbers
->  *currency patterns allow for the currency symbols (¤, ¤¤, ...) at the decimal position, for formats such as "12€50", as in "12€50 pour une omelette" https://unicode-org.atlassian.net/browse/CLDR-13221
+> TBD: The following is a list of changes that have yet to be incorporated into the Modifications. 
+> * Locales
+>    * The algorithm for generating display names for locales has been modified to handle aliased subtags **ALREADY INCLUDED BELOW**
+>    * The tvalues of true are not removed in canonicalization **Part 1, Core; Annex C. LocaleId Canonicalization**
+>    * The variantAlias replacements that are region codes are converted to subdivision codes in rg and sd kvalues (by appending "zzzz") **Part 1, Core; Annex C. LocaleId Canonicalization**
+>    * The status of the kvalues of true and missing kvalues is clarified **Part 1, Core; 3.6.1 Key And Type Definitions**
+>    * A duplicate example was removed below "Territory Exception" **Part 1, Core; Annex C. LocaleId Canonicalization**
+>    * The text for keyword and tfield ordering in canonicalization has been clarified **Part 1, Core; Annex C. LocaleId Canonicalization**
+>    * Duplicate variants in tlang fields are clearly disallowed  **Part 1, Core; 3.2 Unicode Locale Identifier**
+>    * The use of uppercase letters in the canonical syntax of locales is now consistent (as only used in the Unicode language identifier) **Part 1, Core; 3.2.1 Canonical Unicode Locale Identifiers, 3.4 Language Identifier Field Definitions**
+> * Units
+>    * The text for inverse unit handling has been clarified  **Part 6: Supplemental, 13 Unit Conversion**
+>    * The ordering of units in a normalized unit identifier has been fixed to correspond to data ordering changes  **Part 6: Supplemental, 13 Unit Conversion**
+>    * The EBNF for unit identifiers is expanded for binary prefixes **Part 2: General; Section 6.2 Unit Identifiers**
+>    * The new description attribute and unit systems attribute values (metric, si, other) are documented **Part 6: Supplemental, 13 Unit Conversion**
+>    * Deriving gender in the unusual case of no denominator in the per compound is described **Part 2: General, Section 16.1 Deriving the Gender of Compound Units**
+> * Currency
+>    * The policies for use of region (territory) names in currency names are included **ALREADY INCLUDED BELOW**
+>    * Currency patterns allow for the currency symbols (¤, ¤¤, ...) at the decimal position, for formats such as "12€50", as in "12€50 pour une omelette" **Part 3: Numbers — 3.2 Special Pattern Characters**
+> * Linebreak
+>    * A description is provided for using delimiter information in linebreaking **ALREADY INCLUDED BELOW**
+> * Grammatical Features
+>   * The targets, scope, and locales attributes are documented **Part 2: General, Section 15 Grammatical Features**
+>   * Additional grammatical case values are documented, such as abessive **Part 2: General, Section 15 Grammatical Features**
+> * Inheritance
+>    * The special behavior of the 'alt' value in inheritance is described **Part 1, Core; 4.1.2 Lateral Inheritance**
 
-* **Part 1: [Core](tr35.md#Contents) (languages, locales, basic structure)**
-  * **Section 3.2.1 [Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers)**: replaced text by a reference to **Annex C. [LocaleId Canonicalization](#LocaleId_Canonicalization)**
-  * **Section 3.3.1 [BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion):** replaced text by a reference to **Annex C. [LocaleId Canonicalization](#LocaleId_Canonicalization)**
-  * **Section 3.6.1 [Key And Type Definitions](#Key_And_Type_Definitions_)**: added new key “dx”, for [Unicode Dictionary Break Exclusion Identifier](#UnicodeDictionaryBreakExclusionIdentifier).
-  * **Section 3.6.4 [U Extension Data Files](#Unicode_Locale_Extension_Data_Files)**: added description of [SCRIPT_CODE](#SCRIPT_CODE) value for key “dx”.
-  * **Section 4.1.2 [Lateral Inheritance](#Lateral_Inheritance):** specified lateral inheritance in more detail, added case and gender.
-  * **Annex C. [LocaleId Canonicalization](#LocaleId_Canonicalization)**
-    * Added new Annex, replacing text in **Section 3.2.1 [Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers)** and **Section 3.3.1 [BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion)**
-    * Cleans up ambiguities in the previous specification of canonicalization. (This was done in concert with fixes to the alias data to work better with the specification.)
 * **Part 2: [General](tr35-general.md#Contents) (display names &transforms, etc.)**
   * **Section 1.1 [Locale Display Name Algorithm](tr35-general.md#locale_display_name_algorithm)**
     * Revised to clarify that first lookup should be with locale identifier in *canonical syntax*, but if there is no match for language code, the identifier should then be converted to *canonical form* and the lookup retried.
@@ -3730,22 +3722,11 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
     * Added notes on considerations for territory display names.
   * **Section 4.1 [Tailoring Linebreak Using Delimiters](tr35-general.md#Tailor_Linebreak_With_Delimiters)**
     * Added new section on use of delimiter data for linebreak tailoring.
-  * **Section 6 [Unit Elements](tr35-general.md#Unit_Elements)**
-    * Added new element compoundUnitPattern1
-    * Added case attribute to compoundUnitPattern
-    * Provided full description of compound unit components
-  * **Section 14.2 [Annotations Character Labels](tr35-general.md#Character_Labels)**
-    * Added new characterLabelPattern type attribute values subscript and superscript.
-  * **Section 16 [Grammatical Derivations](tr35-general.md#Grammatical_Derivations)** — new
 * **Part 3: [Numbers](tr35-numbers.md#Contents) (number & currency formatting)**
-  * **Section 2.3 [Number Symbols](tr35-numbers.md#Number_Symbols):** added approximatelySign.
-  * **Section 2.6 [Minimal Pairs](tr35-numbers.md#Minimal_Pairs):** added case and gender minimal pairs. Removed the alt/draft ATTLIST since those are documented elsewhere and just obfuscate the text.
   * **Section 4 [Currencies](tr35-numbers.md#Currencies):**
     * Added notes on considerations for currency display names.
-  * **Section 5 [Language Plural Rules](tr35-numbers.md#Language_Plural_Rules):** added the 'e' operand for use in certain compact number formatting.
-* **Part 6: [Supplemental](tr35-info.md#Contents) (supplemental data)**
-  * **Section 14 [Unit Preferences](tr35-info.md#Unit_Preferences)**: defined the userPreferences skeleton more precisely.
-* **Throughout:** Where possible, use “legacy” (for language tag or unit) instead of “grandfathered”.
+
+Note that small changes such as typos and link fixes are not listed above.
 
 Modifications in previous versions are listed in those respective versions. Click on **Previous Version** in the header until you get to the desired version.
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -29,6 +29,8 @@ _This is a draft document which may be updated, replaced, or superseded by other
 
 _Please submit corrigenda and other comments with the CLDR bug reporting form [[Bugs](http://cldr.unicode.org/index/bug-reports)]. Related information that is useful in understanding this document is found in the [References](#References). For the latest version of the Unicode Standard see [[Unicode](https://www.unicode.org/versions/latest/)]. For a list of current Unicode Technical Reports see [[Reports](https://www.unicode.org/reports/)]. For more information about versions of the Unicode Standard, see [[Versions](https://www.unicode.org/versions/)]._
 
+>**_NOTE: The source for the LDML specification has been converted to Github Markdown (GFM) instead of HTML. The formatting is now simpler, but some features — such as formatting for table captions — may not be complete by the release date. Improvements in the formatting for the v39 specification are planned for after the release, but no substantive changes would be made to the content._**
+
 ## <a name="Parts" href="#Parts">Parts</a>
 
 The LDML specification is divided into the following parts:
@@ -3685,9 +3687,33 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
-**Revision 61**
+**Revision 62**
+> TBD: Modify the following to show the v39 changes instead of v38 changes. That will incorporate the following, but with section locations instead of bug tickets.
+> Locales
+>  *the modified use of the language codes 'no' and 'nb' is documented https://unicode-org.atlassian.net/browse/CLDR-2698
+>  *the algorithm for generating display names for locales has been modified to handle aliased subtags https://unicode-org.atlassian.net/browse/CLDR-14490
+>  *tvalues of true are not removed in canonicalization https://unicode-org.atlassian.net/browse/CLDR-14318
+>  *variantAlias replacements that are region codes are converted to subdivision codes in rg and sd kvalues (by appending "zzzz") https://unicode-org.atlassian.net/browse/CLDR-14312
+>  *the status of the kvalues of true and missing kvalues is clarified https://unicode-org.atlassian.net/browse/CLDR-14330
+>  *a duplicate example was removed below "Territory Exception" in Appendix A https://unicode-org.atlassian.net/browse/CLDR-14319
+>  *the text for keyword and tfield ordering in canonicalization has been clarified https://unicode-org.atlassian.net/browse/CLDR-14320
+>  *duplicate variants in tlang fields are clearly disallowed https://unicode-org.atlassian.net/browse/CLDR-14329
+>  *the use of uppercase letters in the canonical syntax of locales is now consistent (as only used in the Unicode language identifier) https://unicode-org.atlassian.net/browse/CLDR-14330
+>  *a link in Annex C is fixed https://unicode-org.atlassian.net/browse/CLDR-14508
+> Units
+>  *the text for inverse unit handling has been clarified https://unicode-org.atlassian.net/browse/CLDR-13787
+>  *the ordering of units in a normalized unit identifier has been fixed to correspond to data ordering changes https://unicode-org.atlassian.net/browse/CLDR-14410
+>  *the EBNF for unit identifiers is expanded for binary prefixes, https://unicode-org.atlassian.net/browse/CLDR-14253
+>  *the new description attribute and unit systems attribute values (metric, si, other) are documented https://unicode-org.atlassian.net/browse/CLDR-14209
+> Currency
+>  *policies for use of region names and region names in currency names are included https://unicode-org.atlassian.net/browse/CLDR-14209
+> Linebreak
+>  *a description is provided for using delimiter information in linebreaking https://unicode-org.atlassian.net/browse/CLDR-14221
+> Inheritance
+>  *the special behavior of the 'alt' value in inheritance is described https://unicode-org.atlassian.net/browse/CLDR-14244
+> Numbers
+>  *currency patterns allow for the currency symbols (¤, ¤¤, ...) at the decimal position, for formats such as "12€50", as in "12€50 pour une omelette" https://unicode-org.atlassian.net/browse/CLDR-13221
 
-* **Reissued** for CLDR 38.
 * **Part 1: [Core](tr35.md#Contents) (languages, locales, basic structure)**
   * **Section 3.2.1 [Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers)**: replaced text by a reference to **Annex C. [LocaleId Canonicalization](#LocaleId_Canonicalization)**
   * **Section 3.3.1 [BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion):** replaced text by a reference to **Annex C. [LocaleId Canonicalization](#LocaleId_Canonicalization)**

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3700,6 +3700,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 * **Part 2: [General](tr35-general.md#Contents) (display names &transforms, etc.)**
   * **Section 1.1 [Locale Display Name Algorithm](tr35-general.md#locale_display_name_algorithm)**
     * Revised to clarify that first lookup should be with locale identifier in *canonical syntax*, but if there is no match for language code, the identifier should then be converted to *canonical form* and the lookup retried.
+  * **Section 1.2 [Locale Display Name Fields](tr35-general.md#locale_display_name_fields)**
+    * Added notes on considerations for territory display names.
   * **Section 4.1 [Tailoring Linebreak Using Delimiters](tr35-general.md#Tailor_Linebreak_With_Delimiters)**
     * Added new section on use of delimiter data for linebreak tailoring.
   * **Section 6 [Unit Elements](tr35-general.md#Unit_Elements)**
@@ -3712,6 +3714,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 * **Part 3: [Numbers](tr35-numbers.md#Contents) (number & currency formatting)**
   * **Section 2.3 [Number Symbols](tr35-numbers.md#Number_Symbols):** added approximatelySign.
   * **Section 2.6 [Minimal Pairs](tr35-numbers.md#Minimal_Pairs):** added case and gender minimal pairs. Removed the alt/draft ATTLIST since those are documented elsewhere and just obfuscate the text.
+  * **Section 4 [Currencies](tr35-numbers.md#Currencies):**
+    * Added notes on considerations for currency display names.
   * **Section 5 [Language Plural Rules](tr35-numbers.md#Language_Plural_Rules):** added the 'e' operand for use in certain compact number formatting.
 * **Part 6: [Supplemental](tr35-info.md#Contents) (supplemental data)**
   * **Section 14 [Unit Preferences](tr35-info.md#Unit_Preferences)**: defined the userPreferences skeleton more precisely.

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -6,7 +6,7 @@
 <table><tbody>
 <tr><td>Version</td><td>39</td></tr>
 <tr><td>Editors</td><td>Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a></td></tr>
-<tr><td>Date</td><td>2021-03-23</td></tr>
+<tr><td>Date</td><td>2021-03-24</td></tr>
 <tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-62/tr35.md">https://www.unicode.org/reports/tr35/tr35-61/tr35.md</a></td></tr>
 <tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-61/tr35.md">https://www.unicode.org/reports/tr35/tr35-60/tr35.md</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>
@@ -3700,6 +3700,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 * **Part 2: [General](tr35-general.md#Contents) (display names &transforms, etc.)**
   * **Section 1.1 [Locale Display Name Algorithm](tr35-general.md#locale_display_name_algorithm)**
     * Revised to clarify that first lookup should be with locale identifier in *canonical syntax*, but if there is no match for language code, the identifier should then be converted to *canonical form* and the lookup retried.
+  * **Section 4.1 [Tailoring Linebreak Using Delimiters](tr35-general.md#Tailor_Linebreak_With_Delimiters)**
+    * Added new section on use of delimiter data for linebreak tailoring.
   * **Section 6 [Unit Elements](tr35-general.md#Unit_Elements)**
     * Added new element compoundUnitPattern1
     * Added case attribute to compoundUnitPattern

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -6,15 +6,15 @@
 <table><tbody>
 <tr><td>Version</td><td>39</td></tr>
 <tr><td>Editors</td><td>Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a></td></tr>
-<tr><td>Date</td><td>2021-03-24</td></tr>
-<tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-62/tr35.md">https://www.unicode.org/reports/tr35/tr35-61/tr35.md</a></td></tr>
-<tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-61/tr35.md">https://www.unicode.org/reports/tr35/tr35-60/tr35.md</a></td></tr>
+<tr><td>Date</td><td>2021-04-06</td></tr>
+<tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-63/tr35.html">https://www.unicode.org/reports/tr35/tr35-63/tr35.html</a></td></tr>
+<tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-61/tr35.html">https://www.unicode.org/reports/tr35/tr35-61/tr35.html</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>
 <tr><td>Corrigenda</td><td><a href="http://unicode.org/cldr/corrigenda.html">http://unicode.org/cldr/corrigenda.html</a></td></tr>
-<tr><td>Latest Proposed Update</td><td><a href="https://www.unicode.org/reports/tr35/proposed.md">https://www.unicode.org/reports/tr35/proposed.md</a></td></tr>
+<tr><td>Latest Proposed Update</td><td><a href="https://unicode-org.github.io/cldr/ldml/tr35.html">https://unicode-org.github.io/cldr/ldml/tr35.html</a></td></tr>
 <tr><td>Namespace</td><td><a href="https://unicode.org/cldr/">https://unicode.org/cldr/</a></td></tr>
 <tr><td>DTDs</td><td><a href="https://github.com/unicode-org/cldr/tree/maint/maint-39/common/dtd">http://unicode.org/cldr/dtd/39/</a></td></tr>
-<tr><td>Revision</td><td><a href="#Modifications">62</a></td></tr>
+<tr><td>Revision</td><td><a href="#Modifications">63</a></td></tr>
 </tbody></table>
 
 ### _Summary_
@@ -23,7 +23,7 @@ This document describes an XML format (_vocabulary_) for the exchange of structu
 
 ### _Status_
 
-_This is a draft document which may be updated, replaced, or superseded by other documents at any time. Publication does not imply endorsement by the Unicode Consortium. This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
+_This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium. This is a stable document and may be used as reference material or cited as a normative reference by other specifications._
 
 > _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -273,7 +273,7 @@ A _Unicode language identifier_ has the following structure (provided in EBNF (P
     <td><a href="#unicode_variant_subtag_validity">validity</a><br/>
         <a href="https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/vairant.xml">latest-data</a></td>
 </tr>
-<tr><td><code>sep</code></td>     <td><pre>= [-_] ;</pre></td></tr>
+   <tr><td><code>sep</code></td>     <td><pre>= [-_] ;</pre></td></tr>
 <tr><td><code>digit</code></td>   <td><pre>= [0-9] ;</pre></td></tr>
 <tr><td><code>alpha</code></td>   <td><pre>= [A-Z a-z] ;</pre></td></tr>
 <tr><td><code>alphanum</code></td><td><pre>= [0-9 A-Z a-z] ;</pre></td></tr>
@@ -304,7 +304,7 @@ As is often the case, the complete syntactic constraints are not easily captured
 | <a name="unicode_subdivision_id" href="#unicode_subdivision_id">`unicode_subdivision_id`</a>          | `= `[`unicode_region_subtag`](#unicode_region_subtag)` unicode_subdivision_suffix ;` | [`validity`](#unicode_subdivision_subtag_validity)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/subdivision.xml) |
 | `unicode_subdivision_suffix`                                                                          | `= alphanum{1,4} ;` |
 | <a name="unicode_measure_unit" href="#unicode_measure_unit">`unicode_measure_unit`</a>                | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Validity_Data)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/validity/unit.xml) |
-| `tlang`                                                                                               | `= unicode_language_subtag`<br/>`  (sep unicode_script_subtag)?`<br/>`  (sep unicode_region_subtag)?`<br/>`  (sep unicode_variant_subtag)* ;` |
+| `tlang`                                                                                               | `= unicode_language_subtag`<br/>`  (sep unicode_script_subtag)?`<br/>`  (sep unicode_region_subtag)?`<br/>`  (sep unicode_variant_subtag)* ;` | same as in unicode_language_id |
 | `tfield`                                                                                              | `= tkey tvalue;` | [`validity`](#BCP47_T_Extension)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47) |
 | `tkey`                                                                                                | `= alpha digit ;` |
 | `tvalue`                                                                                              | `= (sep alphanum{3,8})+ ;` |
@@ -555,7 +555,7 @@ Special Codes:
 
 #### <a name="unicode_variant_subtag_validity" href="#unicode_variant_subtag_validity">`unicode_variant_subtag`</a> (also known as a _Unicode language variant code_)
 
-Subtags in the variant.xml file (see _Section 3.11 [Validity Data](#Validity_Data)_). These are based on [[BCP47](#BCP47)] subtag values marked as **Type: variant**
+Subtags in the variant.xml file (see _Section 3.11 [Validity Data](#Validity_Data)_). These are based on [[BCP47](#BCP47)] subtag values marked as **Type: variant**. The sequence of variant tags must not have any duplicates: thus de-1996-fonipa-1996 is invalid, while de-1996-fonipa and de-fonipa-1996 are both valid.
 
 CLDR provides data for normalizing variant codes. About handling of the "POSIX" variant see _Section 3.8.2, [Legacy Variants](#Legacy_Variants)_.
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -6,7 +6,7 @@
 <table><tbody>
 <tr><td>Version</td><td>39</td></tr>
 <tr><td>Editors</td><td>Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a></td></tr>
-<tr><td>Date</td><td>2021-02-22</td></tr>
+<tr><td>Date</td><td>2021-03-23</td></tr>
 <tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-62/tr35.md">https://www.unicode.org/reports/tr35/tr35-61/tr35.md</a></td></tr>
 <tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-61/tr35.md">https://www.unicode.org/reports/tr35/tr35-60/tr35.md</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>
@@ -3697,6 +3697,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
     * Added new Annex, replacing text in **Section 3.2.1 [Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers)** and **Section 3.3.1 [BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion)**
     * Cleans up ambiguities in the previous specification of canonicalization. (This was done in concert with fixes to the alias data to work better with the specification.)
 * **Part 2: [General](tr35-general.md#Contents) (display names &transforms, etc.)**
+  * **Section 1.1 [Locale Display Name Algorithm](tr35-general.md#locale_display_name_algorithm)**
+    * Revised to clarify that first lookup should be with locale identifier in *canonical syntax*, but if there is no match for language code, the identifier should then be converted to *canonical form* and the lookup retried.
   * **Section 6 [Unit Elements](tr35-general.md#Unit_Elements)**
     * Added new element compoundUnitPattern1
     * Added case attribute to compoundUnitPattern

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -655,6 +655,11 @@ For the complete list of valid keys and types defined for Unicode locale extensi
 
 Most type values are represented by a single subtag in the current version of CLDR. There are exceptions, such as types used for key "ca" (calendar) and "kr" (collation reordering). If the type is not included, then the type value "true" is assumed. Note that the default for key with a possible "true" value is often "false", but may not always be. Note also that "true"/"True" is not a valid script code, since [the ISO 15924 Registration Authority has exceptionally reserved it](https://www.unicode.org/iso15924/codelists.html), which means that it will not be assigned for any purpose.
 
+Note that canonicalization does not change invalid locales to valid locales. For example, und-u-ka canonicalizes to und-u-ka-true, but:
+
+1. "und-u-ka-true" — is invalid, since ‘yes’ is not a valid value for ka
+2. "und-u-ka" — is invalid, since the value “true” is assumed whenever there is no value, and ‘true’ is not a valid value for ka
+
 The BCP 47 form for keys and types is the canonical form, and recommended. Other aliases are included for backwards compatibility.
 
 ##### <a name="Key_Type_Definitions" href="#Key_Type_Definitions">Key/Type Definitions</a>

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -325,8 +325,8 @@ A [`unicode_locale_id`](#unicode_locale_id) has _canonical syntax_ when:
 
 * It starts with a language subtag (those beginning with a script subtag are only for specialized use)
 * Casing
-  * Any script subtag is in title case (eg, Hant)
-  * Any region subtag is in uppercase (eg, DE)
+  * Any script subtag inside unicode_language_id is in title case (eg, Hant)
+  * Any region subtag inside unicode_language_id is in uppercase (eg, DE)
   * All other subtags are in lowercase (eg, en, fonipa)
 * Order
   * Any variants are in alphabetical order (eg, en-fonipa-scouse, not en-scouse-fonipa)
@@ -347,7 +347,9 @@ A [`unicode_locale_id`](#unicode_locale_id) is in _canonical form_ when it has c
 
 A [`unicode_locale_id`](#unicode_locale_id) is _maximal_ when the [`unicode_language_id`](#unicode_language_id) and tlang (if any) have been transformed by the Add Likely Subtags operation in _Section 4.3 [Likely Subtags](#Likely_Subtags)_, excluding "und".
 
-> _Example:_ the maxmal form of ja-Kana-t-it is ja-Kana-JP-t-it-Latn-IT
+> _Example:_ the maxmal form of ja-Kana-t-it is ja-Kana-JP-t-it-latn-it
+
+Note that the _latn_ and final _it_ don't use any uppercase characters, since they are not inside unicode_language_id.  
 
 Two [`unicode_locale_ids`](#unicode_locale_id) are _equivalent_ when their maximal canonical forms are identical.
 
@@ -3515,8 +3517,8 @@ To canonicalize the syntax of _source_:
   * If the first subtag has 4 letters, prepend the source with "und-"
   * Note: These are only for specialized use.
 * Casing
-  * Put any script subtag into title case (eg, Hant)
-  * Put any region subtag int uppercase (eg, DE)
+  * Put any script subtag inside unicode_language_id into title case (eg, Hant)
+  * Put any region subtag inside unicode_language_id int uppercase (eg, DE)
   * Put all other subtags into lowercase (eg, en, fonipa)
 * Order
   * Put any variants into alphabetical order (eg, en-fonipa-scouse, not en-scouse-fonipa)

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1470,22 +1470,23 @@ The locale data does not contain general character properties that are derived f
 <a name="Multiple_Inheritance"></a>
 #### <a name="Lateral_Inheritance" href="#Lateral_Inheritance">4.1.2 Lateral Inheritance</a>
 
-In the following instances, resources may inherit from within the same locale, _before inheriting from the parent_.
+__Lateral Inheritance__ is where resources are inherited from within the same locale, _before inheriting from the parent_. This is used for the following element@attribute instances:
 
-| Element          | Source | Context |
+| Element @Attribute          | Source | Context |
 | ---------------- | ------ | ------- |
-| currency/pattern | currencyFormat   | numberSystem = defaultNumberingSystem, unless otherwise specified*<br/>currencyFormatLength type=none, unless otherwise specified<br/>currencyFormat type="standard", unless otherwise specified |
-| currency/decimal | symbols/decimal  | numberSystem = defaultNumberingSystem, unless otherwise specified |
-| currency/group   | symbols/group    | numberSystem = defaultNumberingSystem, unless otherwise specified |
+| currency @pattern | currencyFormat   | numberSystem = defaultNumberingSystem, unless otherwise specified*<br/>currencyFormatLength type=none, unless otherwise specified<br/>currencyFormat type="standard", unless otherwise specified |
+| currency @decimal | symbols @decimal  | numberSystem = defaultNumberingSystem, unless otherwise specified |
+| currency @group   | symbols @group    | numberSystem = defaultNumberingSystem, unless otherwise specified |
 
-\* The "unless otherwise specified" clause is for when an API or other context indicates a different choice, such as currencyFormat type="accounting".
+>\* The "unless otherwise specified" clause is for when an API or other context indicates a different choice, such as currencyFormat type="accounting".
 
 For example, with /currency [@type="CVE"], the decimal symbol for almost all locales is the value from symbols/decimal, but for pt_CV it is explicitly `<decimal>$</decimal>`.
 
-The following attributes use lateral inheritance for all elements with the DTD root = ldml, except where otherwise noted. The process is applied recursively.
+The following attributes use lateral inheritance for **all elements** with the DTD root = ldml, except where otherwise noted. The process is applied recursively.
 
 | Atttribute | Fallback                               | Exception Elements          |
 | ---------- | -------------------------------------- | --------------------------- |
+| alt        | __no alt attribute__                       | <none>            |
 | case       | "nominative" → ∅                       | caseMinimalPairs            |
 | gender     | default_gender(locale) → ∅            | genderMinimalPairs          |
 | count      | plural_rules(locale, x) → "other" → ∅ | minDays, pluralMinimalPairs |
@@ -1499,9 +1500,9 @@ For example, if there is no value for a path, and that path has a [@count="x"] a
    1. For example, [@count="0"] for English falls back to [@count="other"], while for French falls back to [@count="one"].
 2. If "x" is anything but "other", it falls back to a path [@count="other"], within that the same locale.
 3. If "x" is "other", it falls back to the path that is completely missing the count item, within that the same locale.
-4. If there is no value for that path the same locale, the same process is used for the original path in the parent locale.
+4. If there is no value for that path the same locale, the same process is used for the **original path** in the parent locale.
 
-A path may have multiple attributes with lateral inheritance. In such a case, all of the combinations are tried, and in the order supplied above. For example (this is the very worst case):
+A path may have multiple attributes with lateral inheritance. In such a case, all of the combinations are tried, and in the order supplied above. For example (this is an extreme case):
 
 ```
 /compoundUnitPattern1[@count="few"][@gender="feminine"][@case="accusative">] →
@@ -1548,7 +1549,7 @@ _Examples:_
 | root   | `//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-gram"]/unitPattern[@count="x"]`     |
 | root   | `//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-gram"]/unitPattern[@count="other"]` |
 
-Note that there may be an alias in root that changes the path and starts again from the requested locale, such as:
+> Note that there may also be an alias in root that changes the path and starts again from the requested locale, such as:
 
 ```xml
 <unitLength type="narrow">  
@@ -2520,7 +2521,7 @@ The values for _variantname_ at this time include "variant", "list", "email", "w
 
 For a more complete description of how draft applies to data, see _[Section 4.2 Inheritance and Validity](#Inheritance_and_Validity)_.
 
-Attribute <a name="references_attribute" href="#references_attribute">references</a>
+#### <a name="references_attribute" href="#references_attribute">5.2.4 Attribute references</a>
 
 The value of this attribute is a token representing a reference for the information in the element, including standards that it may conform to. `<references>`. (In older versions of CLDR, the value of the attribute was freeform text. That format is deprecated.)
 

--- a/readme.html
+++ b/readme.html
@@ -12,15 +12,15 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 39</h3>
-    <p>Last updated: 2021-Feb-17</p>
+    <p>Last updated: 2021-Mar-09</p>
 
     <!--<p><b>Note:</b> CLDR 39 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 39, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <p><b>Note:</b> This is a preliminary version of CLDR 39, intended for those wishing to do pre-release testing.
-    It is not recommended for production use.</p>
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 39, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
+    <p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
+    It is not recommended for production use.</p>
     <!--<p>This is the final release version of CLDR 39.</p>-->
     
     <p><strong>Important notes for CLDR 36 and later:</strong></p>

--- a/readme.html
+++ b/readme.html
@@ -12,16 +12,16 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 39</h3>
-    <p>Last updated: 2021-Mar-09</p>
+    <p>Last updated: 2021-Mar-30</p>
 
     <!--<p><b>Note:</b> CLDR 39 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 39, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
     <!--<p><b>Note:</b> This is a preliminary version of CLDR 39, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
-    It is not recommended for production use.</p>
-    <!--<p>This is the final release version of CLDR 39.</p>-->
+    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
+    It is not recommended for production use.</p>-->
+    <p>This is the final release version of CLDR 39.</p>
     
     <p><strong>Important notes for CLDR 36 and later:</strong></p>
     <ul>

--- a/tools/cldr-code/src/license/THIRD-PARTY.properties
+++ b/tools/cldr-code/src/license/THIRD-PARTY.properties
@@ -11,6 +11,6 @@
 # Please fill the missing licenses for dependencies :
 #
 #
-#Fri Feb 19 13:26:13 EST 2021
-com.ibm.icu--utilities-for-cldr--69.1-SNAPSHOT-cldr-2021-02-17=
-com.ibm.icu--icu4j-for-cldr--69.1-SNAPSHOT-cldr-2021-02-17=
+#Tue Mar 09 21:33:58 PST 2021
+com.ibm.icu--icu4j-for-cldr--69.1-SNAPSHOT-cldr-2021-03-09=
+com.ibm.icu--utilities-for-cldr--69.1-SNAPSHOT-cldr-2021-03-09=

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1280,7 +1280,9 @@ public class VettingViewer<T> {
             String localeFound = sourceFile.getSourceLocaleIdExtended(path, status, false /* skipInheritanceMarker */);
             /*
              * Only count it as missing IF the (localeFound is root or codeFallback)
-             * AND the aliasing didn't change the path
+             * AND the aliasing didn't change the path.
+             * Note that localeFound will be where an item with ↑↑↑ was found even though
+             * the value is actually inherited from somewhere else.
              */
             if (localeFound.equals("root") || localeFound.equals(XMLSource.CODE_FALLBACK_ID)) {
                 result = ValuePathStatus.isMissingOk(sourceFile, path, latin, isAliased)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -68,7 +68,7 @@ public class TestCLDRUtils extends TestFmwk {
             .make("fr", true);
 
         checkNames(french, "en_US_POSIX", "anglais américain (informatique)",
-            "anglais [É.-U.] (informatique)",
+            "anglais américain (informatique)", // or "anglais (É.-U., informatique)" if short has priority over dialect
             "anglais (États-Unis, informatique)",
             "anglais (É.-U., informatique)");
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -1379,10 +1379,14 @@ public class TestUtilities extends TestFmwkPlus {
      * Ideally we should also test for MissingStatus.DISPUTED, etc.; that's more difficult
      */
     public void TestMissingStatus() {
-        final String path = "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"volume-barrel\"]/displayName";
+        final String path = "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"volume-cup\"]/displayName";
         final String locale = "fr";
         final CLDRFile cldrFile = testInfo.getCLDRFile(locale, true);
         final MissingStatus expected = MissingStatus.PRESENT;
+        // Note: VettingViewer.getMissingStatus reports PRESENT for items with ↑↑↑ and absent if the item
+        // is removed to inherit from root, even though the value obtained is the same in either case;
+        // so for path pick an item that does not have ↑↑↑, otherwise when that item is stripped for
+        // production data the test will fail.
         final MissingStatus status = VettingViewer.getMissingStatus(cldrFile, path, true /* latin */);
         if (status != expected) {
             errln("Got getMissingStatus = " + status.toString() + "; expected " + expected.toString());

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-SNAPSHOT-cldr-2021-03-09</icu4j.version>
+		<icu4j.version>69.1-SNAPSHOT-release-69-rc</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-SNAPSHOT-cldr-2021-02-17</icu4j.version>
+		<icu4j.version>69.1-SNAPSHOT-cldr-2021-03-09</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>

--- a/tools/scripts/tr-archive/.gitignore
+++ b/tools/scripts/tr-archive/.gitignore
@@ -1,0 +1,4 @@
+/dist
+/reports.css
+/node_modules
+/tr35.zip

--- a/tools/scripts/tr-archive/README.md
+++ b/tools/scripts/tr-archive/README.md
@@ -1,0 +1,29 @@
+# Unicode TR35 archiver
+
+## What this does
+
+- render `../../../docs/ldml/*.md` into `.html`
+- add some CSS and fixup the HTML a little bit
+- The goal is to create .html suitable to end up at, for example, <https://www.unicode.org/reports/tr35/tr35-61/tr35.html>
+
+## Prerequisites
+
+Node.js (Tested with v12)
+
+## How to use
+
+```shell
+$ bash make-tr-archive.sh
+```
+
+You will end up with HTML files under `dist/` and a zipped up `./tr35.zip` archive.
+
+`reports.css` gets downloaded locally so that the relative link ( `../reports.css`) within the HTML will work.
+
+See [../../../README.md](../../../README.md) for full project information.
+
+### Copyright
+
+Copyright &copy; 1991-2021 Unicode, Inc.
+All rights reserved.
+[Terms of use](http://www.unicode.org/copyright.html)

--- a/tools/scripts/tr-archive/archive.js
+++ b/tools/scripts/tr-archive/archive.js
@@ -1,0 +1,90 @@
+const fs = require("fs").promises;
+const marked = require("marked");
+const jsdom = require("jsdom");
+const { JSDOM } = jsdom;
+const path = require("path");
+
+marked.setOptions({
+  renderer: new marked.Renderer(),
+  highlight: function (code, forlanguage) {
+    const hljs = require("highlight.js");
+    language = hljs.getLanguage(forlanguage) ? forlanguage : "plaintext";
+    return hljs.highlight(code, { language }).value;
+  },
+  pedantic: false,
+  gfm: true,
+  breaks: false,
+  sanitize: false,
+  smartLists: true,
+  smartypants: false,
+  xhtml: false,
+});
+
+async function renderit(infile) {
+  console.log(`Reading ${infile}`);
+  basename = path.basename(infile, ".md");
+  const outfile = path.join(path.dirname(infile), `${basename}.html`);
+  let f1 = await fs.readFile(infile, "utf-8");
+  // oh the irony
+  if (f1.charCodeAt(0) == 0xfeff) {
+    f1 = f1.substring(3);
+  }
+
+  // render
+  const rawHtml = marked(f1);
+
+  // now fix
+  const dom = new JSDOM(rawHtml);
+  const document = dom.window.document;
+  const head = dom.window.document.getElementsByTagName("head")[0];
+
+  // add CSS
+  head.innerHTML =
+    head.innerHTML +
+    `<meta charset="utf-8">` +
+    `<link rel='stylesheet' type='text/css' media='screen' href='../reports.css'>`;
+
+  // Move all elements out of the top level body and into a subelement
+  const body = dom.window.document.getElementsByTagName("body")[0];
+  const bp = body.parentNode;
+  div = dom.window.document.createElement("div");
+  div.setAttribute("class", "body");
+  for (const e of body.childNodes) {
+    body.removeChild(e);
+    div.appendChild(e);
+  }
+  body.appendChild(div);
+
+  // now, fix all links from  ….md#…  to ….html#…
+  for (const e of dom.window.document.getElementsByTagName("a")) {
+    const href = e.getAttribute("href");
+    let m;
+    if ((m = /^(.*)\.md#(.*)$/.exec(href))) {
+      e.setAttribute("href", `${m[1]}.html#${m[2]}`);
+    } else if ((m = /^(.*)\.md$/.exec(href))) {
+      e.setAttribute("href", `${m[1]}.html`);
+    }
+  }
+
+  // OK, done munging the DOM, write it out.
+  console.log(`Writing ${outfile}`);
+  await fs.writeFile(outfile, dom.serialize());
+  return outfile;
+}
+
+async function fixall() {
+  outbox = "./dist";
+
+  // TODO: move source file copy into JavaScript?
+  // srcbox = '../../../docs/ldml';
+
+  const fileList = (await fs.readdir(outbox))
+    .filter((f) => /\.md$/.test(f))
+    .map((f) => path.join(outbox, f));
+  return Promise.all(fileList.map(renderit));
+}
+
+fixall().then(
+  (x) => console.dir(x),
+  (e) => console.error(e)
+);

--- a/tools/scripts/tr-archive/make-tr-archive.sh
+++ b/tools/scripts/tr-archive/make-tr-archive.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+npm i
+set -x
+# copy this locally
+if [ ! -f ./reports.css ];
+then
+    wget -c 'https://www.unicode.org/reports/tr35/reports.css'
+fi
+mkdir -p dist
+cp -vR ../../../docs/ldml/ ./dist/
+node archive.js
+zip -r tr35.zip dist/*.html dist/images

--- a/tools/scripts/tr-archive/package-lock.json
+++ b/tools/scripts/tr-archive/package-lock.json
@@ -1,0 +1,718 @@
+{
+  "name": "tr-archive",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+    },
+    "acorn": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA=="
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "highlight.js": {
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg=="
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.2.tgz",
+      "integrity": "sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==",
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.1.0",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "is-potential-custom-element-name": "^1.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.9",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.4",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "marked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw=="
+    },
+    "mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+    },
+    "mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "requires": {
+        "mime-db": "1.47.0"
+      }
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
+    "tr46": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
+    "whatwg-url": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+      "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^6.1.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "ws": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    }
+  }
+}

--- a/tools/scripts/tr-archive/package.json
+++ b/tools/scripts/tr-archive/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tr-archive",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "highlight.js": "^10.7.2",
+    "jsdom": "^16.5.2",
+    "marked": "^2.0.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Steven R. Loomis <srl295@gmail.com>",
+  "license": "Unicode-DFS-2016",
+  "private": true
+}


### PR DESCRIPTION
Hello,

Since Kurdish is a macro language, the dialect must be specified fully.
Currently, Kurdish (ku) is set to Northern Kurdish or Kurdish (Kurmanji), so the language name must also be changed. Fixing this error is very important because tech companies often use incorrect language codes.
*Kurdish (Kurmanji) and Northern Kurdish express the same language.

For more information see;
1- https://translatorswithoutborders.org/wp-content/uploads/2017/07/Kurdish-Factsheet-English.pdf
2- https://iso639-3.sil.org/code/kur

* Example for the problem I mentioned above;
Microsoft Translator uses different language codes than the codes in Unicode. Please check. Incorrect codes are used for Kurdish dialects.  https://docs.microsoft.com/en-us/azure/cognitive-services/translator/language-support
Problems do not occur if the language is specified exactly. For this, "Kurdish" should be changed to Kurdish (Kurmanji) or Northern Kurdish.

Kurdish Crowdsource Team
Thanks.
