### PR TITLE
CLDR-14769 fix pom.xml for language group tool (RDF)

### DIFF
--- a/tools/cldr-rdf/pom.xml
+++ b/tools/cldr-rdf/pom.xml
@@ -12,7 +12,6 @@
     <url>https://unicode.org/cldr</url>
 
     <properties>
-        <mainClass>org.unicode.cldr.rdf.tool.FetchAbstracts</mainClass>
         <jenaVersion>3.16.0</jenaVersion>
     </properties>
 
@@ -89,7 +88,6 @@
             <artifactId>xercesImpl</artifactId>
         </dependency>
     </dependencies>
-        
     <build>
         <pluginManagement>
             <plugins>
@@ -97,7 +95,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <configuration>
-                    	<mainClass>${mainClass}</mainClass>
                         <systemProperties>
                             <systemProperty>
                                 <key>CLDR_DIR</key>


### PR DESCRIPTION
- an incorrect mainClass was there, preventing use of the RDF classes
- in fact, it is better to have no mainClass so that it is given from the command line

CLDR-14769

Discovered this with #1230 

- [x] This PR completes the ticket. (need to update docs also)

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
