### PR TITLE
CLDR-14801 fix a unicode.org/unicode/ URL

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
@@ -112,7 +112,7 @@ public abstract class Chart {
 
     private static void standardFooter(FormattedFileWriter pw, AnalyticsID analytics) throws IOException {
         pw.write("<div style='text-align: center; margin-top:2em; margin-bottom: 60em;'><br>\n"
-            + "<a href='http://www.unicode.org/unicode/copyright.html'>\n"
+            + "<a href='https://www.unicode.org/copyright.html'>\n"
             + "<img src='http://www.unicode.org/img/hb_notice.gif' style='border-style: none; width: 216px; height=50px;' alt='Access to Copyright and terms of use'>"
             + "</a><br>\n<script src='http://www.unicode.org/webscripts/lastModified.js'></script>"
             + "</div><script>\n\n"


### PR DESCRIPTION
CLDR-14801

It relied on old redirects.

- [ ] This PR completes the ticket.