### PR TITLE
CLDR-14330 only uppercase characters inside unicode_language_id

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -325,8 +325,8 @@ A [`unicode_locale_id`](#unicode_locale_id) has _canonical syntax_ when:
 
 * It starts with a language subtag (those beginning with a script subtag are only for specialized use)
 * Casing
-  * Any script subtag is in title case (eg, Hant)
-  * Any region subtag is in uppercase (eg, DE)
+  * Any script subtag inside unicode_language_id is in title case (eg, Hant)
+  * Any region subtag inside unicode_language_id is in uppercase (eg, DE)
   * All other subtags are in lowercase (eg, en, fonipa)
 * Order
   * Any variants are in alphabetical order (eg, en-fonipa-scouse, not en-scouse-fonipa)
@@ -347,7 +347,9 @@ A [`unicode_locale_id`](#unicode_locale_id) is in _canonical form_ when it has c
 
 A [`unicode_locale_id`](#unicode_locale_id) is _maximal_ when the [`unicode_language_id`](#unicode_language_id) and tlang (if any) have been transformed by the Add Likely Subtags operation in _Section 4.3 [Likely Subtags](#Likely_Subtags)_, excluding "und".
 
-> _Example:_ the maxmal form of ja-Kana-t-it is ja-Kana-JP-t-it-Latn-IT
+> _Example:_ the maxmal form of ja-Kana-t-it is ja-Kana-JP-t-it-latn-it
+
+Note that the _latn_ and final _it_ don't use any uppercase characters, since they are not inside unicode_language_id.  
 
 Two [`unicode_locale_ids`](#unicode_locale_id) are _equivalent_ when their maximal canonical forms are identical.
 
@@ -3525,8 +3527,8 @@ To canonicalize the syntax of _source_:
   * If the first subtag has 4 letters, prepend the source with "und-"
   * Note: These are only for specialized use.
 * Casing
-  * Put any script subtag into title case (eg, Hant)
-  * Put any region subtag int uppercase (eg, DE)
+  * Put any script subtag inside unicode_language_id into title case (eg, Hant)
+  * Put any region subtag inside unicode_language_id int uppercase (eg, DE)
   * Put all other subtags into lowercase (eg, en, fonipa)
 * Order
   * Put any variants into alphabetical order (eg, en-fonipa-scouse, not en-scouse-fonipa)


### PR DESCRIPTION
There should not be any uppercase characters in the canonical form of a unicode locale id except inside unicode_language_id

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14330
- [ ] Updated PR title and link in previous line to include Issue number

