### PR TITLE
CLDR-14714 keyboard minimal naming

### DIFF
--- a/keyboards/windows/sat-t-k0-windows.xml
+++ b/keyboards/windows/sat-t-k0-windows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "../dtd/ldmlKeyboard.dtd">
-<keyboard locale="sat-Olck-t-k0-windows">
+<keyboard locale="sat-t-k0-windows">
 	<version platform="10" number="$Revision$"/>
 	<names>
 		<name value="Ol Chiki"/>


### PR DESCRIPTION
CLDR-14714 (renames sat-Olck to sat to meet minimum tag requirement)

- [X] This PR completes the ticket.