### PR TITLE
CLDR-14588 fix known issues output, reduce test noise

### DIFF
--- a/tools/cldr-code/src/main/java/com/ibm/icu/dev/test/UnicodeKnownIssues.java
+++ b/tools/cldr-code/src/main/java/com/ibm/icu/dev/test/UnicodeKnownIssues.java
@@ -1,0 +1,139 @@
+package com.ibm.icu.dev.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * “Known issues” manager.
+ * Intended to be shared between ICU, CLDR, &c.
+ * Test frameworks can create an instance of this to manage known issues
+ */
+public class UnicodeKnownIssues {
+    private Map<String, List<String>> knownIssues = new TreeMap<>();
+    /**
+     * Max number of lines to show by default (including the "more")
+     * unless -allKnownIssues is given. Must be at least 2.
+     */
+    public static final int KNOWN_ISSUES_CURTAILMENT = 2;
+
+    /**
+     * true if all issues should be shown, false if they should
+     * be curtailed.
+     */
+    private boolean allKnownIssues;
+
+    /**
+     * Construct a known issue manager
+     * @param allKnownIssues true if all known issues should be printed,
+     * not curtailed
+     */
+    public UnicodeKnownIssues(boolean allKnownIssues) {
+        this.allKnownIssues = allKnownIssues;
+    }
+
+    /**
+     * Base URL for browsing Unicode JIRA
+     */
+    public static final String UNICODE_JIRA_BROWSE = "https://unicode-org.atlassian.net/browse/";
+
+    static final Pattern ICU_TICKET_PATTERN = Pattern.compile(
+        "(?i)(?:icu-)?(\\d+)"
+    );
+    static final Pattern CLDR_TICKET_PATTERN = Pattern.compile(
+        "(?i)cldr(?:bug:|-)?(\\d+)"
+    );
+
+    /**
+     * Match all linkable ticket patterns
+     * @see {org.unicode.cldr.util.CLDRURLS#CLDR_TICKET_BROWSE}
+     */
+    static final Pattern UNICODE_JIRA_PATTERN = Pattern.compile(
+        "(CLDR|ICU)-(\\d+)"
+    );
+
+    /**
+     * Log the known issue.
+     * Call this from the test framework when logKnownIssue() is called.
+     *
+     * @param path Path to the error, will be returned in the
+     * known issue list
+     * @param ticket A ticket number string. For an ICU ticket, use "ICU-10245".
+     * For a CLDR ticket, use "CLDR-12345".
+     * For compatibility, "1234" -> ICU-1234 and "cldrbug:456" -> CLDR-456
+     * @param comment Additional comment, or null
+     *
+     */
+    public void logKnownIssue(String path, String ticket, String comment) {
+        StringBuilder descBuf = new StringBuilder(path);
+
+        if (comment != null && comment.length() > 0) {
+            descBuf.append(" (" + comment + ")");
+        }
+        String description = descBuf.toString();
+
+        String ticketLink = "Unknown Ticket";
+        if (ticket != null && ticket.length() > 0) {
+            Matcher matcher = ICU_TICKET_PATTERN.matcher(ticket);
+            if (matcher.matches()) {
+                ticketLink = "ICU-" + matcher.group(1);
+            } else {
+                matcher = CLDR_TICKET_PATTERN.matcher(ticket);
+                if (matcher.matches()) {
+                    ticketLink = "CLDR-" + matcher.group(1);
+                }
+            }
+        }
+
+        List<String> lines = knownIssues.get(ticketLink);
+        if (lines == null) {
+            lines = new ArrayList<>();
+            knownIssues.put(ticketLink, lines);
+        }
+        if (!lines.contains(description)) {
+            lines.add(description);
+        }
+    }
+
+    /**
+     * Print out all known issues to the logFn.
+     * Usage:  printKnownIssues(System.out::println)
+     * @param logFn consumer for Strings (e.g. System.out::println)
+     * @return true if (!allKnownIssues) and we had to curtail
+     */
+    boolean printKnownIssues(Consumer<String> logFn) {
+        if (knownIssues.isEmpty()) {
+            return false;
+        }
+        boolean didCurtail = false;
+        logFn.accept("\n " + knownIssues.size() + " Known Issues:");
+        for (Entry<String, List<String>> entry : knownIssues.entrySet()) {
+            String ticketLink = entry.getKey();
+            if (UNICODE_JIRA_PATTERN.matcher(ticketLink) != null) {
+                logFn.accept(ticketLink + " <" + UNICODE_JIRA_BROWSE + ticketLink + ">");
+            } else {
+                // Unknown or something else
+                logFn.accept("<" + ticketLink + ">");
+            }
+            List<String> entries = entry.getValue();
+            int issuesToShow = entries.size();
+            if (!allKnownIssues && issuesToShow > KNOWN_ISSUES_CURTAILMENT) {
+                issuesToShow = (KNOWN_ISSUES_CURTAILMENT - 1);
+            }
+            for (int i=0; i<issuesToShow; i++) {
+                logFn.accept("  - " + entries.get(i));
+            }
+            if (entries.size() > issuesToShow) {
+                didCurtail = true;
+                logFn.accept("  ... and " +
+                    (entries.size() - issuesToShow) + " more");
+            }
+        }
+        return didCurtail;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -18,6 +19,8 @@ import com.ibm.icu.text.MessageFormat;
 import com.ibm.icu.util.Output;
 
 public class PathDescription {
+
+    private final static Logger logger = Logger.getLogger(PathDescription.class.getName());
 
     public enum ErrorHandling {
         SKIP, CONTINUE
@@ -180,7 +183,7 @@ public class PathDescription {
                     }
                 }
                 if (!found) {
-                    System.out.println("Missing country for timezone " + code);
+                    logger.warning("Missing country for timezone " + code);
                 }
             }
             description = MessageFormat.format(MessageFormat.autoQuoteApostrophe(description), new Object[] { code });

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -353,7 +353,7 @@ public class TestAnnotations extends TestFmwkPlus {
                 String name = eng.getShortName(emoji);
                 String lastName = eng.getShortName(lastEmoji);
                 int errorType = ERR;
-                if (logKnownIssue("cldr13660", "slightly out of order")) {
+                if (logKnownIssue("CLDR-13660", "slightly out of order")) {
                     errorType = WARN;
                 }
                 msg("Out of order: "
@@ -509,7 +509,7 @@ public class TestAnnotations extends TestFmwkPlus {
         }
         for (Level level : Level.values()) {
             UnicodeSet us = levels.getSet(level);
-            System.out.println(level + "\t" + us.size());
+            getLogger().fine(level + "\t" + us.size());
             switch(level) {
             case COMPREHENSIVE:
                 UnicodeSet us2 = new UnicodeSet(us).removeAll(us.strings());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -162,7 +162,7 @@ public class TestCLDRFile extends TestFmwk {
     public void testExtraPaths() {
         // for debugging
         final CLDRFile german = CLDRConfig.getInstance().getCldrFactory().make("de", true);
-        System.out.println();
+        getLogger().fine("");
         Set<String> sorted = new TreeSet<>(german.getExtraPaths());
         PathHeader.Factory phf = PathHeader.getFactory();
         PatternPlaceholders pph = PatternPlaceholders.getInstance();
@@ -222,10 +222,10 @@ public class TestCLDRFile extends TestFmwk {
 
             }
         }
-        System.out.println("Units with grammar info: " + GrammarInfo.getUnitsToAddGrammar().size());
-        System.out.println("Inflection Paths");
+        getLogger().fine("Units with grammar info: " + GrammarInfo.getUnitsToAddGrammar().size());
+        getLogger().fine("Inflection Paths");
         for (R2<Long, String> locale : extraPaths.getEntrySetSortedByCount(false, null)) {
-            System.out.println(locale.get0() + "\t" + locale.get1());
+            getLogger().fine(locale.get0() + "\t" + locale.get1());
         }
         if (!badCoverage.isEmpty()) {
             errln("Paths not at modern: " + Joiner.on("\n\t").join(badCoverage));
@@ -856,7 +856,7 @@ public class TestCLDRFile extends TestFmwk {
                 String source = af.getSourceLocaleID(xpath, status);
                 Level level = coverageLevel2.getLevel(xpath);
                 PathHeader ph = pathHeaderFactory.fromPath(xpath);
-                System.out.println(""
+                getLogger().fine(""
                     + "\nPathHeader:\t" + ph
                     + "\nValue:\t" + value
                     + "\nLevel:\t" + level

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -696,7 +696,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
     }
 
     public void testLogicalGroupingSamples() {
-        System.out.println(GrammarInfo.getGrammarLocales());
+        getLogger().fine(GrammarInfo.getGrammarLocales().toString());
         String[][] test = {
             {"de",
                 "SINGLETON",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -442,7 +442,9 @@ public class TestLocale extends TestFmwkPlus {
     }
 
     public void TestLocaleDisplay() {
-        System.out.println("\nUse -v to get samples for tests");
+        if (!isVerbose()) {
+            warnln("\nUse -v to get samples for tests");
+        }
         String fileName = CLDRPaths.TEST_DATA + "localeIdentifiers/localeDisplayName.txt";
         LanguageTagCanonicalizer canonicalizer = new LanguageTagCanonicalizer(LstrType.redundant);
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -93,8 +94,6 @@ import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
 public class TestSupplementalInfo extends TestFmwkPlus {
-    private static final boolean DEBUG = true;
-
     static CLDRConfig testInfo = CLDRConfig.getInstance();
 
     private static final StandardCodes STANDARD_CODES = StandardCodes.make();
@@ -1917,6 +1916,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     }
 
     public void TestGrammarInfo() {
+        final Logger logger = getLogger();
         Multimap<String,String> allValues = TreeMultimap.create();
         for (String locale : SUPPLEMENTAL.hasGrammarInfo()) {
             if (locale.contentEquals("tr")) {
@@ -1935,14 +1935,12 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                     }
                 }
             }
-            if (DEBUG) {
-                System.out.println(grammarInfo.toString("\n" + locale + "\t"));
-            }
+            logger.fine(grammarInfo.toString("\n" + locale + "\t"));
         }
-        if (DEBUG) {
-            System.out.println();
+        if (logger.isLoggable(java.util.logging.Level.FINE)) {  // if level is at least FINE
+            logger.fine("");
             for (Entry<String, Collection<String>> entry : allValues.asMap().entrySet()) {
-                System.out.println(entry.getKey() + "\t" + Joiner.on(", ").join(entry.getValue()));
+                logger.fine(entry.getKey() + "\t" + Joiner.on(", ").join(entry.getValue()));
             }
         }
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
@@ -949,6 +950,7 @@ public class TestUnits extends TestFmwk {
         );
 
     public void TestSystems() {
+        final Logger logger = getLogger();
 //        Map<String, TargetInfo> data = converter.getInternalConversionData();
         Output<String> metricUnit = new Output<>();
         Multimap<Set<UnitSystem>, R3<String, ConversionInfo, String>> systemsToUnits = TreeMultimap.create(Comparators.lexicographical(Ordering.natural()), Ordering.natural());
@@ -975,7 +977,7 @@ public class TestUnits extends TestFmwk {
 //            }
         }
         String std = converter.getStandardUnit("kilogram-meter-per-square-meter-square-second");
-        System.out.println();
+        logger.fine("");
         Output<Rational> outFactor = new Output<>();
         for (Entry<Set<UnitSystem>, Collection<R3<String, ConversionInfo, String>>> systemsAndUnits : systemsToUnits.asMap().entrySet()) {
             Set<UnitSystem> systems = systemsAndUnits.getKey();
@@ -1001,7 +1003,7 @@ public class TestUnits extends TestFmwk {
                     Rational specialFactor = converter.convert(Rational.ONE, unit, specialUnit, false);
                     specialRef = "\t" + specialFactor + "\t" + specialUnit;
                 }
-                System.out.println(systems + "\t" + quantity
+                logger.fine(systems + "\t" + quantity
                     + "\t" + unit
                     + "\t" + factor
                     + "\t" + standard
@@ -1442,7 +1444,7 @@ public class TestUnits extends TestFmwk {
     }
 
     public void TestUnitPreferences() {
-        System.out.println("\n\t\t If this fails, check the output of TestUnitPreferencesSource (with -DTestUnits:SHOW_DATA), fix as needed, then incorporate.");
+        warnln("\n\t\t If this fails, check the output of TestUnitPreferencesSource (with -DTestUnits:SHOW_DATA), fix as needed, then incorporate.");
         UnitPreferences prefs = SDI.getUnitPreferences();
         checkUnitPreferences(prefs);
 //        Map<String, Map<String, Map<String, UnitPreference>>> fastMap = prefs.getFastMap(converter);
@@ -1719,7 +1721,7 @@ public class TestUnits extends TestFmwk {
                 + "\t" + endFactor.toString(FormatStyle.simple)
                 + "\t" + target);
         }
-        if (!DEBUG_ADD) System.out.println("\n\t\tSet -v to show units we could add");
+        if (!DEBUG_ADD) warnln("\n\t\tSet -v to show units we could add");
     }
 
     static final boolean DEBUG_ADD = false;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -505,7 +505,7 @@ public class TestValidity extends TestFmwkPlus {
         if (!changedAliases.isEmpty()) {
             warnln("Changed aliases from LSTR, just double-check: " + changedAliases.size());
             for (Entry<String, String> entry : changedAliases.entrySet()) {
-                System.out.println("\tcurrent=" + entry.getValue() + "\n\tlstr=" + entry.getKey());
+                getLogger().fine("\tcurrent=" + entry.getValue() + "\n\tlstr=" + entry.getKey());
             }
         }
     }

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/rdf/AbstractCache.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/rdf/AbstractCache.java
@@ -75,7 +75,9 @@ public class AbstractCache {
                 logger.fine("# " + simpleName + " read " + root.getAbsolutePath() + " count: " + size());
                 return Instant.ofEpochMilli(xpathToResourceFile.lastModified());
             } catch (IOException ioe) {
-                logger.log(Level.SEVERE, "Could not read files in " + root.getAbsolutePath(), ioe);
+                logger.log(Level.WARNING, "Could not read files in " + root.getAbsolutePath());
+                // Full stacktrace at a higher trace level
+                logger.log(Level.FINE, "Could not read " + root.getAbsolutePath() + " - " + ioe.getMessage());
                 xpathToResource.clear();
                 return null;
             }


### PR DESCRIPTION
CLDR-14588 fix known issues output, reduce test noise

- known issues (ICU and CLDR) are now valid urls once more
- quiet abstractcache errors (don't need full stacktrace for missing file)
- quiet a number of other tests, logger available from getLogger()
- only show n (default: 2) lines of 'known issue' output, to keep the output manageable
All output is still available using for example:
 `mvn --file=tools/pom.xml test -pl cldr-code '-Dorg.unicode.cldr.unittest.testArgs=-allKnownIssues -n -q'`



- [ ] This PR completes the ticket.


With this fix, output is as below. Note that excessive known issues are rolled up, but `-allKnownIssues` will show all lines.


```
 13 Known Issues:
CLDR-11583 <https://unicode-org.atlassian.net/browse/CLDR-11583>
  - CLDR/TestBasic/TestBasicDTDCompatibility (Comment out test until last release data is available for unit tests)
  - CLDR/TestBasic/TestDtdCompatibility (Comment out test until last release data is available for unit tests)
CLDR-13313 <https://unicode-org.atlassian.net/browse/CLDR-13313>
  - CLDR/TestTransforms/TestCasing (Investigate the Lithuanian casing test, it may be wrong)
CLDR-13660 <https://unicode-org.atlassian.net/browse/CLDR-13660>
  - CLDR/TestAnnotations/testEmojiOrdering (slightly out of order)
CLDR-13920 <https://unicode-org.atlassian.net/browse/CLDR-13920>
  - CLDR/TestUnits/TestDerivedCase (finish this as part of unit derivation work)
CLDR-13951 <https://unicode-org.atlassian.net/browse/CLDR-13951>
  - CLDR/TestCoverageLevel/testLogicalGroupingSamples (Add more LogicalGrouping tests, fix DECIMAL_FORMAT_LENGTH, etc.)
CLDR-14166 <https://unicode-org.atlassian.net/browse/CLDR-14166>
  - CLDR/LanguageInfoTest/TestChinese (Skip until CLDR updated for new ICU4J LocaleMatcher)
  ... and 26 more
CLDR-6342 <https://unicode-org.atlassian.net/browse/CLDR-6342>
  - CLDR/TestExampleGenerator/TestAllPaths (Need an example for each path used in context: //ldml/localeDisplayNames/subdivisions/subdivision[@type="([^"]*+)"])
  ... and 68 more
CLDR-7075 <https://unicode-org.atlassian.net/browse/CLDR-7075>
  - CLDR/TestSupplementalInfo/TestPluralCompleteness (Missing ordinal minimal pairs)
  - CLDR/TestSupplementalInfo/TestPluralSamples2 (Missing ordinal minimal pairs)
CLDR-7839 <https://unicode-org.atlassian.net/browse/CLDR-7839>
  - CLDR/TestSupplementalInfo/TestPluralCompleteness (Missing plural data for modern locales)
  - CLDR/TestSupplementalInfo/TestPluralRanges (Missing plural data for modern locales)
CLDR-8909 <https://unicode-org.atlassian.net/browse/CLDR-8909>
  - CLDR/TestDtdData/TestValueAttributesWithChildren (waiting for RBNF to use data)
CLDR-9784 <https://unicode-org.atlassian.net/browse/CLDR-9784>
  - CLDR/TestPaths/TestNonLdml (fix TODO's in Attribute validity tests)
CLDR-9982 <https://unicode-org.atlassian.net/browse/CLDR-9982>
  - CLDR/TestDtdData/TestValueAttributesWithChildren (Lower priority fixes to bad xml)
ICU-21241 <https://unicode-org.atlassian.net/browse/ICU-21241>
  - CLDR/LanguageInfoTest/testFallbacks (waiting on LocaleMatcherData update)
  ... and 6 more
 (Use -allKnownIssues to show all known issue sites) 
```