### PR TITLE
CLDR-14646 az_Cyrl spelling error, Latin K over Cyrillic K

### DIFF
--- a/common/main/az_Cyrl.xml
+++ b/common/main/az_Cyrl.xml
@@ -482,7 +482,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG">Конго-Браззавил</territory>
 			<territory type="CG" alt="variant">Конго (Республика)</territory>
 			<territory type="CH">Исвечрә</territory>
-			<territory type="CI">Kотд’ивуар</territory>
+			<territory type="CI">Котд’ивуар</territory>
 			<territory type="CK">Кук адалары</territory>
 			<territory type="CL">Чили</territory>
 			<territory type="CM">Камерун</territory>


### PR DESCRIPTION
- [X] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14646

`<territory type="CI">Kотд’ивуар</territory>` is using a Latin K when all other cases using a Cyrillic K

