### PR TITLE
CLDR-14668 fix additional coverage/General Info issues

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrCoverage.js
+++ b/tools/cldr-apps/js/src/esm/cldrCoverage.js
@@ -48,14 +48,14 @@ function covName(lev) {
 }
 
 function effectiveCoverage(locale) {
-  const orgCov = getSurveyOrgCov(locale);
-  if (!orgCov) {
-    throw new Error(`surveyOrgCov(${locale}) not yet initialized`);
-  }
   const userCov = getSurveyUserCov();
   if (userCov) {
     return covValue(userCov);
   } else {
+    const orgCov = getSurveyOrgCov(locale);
+    if (!orgCov) {
+      throw new Error(`surveyOrgCov(${locale}) not yet initialized`);
+    }
     return covValue(orgCov);
   }
 }

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -715,20 +715,15 @@ function loadGeneral(itemLoadInfo) {
  */
 function showPossibleProblems() {
   const currentLocale = cldrStatus.getCurrentLocale();
-  const effectiveCov = cldrCoverage.covName(
-    cldrCoverage.effectiveCoverage(currentLocale)
-  );
-  const requiredCov = effectiveCov;
+  const userCov = cldrCoverage.getSurveyUserCov();
   const url =
     cldrStatus.getContextPath() +
     "/SurveyAjax?what=possibleProblems&_=" +
     currentLocale +
     "&s=" +
     cldrStatus.getSessionId() +
-    "&eff=" +
-    effectiveCov +
-    "&req=" +
-    requiredCov +
+    "&userCov=" +
+    (userCov||'auto') +
     cldrSurvey.cacheKill();
   myLoad(url, "possibleProblems", loadPossibleProblemsFromJson);
 }

--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -85,6 +85,7 @@ export default {
       logLink: null,
       logText: null,
       org: null,
+      orgCoverage: null,
       sessionMessage: null,
       specialHeader: null,
       stVersionPhase: null,

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -700,9 +700,14 @@ public class SurveyAjax extends HttpServlet {
                             return;
                         }
 
-                        String eff = request.getParameter("eff");
+                        final String userCov = request.getParameter("userCov");
+                        String eff = userCov;
+                        if (eff.equals("auto")) {
+                            eff = mySession.getEffectiveCoverageLevel(loc);
+                        }
 
                         UserLocaleStuff uf = sm.getUserFile(mySession, locale);
+                        @SuppressWarnings("unchecked")
                         List<CheckStatus> checkCldrResult = (List<CheckStatus>) uf.hash.get(SurveyMain.CHECKCLDR_RES + eff);
 
                         if (checkCldrResult == null) {


### PR DESCRIPTION
 - fix orgCoverage missing from data() in MainHeaderVue.js
 - update cldrLoad.js / SurveyAjax.java to not pass the org coverage back from
 client to server, but send "auto" and let the server figure it out. Otherwise we'd
 need to delay load.

CLDR-14668

- [X] This PR completes the ticket.

Note:
- Split off CLDR-14703 to modernize cldrLoad and the General Info page