### PR TITLE
CLDR-14668 MainHeader.vue: make coverage menu reactive

### DIFF
--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -79,6 +79,7 @@ export default {
   data() {
     return {
       coverageLevel: null,
+      coverageMenu: null,
       coverageTitle: null,
       email: null,
       loggedIn: false,


### PR DESCRIPTION
CLDR-14668 MainHeader.vue: make coverage menu reactive

- Vue makes items reactive that are in `data()`, see <https://v3.vuejs.org/guide/reactivity.html#how-vue-tracks-these-changes>