### PR TITLE
CLDR-14754 fail ST tests if SurveyTool becomes busted

### DIFF
--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestSTFactory.java
@@ -867,6 +867,8 @@ public class TestSTFactory extends TestFmwk {
             et0 = new ElapsedTimer("Set up STFactory");
             gFac = sm.getSTFactory();
             logln(et0.toString());
+
+            assertFalse("SurveyTool shouldn’t be busted!", SurveyMain.isBusted());
         }
         return gFac;
     }


### PR DESCRIPTION
CLDR-14754 add an assert that the SurveyTool is not busted during tests

- [X] This PR completes the ticket.

Example if #1245 isn't merged:

```
      Error: (TestSTFactory.java:55) : SurveyTool shouldn?t be busted!: expected false
```