### PR TITLE
CLDR-14782 Better root abbreviated names for Islamic calendar months

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1713,16 +1713,16 @@ for derived annotations.
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">Muh.</month>
-							<month type="2">Saf.</month>
-							<month type="3">Rab. I</month>
-							<month type="4">Rab. II</month>
-							<month type="5">Jum. I</month>
-							<month type="6">Jum. II</month>
-							<month type="7">Raj.</month>
-							<month type="8">Sha.</month>
-							<month type="9">Ram.</month>
-							<month type="10">Shaw.</month>
+							<month type="1">Mhrm.</month>
+							<month type="2">Safr.</month>
+							<month type="3">Rab. I</month>
+							<month type="4">Rab. II</month>
+							<month type="5">Jmd. I</month>
+							<month type="6">Jmd. II</month>
+							<month type="7">Rajb.</month>
+							<month type="8">Shbn.</month>
+							<month type="9">Rmdn.</month>
+							<month type="10">Shwl.</month>
 							<month type="11">Dhuʻl-Q.</month>
 							<month type="12">Dhuʻl-H.</month>
 						</monthWidth>


### PR DESCRIPTION
CLDR-14782

- [x] This PR completes the ticket.

Better root names for Islamic calendar months. Note that these also change the spaces in 4 of the names from regular space to narrow no-break space U+202F (better layout behavior).