### PR TITLE
CLDR-14395 improve login popup

### DIFF
--- a/tools/cldr-apps/js/src/cldrVueRouter.js
+++ b/tools/cldr-apps/js/src/cldrVueRouter.js
@@ -7,13 +7,14 @@ import { getCldrOpts } from "./getCldrOpts";
 // components. See index.js for css imports.
 // example: import {SomeComponent} from 'whatever'
 import {
-  Popover,
-  Spin,
+  Alert,
+  Button,
+  Checkbox,
   Form,
   Icon,
   Input,
-  Button,
-  Checkbox,
+  Popover,
+  Spin,
 } from "ant-design-vue";
 
 // local components
@@ -107,6 +108,7 @@ function setupComponents(app) {
   // example:
   // app.component('SomeComponent', SomeComponent)
   // Keep this list sorted
+  app.component("a-alert", Alert);
   app.component("a-button", Button);
   app.component("a-checkbox", Checkbox);
   app.component("a-form-item", Form.Item);
@@ -114,10 +116,10 @@ function setupComponents(app) {
   app.component("a-icon", Icon);
   app.component("a-input-password", Input.Password);
   app.component("a-input", Input);
+  app.component("a-popover", Popover);
   app.component("a-spin", Spin);
   app.component("cldr-loginbutton", LoginButton);
   app.component("cldr-value", CldrValue);
-  app.component("Popover", Popover);
 }
 
 export { showPanel, handleCoverageChanged, createCldrApp, setupComponents };

--- a/tools/cldr-apps/js/src/esm/cldrEvent.js
+++ b/tools/cldr-apps/js/src/esm/cldrEvent.js
@@ -477,7 +477,7 @@ function toggleOverlay() {
     }, 500 /* half a second */);
   } else {
     toToggleOverlay = false;
-    overlay.css("z-index", "1000");
+    overlay.css("z-index", "800");
     overlay.addClass("active");
   }
 }

--- a/tools/cldr-apps/js/src/views/LoginButton.vue
+++ b/tools/cldr-apps/js/src/views/LoginButton.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="loginwrap">
-    <div v-if="!user" class="loginform">
+  <a-popover
+    v-model:visible="loginShown"
+    title="Enter your SurveyTool credentials:"
+    placement="leftBottom"
+    trigger="none"
+  >
+    <template #content>
       <a-input placeholder="Username" v-model:value="userName">
         <template #prefix>
           <span class="glyphicon glyphicon-user tip-log" />
@@ -8,20 +13,37 @@
       </a-input>
       <a-input-password placeholder="Password" v-model:value="password">
       </a-input-password>
+      <a-button
+        :disabled="!user && (!userName || !password)"
+        v-on:click="login()"
+        >Log In</a-button
+      >
       <a-checkbox v-model:checked="remember">Stay Logged In</a-checkbox>
-    </div>
-    <a-button
-      :disabled="!user && (!userName || !password)"
-      v-on:click="loginout()"
-      >{{ logText }}</a-button
-    >
-  </div>
+      &nbsp;
+      <a-alert
+        v-if="loginErrorMessage"
+        type="error"
+        v-model:message="loginErrorMessage"
+      />
+    </template>
+    <a-button v-on:click="loginout()">{{ logText }}</a-button>
+  </a-popover>
 </template>
 
 <script>
+import { notification } from "ant-design-vue";
 import * as cldrStatus from "../esm/cldrStatus.js";
 import { run } from "../esm/cldrGui.js";
