### PR TITLE
CLDR-14651 fix charts for /trunk/ in link problem, grammatical forms

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -37,7 +37,7 @@ import com.ibm.icu.util.ULocale;
 
 public class ChartAnnotations extends Chart {
 
-    private static final String LDML_ANNOTATIONS = "<a href='http://unicode.org/repos/cldr/trunk/specs/ldml/tr35-general.html#Annotations'>LDML Annotations</a>";
+    private static final String LDML_ANNOTATIONS = "<a href='https://unicode.org/reports/tr35/tr35-general.html#Annotations'>LDML Annotations</a>";
 
     private static final String MAIN_HEADER = "<p>Annotations provide names and keywords for Unicode characters, currently focusing on emoji. "
         + "If you see any problems, please <a target='_blank' href='"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
@@ -36,7 +36,7 @@ public class ChartDayPeriods extends Chart {
             + "The following shows the ones that can be used as selectors in messages. "
             + "The first column has a language group to collect languages together that are more likely to have similar day periods. "
             + "For more information, see: "
-            + "<a href='http://unicode.org/repos/cldr/trunk/specs/ldml/tr35-dates.html#Day_Period_Rule_Sets'>Day Period Rules</a>. "
+            + "<a href='https://unicode.org/reports/tr35/tr35-dates.html#Day_Period_Rule_Sets'>Day Period Rules</a>. "
             + "The latest release data for this chart is in "
             + "<a href='http://unicode.org/cldr/latest/common/supplemental/dayPeriods.xml'>dayPeriods.xml</a>.<p>";
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateAllCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateAllCharts.java
@@ -8,6 +8,10 @@ import org.unicode.cldr.util.VerifyZones;
 
 /**
  * Use -DCHART_VERSION=38.1 (for example) to get a specific version
+ * Plus options
+ * -DCHART_STATUS=beta (default, uses trunk, calls it β)
+ * -DCHART_STATUS=trunk (uses trunk, no β. Used at the end of the release, but before the final data is in cldr-archive)
+ * -DCHART_STATUS=release (only uses the cldr-archive, no β)
  * @author markdavis
  *
  */

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -349,7 +349,7 @@ public class GenerateTransformCharts {
             + "These charts do not show the available script and language transliterations that are not to/from Latin. "
             + "It also does not show other transforms that are available in CLDR, such as the casing transformations, "
             + "full-width and half-width transformations, and specialized transformations such as IPA-XSampa. "
-            + "For the latest snapshot of the data files, see <a href='http://unicode.org/repos/cldr/trunk/common/transforms/'>Transform XML Data</a>. "
+            + "For the latest snapshot of the data files, see <a href='https://github.com/unicode-org/cldr/tree/master/common/transforms'>Transform XML Data</a>. "
             + "For more information, see below.</blockquote>");
         index.flush();
         index.println("<ul>");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
@@ -2,6 +2,7 @@ package org.unicode.cldr.tool;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
@@ -59,17 +60,23 @@ public class ToolConstants {
         "36.1",
         "37.0",
         "38.0",
-        "38.1"
+        "38.1",
+        "39.0"
         // add to this once the release is final!
         );
-    public static final String DEV_VERSION = "39";
+    public static final List<VersionInfo> CLDR_VERSIONS_VI = CLDR_VERSIONS.stream()
+        .map(x -> VersionInfo.getInstance(x))
+        .collect(Collectors.toUnmodifiableList());
+
+    public static final String DEV_VERSION = "40";
+    public static final VersionInfo DEV_VERSION_VI = VersionInfo.getInstance(DEV_VERSION);
 
     public static final Set<String> CLDR_RELEASE_VERSION_SET = ImmutableSet.copyOf(ToolConstants.CLDR_VERSIONS);
     public static final Set<String> CLDR_RELEASE_AND_DEV_VERSION_SET = ImmutableSet.<String>builder().addAll(CLDR_RELEASE_VERSION_SET).add(DEV_VERSION).build();
 
-    public static String previousVersion(String version) {
-        String last = "";
-        for (String current : CLDR_VERSIONS) {
+    public static VersionInfo previousVersion(VersionInfo version) {
+        VersionInfo last = null;
+        for (VersionInfo current : CLDR_VERSIONS_VI) {
             if (current.equals(version)) {
                 break;
             }
@@ -77,27 +84,40 @@ public class ToolConstants {
         }
         return last;
     }
+    public static String previousVersion(String version, int minFields) {
+        VersionInfo result = previousVersion(VersionInfo.getInstance(version));
+        return result.getVersionString(minFields, 2);
+    }
+    public static String previousVersion(String version) {
+        return previousVersion(version, 2);
+    }
 
-    public static String getBaseDirectory(String version) {
-        if (version.equals(DEV_VERSION) || version.equals(DEV_VERSION + ".0")) {
+    public static String getBaseDirectory(VersionInfo vi) {
+        if (vi.equals(DEV_VERSION_VI)) {
             return CLDRPaths.BASE_DIRECTORY;
-        } else if (CLDR_RELEASE_VERSION_SET.contains(version)) {
-            return CLDRPaths.ARCHIVE_DIRECTORY + "cldr-" + version + "/";
+        } else if (CLDR_VERSIONS_VI.contains(vi)) {
+            return CLDRPaths.ARCHIVE_DIRECTORY + "cldr-" + vi.getVersionString(2, 2) + "/";
         } else {
-            throw new IllegalArgumentException("not a known version: " + version);
+            throw new IllegalArgumentException("not a known version: " + vi.getVersionString(2, 2)
+                + ", must be in: " + CLDR_VERSIONS_VI);
         }
+    }
+    public static String getBaseDirectory(String version) {
+        VersionInfo vi = VersionInfo.getInstance(version);
+        return getBaseDirectory(vi);
     }
 
     // allows overriding with -D
-    public static final String CHART_VERSION = CldrUtility.getProperty("CHART_VERSION", DEV_VERSION);
-    public static final VersionInfo CHART_VI = VersionInfo.getInstance(CHART_VERSION);
+    public static final VersionInfo CHART_VI = VersionInfo.getInstance(CldrUtility.getProperty("CHART_VERSION", DEV_VERSION));
+    public static final String CHART_VERSION = CHART_VI.getVersionString(1, 2);
 
-    public static final String PREV_CHART_VERSION = CldrUtility.getProperty("PREV_CHART_VERSION", previousVersion(CHART_VERSION));
-    public static final VersionInfo PREV_CHART_VI = VersionInfo.getInstance(PREV_CHART_VERSION);
+    public static final String PREV_CHART_VERSION_RAW = CldrUtility.getProperty("PREV_CHART_VERSION", previousVersion(CHART_VERSION));
+    public static final VersionInfo PREV_CHART_VI = VersionInfo.getInstance(PREV_CHART_VERSION_RAW);
+    public static final String PREV_CHART_VERSION = PREV_CHART_VI.getVersionString(1, 2);
     public static final String PREV_CHART_VERSION_WITH0 = PREV_CHART_VI.getVersionString(2, 2); // must have 1 decimal
 
     public static final ChartStatus CHART_STATUS = ChartStatus.valueOf(CldrUtility.getProperty("CHART_STATUS",
-        CLDR_RELEASE_VERSION_SET.contains(CHART_VERSION)
+        CLDR_VERSIONS_VI.contains(CHART_VI)
         ? "release"
             : "beta"));
     public static final boolean BETA = CHART_STATUS == ChartStatus.beta;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
@@ -64,9 +64,9 @@ public class ToolConstants {
         "39.0"
         // add to this once the release is final!
         );
-    public static final List<VersionInfo> CLDR_VERSIONS_VI = CLDR_VERSIONS.stream()
+    public static final Set<VersionInfo> CLDR_VERSIONS_VI = ImmutableSet.copyOf(CLDR_VERSIONS.stream()
         .map(x -> VersionInfo.getInstance(x))
-        .collect(Collectors.toUnmodifiableList());
+        .collect(Collectors.toList()));
 
     public static final String DEV_VERSION = "40";
     public static final VersionInfo DEV_VERSION_VI = VersionInfo.getInstance(DEV_VERSION);

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/GenerateScriptMetadata.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/GenerateScriptMetadata.txt
@@ -53,5 +53,5 @@
 # Such scripts are marked with a "provisional" comment.
 #
 # Note: For the most likely language for each script, see 
-#		http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/likely_subtags.html
+#		https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/likely_subtags.html
 #

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -57,7 +57,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.impl.Row.R3;
-import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.Output;
 
 public class TestAttributeValues extends TestFmwk {
@@ -205,8 +204,7 @@ public class TestAttributeValues extends TestFmwk {
                 throw (IllegalArgumentException) new IllegalArgumentException(" at " + r.getLocation()).initCause(e);
             }
         } catch (Exception e) {
-            System.err.println("Exception occured in " + fullFile + " after parsing " + lastElement);
-            throw new ICUException(fullFile, e);
+            errln("Exception occured in " + fullFile + " after parsing " + lastElement);
         }
         pathChecker.elementCount.addAndGet(_elementCount);
         pathChecker.attributeCount.addAndGet(_attributeCount);


### PR DESCRIPTION
NOTE: code changes are in v40, but the data is for v39 and the charts for v39 also.

The biggest number of changes was in ToolConstants, where I put in some extra code to distinguish the two ways that we use the version numbers in folder/file names. eg cldr-39.0 vs cldr-39 

Second biggest was in ChartGrammatical forms. I'd done this earlier, but never committed the changes.

(longer term fix would be to only use one style)

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-14651
- [ ] Updated PR title and link in previous line to include Issue number

