### PR TITLE
CLDR-14790 handle another case where ST could not coldstart

### DIFF
--- a/tools/cldr-apps/js/src/cldrVueRouter.js
+++ b/tools/cldr-apps/js/src/cldrVueRouter.js
@@ -79,6 +79,16 @@ function createCldrApp(component, specialPage, extraProps) {
   app.config.globalProperties.$cldrOpts = getCldrOpts();
   app.config.globalProperties.$specialPage = specialPage || null;
 
+  // Setup err handling
+  app.config.errorHandler = (err, vm, info) => {
+    console.error(err);
+    notification.error({
+      message: `Error: ${err.name} in ${specialPage || "vue component"}`,
+      description: `${err.message}`,
+      duration: 0, // keep open
+    });
+  };
+
   // There is no global registration in Vue3, so we re-register
   // the components here.
   setupComponents(app);

--- a/tools/cldr-apps/js/src/esm/cldrGui.js
+++ b/tools/cldr-apps/js/src/esm/cldrGui.js
@@ -12,6 +12,7 @@ import * as cldrSurvey from "./cldrSurvey.js";
 import { createCldrApp } from "../cldrVueRouter";
 import MainHeader from "../views/MainHeader.vue";
 import DashboardWidget from "../views/DashboardWidget.vue";
+import { notification } from "ant-design-vue";
 
 const GUI_DEBUG = true;
 
@@ -41,6 +42,7 @@ function run() {
         console.log(
           "cldrGui.run doing nothing since '" + runGuiId + "' not found"
         );
+        return Promise.reject(Error(`${runGuiId} element was not present.`));
       }
       return Promise.resolve();
     }
@@ -143,6 +145,11 @@ function insertHeader() {
     console.error(
       "Error mounting main header vue " + e.message + " / " + e.name
     );
+    notification.error({
+      message: `${e.name} while loading MainHeader.vue`,
+      description: `${e.message}`,
+      duration: 0,
+    });
   }
 }
 

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -299,6 +299,12 @@ export default {
 </script>
 
 <style scoped>
+.st-sad {
+  font-style: italic;
+  border: 1px dashed red;
+  color: darkred;
+}
+
 #DashboardSection {
   border-top: 4px solid #cfeaf8;
   font-size: small;

--- a/tools/cldr-apps/js/src/views/WaitingPanel.vue
+++ b/tools/cldr-apps/js/src/views/WaitingPanel.vue
@@ -113,7 +113,6 @@ export default {
             if (this.$specialPage == "retry") {
               // immediately head back to the main page.
               window.location.replace("v#");
-              run(); // reboot everything
               setTimeout(
                 () =>
                   notification.success({
@@ -122,6 +121,15 @@ export default {
                   }),
                 4000
               );
+              run().catch((e) => {
+                // We can get here if run() was not able to boot the page
+                // That's OK, it may have been a waiting page. Reload should
+                // clear it up.
+                console.log(
+                  `run() threw an error, so we will do a page reload. Err was: ${e}`
+                );
+                window.location.reload();
+              });
             } else {
               window.setTimeout(() => window.location.reload(), NORMAL_RETRY);
             }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -89,6 +89,7 @@ public class SurveyTool extends HttpServlet {
         throws IOException {
 
         out.write("<html lang='" + SurveyMain.TRANS_HINT_LOCALE.toLanguageTag() + "' class='claro'>\n");
+        out.write("<!-- serveWaitingPage() -->\n");
         out.write("<head>\n");
         out.write("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>\n");
         out.write("<title>CLDR Survey Tool | Starting</title>\n");
@@ -133,6 +134,7 @@ public class SurveyTool extends HttpServlet {
 
     private void serveProblemNoSessionPage(HttpServletRequest request, PrintWriter out, String sessionMessage) {
         out.write("<html class='claro'>\n<head class='claro'>\n");
+        out.write("<!-- serveProblemNoSessionPage() -->");
         out.write("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>\n");
         out.write("<title>CLDR Survey Tool</title>\n");
         out.write("</head>\n<body>\n");
@@ -154,6 +156,7 @@ public class SurveyTool extends HttpServlet {
         throws IOException {
         String lang = SurveyMain.TRANS_HINT_LOCALE.toLanguageTag();
         out.write("<html lang='" + lang + "' class='claro'>\n");
+        out.write("<!-- serveRunnningNormallyPage() -->");
         out.write("<head>\n");
         out.write("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>\n");
         out.write("<title>CLDR Survey Tool</title>\n");


### PR DESCRIPTION
Bugs Everywhere! Well, hopefully not. This PR catches the rest of the err cases (the known knowns!) that
ought to make "ST seems stuck/dead/hung" move even more towards 0%.

- the 'waiting' page is not able to run cldrGui.run(), we just need to reload first.
- make cldrGui.run() throw an exception instead of 'doing nothing'.
- also, annotate which function generated the /v page
- show err if there's a problem mounting the main header
- fix a css err in dashboardwidget
- add an error handler when mounting vue components

CLDR-14790

- [X] This PR completes the ticket.


Note: The following are all _simulated_ errors! (hence 'foo')

## Typo in MainHeader.vue

![TypeError while loading](https://user-images.githubusercontent.com/855219/121749692-b85c5800-cad0-11eb-8a42-25103fc8cacc.png)

## Typo in Dashboard (hence 'vue component') as the special name is not available

![hi  This site uses cookies](https://user-images.githubusercontent.com/855219/121749721-c4481a00-cad0-11eb-9207-2dc42c1e6026.png)

## Typo in some other page (`transfervotes`)

![This site uses cookies](https://user-images.githubusercontent.com/855219/121749755-d1650900-cad0-11eb-9cbe-d42c74de2bf8.png)

