### PR TITLE
CLDR-14377 Clarify use of the implicit "true"

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -653,6 +653,11 @@ For the complete list of valid keys and types defined for Unicode locale extensi
 
 Most type values are represented by a single subtag in the current version of CLDR. There are exceptions, such as types used for key "ca" (calendar) and "kr" (collation reordering). If the type is not included, then the type value "true" is assumed. Note that the default for key with a possible "true" value is often "false", but may not always be. Note also that "true"/"True" is not a valid script code, since [the ISO 15924 Registration Authority has exceptionally reserved it](https://www.unicode.org/iso15924/codelists.html), which means that it will not be assigned for any purpose.
 
+Note that canonicalization does not change invalid locales to valid locales. For example, und-u-ka canonicalizes to und-u-ka-true, but:
+
+1. "und-u-ka-true" — is invalid, since ‘yes’ is not a valid value for ka
+2. "und-u-ka" — is invalid, since the value “true” is assumed whenever there is no value, and ‘true’ is not a valid value for ka
+
 The BCP 47 form for keys and types is the canonical form, and recommended. Other aliases are included for backwards compatibility.
 
 ##### <a name="Key_Type_Definitions" href="#Key_Type_Definitions">Key/Type Definitions</a>


### PR DESCRIPTION
Make it clear that canonicalization does not 'fix' invalid key values.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14377
- [ ] Updated PR title and link in previous line to include Issue number

