### PR TITLE
CLDR-14662 fixes to Coverage menu

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrCoverage.js
+++ b/tools/cldr-apps/js/src/esm/cldrCoverage.js
@@ -2,9 +2,11 @@
  * cldrCoverage: encapsulate Survey Tool "Coverage" functions
  */
 
+import * as cldrStatus from "../esm/cldrStatus.js";
+
 let surveyLevels = null;
 
-let surveyOrgCov = null;
+const surveyOrgCov = {};
 
 let surveyUserCov = null;
 
@@ -45,10 +47,10 @@ function covName(lev) {
   return null;
 }
 
-function effectiveCoverage() {
-  const orgCov = getSurveyOrgCov();
+function effectiveCoverage(locale) {
+  const orgCov = getSurveyOrgCov(locale);
   if (!orgCov) {
-    throw new Error("surveyOrgCov not yet initialized");
+    throw new Error(`surveyOrgCov(${locale}) not yet initialized`);
   }
   const userCov = getSurveyUserCov();
   if (userCov) {
@@ -76,12 +78,12 @@ function effectiveName() {
   return null; // no error
 }
 
-function getSurveyOrgCov() {
-  return surveyOrgCov;
+function getSurveyOrgCov(locale) {
+  return surveyOrgCov[locale];
 }
 
-function setSurveyOrgCov(cov) {
-  surveyOrgCov = cov;
+function setSurveyOrgCov(cov, locale) {
+  surveyOrgCov[locale] = cov;
 }
 
 function getSurveyUserCov() {
@@ -100,9 +102,8 @@ function updateCovFromJson(json) {
   }
 
   if (json.covlev_org) {
-    setSurveyOrgCov(json.covlev_org);
-  } else {
-    setSurveyOrgCov(null);
+    // sets the organization coverage for this specific locale
+    setSurveyOrgCov(json.covlev_org, json.loc);
   }
 }
 
@@ -118,7 +119,8 @@ function updateCoverage(theDiv) {
   }
   const levs = getSurveyLevels();
   if (levs != null) {
-    var effective = effectiveCoverage();
+    const currentLocale = cldrStatus.getCurrentLocale();
+    var effective = effectiveCoverage(currentLocale);
     var newStyle = theTable.origClass;
     for (var k in levs) {
       var level = levs[k];

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -720,12 +720,15 @@ function loadGeneral(itemLoadInfo) {
  * Show the "possible problems" section which has errors for the locale
  */
 function showPossibleProblems() {
-  const effectiveCov = cldrCoverage.covName(cldrCoverage.effectiveCoverage());
+  const currentLocale = cldrStatus.getCurrentLocale();
+  const effectiveCov = cldrCoverage.covName(
+    cldrCoverage.effectiveCoverage(currentLocale)
+  );
   const requiredCov = effectiveCov;
   const url =
     cldrStatus.getContextPath() +
     "/SurveyAjax?what=possibleProblems&_=" +
-    cldrStatus.getCurrentLocale() +
+    currentLocale +
     "&s=" +
     cldrStatus.getSessionId() +
     "&eff=" +

--- a/tools/cldr-apps/js/src/esm/cldrMenu.js
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.js
@@ -123,13 +123,9 @@ function setupCoverageLevels(json) {
   levelNums.sort(function (a, b) {
     return a.num - b.num;
   });
-  const orgCov = cldrCoverage.getSurveyOrgCov();
-  const defaultLabel = cldrText.sub("coverage_auto_msg", {
-    surveyOrgCov: cldrText.get("coverage_" + orgCov),
-  });
   coverageMenu.length = 0;
   coverageMenu.push({
-    label: "Auto",
+    label: cldrText.get("coverage_auto"),
     value: "auto",
   });
   for (let j in levelNums) {
@@ -144,10 +140,7 @@ function setupCoverageLevels(json) {
       continue; // hide Optional in production
     }
     const level = levelNums[j].level;
-    const label =
-      level.name === orgCov
-        ? defaultLabel
-        : cldrText.get("coverage_" + level.name);
+    const label = cldrText.get("coverage_" + level.name);
     coverageMenu.push({
       label: label,
       value: level.name,

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -890,7 +890,7 @@ function getMenusFilteredByCov() {
   // get name of current coverage
   var cov = cldrCoverage.getSurveyUserCov();
   if (!cov) {
-    cov = cldrCoverage.getSurveyOrgCov();
+    cov = cldrCoverage.getSurveyOrgCov(cldrStatus.getCurrentLocale());
   }
 
   // get the value

--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -354,6 +354,7 @@ const strings = {
   ari_sessiondisconnect_message: "Your session has been disconnected.",
   ari_force_reload: "[Second try: will force page reload]",
 
+  coverage_auto: "Default",
   coverage_auto_msg: "${surveyOrgCov} (Default)",
   coverage_core: "Core",
   coverage_posix: "POSIX",
@@ -365,7 +366,7 @@ const strings = {
   coverage_optional: "Optional",
   coverage_no_items: "No items at this current coverage level.",
   coverage_menu_desc:
-    'Change the displayed coverage level. "Automatic" will use your organization\'s preferred value for this locale, if any.',
+    'Change the displayed coverage level. "Default" will use your organization\'s preferred value for this locale, if any.',
 
   section_mail: "Messages",
 


### PR DESCRIPTION
CLDR-14662

- rename Auto to Default
- org coverage is really per locale, store it this way in the APIs
- move the default labelling into the vue code
- add a $forceReload() in MainHeader if the menus change
workaround for a lack of reactivity

- [X] yea, i think this fixes the issue, but that's what i said last time!