### PR TITLE
CLDR-14790 break the error loop on #retry

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.js
+++ b/tools/cldr-apps/js/src/esm/cldrGui.js
@@ -25,6 +25,8 @@ let dashboardVisible = false;
 
 /**
  * Set up the DOM and start executing Survey Tool as a single page app
+ * This is also called from LoginButton.vue (on login)
+ * and WaitingPanel.vue (on successful reload)
  * @returns Promise
  */
 function run() {

--- a/tools/cldr-apps/js/src/views/WaitingPanel.vue
+++ b/tools/cldr-apps/js/src/views/WaitingPanel.vue
@@ -1,6 +1,9 @@
 <template>
   <div id="home">
-    <h1 class="hang">Waiting for the SurveyTool to start up…</h1>
+    <!-- if $specialPage == retry then we have reached this page 'directly' -->
+    <h1 v-if="$specialPage != 'retry'" class="hang">
+      Waiting for the SurveyTool to start up…
+    </h1>
     <h1>
       <a-spin size="large" :delay="1000" />
     </h1>
@@ -58,6 +61,9 @@
 </template>
 
 <script>
+import { run } from "../esm/cldrGui.js";
+import { notification } from "ant-design-vue";
+
 export default {
   data: function () {
     return {
@@ -104,7 +110,21 @@ export default {
             );
           }
           if (data.status && data.status.isSetup) {
-            window.setTimeout(() => window.location.reload(), NORMAL_RETRY);
+            if (this.$specialPage == "retry") {
+              // immediately head back to the main page.
+              window.location.replace("v#");
+              run(); // reboot everything
+              setTimeout(
+                () =>
+                  notification.success({
+                    message: "Reconnected",
+                    description: "You have been reconnected to the SurveyTool.",
+                  }),
+                4000
+              );
+            } else {
+              window.setTimeout(() => window.location.reload(), NORMAL_RETRY);
+            }
           } else if (data.status && data.status.isBusted) {
             window.setTimeout(this.fetchStatus.bind(this), BUSTED_RETRY); // try in a minute
           } else {

--- a/tools/cldr-apps/js/test/pretty.sh
+++ b/tools/cldr-apps/js/test/pretty.sh
@@ -1,10 +1,8 @@
 npx prettier --write tools/cldr-apps/js/src/*.js \
     tools/cldr-apps/js/src/css/*.css \
-    tools/cldr-apps/js/src/esm/*.js \
-    tools/cldr-apps/js/src/esm/*.mjs \
+    tools/cldr-apps/js/src/esm/*.{js,mjs} \
     tools/cldr-apps/js/src/views/*.vue \
     tools/cldr-apps/js/test/*.js \
     tools/cldr-apps/js/test/nonbrowser/*.js \
     tools/cldr-apps/js/test/*.html \
-    tools/cldr-apps/js/util/*.mjs \
-    tools/cldr-apps/js/util/*.js
+    tools/cldr-apps/js/util/*.mjs


### PR DESCRIPTION
- just go back to the default (locales) page if ST is up
- show a brief popup on reconnect
- also document cldrGui.run()'s callers
- fix a minor pretty.sh script error

CLDR-14790

- [ ] This PR completes the ticket. (not yet, but covers the worst case)

brief popup below:
![image](https://user-images.githubusercontent.com/855219/121266271-cf583b80-c87f-11eb-8feb-2a63917b6ed3.png)
It's not visible in the screen shot, but the URL goes back to `/cldr-apps/v#locales///` with the usual locale list on the left