### PR TITLE
CLDR-14320 clarify ordering of keys in extensions

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3533,7 +3533,7 @@ To canonicalize the syntax of _source_:
   * Put any extensions into alphabetical order by their singleton (eg, en-t-xxx-u-yyy, not en-u-yyy-t-xxx)
   * Put all attributes into alphabetical order.
   * Put all ufields (<ukey, uvalue>) and tfields (<tkey, tvalue>) into alphabetical order according to their keys (ukey or tkey), within their respective extensions.
-  * Remove any uvalue (aka type) or tvalue of "true"
+  * Remove any uvalue (aka type) equal to "true"
 * Separator
   * Replace '\_' by '-'
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3533,7 +3533,7 @@ To canonicalize the syntax of _source_:
   * Put any extensions into alphabetical order by their singleton (eg, en-t-xxx-u-yyy, not en-u-yyy-t-xxx)
   * Put all attributes into alphabetical order.
   * Put all ufields (<ukey, uvalue>) and tfields (<tkey, tvalue>) into alphabetical order according to their keys (ukey or tkey), within their respective extensions.
-  * Remove any uvalue (aka type) equal to "true"
+  * Remove any uvalue (aka type) equal to "true". Note that "true" values cannot be removed from tvalues.
 * Separator
   * Replace '\_' by '-'
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -291,13 +291,13 @@ As is often the case, the complete syntactic constraints are not easily captured
 
 |                                                                                                       | EBNF                                            | Validity / Comments |
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------- |
-| <a name="unicode_locale_id" href="#unicode_locale_id">`unicode_locale_id`</a>                         | `= unicode_language_id`<br/>`  extensions*`<br/>`  pu_extensions? ;` |
+| <a name="unicode_locale_id" href="#unicode_locale_id">`unicode_locale_id`</a>                         | `= unicode_language_id`<br/>  `extensions*`<br/>  `pu_extensions? ;` |
 | <a name="extensions" href="#extensions">`extensions`</a>                                              | `= unicode_locale_extensions`<br/>`\| transformed_extensions`<br/>` \| other_extensions ;` |
-| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>`  ((sep keyword)+`<br/>`  \|(sep attribute)+ (sep keyword)*) ;` |
-| <a name="transformed_extensions" href="#transformed_extensions">`transformed_extensions`</a>          | `= sep [tT]`<br/>`  ((sep tlang (sep tfield)*)`<br/>`  \| (sep tfield)+) ;` |
+| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>  `((sep keyword)+`<br/>  `\|(sep attribute)+ (sep keyword)*) ;` |
+| <a name="transformed_extensions" href="#transformed_extensions">`transformed_extensions`</a>          | `= sep [tT]`<br/>  `((sep tlang (sep tfield)*)`<br/>  `\| (sep tfield)+) ;` |
 | <a name="pu_extensions" href="#pu_extensions">`pu_extensions`</a>                                     | `= sep [xX]`<br/>`  (sep alphanum{1,8})+ ;` |
 | <a name="other_extensions" href="#other_extensions">`other_extensions`</a>                            | `= sep [alphanum-[tTuUxX]]`<br/>`  (sep alphanum{2,8})+ ;` |
-| `keyword`<br/>(Also known as `uvalue`)                                                                | `= key (sep type)? ;` |
+| `keyword`<br/>(Also known as `ufield`)                                                                | `= key (sep type)? ;` |
 | `key`<br/>(Also known as `ukey`)                                                                      | `= alphanum alpha ;`<br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with tkey.) | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47) |
 | `type`<br/>(Also known as `uvalue`)                                                                   | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-38/common/bcp47) |
 | `attribute`                                                                                           | `= alphanum{3,8} ;` |
@@ -3532,8 +3532,8 @@ To canonicalize the syntax of _source_:
   * Put any variants into alphabetical order (eg, en-fonipa-scouse, not en-scouse-fonipa)
   * Put any extensions into alphabetical order by their singleton (eg, en-t-xxx-u-yyy, not en-u-yyy-t-xxx)
   * Put all attributes into alphabetical order.
-  * Put all <keywords, tfields> pairs into alphabetical order of their keys, within their respective extensions.
-  * Remove any type or tfield value of "true"
+  * Put all ufields (<ukey, uvalue>) and tfields (<tkey, tvalue>) into alphabetical order according to their keys (ukey or tkey), within their respective extensions.
+  * Remove any uvalue (aka type) or tvalue of "true"
 * Separator
   * Replace '\_' by '-'
 


### PR DESCRIPTION
Also fixes typo in the BNF for 'keyword'

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14320
- [ ] Updated PR title and link in previous line to include Issue number

