### PR TITLE
CLDR-14590 Modernize Ajax; implement cldrVote.isBusy

### DIFF
--- a/tools/cldr-apps/src/main/webapp/js/esm/cldrLoad.js
+++ b/tools/cldr-apps/src/main/webapp/js/esm/cldrLoad.js
@@ -99,12 +99,17 @@ function continueInitializing(canAutoImport) {
 }
 
 function doHashChange(event) {
-  const changedHash = getHash();
-  if (sliceHash(new URL(event.newURL).hash) !== changedHash) {
+  const changedHash = getHash(); // window.location.hash minus "#"
+  if (
+    CLDR_LOAD_DEBUG &&
+    sliceHash(new URL(event.newURL).hash) !== changedHash
+  ) {
+    // This can happen when rapidly clicking on one row after another.
+    // In such cases, window.location.hash is more recent (per testing), so use it.
     console.log(
-      "Error in doHashChange: expected " +
-        event.newURL.hash +
-        " === " +
+      "Mismatch in doHashChange: (event:) " +
+        new URL(event.newURL).hash +
+        " !== (window:) " +
         changedHash
     );
   }
@@ -372,7 +377,7 @@ function scrollToItem() {
     const xtr = document.getElementById("r@" + curId);
     if (xtr) {
       console.log("Scrolling to " + curId);
-      xtr.scrollIntoView({ block: "center" });
+      xtr.scrollIntoView({ block: "nearest" });
     }
   }
 }

--- a/tools/cldr-apps/src/main/webapp/js/esm/cldrOldVotes.js
+++ b/tools/cldr-apps/src/main/webapp/js/esm/cldrOldVotes.js
@@ -8,6 +8,7 @@ import * as cldrRetry from "./cldrRetry.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
 import * as cldrText from "./cldrText.js";
+import * as cldrVote from "./cldrVote.js";
 
 // called as special.load
 function load() {
@@ -407,13 +408,13 @@ function showVoteTable(voteList, type, json) {
     tr.appendChild(td00);
     var td0 = cldrDom.createChunk("", "td", "v-win");
     if (row.winValue) {
-      var span0 = cldrSurvey.appendItem(td0, row.winValue, "winner");
+      var span0 = cldrVote.appendItem(td0, row.winValue, "winner");
       span0.dir = dir;
     }
     tr.appendChild(td0);
     var td1 = cldrDom.createChunk("", "td", "v-mine");
     var label = cldrDom.createChunk("", "label", "");
-    var span1 = cldrSurvey.appendItem(label, row.myValue, "value");
+    var span1 = cldrVote.appendItem(label, row.myValue, "value");
     td1.appendChild(label);
     span1.dir = dir;
     tr.appendChild(td1);


### PR DESCRIPTION
-New function cldrVote.isBusy replaces stub cldrVote.pending

-Use both timer and pending count for cldrVote.isBusy

-Move more code from cldrSurvey.js to cldrVote.js, or to cldrTable.js

-Fix scrollToItem to use nearest not middle; avoid scrolling if already visible

-Revise log message in doHashChange, make contingent on CLDR_LOAD_DEBUG

-Comments

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14590
- [x] Updated PR title and link in previous line to include Issue number

