### PR TITLE
CLDR-13928 Value for 20-vote item moved to Winning column with 8 votes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
@@ -116,7 +116,7 @@ public final class SurveyJSONWrapper {
     public static JSONObject wrap(final VoteResolver<String> r) throws JSONException {
         JSONObject ret = new JSONObject()
             .put("raw", r.toString()) /* "raw" is only used for debugging (stdebug_enabled) */
-            .put("requiredVotes", r.getRequiredVotes());
+            .put("requiredVotes", r.getAdjustedRequiredVotes());
 
         EnumSet<Organization> conflictedOrgs = r.getConflictedOrganizations();
 

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
@@ -202,4 +202,29 @@
 	<vote name="OrgStatM1" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">pistolet à eau</vote>
 	<vote name="OrgStatG1" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">↑↑↑</vote>
 	<verify status="approved" orgStatus="ok" statusOrg="google" locale="fr_CA" xpath="//ldml/annotations/annotation[@cp='🔫'][@type='tts']">pistolet à eau</verify>
+
+	<echo>Tests involving 20-vote items</echo>
+
+	<!-- Rules:
+	       1. For a 20 vote item, 8 votes are needed to change from non-approved to approved.
+	       2. Once Approved, it requires 20 votes to change.
+	     Note: this test assumes and requires that the .../minimumGroupingDigits path
+	     is "contributed" in fr.xml, and that the .../decimal path is "approved" in fr.xml.
+	     Ideally this test might mock the data to avoid the assumption.
+	     Compare TestUtilities.TestVoteResolver where it is possible to set oldStatus, etc. -->
+	<user name="TwenA" org="apple" level="vetter" locales="*"/>
+	<user name="TwenB" org="ibm" level="vetter" locales="*"/>
+
+	<verify status="contributed" locale="fr" xpath="//ldml/numbers/minimumGroupingDigits">1</verify>
+	<vote name="TwenA" locale="fr" xpath="//ldml/numbers/minimumGroupingDigits">2</vote>
+	<vote name="TwenB" locale="fr" xpath="//ldml/numbers/minimumGroupingDigits">2</vote>
+	<!-- 8 votes is enough to change from non-approved to approved -->
+	<verify status="approved" locale="fr" xpath="//ldml/numbers/minimumGroupingDigits">2</verify>
+
+	<verify status="approved" locale="fr" xpath="//ldml/numbers/symbols[@numberSystem='latn']/decimal">,</verify>
+	<vote name="TwenA" locale="fr" xpath="//ldml/numbers/symbols[@numberSystem='latn']/decimal">?</vote>
+	<vote name="TwenB" locale="fr" xpath="//ldml/numbers/symbols[@numberSystem='latn']/decimal">?</vote>
+	<!-- 8 votes is not enough to change an already-approved item, so the original value (comma) should still be approved -->
+	<verify status="approved" locale="fr" xpath="//ldml/numbers/symbols[@numberSystem='latn']/decimal">,</verify>
+
 </TestSTFactory>


### PR DESCRIPTION
-Add tests for two rules:

--- (1) For a 20 vote item, 8 votes are needed to change from non-approved to approved

--- (2) Once Approved, it requires 20 votes to change

-Revise VoteResolver to pass both tests; adjust from HIGH_BAR (20) to LOWER_BAR (8) if not approved

-Revise SurveyJSONWrapper.wrap(VoteResolver) to send client the adjusted required votes

-Remove unneeded 3rd arg of computeStatus (always trunkStatus)

CLDR-13928

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
