### PR TITLE
CLDR-13595 Make ckb regions non-secondary so Persian cal months show up in ST for ckb

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1454,8 +1454,7 @@ XXX Code for transations where no currency is involved
 		<language type="cjm" scripts="Cham"/>
 		<language type="cjm" scripts="Arab" alt="secondary"/>
 		<language type="cjs" scripts="Cyrl"/>
-		<language type="ckb" scripts="Arab"/>
-		<language type="ckb" territories="IQ IR" alt="secondary"/>
+		<language type="ckb" scripts="Arab" territories="IQ IR"/>
 		<language type="ckt" scripts="Cyrl"/>
 		<language type="co" scripts="Latn"/>
 		<language type="cop" scripts="Arab Copt Grek" alt="secondary"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -90,6 +90,26 @@ public class TestCoverageLevel extends TestFmwkPlus {
         }
     }
 
+    public void testSpecificPathsPersCal() {
+        String[][] rows = {
+            { "//ldml/dates/calendars/calendar[@type=\"persian\"]/eras/eraAbbr/era[@type=\"0\"]", "basic", "4" },
+            { "//ldml/dates/calendars/calendar[@type=\"persian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"1\"]", "basic", "4" }
+        };
+        Factory phf = PathHeader.getFactory(ENGLISH);
+        CoverageLevel2 coverageLevel = CoverageLevel2.getInstance(SDI, "ckb_IR");
+        CLDRLocale loc = CLDRLocale.getInstance("ckb_IR");
+        for (String[] row : rows) {
+            String path = row[0];
+            Level expectedLevel = Level.fromString(row[1]);
+            Level level = coverageLevel.getLevel(path);
+            assertEquals("Level for " + path, expectedLevel, level);
+
+            int expectedRequiredVotes = Integer.parseInt(row[2]);
+            int votes = SDI.getRequiredVotes(loc, phf.fromPath(path));
+            assertEquals("Votes for " + path, expectedRequiredVotes, votes);
+        }
+    }
+
     public void oldTestInvariantPaths() {
         org.unicode.cldr.util.Factory factory = testInfo.getCldrFactory();
         PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("*");


### PR DESCRIPTION
CLDR-13595

- [ ] This PR completes the ticket.

Make ckb regions non-secondary in <languageData> so Persian calendar months show up in ST for ckb_IR (and ckb).

Need a way either to
- make that permanent so the next run of ConvertLanguageData does not revert
- provide a different solution that assoicates IR with ckb for coverage purposes; that can be associating all regions (and scripts) for which we actually have a locale with the corresponding language for coverage purposes.

Either way that can be another PR.