### PR TITLE
CLDR-14395 Improve ST Login

### DIFF
--- a/tools/cldr-apps/js/src/cldrVueRouter.js
+++ b/tools/cldr-apps/js/src/cldrVueRouter.js
@@ -6,7 +6,15 @@ import { getCldrOpts } from "./getCldrOpts";
 
 // components. See index.js for css imports.
 // example: import {SomeComponent} from 'whatever'
-import { Spin } from "ant-design-vue";
+import {
+  Popover,
+  Spin,
+  Form,
+  Icon,
+  Input,
+  Button,
+  Checkbox,
+} from "ant-design-vue";
 
 // local components
 import CldrValue from "./views/CldrValue.vue";
@@ -59,7 +67,7 @@ function handleCoverageChanged(newLevel) {
  * @param {Object} extraProps data to pass through as global properties
  * @returns {App} the App object
  */
-function createCldrApp(component, specialPage, cldrOpts, extraProps) {
+function createCldrApp(component, specialPage, extraProps) {
   const app = createApp(component, extraProps || {});
 
   // These are available on all components.
@@ -98,9 +106,18 @@ function show(component, el, specialPage, extraProps) {
 function setupComponents(app) {
   // example:
   // app.component('SomeComponent', SomeComponent)
+  // Keep this list sorted
+  app.component("a-button", Button);
+  app.component("a-checkbox", Checkbox);
+  app.component("a-form-item", Form.Item);
+  app.component("a-form", Form);
+  app.component("a-icon", Icon);
+  app.component("a-input-password", Input.Password);
+  app.component("a-input", Input);
   app.component("a-spin", Spin);
-  app.component("cldr-value", CldrValue);
   app.component("cldr-loginbutton", LoginButton);
+  app.component("cldr-value", CldrValue);
+  app.component("Popover", Popover);
 }
 
 export { showPanel, handleCoverageChanged, createCldrApp, setupComponents };

--- a/tools/cldr-apps/js/src/esm/cldrAccount.js
+++ b/tools/cldr-apps/js/src/esm/cldrAccount.js
@@ -1148,7 +1148,7 @@ function needOrgList() {
 function getLoginUrl(email, password) {
   const p = new URLSearchParams();
   p.append("email", email);
-  p.append("uid", password);
+  p.append("pw", password);
   // CAUTION: this is /survey not /SurveyAjax -- don't use cldrAjax.makeUrl until this is changed
   return cldrStatus.getContextPath() + "/survey?" + p.toString();
 }

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -75,12 +75,12 @@ function showV() {
    * Arrange for getInitialMenusEtc to be called soon after we've gotten the session id.
    * Add a short timeout to avoid interrupting the code that sets the session id.
    */
-  cldrStatus.setSessionIdChangeCallback(function (sessionId) {
+  cldrStatus.on("sessionId", () =>
     setTimeout(function () {
       parseHashAndUpdate(getHash());
-      cldrMenu.getInitialMenusEtc(sessionId);
-    }, 100 /* one tenth of a second */);
-  });
+      cldrMenu.getInitialMenusEtc(cldrStatus.getSessionId());
+    }, 100 /* one tenth of a second */)
+  );
 }
 
 function continueInitializing(canAutoImport) {

--- a/tools/cldr-apps/js/src/esm/cldrStatus.js
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.js
@@ -9,8 +9,11 @@ import * as cldrGui from "./cldrGui.js";
 const statusTarget = new EventTarget();
 
 /**
- * Re-export addEventListener as 'on',
- * so: cldrStatus.on('userChanged', …)
+ * Re-export addEventListener as 'on'
+ * so: cldrStatus.on('sessionId', …)
+ * Events:
+ * - sessionId:  session ID changed
+ * - surveyUser: survey user changed
  */
 const on = statusTarget.addEventListener.bind(statusTarget);
 
@@ -256,7 +259,6 @@ function setIsPhaseBeta(i) {
  * a.k.a. surveySessionId
  */
 let sessionId = null;
-let sessionIdChangeCallback = null;
 
 function getSessionId() {
   return sessionId;
@@ -266,15 +268,7 @@ function setSessionId(i) {
   if (i !== sessionId) {
     sessionId = i;
   }
-  // TODO: always fire the sessionIdChangeCallback as it is a one shot.
-  if (sessionIdChangeCallback) {
-    sessionIdChangeCallback(sessionId);
-    sessionIdChangeCallback = null;
-  }
-}
-
-function setSessionIdChangeCallback(func) {
-  sessionIdChangeCallback = func;
+  statusTarget.dispatchEvent(new Event("sessionId"));
 }
 
 /**
@@ -454,7 +448,6 @@ export {
   setPermissions,
   setPhase,
   setSessionId,
-  setSessionIdChangeCallback,
   setSessionMessage,
   setSpecialHeader,
   setSurveyUser,

--- a/tools/cldr-apps/js/src/runGui.js
+++ b/tools/cldr-apps/js/src/runGui.js
@@ -1,7 +1,7 @@
 import * as cldrGui from "./esm/cldrGui.js";
 
 function runGui() {
-  cldrGui.run();
+  return cldrGui.run();
 }
 
 export { runGui };

--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -57,6 +57,7 @@
       <li>
         <span class="hasTooltip" v-bind:title="email">{{ userName }}</span>
         <span
+          v-if="email"
           class="glyphicon glyphicon-user tip-log"
           v-bind:title="org"
         ></span>

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -45,6 +45,13 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- For rendering JSON. Avoids error about an insecure Stax XML processor -->
+		<dependency>
+			<groupId>org.codehaus.woodstox</groupId>
+			<artifactId>woodstox-core-asl</artifactId>
+			<version>4.4.1</version>
+		</dependency>
+
 		<!-- test -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -102,7 +102,6 @@ import com.ibm.icu.util.ULocale;
  */
 public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Externalizable {
 
-    private static final String VURL_LOCALES = "v#locales///";
     private static final String CLDR_OLDVERSION = "CLDR_OLDVERSION";
     private static final String CLDR_NEWVERSION = "CLDR_NEWVERSION";
     private static final String CLDR_LASTVOTEVERSION = "CLDR_LASTVOTEVERSION";
@@ -301,8 +300,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
 
     // ======= query fields
     public static final String QUERY_PASSWORD = "pw";
-    public static final String QUERY_PASSWORD_ALT = "uid";
     public static final String QUERY_EMAIL = "email";
+    public static final String QUERY_PASSWORD_ALT = "uid";
     public static final String QUERY_SESSION = "s";
     public static final String QUERY_LOCALE = "_";
     public static final String QUERY_SECTION = "x";
@@ -479,7 +478,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     /**
      * IP exclusion list
      */
-    static Hashtable<String, Object> BAD_IPS = new Hashtable<>();
+    public static Hashtable<String, Object> BAD_IPS = new Hashtable<>();
     public static String fileBaseA;
     public static String fileBaseASeed;
 
@@ -1864,8 +1863,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             title = title + " Example";
         } else if (which == null || which.isEmpty()) {
             if (ctx.getLocale() == null) {
-                ctx.redirect(ctx.context(VURL_LOCALES));
-                ctx.redirectToVurl(ctx.context(VURL_LOCALES)); // may blink.
+                ctx.redirect(ctx.vurl());
                 return;
             } else {
                 title = ""; // general";
@@ -2109,9 +2107,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             locale = ctx.getLocale().toString();
         }
         if ((locale == null) || (locale.length() <= 0)) {
-            ctx.println("<i>Loading locale list...</i>");
-            ctx.flush();
-            ctx.redirectToVurl(ctx.context(VURL_LOCALES)); // may blink.
+            ctx.redirect(ctx.vurl());
             return;
         } else {
             showLocale(ctx, which, whyBad);
@@ -2749,6 +2745,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         String vurl = ctx.vurl(ctx.getLocale(), ctx.getPageId(), null, null);
         // redirect to /v#...
         ctx.redirectToVurl(vurl);
+        ctx.redirect(vurl);
     }
 
     /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -165,12 +165,19 @@ public class SurveyTool extends HttpServlet {
         out.write("</head>\n");
         out.write("<body lang='" + lang + "'>\n");
         out.write("<div id='st-run-gui'>Loading...</div>\n");
+        // runGui() returns a Promise.
+        // But, we also want to catch exceptions in calling cldrBundle or runGui.
         out.write("<script>\n" +
-            "try {\n" +
-            "  cldrBundle.runGui();\n" +
-            "} catch(e) {\n" +
+            "function stRunGuiErr(e) {\n" +
             "  console.error(e);\n" +
-            "  document.write('&#x26A0; Error: Could not load CLDR ST Retry Panel. Try reloading? ' + e + '\\n' + e.stack);\n" +
+            "  document.write('<h1>&#x26A0; Error: Could not load CLDR ST GUI. Try reloading?</h1> '" +
+            " + e + '\\n<hr />\\n<pre>' + (e.stack||'') + '</pre>');\n" +
+            "}\n" +
+            "try {\n" +
+            "  cldrBundle.runGui()\n" +
+            "  .then(() => {}, stRunGuiErr);\n" +
+            "} catch(e) {\n" +
+            "  stRunGuiErr(e);\n" +
             "}\n" +
             "</script>\n");
         out.write("</body>\n</html>\n");

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -587,7 +587,7 @@ public class UserRegistry {
     }
 
     public static void printPasswordLink(WebContext ctx, String email, String password) {
-        ctx.println("<a href='" + ctx.base() + "?email=" + email + "&amp;uid=" + password + "'>Login for " + email + "</a>");
+        ctx.println("<a href='" + ctx.base() + "?email=" + email + "&amp;pw=" + password + "'>Login for " + email + "</a>");
     }
 
     private static Map<String, Organization> orgToVrOrg = new HashMap<>();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
@@ -614,15 +614,26 @@ public class WebContext implements Cloneable, Appendable {
         return vurl(loc, null, null, null);
     }
 
+    public String vurl() {
+        return vurl(null, null, null, null);
+    }
+
     /**
      * Get the new '/v' viewing URL. Note that this will include a fragment, do NOT append to the result (pass in something in queryAppend)
      * @param loc locale to view.
      * @param page pageID to view. Example:  PageId.Africa (shouldn't be null- yet)
      * @param strid strid to view. Example: "12345678" or null
-     * @param queryAppend  this will be appended as the query. Example: "?email=foo@bar"
+     * @param queryAppend  this will be appended as the query. Example: "?email=foo@bar".
+     * Defaults to the session key.
      * @return
      */
     public String vurl(CLDRLocale loc, PageId page, String strid, String queryAppend) {
+        // If we have a session, use it.
+        if (queryAppend == null || queryAppend.isEmpty()) {
+            if (session != null && session.id != null) {
+                queryAppend = "?s=" + session.id;
+            }
+        }
         StringBuilder sb = new StringBuilder(request.getContextPath());
         return WebContext.appendContextVurl(sb, loc, page, strid, queryAppend).toString();
     }
@@ -637,7 +648,9 @@ public class WebContext implements Cloneable, Appendable {
 
         // locale
         sb.append('/');
-        sb.append(loc.getBaseName());
+        if (loc != null) {
+            sb.append(loc.getBaseName());
+        }
 
         // page
         sb.append('/');
@@ -1518,7 +1531,17 @@ public class WebContext implements Cloneable, Appendable {
      * @return
      */
     public String getCookieValue(String id) {
-        Cookie c = getCookie(id);
+        return getCookieValue(request, id);
+    }
+
+    /**
+     * Get a cookie value or null
+     *
+     * @param id
+     * @return
+     */
+    public static String getCookieValue(HttpServletRequest hreq, String id) {
+        Cookie c = getCookie(hreq, id);
         if (c != null) {
             return c.getValue();
         }

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -104,7 +104,7 @@
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.9</version>
+				<version>1.15</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-fileupload</groupId>


### PR DESCRIPTION
    - bump commons-codec version to recommended level
    - add more <a- components to vue router
    - cause cldrGui.run() to erase all <body> elements before starting up
    - add basic login form
    - update mainheader to hide 'user' icon if no user
    - refactor cookie code
    - auth/login: fetch from cookie if needed (still need to support anonymous)
    - login/out seems to work
    - improve error handling in startup
    - anonymous sessions (from API)!
    - bump woodstox version to most recent (2014) and document why it is there
    - prefer 'pw=' for the password query in URL (but still support uid=)
    - allow cldrGui.run() to consume a "s=" session param
    (which gets removed from the query)
    - make cldrGui.run() return a promise
    - cleanup how the "/v#" URL is generated from SurveyMain