### PR TITLE
CLDR-14633 Rohingya: name, territoryInfo, likelySubtags, seed locales; change default script

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -481,6 +481,7 @@ annotations.
 			<language type="rap">Rapanui</language>
 			<language type="rar">Rarotongan</language>
 			<language type="rgn">Romagnol</language>
+			<language type="rhg">Rohingya</language>
 			<language type="rif">Riffian</language>
 			<language type="rm">Romansh</language>
 			<language type="rn">Rundi</language>
@@ -801,7 +802,8 @@ annotations.
 			<script type="Prti">Inscriptional Parthian</script>
 			<script type="Qaag">Zawgyi</script>
 			<script type="Rjng">Rejang</script>
-			<script type="Rohg">Hanifi Rohingya</script>
+			<script type="Rohg">Hanifi</script>
+			<script type="Rohg" alt="stand-alone">Hanifi Rohingya</script>
 			<script type="Roro">Rongorongo</script>
 			<script type="Runr">Runic</script>
 			<script type="Samr">Samaritan</script>

--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -27,7 +27,7 @@
 				om or os
 				pa pcm pl prg ps pt
 				qu
-				rm rn ro rof
+				rhg rm rn ro rof
 				und
 				ru rw rwk
 				sa sah saq sat sbp sd se seh ses sg shi si sk sl smn sn so sq sr su sv sw

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -99,7 +99,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%language60_GA" value="(fan|mye)"/>
 		<coverageVariable key="%language60_NG" value="(ff|ha|ibb|ig|kr|yo)"/>
 		<coverageVariable key="%language60_TD" value="(shu|dzg|kbl|mde|mua|sba)"/>
-		<coverageVariable key="%language80" value="(doi|a([fkmrz]|gq|s[at]?)|b([gm-os]|as|e[mz]?|rx?)|c([aosy]|cp|eb?|gg|hr|kb)|d([ez]|av?|je|sb|ua|yo)|e([elnos-u]|bu|wo)|f([afory]|il?|ur)|fa_AF|g([adlv]|sw|uz?)|h([eirtuy]|aw?|mn|sb)|i[adgist]|j([av]|go|mc)|k([imnuwy]|a[bm]?|de|ea|hq|kj?|ln?|ok?|s[bfh]?)|l([bgnotv]|ag?|kt|rc|u[oy]?)|m([iklr-ty]|a[is]|er|fe|g[ho]?|ni?|u[al]|zn)|n([belo]|aq|ds?|mg|nh?|us|yn?)|o[mrs]|p([alst]|cm)|qu|r([mnu]|of?|wk?)|s([dgiklnoqrt-w]|a[hqt]?|bp|e[hs]?|hi|mn?)|t([ag-ikort]|eo?|wq|zm)|u([gkrz]|nd)|v([i]|ai|un)|w(ae|o)|x(h|og)|y([io]|av|ue)|z([hu]|gh|xx))"/>
+		<coverageVariable key="%language80" value="(doi|a([fkmrz]|gq|s[at]?)|b([gm-os]|as|e[mz]?|rx?)|c([aosy]|cp|eb?|gg|hr|kb)|d([ez]|av?|je|sb|ua|yo)|e([elnos-u]|bu|wo)|f([afory]|il?|ur)|fa_AF|g([adlv]|sw|uz?)|h([eirtuy]|aw?|mn|sb)|i[adgist]|j([av]|go|mc)|k([imnuwy]|a[bm]?|de|ea|hq|kj?|ln?|ok?|s[bfh]?)|l([bgnotv]|ag?|kt|rc|u[oy]?)|m([iklr-ty]|a[is]|er|fe|g[ho]?|ni?|u[al]|zn)|n([belo]|aq|ds?|mg|nh?|us|yn?)|o[mrs]|p([alst]|cm)|qu|r([mnu]|of?|wk?|hg)|s([dgiklnoqrt-w]|a[hqt]?|bp|e[hs]?|hi|mn?)|t([ag-ikort]|eo?|wq|zm)|u([gkrz]|nd)|v([i]|ai|un)|w(ae|o)|x(h|og)|y([io]|av|ue)|z([hu]|gh|xx))"/>
 		<coverageVariable key="%languagecomp" value="(gan|hak|hsn|nan|wuu)"/> <!-- not currently used, just for reference: the only valid language codes that are not in modern coverage -->
 		<coverageVariable key="%lbTypes80" value="(strict|normal|loose)"/>
         <coverageVariable key="%lwTypes" value="(normal|breakall|keepall)"/>

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -2048,8 +2048,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Reshe; ?; ? } => { Reshe; Latin; Unknown Region }-->
 		<likelySubtag from="rgn" to="rgn_Latn_IT"/>
 		<!--{ Romagnol; ?; ? } => { Romagnol; Latin; Italy }-->
