### PR TITLE
CLDR-14451 add README.md and LICENSE to cldr-json packages

### DIFF
--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -80,6 +80,18 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+			<resource>
+		       <directory>${project.basedir}/../..</directory>
+		       <targetPath>${project.build.directory}/classes/org/unicode/cldr/util/data</targetPath>
+				<includes>
+					<include>unicode-license.txt</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/cldr-json-readme.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/cldr-json-readme.md
@@ -1,0 +1,22 @@
+# cldr-json package
+
+This package is part of the JSON distribution of [CLDR](http://cldr.unicode.org/)
+locale data for internationalization
+
+For full details, please see <https://github.com/unicode-org/cldr-json>
+
+## Bug reports
+
+CLDR does not use Github's issue tracking system to track bugs.  If you find an error in
+the data contained here, please file a new ticket at [Unicode Jira](https://unicode-org.atlassian.net/projects/CLDR/issues)
+
+### Licenses
+
+- Usage of CLDR data and software is governed by the [Unicode Terms of Use](http://www.unicode.org/copyright.html)
+a copy of which is included as [LICENSE](./LICENSE).
+
+### Copyright
+
+Copyright &copy; 1991-2021 Unicode, Inc.
+All rights reserved.
+[Terms of use](http://www.unicode.org/copyright.html)

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-SNAPSHOT-cldr-2021-02-17</icu4j.version>
+		<icu4j.version>69.1-SNAPSHOT-cldr-2021-03-09</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>


### PR DESCRIPTION
- automatically copy unicode-license.txt into the CLDR dataset
- also, improve Ldml2JsonConverter response to incorrect -t options

This concludes CLDR-14451