### PR TITLE
CLDR-14557 Modernize Look Up: disable What Is; various improvements

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAjax.js
+++ b/tools/cldr-apps/js/src/esm/cldrAjax.js
@@ -6,41 +6,6 @@ import * as cldrStatus from "./cldrStatus.js";
 const ST_AJAX_DEBUG = true;
 
 /**
- * Run the load handler (load2)
- *
- * @param xhrArgs the request parameters plus such things as xhrArgs.load2
- * @param data the data (typically json)
- */
-function myLoad0(xhrArgs, data) {
-  if (ST_AJAX_DEBUG) {
-    xhrArgs.stopTime = new Date().getTime();
-    xhrArgs.tookTime = xhrArgs.stopTime - xhrArgs.startTime;
-    console.log(
-      "PXQ(" + queueOfXhr.length + "): time took= " + xhrArgs.tookTime
-    );
-    console.log("myLoad0!:" + xhrArgs.url);
-  }
-  if (xhrArgs.load2) {
-    xhrArgs.load2(data);
-  }
-}
-
-/**
- * Run the error handler (err2)
- *
- * @param xhrArgs the request parameters plus such things as xhrArgs.err2
- * @param err the error-message string
- */
-function myErr0(xhrArgs, err) {
-  if (ST_AJAX_DEBUG) {
-    console.log("myErr0!:" + xhrArgs.url);
-  }
-  if (xhrArgs.err2) {
-    xhrArgs.err2(err);
-  }
-}
-
-/**
  * Send a request
  *
  * It will be a GET *unless* either postData or content are set.

--- a/tools/cldr-apps/js/src/views/AddUser.vue
+++ b/tools/cldr-apps/js/src/views/AddUser.vue
@@ -1,103 +1,105 @@
 <template>
-  <a-spin v-if="loading" :delay="500" />
-  <div v-if="errors.length">
-    <span class="addUserErrors">Please correct the following error(s):</span>
-    <ul>
-      <li v-for="error in errors">{{ error }}</li>
-    </ul>
-  </div>
-  <div v-if="!loading && !addedNewUser" class="adduser">
-    <h2>Add User</h2>
-    <table>
-      <tr>
-        <th><label for="new_name">Name:</label></th>
-        <td>
-          <input
-            size="40"
-            id="new_name"
-            name="new_name"
-            v-model="newUser.name"
-          />
-        </td>
-      </tr>
-      <tr>
-        <th><label for="new_email">E-mail:</label></th>
-        <td>
-          <input
-            size="40"
-            id="new_email"
-            name="new_email"
-            v-model="newUser.email"
-            type="email"
-          />
-        </td>
-      </tr>
-      <tr>
-        <th><label for="new_org">Organization:</label></th>
-        <td v-if="canChooseOrg">
-          <select id="new_org" name="new_org" v-model="newUser.org">
-            <option disabled value="">Please select one</option>
-            <option v-for="org in orgList">{{ org }}</option>
-          </select>
-        </td>
-        <td v-else>
-          <input id="new_org" disabled="disabled" v-model="newUser.org" />
-        </td>
-      </tr>
-      <tr>
-        <th><label for="new_level">User level:</label></th>
-        <td>
-          <select id="new_level" name="new_level" v-model="newUser.level">
-            <option disabled value="">Please select one</option>
-            <option
-              v-for="(v, number) in levelList"
-              v-bind:value="number"
-              :disabled="!v.canCreateOrSetLevelTo"
-            >
-              {{ v.string }}
-            </option>
-          </select>
-        </td>
-      </tr>
-      <tr>
-        <th><label for="new_locales">Languages responsible:</label></th>
-        <td>
-          <input
-            id="new_locales"
-            name="new_locales"
-            v-model="newUser.locales"
-          />
-          <button v-on:click="setAllLocales()">All Locales</button><br />
-          (Space separated. Examples: "en de de_CH fr zh_Hant". Use the All
-          Locales button to grant access to all locales. )
-        </td>
-      </tr>
-      <tr class="addButton">
-        <td colspan="2"><button v-on:click="add()">Add</button></td>
-      </tr>
-    </table>
-  </div>
+  <article>
+    <a-spin v-if="loading" :delay="500" />
+    <div v-if="errors.length">
+      <span class="addUserErrors">Please correct the following error(s):</span>
+      <ul>
+        <li v-for="error in errors">{{ error }}</li>
+      </ul>
+    </div>
+    <div v-if="!loading && !addedNewUser" class="adduser">
+      <h2>Add User</h2>
+      <table>
+        <tr>
+          <th><label for="new_name">Name:</label></th>
+          <td>
+            <input
+              size="40"
+              id="new_name"
+              name="new_name"
+              v-model="newUser.name"
+            />
+          </td>
+        </tr>
+        <tr>
+          <th><label for="new_email">E-mail:</label></th>
+          <td>
+            <input
+              size="40"
+              id="new_email"
+              name="new_email"
+              v-model="newUser.email"
+              type="email"
+            />
+          </td>
+        </tr>
+        <tr>
+          <th><label for="new_org">Organization:</label></th>
+          <td v-if="canChooseOrg">
+            <select id="new_org" name="new_org" v-model="newUser.org">
+              <option disabled value="">Please select one</option>
+              <option v-for="org in orgList">{{ org }}</option>
+            </select>
+          </td>
+          <td v-else>
+            <input id="new_org" disabled="disabled" v-model="newUser.org" />
+          </td>
+        </tr>
+        <tr>
+          <th><label for="new_level">User level:</label></th>
+          <td>
+            <select id="new_level" name="new_level" v-model="newUser.level">
+              <option disabled value="">Please select one</option>
+              <option
+                v-for="(v, number) in levelList"
+                v-bind:value="number"
+                :disabled="!v.canCreateOrSetLevelTo"
+              >
+                {{ v.string }}
+              </option>
+            </select>
+          </td>
+        </tr>
+        <tr>
+          <th><label for="new_locales">Languages responsible:</label></th>
+          <td>
+            <input
+              id="new_locales"
+              name="new_locales"
+              v-model="newUser.locales"
+            />
+            <button v-on:click="setAllLocales()">All Locales</button><br />
+            (Space separated. Examples: "en de de_CH fr zh_Hant". Use the All
+            Locales button to grant access to all locales. )
+          </td>
+        </tr>
+        <tr class="addButton">
+          <td colspan="2"><button v-on:click="add()">Add</button></td>
+        </tr>
+      </table>
+    </div>
 
-  <div v-if="addedNewUser">
-    <h2>Added User</h2>
-    <p>
-      ✅ The new user was added. Name: <kbd>{{ newUser.name }}</kbd> E-mail:
-      <kbd>{{ newUser.email }}</kbd> ID:
-      <kbd>{{ userId }}</kbd>
-    </p>
-    <p>
-      ⚠️ <em>The password is not sent to the user automatically!</em> You must
-      click the <em>Manage this user</em> button and choose
-      <em>Send password</em> from the menu.
-    </p>
-    <p>
-      <button class="manageButton" v-on:click="manageThisUser()">
-        Manage this user
-      </button>
-    </p>
-    <hr />
-    <p><button v-on:click="initializeData()">Add another user</button></p>
-  </div>
+    <div v-if="addedNewUser">
+      <h2>Added User</h2>
+      <p>
+        ✅ The new user was added. Name: <kbd>{{ newUser.name }}</kbd> E-mail:
+        <kbd>{{ newUser.email }}</kbd> ID:
+        <kbd>{{ userId }}</kbd>
+      </p>
+      <p>
+        ⚠️ <em>The password is not sent to the user automatically!</em> You must
+        click the <em>Manage this user</em> button and choose
+        <em>Send password</em> from the menu.
+      </p>
+      <p>
+        <button class="manageButton" v-on:click="manageThisUser()">
+          Manage this user
+        </button>
+      </p>
+      <hr />
+      <p><button v-on:click="initializeData()">Add another user</button></p>
+    </div>
+  </article>
 </template>
 
 <script>

--- a/tools/cldr-apps/js/src/views/GearMenu.vue
+++ b/tools/cldr-apps/js/src/views/GearMenu.vue
@@ -102,7 +102,7 @@
         <li><a href="#about">About</a></li>
       </ul>
     </li>
-    <li v-if="canLookup">
+    <li v-if="loggedIn">
       <ul>
         <li><a href="#lookup">Look up a code or xpath</a></li>
       </ul>
@@ -124,7 +124,6 @@ export default {
       accountLocked: false,
       canImportOldVotes: false,
       canListUsers: false,
-      canLookup: false,
       canMonitorVetting: false,
       canUseVettingSummary: false,
       isAdmin: false,
@@ -147,7 +146,6 @@ export default {
       this.canImportOldVotes = perm && perm.userCanImportOldVotes;
       this.canListUsers = this.canMonitorVetting =
         perm && (perm.userIsTC || perm.userIsVetter);
-      this.canLookup = perm && perm.hasDataSource;
       this.canMonitorForum = perm && perm.userCanMonitorForum;
       this.canUseVettingSummary = perm && perm.userCanUseVettingSummary;
       this.isAdmin = perm && perm.userIsAdmin;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
@@ -107,7 +107,15 @@ public class XPathAPI {
 
         // the actual implementation
         XPathTable xpt = getXPathTable();
-        final String xpath = xpt.getByStringID(hexId);
+        String xpath = null;
+        try {
+            xpath = xpt.getByStringID(hexId);
+        } catch (RuntimeException e) {
+            /*
+             * Don't report the exception. This happens when it simply wasn't found.
+             * Possibly getByStringID, or some version of it, should not throw an exception.
+             */
+        }
         if (xpath == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity(new STError("XPath " + hexId + " not found"))
@@ -140,9 +148,16 @@ public class XPathAPI {
     public Response getByDecimal(
         @Parameter(required = true, example = "5678", schema = @Schema(type = SchemaType.INTEGER)) @PathParam("decId") int decId) {
 
-        // the actual implementation
         XPathTable xpt = getXPathTable();
-        final String xpath = xpt.getById(decId);
+        String xpath = null;
+        try {
+            xpath = xpt.getById(decId);
+        } catch (RuntimeException e) {
+            /*
+             * Don't report the exception. This happens when it simply wasn't found.
+             * Possibly getById, or some version of it, should not throw an exception.
+             */
+        }
         if (xpath == null) {
             return Response.status(Response.Status.NOT_FOUND)
                 .entity(new STError("XPath #" + decId + " not found"))


### PR DESCRIPTION
-Back end WhatisResponse.java not serializing to json yet with Open Liberty

-Slow response was already a problem; long-running What Is task should have progress bar

-Show Look up... in the menu for any logged-in user

-Catch exceptions thrown for path not found, avoid useless log messages

-Make more user-friendly message Not Found instead of Status 404...

-Use cldrAjax.makeApiUrl for encapsulation

-Delete dead code from cldrAjax

-Fix Vue browser warning Extraneous non-props: add top-level article tags in 2 templates

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14557
- [x] Updated PR title and link in previous line to include Issue number