-		<likelySubtag from="rhg" to="rhg_Arab_MM"/>
-		<!--{ Rohingya; ?; ? } => { Rohingya; Arabic; Myanmar (Burma) }-->
+		<likelySubtag from="rhg" to="rhg_Rohg_MM"/>
+		<!--{ Rohingya; ?; ? } => { Rohingya; Hanifi; Myanmar (Burma) }-->
 		<likelySubtag from="ria" to="ria_Latn_IN"/>
 		<!--{ Riang (India); ?; ? } => { Riang (India); Latin; India }-->
 		<likelySubtag from="rif" to="rif_Tfng_MA"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2064,6 +2064,8 @@ XXX Code for transations where no currency is involved
 		<language type="rej" scripts="Latn"/>
 		<language type="rej" scripts="Rjng" territories="ID" alt="secondary"/>
 		<language type="rgn" scripts="Latn"/>
+		<language type="rhg" scripts="Rohg"/>
+		<language type="rhg" scripts="Arab Latn" alt="secondary"/>
 		<language type="ria" scripts="Latn"/>
 		<language type="rif" scripts="Latn Tfng"/>
 		<language type="rif" territories="MA" alt="secondary"/>
@@ -2495,6 +2497,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="en" populationPercent="18"/>	<!--English-->
 			<languagePopulation type="rkt" literacyPercent="20" populationPercent="6.5" references="R1087"/>	<!--Rangpuri-->
 			<languagePopulation type="syl" literacyPercent="35" populationPercent="5"/>	<!--Sylheti-->
+			<languagePopulation type="rhg" populationPercent="0.52"/>	<!--Rohingya-->
 			<languagePopulation type="ccp" populationPercent="0.22"/>	<!--Chakma-->
 			<languagePopulation type="my" populationPercent="0.21"/>	<!--Burmese-->
 			<languagePopulation type="grt" populationPercent="0.073"/>	<!--Garo-->
@@ -3496,6 +3499,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="my" populationPercent="64" officialStatus="official"/>	<!--Burmese-->
 			<languagePopulation type="shn" populationPercent="6.4"/>	<!--Shan-->
 			<languagePopulation type="kac" populationPercent="1.7"/>	<!--Kachin-->
+			<languagePopulation type="rhg" populationPercent="1.6"/>	<!--Rohingya-->
 			<languagePopulation type="mnw" populationPercent="1.5"/>	<!--Mon-->
 			<languagePopulation type="kht" populationPercent="0.0075"/>	<!--Khamti-->
 		</territory>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1678,7 +1678,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			oc_FR om_ET or_IN os_GE osa_US
 			pa_Arab_PK pa_Guru pa_Guru_IN pcm_NG pl_PL prg_001 ps_AF pt_BR
 			qu_PE quc_GT
-			rm_CH rn_BI ro_RO rof_TZ ru_RU rw_RW rwk_TZ
+			rhg_Rohg rhg_Rohg_MM rm_CH rn_BI ro_RO rof_TZ ru_RU rw_RW rwk_TZ
 			sa_IN sah_RU saq_KE sat_Deva_IN sat_Olck sat_Olck_IN sbp_TZ sc_IT scn_IT
 			sd_Arab sd_Arab_PK sd_Deva_IN sdh_IR se_NO seh_MZ ses_ML sg_CF shi_Latn_MA
 			shi_Tfng shi_Tfng_MA si_LK sid_ET sk_SK sl_SI sma_SE smj_SE smn_FI sms_FI sn_ZW

