### PR TITLE
CLDR-14797 Dont count narrow units as missing

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/paths/missingOk.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/paths/missingOk.txt
@@ -29,3 +29,4 @@
 //ldml/characters/parseLenients.* ; ok
 
 //ldml/layout/orientation/.* ; ok
+//ldml/units/unitLength[@type="narrow"]/.* ; ok


### PR DESCRIPTION
CLDR-14797

The narrow units are typically a nice-to-have, and this makes them not counted among the Missing. That almost halves the number of Missing items for a language like Croatian.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
