### PR TITLE
CLDR-14801 make the single-arg getPath() public

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
@@ -156,7 +156,7 @@ public class CldrUtility {
         return PathUtilities.getNormalizedPathString(path) + File.separatorChar;
     }
 
-    static String getPath(String path) {
+    public static String getPath(String path) {
         return getPath(path, null);
     }
 


### PR DESCRIPTION
CLDR-14801

I want to use this from Unicode Tools class Settings, removing the null parameter.

- [ ] This PR completes the ticket.