### PR TITLE
CLDR-14498 Incorporate information from survey: phase 1

### DIFF
--- a/common/supplemental/grammaticalFeatures.xml
+++ b/common/supplemental/grammaticalFeatures.xml
@@ -193,7 +193,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="lt">
       <grammaticalCase values="nominative genitive dative accusative instrumental vocative locative"/>
-      <grammaticalCase values="nominative genitive dative accusative instrumental locative"/>
+      <grammaticalCase scope="units" values="nominative genitive dative accusative instrumental locative"/>
       <grammaticalGender values="masculine feminine"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="cs hr sk sr">
@@ -205,7 +205,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="ru">
       <grammaticalCase values="nominative genitive dative accusative instrumental prepositional vocative locative"/>
-      <grammaticalCase scope="units" values="nominative accusative dative genitive instrumental nominative"/>
+      <grammaticalCase scope="units" values="nominative accusative dative genitive prepositional instrumental"/>
       <grammaticalGender values="masculine feminine neuter"/>
       <grammaticalGender scope="units" values="masculine feminine"/>
     </grammaticalFeatures>

--- a/common/supplemental/grammaticalFeatures.xml
+++ b/common/supplemental/grammaticalFeatures.xml
@@ -33,12 +33,9 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
 <supplementalData>
   <version number="$Revision: 1 $"/>
   <grammaticalData>
-    <grammaticalFeatures targets="nominal" locales="af en fil ja ko lo ms my ne sw th vi zh zu">
-      <!-- No grammatical features (number is not considered). -->
-      <!-- Zulu and Swahili, like other Bantu languages, has a notion
-	   of noun class governing agreement of nouns and other
-	   forms; since it is fixed for a given noun, we don't
-	   consider it as an independent grammaticalFeature here. -->
+    <grammaticalFeatures targets="nominal" locales="af en fil ja ko lo ms my ne th vi zh">
+      <!-- No grammatical features (number is not considered). 
+      	   However, the data doesn't yet clearly distinguish semantic gender from non-semantic gender; that is to come later. -->
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="ca es fr it pt"> <!-- add lij if it is added as a locale -->
       <grammaticalGender values="masculine feminine"/>
@@ -54,6 +51,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="ta">
       <grammaticalCase values="nominative genitive accusative dative locative instrumental ablative vocative"/>
+      <grammaticalCase scope="units" values="nominative accusative dative ablative"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="fi">
       <grammaticalCase values="nominative abessive ablative adessive allative comitative elative essive genitive illative inessive instrumental partitive translative"/>
@@ -61,6 +59,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="hu">
       <grammaticalCase values="nominative ablative accusative adessive allative causal dative delative elative essive illative inessive instrumental sublative superessive terminative translative"/>
+      <grammaticalCase scope="units" values="nominative accusative instrumental terminative translative"/>
       <!-- Hungarian nouns also inflect in possessives, with agreement on number and person. -->
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="kk tr">
@@ -77,6 +76,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="el">
       <grammaticalCase values="nominative genitive accusative vocative"/>
+      <grammaticalCase scope="units" values="nominative genitive accusative"/>
       <grammaticalGender values="masculine feminine neuter"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="sl">
@@ -98,12 +98,20 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     <grammaticalFeatures targets="nominal" locales="mr">
       <grammaticalCase values="nominative oblique accusative dative ergative locative ablative genitive"/>
       <grammaticalGender values="masculine feminine neuter"/>
+      <grammaticalGender scope="units" values="neuter"/>
       <!-- Genitive agrees in gender, case and number with the antecedent. -->
       <!-- Oblique can be further inflected by semantics-defining suffixes. -->
     </grammaticalFeatures>
-    <grammaticalFeatures targets="nominal" locales="gu kn">
+    <grammaticalFeatures targets="nominal" locales="gu">
       <grammaticalCase values="nominative genitive accusative dative locative instrumental vocative"/>
       <grammaticalGender values="masculine feminine neuter"/>
+      <grammaticalGender scope="units" values="masculine feminine"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="kn">
+      <grammaticalCase values="nominative genitive accusative dative locative instrumental vocative"/>
+      <grammaticalCase scope="units" values="nominative genitive accusative dative locative vocative"/>
+      <grammaticalGender values="masculine feminine neuter"/>
+      <grammaticalGender scope="units" values="neuter"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="he">
       <grammaticalGender values="masculine feminine"/>
@@ -124,12 +132,14 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     <grammaticalFeatures targets="nominal" locales="bn">
       <grammaticalCase values="nominative accusative genitive locative"/>
       <grammaticalGender values="masculine feminine"/>
+      <grammaticalGender scope="units"/>
       <grammaticalDefiniteness values="definite indefinite"/>
       <!-- Gender is only used for expressing human activities/professions. -->
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="si">
       <grammaticalCase values="nominative genitive ablative accusative dative"/>
       <grammaticalGender values="masculine feminine neuter"/>
