### PR TITLE
CLDR-14461 bump ICU4J level to the ICU 69RC

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-SNAPSHOT-cldr-2021-03-09</icu4j.version>
+		<icu4j.version>69.1-SNAPSHOT-release-69-rc</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>


### PR DESCRIPTION
Note: this is on the maint branch only.
CLDR 40 can update to release 69 when available.