### PR TITLE
CLDR-14711 SBRS 40: Update CLDR snapshot version in pom files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.unicode.cldr</groupId>
 	<artifactId>cldr-data</artifactId>
-	<version>39.0-SNAPSHOT</version>
+	<version>40.0-SNAPSHOT</version>
 	<name>CLDR Top Level and Data</name>
 	<packaging>pom</packaging>
 	<licenses>

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.unicode.cldr</groupId>
 		<artifactId>cldr-all</artifactId>
-		<version>39.0-SNAPSHOT</version>
+		<version>40.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.unicode.cldr</groupId>
 		<artifactId>cldr-all</artifactId>
-		<version>39.0-SNAPSHOT</version>
+		<version>40.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/tools/cldr-rdf/pom.xml
+++ b/tools/cldr-rdf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.unicode.cldr</groupId>
         <artifactId>cldr-all</artifactId>
-        <version>39.0-SNAPSHOT</version>
+        <version>40.0-SNAPSHOT</version>
     </parent>
 
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.unicode.cldr</groupId>
 	<artifactId>cldr-all</artifactId>
-	<version>39.0-SNAPSHOT</version>
+	<version>40.0-SNAPSHOT</version>
 	<name>CLDR All Tools</name>
 	<packaging>pom</packaging>
 	<licenses>


### PR DESCRIPTION
CLDR-14711

- [ ] This PR completes the ticket.

Finish the SBRS task of updating CLDR version by updating the <version>40.0-SNAPSHOT</version> in all relevant pom.xml files.