--- a/exemplars/main/rhg_Arab.xml
+++ b/exemplars/main/rhg_Arab.xml
@@ -9,6 +9,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<identity>
 		<version number="$Revision$"/>
 		<language type="rhg"/>
+		<script type="Arab"/>
 	</identity>
 	<layout>
 		<orientation>

--- a/seed/main/rhg.xml
+++ b/seed/main/rhg.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="rhg"/>
+	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="rhg" draft="contributed">𐴌𐴗𐴥𐴝𐴙𐴚𐴒𐴙𐴝</language>
+		</languages>
+	</localeDisplayNames>
+	<layout>
+		<orientation>
+			<characterOrder>right-to-left</characterOrder>
+		</orientation>
+	</layout>
+	<characters>
+		<exemplarCharacters draft="contributed">[𐴀 𐴁 𐴂 𐴃 𐴄 𐴅 𐴆 𐴇 𐴈 𐴉 𐴊 𐴋 𐴌 𐴍 𐴎 𐴏 𐴐 𐴑 𐴒 𐴓 𐴔 𐴕 𐴖 𐴗 𐴘 𐴙 𐴚 𐴛 𐴝 𐴞 𐴟 𐴠 𐴡 𐴢 𐴣 𐴤 𐴥 𐴦 𐴧]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary" draft="contributed">[ـ]</exemplarCharacters>
+		<exemplarCharacters type="numbers" draft="contributed">[\- ‑ , . % + 0𐴰 1𐴱 2𐴲 3𐴳 4𐴴 5𐴵 6𐴶 7𐴷 8𐴸 9𐴹]</exemplarCharacters>
+		<exemplarCharacters type="punctuation" draft="contributed">[\- ‐ ‑ – — ، ؛ \: ! ؟ . … ' \u0022 ( ) \[ \]]</exemplarCharacters>
+	</characters>
+	<dates>
+		<calendars>
+			<calendar type="gregorian">
+				<timeFormats>
+					<timeFormatLength type="full">
+						<timeFormat>
+							<pattern>HH:mm:ss zzzz</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="long">
+						<timeFormat>
+							<pattern>HH:mm:ss z</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="medium">
+						<timeFormat>
+							<pattern>HH:mm:ss</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="short">
+						<timeFormat>
+							<pattern>H:mm</pattern>
+						</timeFormat>
+					</timeFormatLength>
+				</timeFormats>
+			</calendar>
+		</calendars>
+	</dates>
+</ldml>

--- a/seed/main/rhg_Rohg.xml
+++ b/seed/main/rhg_Rohg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="rhg"/>
+		<script type="Rohg"/>
+	</identity>
+</ldml>

--- a/seed/main/rhg_Rohg_BD.xml
+++ b/seed/main/rhg_Rohg_BD.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="rhg"/>
+		<script type="Rohg"/>
+		<territory type="BD"/>
+	</identity>
+	<dates>
+		<calendars>
+			<calendar type="gregorian">
+				<timeFormats>
+					<timeFormatLength type="full">
+						<timeFormat>
+							<pattern>h:mm:ss a zzzz</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="long">
+						<timeFormat>
+							<pattern>h:mm:ss a z</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="medium">
+						<timeFormat>
+							<pattern>h:mm:ss a</pattern>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="short">
+						<timeFormat>
+							<pattern>h:mm a</pattern>
+						</timeFormat>
+					</timeFormatLength>
+				</timeFormats>
+			</calendar>
+		</calendars>
+	</dates>
+</ldml>

--- a/seed/main/rhg_Rohg_MM.xml
+++ b/seed/main/rhg_Rohg_MM.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2020 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="rhg"/>
+		<script type="Rohg"/>
+		<territory type="MM"/>
+	</identity>
+</ldml>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -74,6 +74,7 @@ Bangladesh	BD	"159,453,001"	58%	"690,300,000,000"		Garo	grt	"116,000"
 Bangladesh	BD	"159,453,001"	58%	"690,300,000,000"		Manipuri	mni	"17,200"			
 Bangladesh	BD	"159,453,001"	58%	"690,300,000,000"		Mru	mro	"28,800"			https://www.ethnologue.com/language/mro and https://en.wikipedia.org/wiki/Mru_language
 Bangladesh	BD	"159,453,001"	58%	"690,300,000,000"		Rangpuri	rkt	6.5%	20%		http://www.ethnologue.com/show_language.asp?code=rkt
+Bangladesh	BD	"159,453,001"	58%	"690,300,000,000"		Rohingya	rhg	"850,000"			
 Bangladesh	BD	"159,453,001"	58%	"690,300,000,000"		Sylheti	syl	5%	35%		
 Barbados	BB	"293,131"	100%	"5,218,000,000"	official	English	en	100%			
 Belarus	BY	"9,527,543"	100%	"179,400,000,000"	official	Belarusian	be	100%			
@@ -843,6 +844,7 @@ Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"	official	Burmese	my	64%
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Kachin	kac	"945,000"			
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Khamti	kht	"4,240"			
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Mon	mnw	"828,000"			
+Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Rohingya	rhg	"930,000"			
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Shan	shn	6.4%			
 Namibia	NA	"2,533,224"	89%	"26,600,000,000"		Afrikaans	af	75%			"https://www.cia.gov/library/publications/the-world-factbook/geos/wa.html most of population use Afrikaans commonly, about 89% literacy"
 Namibia	NA	"2,533,224"	89%	"26,600,000,000"	official	English	en	7%			

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script_raw.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script_raw.txt
@@ -641,6 +641,9 @@ rcf	Réunion Creole French	primary	Latn	Latin
 rej	Rejang	primary	Latn	Latin
 rej	Rejang	secondary	Rjng	Rejang
 rgn	Romagnol	primary	Latn	Latin
+rhg	Rohingya	primary	Rohg	Hanifi
+rhg	Rohingya	secondary	Arab	Arabic
+rhg	Rohingya	secondary	Latn	Latin
 ria	Riang [India]	primary	Latn	Latin
 rif	Riffian	primary	Latn	Latin
 rif	Riffian	primary	Tfng	Tifinagh

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -49,8 +49,8 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
     }
 
     public void TestLanguageNameCoverage() {
-        
-        Set<String> additionsToTranslate = new TreeSet<>(Arrays.asList("zxx", "ceb", "ny", "co", "ht", "hmn", "la", "sm", "st", "sa", "mul"));
+        // not sure why we need rhg here, since it is in seed it should be in mainLocales
+        Set<String> additionsToTranslate = new TreeSet<>(Arrays.asList("zxx", "ceb", "ny", "co", "ht", "hmn", "la", "sm", "st", "sa", "mul", "rhg"));
         
         Map<String, Status> validity = Validity.getInstance().getCodeToStatus(LstrType.language);
         Multimap<Status, String> statusToLang = Multimaps.invertFrom(Multimaps.forMap(validity), TreeMultimap.create());


### PR DESCRIPTION
CLDR-14633

- [x] This PR completes the ticket.

Add basic support for Rohingya (rhg), per discussion in ticket:
- Add to the set of language names we translate (attributeValueValidity)
- Add display name in English, and include display name in modern coverage
- For script Rohg, make "Hanifi Rohingya" the stand-alone English name, with the combining name being just "Hanifi"
- Add territoryInfo, language info, likelySubtags; change default script from Arab to Rohg
- Add seed locales for rhg, rhg_Rohg, rhg_Rohg_MM, rhg_Rohg_BD with exemplars, layout direction, endonym, and standard time formats that match region timecycle prefs.