### PR TITLE
CLDR-14765 stui: Dashboard vue warning

### DIFF
--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -58,7 +58,7 @@
           v-for="n in data.notifications"
           :key="'template-' + n.notification"
         >
-          <template v-for="g in n.entries" :key="g.header">
+          <template v-for="g in n.entries" :key="g.section + g.page + g.header">
             <template v-for="e in g.entries">
               <p
                 v-if="!(hideChecked && e.checked)"


### PR DESCRIPTION
-In DashboardWidget.vue, use key g.section + g.page + g.header, instead of just g.header

-Delete unused deprecated getJSONReview in VettingViewerQueue.java

CLDR-14765

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
