### PR TITLE
CLDR-13981 Remove narrow symbols for BYN/RUR in root, add elsewhere as needed

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3810,9 +3810,6 @@ for derived annotations.
 			<currency type="BWP">
 				<symbol alt="narrow">P</symbol>
 			</currency>
-			<currency type="BYN">
-				<symbol alt="narrow">р.</symbol>
-			</currency>
 			<currency type="BZD">
 				<symbol alt="narrow">$</symbol>
 			</currency>
@@ -4013,9 +4010,6 @@ for derived annotations.
 			</currency>
 			<currency type="RUB">
 				<symbol alt="narrow">₽</symbol>
-			</currency>
-			<currency type="RUR">
-				<symbol alt="narrow">р.</symbol>
 			</currency>
 			<currency type="RWF">
 				<symbol alt="narrow">RF</symbol>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -7779,6 +7779,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="RUR">
 				<displayName>Российский рубль (1991–1998)</displayName>
 				<symbol>р.</symbol>
+				<symbol alt="narrow">р.</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>франк Руанды</displayName>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -7488,6 +7488,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="few">російські рублі (RUR)</displayName>
 				<displayName count="many">російських рублів (RUR)</displayName>
 				<displayName count="other">російського рубля (RUR)</displayName>
+				<symbol draft="contributed">RUR</symbol>
+				<symbol alt="narrow">р.</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>руандійський франк</displayName>


### PR DESCRIPTION

CLDR-13981

- [x] This PR completes the ticket.

The goal was for the root narrow currency symbol for BYN (Belarusian Ruble) and RUR (old Russian Ruble to 1998) to change from Cyrillic "р." to just the ISO 4217 3-letter code, with the "р." added as narrow symbol in Cyrillic locales as necessary.

1. In root that just means removing the currency entries for BYN and RUR, which only had the narrow symbol.
2. be Belarusian already has an antry using a different symbol:
```
	<currency type="BYN">
		<symbol>Br</symbol>
		<symbol alt="narrow" draft="contributed">Br</symbol>
```
3. ru Russian already had the following; we add the narrow symbol for RUR (not strictly necessary):
```
	<currency type="BYN">
		<symbol alt="narrow" draft="contributed">р.</symbol>
	</currency>
	<currency type="RUR">
		<symbol>р.</symbol>
	</currency>
```
4. uk Ukrainian already had the following so we just add the regular (somewhat redundant) and narrow symbols for RUR:
```
	<currency type="BYN">
		<symbol alt="narrow" draft="contributed">р.</symbol>
	</currency>
```