+      <grammaticalGender scope="units"/>
       <grammaticalDefiniteness values="definite indefinite"/>
       <!-- Neuter is only used for inanimate nouns; plurals have no definiteness marker. -->
     </grammaticalFeatures>
@@ -160,6 +170,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
 	   indefinite accusative -->
       <grammaticalCase values="nominative accusative"/>
       <grammaticalGender values="masculine feminine"/>
+      <grammaticalGender scope="units"/>
       <grammaticalDefiniteness values="definite indefinite"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="nb no">
@@ -171,24 +182,30 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="uk">
       <grammaticalCase values="nominative genitive dative accusative instrumental vocative locative"/>
+      <grammaticalCase scope="units" values="nominative genitive accusative"/>
       <grammaticalGender values="masculine feminine neuter"/>
+      <grammaticalGender scope="units" values="masculine feminine"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="lv">
       <grammaticalCase values="nominative genitive dative accusative vocative locative"/>
+      <grammaticalCase scope="units" values="nominative genitive dative accusative locative"/>
       <grammaticalGender values="masculine feminine"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="lt">
       <grammaticalCase values="nominative genitive dative accusative instrumental vocative locative"/>
+      <grammaticalCase values="nominative genitive dative accusative instrumental locative"/>
       <grammaticalGender values="masculine feminine"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="cs hr sk sr">
       <grammaticalCase values="nominative genitive dative accusative instrumental vocative locative"/>
+      <grammaticalCase scope="units" values="nominative genitive accusative instrumental"/>
       <grammaticalGender values="animate inanimate feminine neuter"/>
+      <grammaticalGender scope="units" values="inanimate feminine neuter"/>
       <!-- Czech also inflects in polarity (negation is a prefix) -->
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="ru">
       <grammaticalCase values="nominative genitive dative accusative instrumental prepositional vocative locative"/>
-      <grammaticalCase scope="units" values="accusative dative genitive instrumental locative nominative vocative"/>
+      <grammaticalCase scope="units" values="nominative accusative dative genitive instrumental nominative"/>
       <grammaticalGender values="masculine feminine neuter"/>
       <grammaticalGender scope="units" values="masculine feminine"/>
     </grammaticalFeatures>

--- a/common/transforms/Turkmen-Latin-BGN.xml
+++ b/common/transforms/Turkmen-Latin-BGN.xml
@@ -63,7 +63,7 @@ $lower = [$lowerConsonants $lowerVowels] ;
 # http://bugs.icu-project.org/cgi-bin/icu-bugs/transliterate?id=2034;expression=boundary;user=guest
 #
 
-$wordBoundary =  [^[:L:][:M:][:N:]] ;
+$wordBoundary =  [^[:L:][:M:][:N:] ] ;
 #
 #
 ########################################################################
@@ -100,11 +100,11 @@ $wordBoundary =  [^[:L:][:M:][:N:]] ;
 ########################################################################
 #
 
-Е}[[$upperVowels - [Ә]] [ЙЪЬ]] → YE ; # CYRILLIC CAPITAL LETTER IE
-Е}[[$lowerVowels - [ә]] [йъь]] → Ye ; # CYRILLIC CAPITAL LETTER IE
+Е}[[$upperVowels - [Ә] ] [ЙЪЬ] ] → YE ; # CYRILLIC CAPITAL LETTER IE
+Е}[[$lowerVowels - [ә] ] [йъь] ] → Ye ; # CYRILLIC CAPITAL LETTER IE
 $wordBoundary{Е → Ye ; # CYRILLIC CAPITAL LETTER IE
 Е →  E ; # CYRILLIC CAPITAL LETTER IE
-е}[[$upperVowels - [Ә]] [$lowerVowels - [ә]] [ЙйЪъЬь]] → ye ; # CYRILLIC SMALL LETTER IE
+е}[[$upperVowels - [Ә] ] [$lowerVowels - [ә] ] [ЙйЪъЬь] ] → ye ; # CYRILLIC SMALL LETTER IE
 $wordBoundary{е → ye ; # CYRILLIC SMALL LETTER IE
 е →  e ; # CYRILLIC SMALL LETTER IE
 #
@@ -335,8 +335,7 @@ $wordBoundary{е → ye ; # CYRILLIC SMALL LETTER IE
 #
 #
 ########################################################################
-
-			]]></tRule>
+            ]]></tRule>
 		</transform>
 	</transforms>
 </supplementalData>


### PR DESCRIPTION
CLDR-14498

Note: this incorporates the preliminary data from the survey. There are still questions out for about a dozen locales that may result in further changes.

Most of the changes are adding new lines with a restriction to scope="units", to reflect that a subset of the grammatical forms are needed for normal messages with placeholders of formatted units (eg "3.5 kilometers")

There was also a change to sw and zu, which should be changed to 'no information included yet' (that is, removed from the data until we get more information). Also left a note that the data is not completely clear regarding when gender is really only scoped to 'semantic gender' (aka gender of people).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