+import { ref } from "vue";
 export default {
+  setup() {
+    const loginShown = ref(false);
+    const loginErrorMessage = ref(null);
+    return {
+      loginShown,
+      loginErrorMessage,
+    };
+  },
   created: function () {
     // listen for updates
     cldrStatus.on(
@@ -38,46 +60,92 @@ export default {
       const loggedIn = !!this.user;
       this.loggedIn = loggedIn;
 
-      if (loggedIn) {
+      if (this.loginShown.value) {
+        this.logText = "Cancel";
+      } else if (loggedIn) {
         this.logText = "Log Out";
       } else {
         this.logText = "Log In";
       }
     },
-    async loginout() {
-      if (this.loggedIn) {
-        await fetch(`api/auth/logout?session=${cldrStatus.getSessionId()}`);
-        // now reload this page now that we've logged out
-        await window.location.reload();
-      } else {
-        if (this.userName && this.password) {
-          try {
-            const response = await fetch(
-              `api/auth/login?remember=${this.remember}`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                  Accept: "application/json",
-                },
-                body: JSON.stringify({
-                  email: this.userName,
-                  password: this.password,
-                }),
-              }
-            );
-            // TODO: if !response.ok, show login failed
-            const logintoken = await (await response).json();
-            if (/*logintoken.user && */ logintoken.sessionId) {
-              // logged in OK.
-              cldrStatus.setSessionId(logintoken.sessionId);
-              run(); // Restart everything
-            } // TODO: else, handle error.
-          } catch (e) {
-            // TODO: popover needs to show that login failed
-            throw e;
+    /**
+     * Log out
+     */
+    async logout() {
+      await fetch(`api/auth/logout?session=${cldrStatus.getSessionId()}`);
+      // now reload this page now that we've logged out
+      await window.location.reload();
+    },
+    /**
+     * Log in (from header button)
+     */
+    async login() {
+      function errBox(message) {
+        console.error("LoginButton.vue: " + message);
+        notification.error({
+          message,
+          placement: "topLeft",
+        });
+      }
+
+      this.loginErrorMessage = null;
+      if (this.userName && this.password) {
+        try {
+          const response = await fetch(
+            `api/auth/login?remember=${this.remember}`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json",
+              },
+              body: JSON.stringify({
+                email: this.userName,
+                password: this.password,
+              }),
+            }
+          );
+          if (!response.ok) {
+            if (response.status == 403) {
+              return errBox("Unauthorized:\nCheck the username and password.");
+            } else {
+              return errBox(`Login failed: HTTP ${response.status}`);
+            }
+            return;
           }
+          // TODO: if !response.ok, show login failed
+          const logintoken = await (await response).json();
+          if (/*logintoken.user && */ logintoken.sessionId) {
+            // logged in OK.
+            cldrStatus.setSessionId(logintoken.sessionId);
+            this.loginShown = false;
+            notification.success({
+              placement: "topLeft",
+              message: "Logged in as " + this.userName,
+            });
+            run(); // Restart everything
+          } else {
+            return errBox("The server did not return a session ID.");
+          }
+        } catch (e) {
+          errBox("Error:" + e.toString());
         }
+      }
+    },
+    /**
+     * Login or out (the header button)
+     */
+    async loginout() {
+      if (this.loginShown) {
+        // cancel
+        this.loginShown = false;
+        this.logText = "Log In";
+      } else if (!this.loggedIn) {
+        // Log In (show popup)
+        this.loginShown = true;
+        this.logText = "Cancel";
+      } else {
+        await this.logout();
       }
     },
   },

--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -188,7 +188,7 @@ header {
   padding: 0.2em;
   background-color: white;
   background-image: linear-gradient(white, #e7f7ff);
-  z-index: 10000000000; /* prevent transparency when scrolling; also stay in front of "overlay"  */
+  z-index: 900; /* prevent transparency when scrolling; also stay in front of "overlay"  */
 }
 
 ul {

--- a/tools/cldr-apps/src/main/webapp/css/redesign.css
+++ b/tools/cldr-apps/src/main/webapp/css/redesign.css
@@ -1,9 +1,9 @@
 @import url("//fonts.googleapis.com/css?family=Noto+Sans:400italic,700italic,400,700");
 @import url("//fonts.googleapis.com/css?family=Noto+Sans+Symbols:400italic,700italic,400,700");
-/* @override 
+/* @override
 	http://naf:8080/cldr-apps/css/redesign.css */
 
-/* 
+/*
     Created on : Feb 21, 2014, 11:08:36 AM
     Author     : pwauquie
 */
@@ -13,7 +13,7 @@ body {
 	             "Noto Sans Symbols",
 /* The rest of the individual scripts should be looked at later.  The best solution would be to
    load the appropriate font based on the language being rendered. But we don't want to load
-   everything, as that would be painfully slow. 
+   everything, as that would be painfully slow.
 				 "Noto Sans Armenian",
 				 "Noto Naskh Arabic",
 				 "Noto Sans Bengali",
@@ -47,7 +47,7 @@ body {
 }
 
 .hasTooltip {
-	cursor: pointer;	
+	cursor: pointer;
 }
 
 .collapse-review span.glyphicon-chevron-down {
@@ -57,11 +57,11 @@ body {
 }
 
 .table-wrapper table tr td:nth-child(6) {
-    width:30px; 
+    width:30px;
 }
 
 .table-wrapper table tr td:nth-child(5) {
-    width:188px; 
+    width:188px;
 }
 
 tr.hidden-line {
@@ -77,9 +77,9 @@ tr.shown {
 }
 
 .menu-position {
-    position: fixed; 
-    background-color: white; 
-    z-index: 999; 
+    position: fixed;
+    background-color: white;
+    z-index: 800;
 }
 
 p.specialmessage {
@@ -111,7 +111,7 @@ p.specialmessage {
 }
 
 .table-review .label {
-	font-size:14px;	
+	font-size:14px;
 }
 
 th[dir=rtl] {
@@ -129,7 +129,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 .fix-info, .fix-info>td {
     padding: 0px!important;
     border-top: 0px!important;
-    
+
 }
 
 .fix-info .fix-content {
@@ -174,7 +174,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 
 .table-review .popover {
 	min-width:35%;
-	
+
 }
 
 .fix-parent > .popover {
@@ -192,7 +192,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 .data-vertical {
-	padding-right:2%;	
+	padding-right:2%;
 	border-right:1px solid #eeeeee;
 }
 .data-vertical, .data-vote {
@@ -234,8 +234,8 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 .help-vote {
 	color:gray;
 	font-weight: normal;
-	font-style: italic;	
-	display: inline-block;	
+	font-style: italic;
+	display: inline-block;
 	float: right;
 	position:relative;
 	top:5px;
@@ -288,7 +288,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 .table-vote {
-	margin-top:10px;	
+	margin-top:10px;
 }
 
 
@@ -322,7 +322,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 	padding-top: 25px;
 	margin-top: 10px;
 	border-top: 1px solid #eeeeee;
-	
+
 }
 
 .winner, .value {
@@ -330,7 +330,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 .value-div .winner, .value-div .value {
-	font-size:16px;	
+	font-size:16px;
 }
 
 .button-add input.form-control {
@@ -361,7 +361,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
     left: 20px;
 }
 .data .close {
-	position: absolute;	
+	position: absolute;
 	top: 6px;
 	right: 9px;
 }
@@ -390,8 +390,8 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
    TODO: explain and/or reevaluate this "override". Potentially problematic for performance
    (especially z-index) and compatibility with newer versions of bootstrap if we update. */
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {vertical-align:middle}
-.modal-backdrop {z-index:104000000;}
-.modal {z-index:104000001;}
+.modal-backdrop {z-index:140;}
+.modal {z-index:141;}
 
 /*sidebar stuff*/
 .nav-pills>li>a {
@@ -406,7 +406,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 	left:-18%;
 	left:calc(-18% - 1px);
 	transition:left 0.5s ease;
-	z-index:99999999;
+	z-index:801;
 	background-color:white;
 }
 
@@ -450,7 +450,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 #locale-list.active {
-	height:20%;	
+	height:20%;
 }
 
 #locale-menu {
@@ -460,7 +460,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 #locale-menu.active {
-	height:72%;	
+	height:72%;
 }
 
 #locale-list .topLocaleRow {
@@ -471,7 +471,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 #locale-list .topLocaleRow .subLocaleList {
-	padding-left:25px;	
+	padding-left:25px;
 }
 
 #locale-list a {
@@ -521,7 +521,7 @@ div#additional-top div.beta span#betanotice  {
     position: inherit !important;
     right:  inherit !important;
     top: inherit !important;
-    background-color: #fbfac1;    
+    background-color: #fbfac1;
     border:  none;
 }
 
@@ -586,7 +586,7 @@ div#additional-top div.beta span#betanotice  {
 	margin-top:-20px;
 	margin: auto;
 	margin-top: -18px;
-	width:500px;	
+	width:500px;
 }
 
 /* help content */
@@ -670,7 +670,7 @@ fieldset[disabled] .btn-success.active {
   background-color: #5cb85c;
   border-color: #4cae4c;
   background-image:none;
-  
+
 }
 .btn-success .badge {
   color: #5cb85c;
@@ -955,7 +955,7 @@ fieldset[disabled] .btn-primary.active {
 	position:fixed;
 	right:0px;
 	bottom:0px;
-	z-index: 100000000000000000000000000;
+	z-index:800;
 }
 
 #feedback > div {
@@ -1059,7 +1059,7 @@ html {
 }
 
 #toptitle h1::before {
-	content: " / ";	
+	content: " / ";
 }
 
 #toptitle #title-locale-container h1::before {


### PR DESCRIPTION
- notification on login and on login failures
(no notification on logout due to reload)
- address z-index inflation among CSS files
- move login form to popup window

CLDR-14395

- [X] This PR completes the ticket. Hope so!


-----
Example UI:
- Logged out:
![image](https://user-images.githubusercontent.com/855219/117518813-cd404b80-af66-11eb-955e-23665980f102.png)
- Clicking Login shows the login panel
![image](https://user-images.githubusercontent.com/855219/117518839-ee08a100-af66-11eb-86cc-f647c20de658.png)
(Cancel returns to previous state)
- Login Failed popup
![image](https://user-images.githubusercontent.com/855219/117518868-17c1c800-af67-11eb-8e7b-76522455bd64.png)
- When logged in, button says "Log Out"
![image](https://user-images.githubusercontent.com/855219/117518886-25774d80-af67-11eb-989c-2fc4b63f6ec1.png)

(Note: _hi._ is my site message of the day.)