### PR TITLE
CLDR-14758 fix Dashboard for sandbox locales

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
@@ -719,8 +719,10 @@ public class VettingViewerQueue {
         Organization usersOrg = Organization.fromString(user.voterOrg());
         final boolean quick = false;
         STFactory sourceFactory = sm.getSTFactory();
+        final Factory baselineFactory = CookieSession.sm.getDiskFactory();  // Use the SurveyTool's baseline factory
         VettingViewer<Organization> vv = new VettingViewer<>(sm.getSupplementalDataInfo(), sourceFactory,
             getUsersChoice(sm), "Winning " + SurveyMain.getNewVersion());
+        vv.setBaselineFactory(baselineFactory);
 
         EnumSet<VettingViewer.Choice> choiceSet = getChoiceSetForOrg(usersOrg);
 
@@ -737,7 +739,6 @@ public class VettingViewerQueue {
          * technical committee by committing directly to version control rather than voting.
          */
         CLDRFile sourceFile = sourceFactory.make(loc, true);
-        Factory baselineFactory = CLDRConfig.getInstance().getCommonAndSeedAndMainAndAnnotationsFactory();
         CLDRFile baselineFile = baselineFactory.make(loc, true);
         Relation<R2<SectionId, PageId>, VettingViewer<Organization>.WritingInfo> file;
         file = vv.generateFileInfoReview(choiceSet, loc, usersOrg, usersLevel, quick, sourceFile, quick ? null : baselineFile);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -407,7 +407,7 @@ public class VettingViewer<T> {
     private final SupplementalDataInfo supplementalDataInfo;
     private final String baselineTitle = "Baseline";
     private final String currentWinningTitle;
-
+    private Factory baselineFactory;
     private final Set<String> defaultContentLocales;
 
     /**
@@ -433,7 +433,20 @@ public class VettingViewer<T> {
 
         this.currentWinningTitle = currentWinningTitle;
         reasonsToPaths = Relation.of(new HashMap<String, Set<String>>(), HashSet.class);
+
+        // Default baseline factory
+        this.baselineFactory = CLDRConfig.getInstance().getCommonAndSeedAndMainAndAnnotationsFactory();
     }
+
+    public Factory getBaselineFactory() {
+        return baselineFactory;
+    }
+
+    public void setBaselineFactory(Factory baselineFactory) {
+        this.baselineFactory = baselineFactory;
+    }
+
+
 
     public class WritingInfo implements Comparable<WritingInfo> {
         public final PathHeader codeOutput;


### PR DESCRIPTION
- add a get/set baselineFactory() function to VettingViewer
- use SurveyTool's getDiskFactory() as the baseline factory

CLDR-14758

- [X] This PR completes the ticket.

Ideally, the `get…Factory()` functions would only be used in tests and tools, and not in main library functions.