### PR TITLE
CLDR-14445 Minor improvements from review of first markdown version of Dates

### DIFF
--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -57,6 +57,7 @@ The LDML specification is divided into the following parts:
     *   4.1 [Calendar Data](#Calendar_Data)
     *   4.2 [Calendar Preference Data](#Calendar_Preference_Data)
     *   4.3 [Week Data](#Week_Data)
+        *   Table: [Week Designation Types](#Week_Designation_Types)
     *   4.4 [Time Data](#Time_Data)
     *   4.5 [Day Period Rule Sets](#Day_Period_Rule_Sets)
         *   4.5.1 [Day Period Rules](#Day_Period_Rules)
@@ -1196,7 +1197,7 @@ For examples, see [Day Periods Chart](https://unicode-org.github.io/cldr-staging
 
 The time zone IDs (tzid) are language-independent, and follow the _TZ time zone database_ [[Olson](tr35.md#Olson)] and naming conventions. However, the display names for those IDs can vary by locale. The generic time is so-called _wall-time_; what clocks use when they are correctly switched from standard to daylight time at the mandated time of the year.
 
-Unfortunately, the canonical tzid's (those in zone.tab) are not stable: may change in each release of the _TZ_ Time Zone database. In CLDR, however, stability of identifiers is very important. So the canonical IDs in CLDR are kept stable as described in [Canonical Form](tr35.md#Canonical_Form).
+Unfortunately, the canonical tzid's (those in zone.tab) are not stable: they may change in each release of the _TZ_ Time Zone database. In CLDR, however, stability of identifiers is very important. So the canonical IDs in CLDR are kept stable as described in [Canonical Form](tr35.md#Canonical_Form).
 
 The _TZ time zone database_ can have multiple IDs that refer to the same entity. It does contain information on equivalence relationships between these IDs, such as "Asia/Calcutta" and "Asia/Kolkata". It does not remove IDs (with a few known exceptions), but it may change the "canonical" ID which is in the file zone.tab.
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14445
- [x] Updated PR title and link in previous line to include Issue number

(This replaces https://github.com/unicode-org/cldr/pull/1141 which did the same thing but was abandoned after an attempt to rebase got messed up)

Just a couple of minor improvements found while reviewing the markdown conversion of the Dates section; these are not actually connected to the conversion itself (missing TOC entry for a table, missing word).

Note that there is a separate issue about table captions, I have not made any changes for those here; it is covered by https://unicode-org.atlassian.net/browse/CLDR-14611
