### PR TITLE
CLDR-13660 en_IN, compact decimals long should also use lakh, crore

### DIFF
--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -5195,30 +5195,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="one" draft="contributed">0T</pattern>
+					<pattern type="1000" count="other" draft="contributed">0T</pattern>
+					<pattern type="10000" count="one" draft="contributed">00T</pattern>
+					<pattern type="10000" count="other" draft="contributed">00T</pattern>
+					<pattern type="100000" count="one" draft="contributed">0 lakh</pattern>
+					<pattern type="100000" count="other" draft="contributed">0 lakh</pattern>
+					<pattern type="1000000" count="one" draft="contributed">00 lakh</pattern>
+					<pattern type="1000000" count="other" draft="contributed">00 lakh</pattern>
+					<pattern type="10000000" count="one" draft="contributed">0 crore</pattern>
+					<pattern type="10000000" count="other" draft="contributed">0 crore</pattern>
+					<pattern type="100000000" count="one" draft="contributed">00 crore</pattern>
+					<pattern type="100000000" count="other" draft="contributed">00 crore</pattern>
+					<pattern type="1000000000" count="one" draft="contributed">000 crore</pattern>
+					<pattern type="1000000000" count="other" draft="contributed">000 crore</pattern>
+					<pattern type="10000000000" count="one" draft="contributed">0T crore</pattern>
+					<pattern type="10000000000" count="other" draft="contributed">0T crore</pattern>
+					<pattern type="100000000000" count="one" draft="contributed">00T crore</pattern>
+					<pattern type="100000000000" count="other" draft="contributed">00T crore</pattern>
+					<pattern type="1000000000000" count="one" draft="contributed">0 lakh crore</pattern>
+					<pattern type="1000000000000" count="other" draft="contributed">0 lakh crore</pattern>
+					<pattern type="10000000000000" count="one" draft="contributed">00 lakh crore</pattern>
+					<pattern type="10000000000000" count="other" draft="contributed">00 lakh crore</pattern>
+					<pattern type="100000000000000" count="one" draft="contributed">000 lakh crore</pattern>
+					<pattern type="100000000000000" count="other" draft="contributed">000 lakh crore</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">


### PR DESCRIPTION
CLDR-13660

- [x] This PR completes the ticket.

For en_IN, we had changed the compact decimal short forms per https://github.com/unicode-org/cldr/pull/963 to use L for lakh and Cr for crore (as well as T for thousands). However, the long forms were not chnaged; this PR handles the long forms. Basically we copy the short forms, but change L to "lakh" and Cr to "crore", set off with \u202F narrow no-break space.