### PR TITLE
CLDR-14709 Remove old Yukon mapping, now use for Whitehorse,Dawson; undeprecate, add coverage

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -4297,6 +4297,11 @@ annotations.
 					<daylight>Yekaterinburg Summer Time</daylight>
 				</long>
 			</metazone>
+			<metazone type="Yukon">
+				<long>
+					<standard>Yukon Time</standard>
+				</long>
+			</metazone>
 		</timeZoneNames>
 	</dates>
 	<numbers>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -109,7 +109,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%metazone30_AU" value="(Australia_(Central(Western)?|(East|West)ern)|Lord_Howe)"/>
 		<coverageVariable key="%metazone30_AU_stdonly" value="Macquarie"/>
 		<coverageVariable key="%metazone30_BR" value="(Amazon|Brasilia|Noronha)"/>
-		<coverageVariable key="%metazone30_CA" value="(America_(Eastern|Central|Mountain|Pacific)|Newfoundland)"/>
+		<coverageVariable key="%metazone30_CA" value="(America_(Eastern|Central|Mountain|Pacific)|Newfoundland|Yukon)"/>
 		<coverageVariable key="%metazone30_EU" value="Europe_(Central|(East|West)ern)"/>
 		<coverageVariable key="%metazone30_ID" value="Indonesia_(Central|(East|West)ern)"/>
 		<coverageVariable key="%metazone30_KZ" value="Kazakhstan_(East|West)ern"/>
@@ -122,7 +122,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%metazone60_stdonly" value="(Africa_(Central|(East|South)ern)|India|Indochina|Indonesia_(Central|(East|West)ern))"/>
 		<coverageVariable key="%metazone60_AE_stdonly" value="Gulf"/>
 		<coverageVariable key="%metazone80" value="(Alaska|Amazon|Apia|Argentina(_Western)?|Armenia|Azerbaijan|Azores|Bangladesh|Brasilia|Cape_Verde|Chatham|Chile|Choibalsan|Colombia|Cook|Cuba|Easter|Falkland|Fiji|Georgia|Greenland_(East|West)ern|Hawaii_Aleutian|Hong_Kong|Hovd|Iran|Irkutsk|Krasnoyarsk|Lord_Howe|Magadan|Mauritius|Mexico_(Northwest|Pacific)|Mongolia|New_(Caledonia|Zealand)|Newfoundland|Norfolk|Noronha|Novosibirsk|Omsk|Pakistan|Paraguay|Peru|Philippines|Pierre_Miquelon|Sakhalin|Samoa|Taipei|Tonga|Turkmenistan|Uruguay|Uzbekistan|Vanuatu|Vladivostok|Volgograd|Yakutsk|Yekaterinburg)"/>
-		<coverageVariable key="%metazone80_stdonly" value="(Afghanistan|Bhutan|Bolivia|Brunei|Chamorro|Christmas|Cocos|Davis|DumontDUrville|East_Timor|Ecuador|Europe_Further_Eastern|French_(Guiana|Southern)|Gambier|Galapagos|Gilbert_Islands|Gulf|Guyana|Indian_Ocean|Kazakhstan_(East|West)ern|Kosrae|Kyrgystan|Line_Islands|Macquarie|Malaysia|Maldives|Marquesas|Marshall_Islands|Mawson|Myanmar|Nauru|Nepal|Niue|Palau|Papua_New_Guinea|Phoenix_Islands|Pitcairn|Ponape|Pyongyang|Reunion|Rothera|Seychelles|Singapore|Solomon|South_Georgia|Suriname|Syowa|Tahiti|Tajikistan|Tokelau|Truk|Tuvalu|Venezuela|Vostok|Wake|Wallis)"/>
+		<coverageVariable key="%metazone80_stdonly" value="(Afghanistan|Bhutan|Bolivia|Brunei|Chamorro|Christmas|Cocos|Davis|DumontDUrville|East_Timor|Ecuador|Europe_Further_Eastern|French_(Guiana|Southern)|Gambier|Galapagos|Gilbert_Islands|Gulf|Guyana|Indian_Ocean|Kazakhstan_(East|West)ern|Kosrae|Kyrgystan|Line_Islands|Macquarie|Malaysia|Maldives|Marquesas|Marshall_Islands|Mawson|Myanmar|Nauru|Nepal|Niue|Palau|Papua_New_Guinea|Phoenix_Islands|Pitcairn|Ponape|Pyongyang|Reunion|Rothera|Seychelles|Singapore|Solomon|South_Georgia|Suriname|Syowa|Tahiti|Tajikistan|Tokelau|Truk|Tuvalu|Venezuela|Vostok|Wake|Wallis|Yukon)"/>
 		<coverageVariable key="%metazone100" value="(Acre|Almaty|Anadyr|Aqtau|Aqtobe|Kamchatka|Macau|Qyzylorda|Samara)"/>
 		<coverageVariable key="%metazone100_stdonly" value="(Casey|Guam|Lanka|North_Mariana)"/>
 		<coverageVariable key="%miscPatternTypes" value="(atLeast|range)"/>

