### PR TITLE
CLDR-14711 update ICU4J libs to version of 2021-06-15 after integrating CLDR 40 m1

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>69.1-release-69-1</icu4j.version>
+		<icu4j.version>70.0.1-SNAPSHOT-cldr-2021-06-15</icu4j.version>
 		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>


### PR DESCRIPTION
CLDR-14711

- [ ] This PR completes the ticket.

Update the ICU4J libs in CLDR to an ICU snapshot of 2021-06-15 - after integrating CLDR release-40-m1 to ICU per ICU [PR-1742](https://github.com/unicode-org/icu/pull/1742) - which among other things adds ICU support for the new measure units "concentr: item" and "force: kilowatt-hour-per-100-kilometer".