### PR TITLE
CLDR-14711 SBRS 40: Update CLDR version, ICU4J libs, readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unicode CLDR Project
 
-Latest Release: [v39.0](http://cldr.unicode.org/index/downloads/cldr-39) published 2021-04-07
+Latest Release: [v40.0](http://cldr.unicode.org/index/downloads/cldr-40) published 2021-10-20
 
 ## Build Status
 

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -46,7 +46,7 @@ $Revision$
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "39" >
+<!ATTLIST version cldrVersion CDATA #FIXED "40" >
     <!--@MATCH:any-->
     <!--@VALUE-->
 <!ATTLIST version draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/dtd/ldmlBCP47.dtd
+++ b/common/dtd/ldmlBCP47.dtd
@@ -16,7 +16,7 @@ $Revision$
 <!ATTLIST version number CDATA #REQUIRED >
 	<!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "39" >
+<!ATTLIST version cldrVersion CDATA #FIXED "40" >
 	<!--@MATCH:version-->
     <!--@VALUE-->
 

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -17,7 +17,7 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "39" >
+<!ATTLIST version cldrVersion CDATA #FIXED "40" >
     <!--@MATCH:version-->
     <!--@VALUE-->
 <!ATTLIST version unicodeVersion CDATA #FIXED "13.0.0" >

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -21,7 +21,7 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "39" >
+<!ATTLIST version cldrVersion CDATA #FIXED "40" >
     <!--@MATCH:version-->
     <!--@METADATA-->
 

--- a/readme.html
+++ b/readme.html
@@ -11,17 +11,17 @@
 
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
-    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 39</h3>
-    <p>Last updated: 2021-Mar-30</p>
+    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 40</h3>
+    <p>Last updated: 2021-May-05</p>
 
-    <!--<p><b>Note:</b> CLDR 39 is in development and not recommended for use at this stage.</p>-->
-    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 39, intended for those wishing to do pre-release testing.
+    <p><b>Note:</b> CLDR 40 is in development and not recommended for use at this stage.</p>
+    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 40, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a preliminary version of CLDR 39, intended for those wishing to do pre-release testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 40, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 39, intended for testing.
+    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 40, intended for testing.
     It is not recommended for production use.</p>-->
-    <p>This is the final release version of CLDR 39.</p>
+    <!--<p>This is the final release version of CLDR 40.</p>-->
     
     <p><strong>Important notes for CLDR 36 and later:</strong></p>
     <ul>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -123,7 +123,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     public static final String SUPPLEMENTAL_NAME = "supplementalData";
     public static final String SUPPLEMENTAL_METADATA = "supplementalMetadata";
     public static final String SUPPLEMENTAL_PREFIX = "supplemental";
-    public static final String GEN_VERSION = "39";
+    public static final String GEN_VERSION = "40";
     public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "grammaticalFeatures",
         "languageInfo",
         "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "pluralRanges", "plurals", "postalCodeData", "rgScope",

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-SNAPSHOT-release-69-rc</icu4j.version>
+		<icu4j.version>69.1-release-69-1</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>


### PR DESCRIPTION
CLDR-14711

- [ ] This PR completes the ticket.

Some CLDR 40 startup BRS items:
- Update cldrVersion in the dtds and GEN_VERSION in CLDRFile.java (but not unicodeVersion in ldmlSupplemental.dtd yet)
- Update to use latest released ICU4J version (<icu4j.version> in tools/pom.xml)
- Update readme.html and README.md

This does *not* yet update <version>39.0-SNAPSHOT</version> in tools/pom.xml, because doing that caused mvn package to fail, presumably because we have not yet published a CLDR 40 snapshot? Presumably we will have to wait until later to update that.