### PR TITLE
CLDR-14555 remove stray commit() when deleting invalid votes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -743,8 +743,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                         }
                     }
                     if (del > 0) {
-                        System.out.println("Committing delete of " + del + " invalid votes from " + locale);
-                        conn.commit();
+                        logger.warning ("Summary: delete of " + del + " invalid votes from " + locale);
                     }
                     DBUtils.close(rs, ps);
                     ps = openPermVoteQuery(conn);


### PR DESCRIPTION
- rare occurance
- connection is auto commit (explicit `commit()` may not be called)

CLDR-14555

this code was hit because xpaths became invalid for voting.