### PR TITLE
CLDR-14711 SBRS 40, adjust zh_Hant based on first ICU integration

### DIFF
--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -7217,6 +7217,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="GyMMM">Gy年M月</dateFormatItem>
 						<dateFormatItem id="GyMMMd">Gy年M月d日</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">Gy年M月d日E</dateFormatItem>
+						<dateFormatItem id="h">Bh時</dateFormatItem>
+						<dateFormatItem id="H">H時</dateFormatItem>
+						<dateFormatItem id="hm">Bh:mm</dateFormatItem>
+						<dateFormatItem id="Hm">H:mm</dateFormatItem>
+						<dateFormatItem id="hms">Bh:mm:ss</dateFormatItem>
+						<dateFormatItem id="Hms">H:mm:ss</dateFormatItem>
 						<dateFormatItem id="M">M月</dateFormatItem>
 						<dateFormatItem id="Md">M/d</dateFormatItem>
 						<dateFormatItem id="MEd">M/d（E）</dateFormatItem>


### PR DESCRIPTION
CLDR-14711

- [ ] This PR completes the ticket.

While doing a first integration of CLDR 40 into ICU (i.e. an "m1" integration reflecting the state of CLDR soon after the beginning of data submission), ICU tests demonstrated the need to copy some zh_Hant availableFormats for times from the generic to the roc calendar. (This is related to the change in zh_Hant time formats to use Bh)