### PR TITLE
CLDR-14674 en_IN compact decimals, add missing other case for 10^14

### DIFF
--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -5226,6 +5226,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000000000" count="one" draft="contributed">00LCr</pattern>
 					<pattern type="10000000000000" count="other" draft="contributed">00LCr</pattern>
 					<pattern type="100000000000000" count="one" draft="contributed">000LCr</pattern>
+					<pattern type="100000000000000" count="other" draft="contributed">000LCr</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>


### PR DESCRIPTION
CLDR-14674

- [x] This PR completes the ticket.

en_IN compact decimal short forms, add the missing "other" case for 10^14 (100 trillion)
(was missed in https://github.com/unicode-org/cldr/pull/963)