### PR TITLE
CLDR-14791 enable changing vetter email, name, password, and org

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAccount.js
+++ b/tools/cldr-apps/js/src/esm/cldrAccount.js
@@ -215,6 +215,13 @@ function loadHandler(json) {
       orgList = json.orgList;
     }
     shownUsers = json.shownUsers;
+    if (
+      justUser &&
+      shownUsers.length === 1 &&
+      getSelectedAction(shownUsers[0]) === "change_INFO_EMAIL"
+    ) {
+      justUser = shownUsers[0].email;
+    }
     if (json.userPerms.levels) {
       levelList = json.userPerms.levels;
     }
@@ -492,20 +499,42 @@ function getJustUserActionMenuOptions(u, json) {
     html += getDeleteUserOptions(u, json);
   }
   html += " <option disabled='disabled'>" + LIST_ACTION_NONE + "</option>\n"; // separator
-
-  const current = 0; // ?? InfoType.fromAction(action); -- json.preset_do?
+  const selectedAction = getSelectedAction(u.data);
   for (const [info, title] of Object.entries(infoType)) {
     if (info === "INFO_ORG" && !cldrStatus.getPermissions().userIsAdmin) {
       continue;
     }
+    // INFO_EMAIL makes change_INFO_EMAIL, etc.; must be mixed case
+    const changeInfo = "change_" + info;
     html += " <option";
-    if (info === current) {
+    if (changeInfo === selectedAction) {
       html += " selected='selected'";
     }
-    // INFO_EMAIL makes CHANGE_INFO_EMAIL, etc.
-    html += " value='CHANGE_" + info + "'>Change " + title + "...</option>\n";
+    html += " value='" + changeInfo + "'>Change " + title + "...</option>\n";
   }
   return html;
+}
+
+/**
+ * Get the most recently chosen value in the actions menu, based on the server response.
+ *
+ * If the server response includes an object "actions" with at least
+ * one key, assume the first such key matches the most recently chosen item
+ * in the actions menu.
+ *
+ * This awkward implementation is due to incomplete modernization of the old
+ * implementation which was all java, no javascript.
+ *
+ * @return the value such as "change_INFO_EMAIL", or null
+ */
+function getSelectedAction(userData) {
+  if (userData.actions) {
+    const k = Object.keys(userData.actions);
+    if (k.length > 0) {
+      return k[0];
+    }
+  }
+  return null;
 }
 
 function getSetLocalesOption() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -344,14 +344,13 @@ public class UserList {
         if (s0.equals(s1) && s0.length() > 0) {
             String s = "<h4>Change " + what + " to <tt class='codebox'>" + s0 + "</tt></h4>";
             s += "<div class='fnotebox'>" + reg.updateInfo(ctx, u.user.id, u.user.email, type, s0) + "</div>";
-            s += "<i>click Change again to see changes</i>";
+            u.user = reg.getInfo(u.user.id);
             u.ua.put(action, s);
         } else {
             String s = "<h4>Change " + what + "</h4>";
             if (s0.length() > 0) {
                 s += "<p class='ferrbox'>Both fields must match.</p>";
             }
-            u.ua.put(action, s);
             if (type == InfoType.INFO_ORG) {
                 s += "<select name='string0" + what + "'>]n";
                 s += "<option value='' >Choose...</option>\n";
@@ -369,6 +368,7 @@ public class UserList {
                 s += "<label><b>New " + what + ":</b><input name='string1" + what
                     + "'> (confirm)</label>\n";
             }
+            u.ua.put(action, s);
         }
     }
 
@@ -379,7 +379,6 @@ public class UserList {
         if (s0.equals(s1) && s0.length() > 0) {
             String s = "<h4>Change " + what + " to <tt class='codebox'>" + s0 + "</tt></h4>";
             s += "<div class='fnotebox'>" + reg.updateInfo(ctx, u.user.id, u.user.email, type, s0) + "</div>";
-            s += "<i>click Change again to see changes</i>";
             u.ua.put(action, s);
         } else {
             String s = "<h4>Change " + what + "</h4>";


### PR DESCRIPTION
-Make client send change_INFO_EMAIL not CHANGE_INFO_EMAIL

-New getSelectedAction retains menu selection so POST includes change_INFO_EMAIL

-On server, after change, call reg.getInfo to update u.user for correct response to client

-On client, after changing email address, update justUser to the new address

-Remove message: click Change again to see changes; not needed and no Change to click

-Wait until finished forming response string before calling u.ua.put

-Comments

CLDR-14791

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