--- a/common/supplemental/metaZones.xml
+++ b/common/supplemental/metaZones.xml
@@ -197,7 +197,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			</timezone>
 			<timezone type="America/Anchorage">
 				<usesMetazone to="1983-10-30 11:00" mzone="Alaska_Hawaii"/>
-				<usesMetazone to="1983-11-30 09:00" from="1983-10-30 11:00" mzone="Yukon"/>
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/Anguilla">
@@ -358,9 +357,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone from="1996-01-01 03:00" mzone="GMT"/>
 			</timezone>
 			<timezone type="America/Dawson">
-				<usesMetazone to="1973-10-28 09:00" mzone="Yukon"/>
 				<usesMetazone to="2020-11-01 07:00" from="1973-10-28 09:00" mzone="America_Pacific"/>
-				<usesMetazone from="2020-11-01 07:00" mzone="America_Mountain"/>
+				<usesMetazone from="2020-11-01 07:00" mzone="Yukon"/>
 			</timezone>
 			<timezone type="America/Dawson_Creek">
 				<usesMetazone to="1972-08-30 09:00" mzone="America_Pacific"/>
@@ -489,9 +487,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			</timezone>
 			<timezone type="America/Juneau">
 				<usesMetazone to="1980-04-27 10:00" mzone="America_Pacific"/>
-				<usesMetazone to="1980-10-26 10:00" from="1980-04-27 10:00" mzone="Yukon"/>
 				<usesMetazone to="1983-10-30 09:00" from="1980-10-26 10:00" mzone="America_Pacific"/>
-				<usesMetazone to="1983-11-30 09:00" from="1983-10-30 09:00" mzone="Yukon"/>
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/Kentucky/Monticello">
@@ -598,7 +594,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			</timezone>
 			<timezone type="America/Nome">
 				<usesMetazone to="1983-10-30 12:00" mzone="Bering"/>
-				<usesMetazone to="1983-11-30 09:00" from="1983-10-30 12:00" mzone="Yukon"/>
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/Noronha">
@@ -702,7 +697,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			</timezone>
 			<timezone type="America/Sitka">
 				<usesMetazone to="1983-10-30 09:00" mzone="America_Pacific"/>
-				<usesMetazone to="1983-11-30 09:00" from="1983-10-30 09:00" mzone="Yukon"/>
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/St_Barthelemy">
@@ -750,13 +744,12 @@ For terms of use, see http://www.unicode.org/copyright.html
 			</timezone>
 			<timezone type="America/Whitehorse">
 				<usesMetazone to="2020-11-01 07:00" mzone="America_Pacific"/>
-				<usesMetazone from="2020-11-01 07:00" mzone="America_Mountain"/>
+				<usesMetazone from="2020-11-01 07:00" mzone="Yukon"/>
 			</timezone>
 			<timezone type="America/Winnipeg">
 				<usesMetazone mzone="America_Central"/>
 			</timezone>
 			<timezone type="America/Yakutat">
-				<usesMetazone to="1983-11-30 09:00" mzone="Yukon"/>
 				<usesMetazone from="1983-11-30 09:00" mzone="Alaska"/>
 			</timezone>
 			<timezone type="America/Yellowknife">
@@ -1897,7 +1890,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="Yakutsk" territory="001" type="Asia/Yakutsk"/>
 			<mapZone other="Yekaterinburg" territory="001" type="Asia/Yekaterinburg"/>
 			<mapZone other="Yerevan" territory="001" type="Asia/Yerevan"/>
