### PR TITLE
CLDR-14555 reduce JDBC warnings

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/PermanentVote.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/PermanentVote.java
@@ -93,7 +93,7 @@ public class PermanentVote {
         PreparedStatement ps = null;
         int count = 0;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             ps = DBUtils.prepareForwardReadOnly(conn, sql);
             ps.setString(1, localeName);
             ps.setInt(2, xpathId);
@@ -125,7 +125,7 @@ public class PermanentVote {
         PreparedStatement ps = null;
         int count = 0;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             ps = DBUtils.prepareForwardReadOnly(conn, sql);
             ps.setString(1, localeName);
             ps.setInt(2, xpathId);
@@ -164,7 +164,7 @@ public class PermanentVote {
         PreparedStatement ps = null;
         int count = 0;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             ps = DBUtils.prepareForwardReadOnly(conn, sql);
             ps.setString(1, localeName);
             ps.setInt(2, xpathId);
@@ -185,13 +185,12 @@ public class PermanentVote {
      */
     private void lock() {
         String tableName = DBUtils.Table.LOCKED_XPATHS.toString();
-        Connection conn = null;
-        PreparedStatement ps = null;
         String sql = "INSERT INTO " + tableName
             + "(locale,xpath,value,last_mod) VALUES(?,?,?,CURRENT_TIMESTAMP)";
-        try {
-            conn = DBUtils.getInstance().getDBConnection();
-            ps = DBUtils.prepareForwardReadOnly(conn, sql);
+        try (
+            Connection conn = DBUtils.getInstance().getDBConnection();
+            PreparedStatement ps = DBUtils.prepareForwardReadOnly(conn, sql);
+        ) {
             ps.setString(1, localeName);
             ps.setInt(2, xpathId);
             DBUtils.setStringUTF8(ps, 3, value);
@@ -199,8 +198,6 @@ public class PermanentVote {
             conn.commit();
         } catch (SQLException e) {
             SurveyLog.logException(e);
-        } finally {
-            DBUtils.close(ps, conn);
         }
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
@@ -49,7 +49,7 @@ public class ReviewHide {
             PreparedStatement s = null;
             try {
                 try {
-                    conn = DBUtils.getInstance().getDBConnection();
+                    conn = DBUtils.getInstance().getAConnection();
                     s = conn.prepareStatement("SELECT * FROM " + DBUtils.Table.DASH_HIDE + " WHERE user_id=? AND locale=?");
                     s.setInt(1, userId);
                     s.setString(2, locale);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -699,7 +699,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                      * Select several columns (xp, submitter, value, override, last_mod),
                      * from all rows with the given locale in the votes table.
                      */
-                    conn = DBUtils.getInstance().getDBConnection();
+                    conn = DBUtils.getInstance().getAConnection();
                     ps = openQueryByLocaleRW(conn);
                     ps.setString(1, locale.getBaseName());
                     rs = ps.executeQuery();
@@ -1811,11 +1811,9 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         if (dbIsSetup)
             return;
         dbIsSetup = true; // don't thrash.
-        Connection conn = null;
         String sql = "(none)"; // this points to
         Statement s = null;
-        try {
-            conn = DBUtils.getInstance().getDBConnection();
+        try (Connection conn = DBUtils.getInstance().getDBConnection();) {
             if (!DBUtils.hasTable(conn, DBUtils.Table.VOTE_VALUE.toString())) {
                 /*
                  * CREATE TABLE cldr_votevalue ( locale VARCHAR(20), xpath INT
@@ -1947,7 +1945,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             SurveyMain.busted("Setting up DB for STFactory, SQL: " + sql, se);
             throw new InternalError("Setting up DB for STFactory, SQL: " + sql);
         } finally {
-            DBUtils.close(s, conn);
+            DBUtils.close(s);
         }
     }
 
@@ -2154,7 +2152,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         ResultSet rs = null;
         SimpleXMLSource sxs = new SimpleXMLSource(locale.getBaseName());
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
 
             ps = DBUtils.prepareStatementWithArgsFRO(conn, "select xpath,submitter,value," + VOTE_OVERRIDE + " from " + DBUtils.Table.VOTE_VALUE
                 + " where locale=? and value IS NOT NULL", locale);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyBulkClosePosts.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyBulkClosePosts.java
@@ -51,7 +51,7 @@ public class SurveyBulkClosePosts {
 
     private void reportOrExecute() {
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             prepareOpenRequestsDetailQuery();
             rs = ps.executeQuery();
             while (rs.next()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
@@ -571,7 +571,7 @@ public class SurveyForum {
         PreparedStatement ps = null;
         String tableName = DBUtils.Table.FORUM_POSTS.toString();
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
 
             ps = DBUtils.prepareForwardReadOnly(conn, "select count(*) from " + tableName + " where loc=? and xpath=?");
             ps.setString(1, locale.getBaseName());
@@ -608,7 +608,7 @@ public class SurveyForum {
         try {
             Connection conn = null;
             try {
-                conn = sm.dbUtils.getDBConnection();
+                conn = sm.dbUtils.getAConnection();
                 Object[][] o = null;
                 final String forumPosts = DBUtils.Table.FORUM_POSTS.toString();
                 if (ident == 0) {
@@ -904,7 +904,7 @@ public class SurveyForum {
         String tableName = DBUtils.Table.FORUM_POSTS.toString();
         Map<Integer, String> posts = new HashMap<>();
         try {
-            conn = sm.dbUtils.getDBConnection();
+            conn = sm.dbUtils.getAConnection();
             pList = DBUtils.prepareStatement(conn, "pList",
                 "SELECT root,subj FROM " + tableName
                 + " WHERE is_open=true AND type=? AND loc=? AND xpath=? AND poster=? AND NOT value=?");
@@ -961,7 +961,7 @@ public class SurveyForum {
         String tableName = DBUtils.Table.FORUM_POSTS.toString();
         Map<Integer, String> posts = new HashMap<>();
         try {
-            conn = sm.dbUtils.getDBConnection();
+            conn = sm.dbUtils.getAConnection(); // readonly
             pList = DBUtils.prepareStatement(conn, "pList",
                 "SELECT id,subj FROM " + tableName
                 + " WHERE is_open=true AND type=? AND loc=? AND xpath=? AND poster=? AND NOT value=?");

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyVettingParticipation.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyVettingParticipation.java
@@ -43,7 +43,7 @@ public class SurveyVettingParticipation {
         JSONArray userObj = new JSONArray();
         JSONArray participationObj = new JSONArray();
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             psUsers = sm.reg.list(org, conn);
             if (org == null) {
                 r.put("org", "*");

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -135,7 +135,7 @@ public class UserList {
         PreparedStatement ps = null;
         java.sql.ResultSet rs = null;
         try {
-            conn = sm.dbUtils.getDBConnection();
+            conn = sm.dbUtils.getAConnection();
             synchronized (reg) {
                 ps = reg.list(org, conn); // org = null to list all
                 rs = ps.executeQuery();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -93,7 +93,7 @@ public class UserRegistry {
         Set<String> res = new HashSet<>();
 
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             s = DBUtils
                 .prepareStatementWithArgs(
                     conn,
@@ -119,7 +119,7 @@ public class UserRegistry {
         Set<CLDRLocale> res = new HashSet<>();
 
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             s = DBUtils
                 .prepareStatementWithArgs(
                     conn,
@@ -805,7 +805,7 @@ public class UserRegistry {
             if (ret == null) { // synchronized(conn) {
                 ResultSet rs = null;
                 PreparedStatement pstmt = null;
-                Connection conn = DBUtils.getInstance().getDBConnection();
+                Connection conn = DBUtils.getInstance().getAConnection();
                 try {
                     pstmt = DBUtils.prepareForwardReadOnly(conn, UserRegistry.SQL_queryIdStmt_FRO);
                     pstmt.setInt(1, id);
@@ -914,7 +914,7 @@ public class UserRegistry {
         Connection conn = null;
         PreparedStatement pstmt = null;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             if ((pass != null) && !letmein) {
                 pstmt = DBUtils.prepareForwardReadOnly(conn, SQL_queryStmt_FRO);
                 pstmt.setString(1, email);
@@ -1531,7 +1531,7 @@ public class UserRegistry {
             logger.info("UR: Attempt getPassword by " + ctx.session.user.email + ": of #" + theirId);
         }
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             s = conn.createStatement();
             rs = s.executeQuery("SELECT password FROM " + CLDR_USERS + " WHERE id=" + theirId);
             if (!rs.next()) {
@@ -2098,7 +2098,7 @@ public class UserRegistry {
             PreparedStatement ps = null;
             Connection conn = null;
             try {
-                conn = DBUtils.getInstance().getDBConnection();
+                conn = DBUtils.getInstance().getAConnection();
                 ps = list(null, conn);
                 rs = ps.executeQuery();
                 // id,userlevel,name,email,org,locales,intlocs,lastlogin
@@ -2169,7 +2169,7 @@ public class UserRegistry {
         Connection conn = null;
         Statement s = null;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             s = conn.createStatement();
             ResultSet rs = s.executeQuery("SELECT distinct org FROM " + CLDR_USERS + " order by org");
             while (rs.next()) {
@@ -2377,7 +2377,7 @@ public class UserRegistry {
         PreparedStatement ps = null;
         ResultSet rs = null;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             synchronized (this) {
                 ps = list(org, conn);
                 rs = ps.executeQuery();
@@ -2477,7 +2477,7 @@ public class UserRegistry {
         PreparedStatement ps = null;
         Connection conn = null;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             ps = list(null, conn);
             rs = ps.executeQuery();
             // id,userlevel,name,email,org,locales,intlocs,lastlogin

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserSettingsData.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserSettingsData.java
@@ -111,7 +111,7 @@ public class UserSettingsData {
                 Connection conn = null;
                 try {
                     conn = DBUtils.getInstance().getDBConnection();
-                    internalSet(id, name, value, conn);
+                    internalSet(id, name, value, conn);  // calls commit()
                 } finally {
                     DBUtils.closeDBConnection(conn);
                     if (value == null) {
@@ -190,7 +190,7 @@ public class UserSettingsData {
     }
 
     private String internalGet(int id, String name) throws SQLException {
-        Connection conn = DBUtils.getInstance().getDBConnection();
+        Connection conn = DBUtils.getInstance().getAConnection();
 
         String sql = "select " + SET_VALUES + ".set_value from " + SET_VALUES + "," + SET_KINDS + " where " + SET_VALUES
             + ".usr_id=? AND " + SET_KINDS + ".set_id=" + SET_VALUES + ".set_id AND " + SET_KINDS + ".set_name=?";

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
@@ -184,7 +184,7 @@ public class XPathTable {
         Connection conn = null;
         PreparedStatement queryStmt = null;
         try {
-            conn = DBUtils.getInstance().getDBConnection();
+            conn = DBUtils.getInstance().getAConnection();
             if (!DEBUG) {
                 addXpaths(unloadedXpaths, conn);
             } else {
@@ -296,6 +296,7 @@ public class XPathTable {
             setById(id, xpath);
             // logger.info("Mapped " + id + " back to " + xpath);
             rs.close();
+            conn.commit();
             return nid;
         } catch (SQLException sqe) {
             SurveyLog.logger.warning("xpath [" + xpath + "] len " + xpath.length());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StackTracker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StackTracker.java
@@ -10,6 +10,7 @@ package org.unicode.cldr.util;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Debugging utility.
@@ -114,6 +115,25 @@ public class StackTracker implements Iterable<Object> {
      */
     public static StackTraceElement currentElement(int skip) {
         return Thread.currentThread().getStackTrace()[3 + skip];
+    }
+
+    /**
+     * Return the 'calling' element, skipping
+     * @param matchFirst matching predicate
+     * @return first matching stack. If none match, return currentElement(0)
+     * Example: to skip callers in my own class:
+     * currentElement(
+     *  (StackTraceElement s) ->
+     *    !s.getClassName().equals(MyClass.class.getName()));
+     */
+    public static StackTraceElement firstCallerMatching(Predicate<StackTraceElement> matchFirst) {
+        final StackTraceElement stacks[] = Thread.currentThread().getStackTrace();
+        for (int i=3; i<stacks.length; i++) {
+            if (matchFirst.test(stacks[i])) {
+                return stacks[i];
+            }
+        }
+        return stacks[3];
     }
 
     /**


### PR DESCRIPTION
- replace getDBConnection() with getAConnection() for locations
where commit() is not called (such as read-only usage)
- property org.unicode.cldr.web.DBUtils.DEBUG_DB_OPEN for tracing
where connections are being opened
- update StackTracker to be able to skip with a Predicate<> (debug)

CLDR-14555

- [X] This PR completes the ticket. hopefully!