### PR TITLE
CLDR-14395 fix sessionIdChangeCallback

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrStatus.js
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.js
@@ -265,10 +265,11 @@ function getSessionId() {
 function setSessionId(i) {
   if (i !== sessionId) {
     sessionId = i;
-    if (sessionIdChangeCallback) {
-      sessionIdChangeCallback(sessionId);
-      sessionIdChangeCallback = null;
-    }
+  }
+  // TODO: always fire the sessionIdChangeCallback as it is a one shot.
+  if (sessionIdChangeCallback) {
+    sessionIdChangeCallback(sessionId);
+    sessionIdChangeCallback = null;
   }
 }
 


### PR DESCRIPTION
- sessionIdChangeCallback was not being called if the session ID was already set

CLDR-14395

- [ ] This PR completes the ticket.
