### PR TITLE
CLDR-14841 create production tag on push to production

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git-ref }}
           lfs: false
+      - name: Calculate Tag Name
+        id: tagname
+        run: >
+          echo "::set-output name=tag::$(env TZ=UTC date +'production/%Y-%m-%d-%H%Mz')"
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -55,6 +59,14 @@ jobs:
         with:
           name: cldr-apps-server
           path: tools/cldr-apps/target/cldr-apps.zip
+      - name: Tag Production Commit
+        uses: simpleactions/create-tag@d5c32a2d86b1f96142bbe1ebe8b3b62b0a0587ff
+        with:
+          sha: ${{ github.event.inputs.git-ref }}
+          tag: "${{ steps.tagname.outputs.tag }}"
+          message: "Deployed via GitHub by @${{ github.actor }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
     name: Deploy to Production
     needs:


### PR DESCRIPTION
- Create a tag of the form `production/2021-06-22-2206z` during
the manual push to production process.
- The date and time are UTC (June 22nd, 22:06 UTC)

CLDR-14841

- [ ] This PR completes the ticket. (no, there are other items

Example tag: https://github.com/srl295/cldr/releases/tag/production%2F2021-06-22-2206z

I have tested the exact code stanza involved, but have not tested an actual push to production (I had my test case stop before continuing that far).

Probably once this is merged, we will want to test it with an actual push. It could wait to merge until the next time we're doing such a push.