-			<mapZone other="Yukon" territory="001" type="America/Yakutat"/>
+			<mapZone other="Yukon" territory="001" type="America/Whitehorse"/>
 		</mapTimezones>
 	</metaZones>
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/MetazoneSortMode.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/MetazoneSortMode.java
@@ -155,11 +155,8 @@ public class MetazoneSortMode extends SortMode {
                 return (pp != null && pp.matches("0-names\\|metazone\\|Bering:.++"));
             }
         },
-        new Partition.Membership("Yukon", "The Yukon time zone was used in the states of Alaska and Hawaii in the "
-            + "United States until 1983.  It is not currently in use. "
-            + "Daylight savings time was observed briefly in some areas, but was not the norm."
-            + "When DST was not in effect, the time zone was 10 hours behind UTC (UTC-10). "
-            + "When DST was in effect, the time zone was 9 hours behind UTC (UTC-9).") {
+        new Partition.Membership("Yukon", "The Yukon time zone is used by Yukon, Canada since November 2020. "
+            + "Daylight savings is not used. The time zone is 7 hours behind UTC (UTC-7).") {
             @Override
             public boolean isMember(DataRow p) {
                 String pp = p.getPrettyPath();

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -16,7 +16,7 @@
 %F = (electric|frequency)
 %H = ([hH])
 %L = (long|short|narrow)
-%M = (Alaska_Hawaii|Bering|Dominican|Goose_Bay|Greenland_Central|Yukon|Dutch_Guiana|Africa_FarWestern|Liberia|British|Irish|Kuybyshev|Sverdlovsk|Baku|Tbilisi|Turkey|Yerevan|Aktyubinsk|Ashkhabad|Dushanbe|Frunze|Kizilorda|Oral|Samarkand|Shevchenko|Tashkent|Uralsk|Urumqi|Dacca|Karachi|Borneo|Malaya|Kwajalein)
+%M = (Alaska_Hawaii|Bering|Dominican|Goose_Bay|Greenland_Central|Dutch_Guiana|Africa_FarWestern|Liberia|British|Irish|Kuybyshev|Sverdlovsk|Baku|Tbilisi|Turkey|Yerevan|Aktyubinsk|Ashkhabad|Dushanbe|Frunze|Kizilorda|Oral|Samarkand|Shevchenko|Tashkent|Uralsk|Urumqi|Dacca|Karachi|Borneo|Malaya|Kwajalein)
 %N = (gregorian|generic|buddhist|chinese|coptic|dangi|ethiopic|hebrew|indian|islamic|japanese|persian|roc)
 %O = (gregorian|chinese|coptic|dangi|ethiopic|hebrew|indian|islamic|persian)
 %P = (future|past)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -338,7 +338,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
          */
         final ImmutableSet<String> inactiveMetazones = ImmutableSet.of("Bering", "Dominican", "Shevchenko", "Alaska_Hawaii", "Yerevan",
             "Africa_FarWestern", "British", "Sverdlovsk", "Karachi", "Malaya", "Oral", "Frunze", "Dutch_Guiana", "Irish", "Uralsk", "Tashkent", "Kwajalein",
-            "Yukon", "Ashkhabad", "Kizilorda", "Kuybyshev", "Baku", "Dushanbe", "Goose_Bay", "Liberia", "Samarkand", "Tbilisi", "Borneo", "Greenland_Central",
+            "Ashkhabad", "Kizilorda", "Kuybyshev", "Baku", "Dushanbe", "Goose_Bay", "Liberia", "Samarkand", "Tbilisi", "Borneo", "Greenland_Central",
             "Dacca", "Aktyubinsk", "Turkey", "Urumqi", "Acre", "Almaty", "Anadyr", "Aqtau", "Aqtobe", "Kamchatka", "Macau", "Qyzylorda", "Samara",
             "Casey", "Guam", "Lanka", "North_Mariana");
 


### PR DESCRIPTION
CLDR-14709

- [x] This PR completes the ticket.

- metaZones.xml
    - remove old mappings to Yukon metazone
    - change current mappings for America/Dawson and America/Whitehorse from America_Mountain to Yukon
    - change golden zone for Yukon from America/Yakutat to America/Whitehorse
- en.xml, add English name for Yukon metazone (only for &lt;standard&gt;)
- coverageLevels.xml, add coverage for Yukon metazone (level 30 for CA, level 80 otherwise)
- MetazoneSortMode.java, update description for Yukon metazone
- PathHeader.txt & TestCoverageLevel.java, remove Yukon from list of deprecated metazones

There did not seem to be anything relevant in XMLSource.java