### PR TITLE
CLDR-14846 change kdh default script

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -1142,8 +1142,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Kaian; ?; ? } => { Kaian; Latin; Unknown Region }-->
 		<likelySubtag from="kde" to="kde_Latn_TZ"/>
 		<!--{ Makonde; ?; ? } => { Makonde; Latin; Tanzania }-->
-		<likelySubtag from="kdh" to="kdh_Arab_TG"/>
-		<!--{ Tem; ?; ? } => { Tem; Arabic; Togo }-->
+		<likelySubtag from="kdh" to="kdh_Latn_TG"/>
+		<!--{ Tem; ?; ? } => { Tem; Latin; Togo }-->
 		<likelySubtag from="kdl" to="kdl_Latn_ZZ"/>
 		<!--{ Tsikimba; ?; ? } => { Tsikimba; Latin; Unknown Region }-->
 		<likelySubtag from="kdt" to="kdt_Thai_TH"/>

--- a/exemplars/main/kdh.xml
+++ b/exemplars/main/kdh.xml
@@ -12,12 +12,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</identity>
 	<layout>
 		<orientation>
-			<characterOrder>right-to-left</characterOrder>
+			<characterOrder>left-to-right</characterOrder>
 			<lineOrder>top-to-bottom</lineOrder>
 		</orientation>
 	</layout>
 	<characters>
-		<exemplarCharacters draft="unconfirmed">[\u06E4\u06EA \u064B \u064C \u064E \u064F \u0650 \u0652 ا ب پ ت ج چ د ر ز س ض غ ۼ ف ڢ ك ڮ ل م ن ڼ ڹ ه و ي]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary" draft="unconfirmed">[\u200C\u200D\u200E\u200F]</exemplarCharacters>
+		<exemplarCharacters draft="unconfirmed">[a á b c d ɖ e é ɛ {ɛ\u0301} f g {gb} h i í ɩ {ɩ\u0301} j k {kp} l m ḿ n ń {ny} ŋ {ŋm} o ó ɔ {ɔ\u0301} p r s t u ú ʊ {ʊ\u0301} v w y z]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary" draft="unconfirmed">[q x]</exemplarCharacters>
+		<exemplarCharacters type="index" draft="unconfirmed">[A B C D Ɖ E Ɛ F G {Gb} H I Ɩ J K {Kp} L M N {Ny} Ŋ {Ŋm} O Ɔ P R S T U Ʊ V W Y Z]</exemplarCharacters>
 	</characters>
 </ldml>

--- a/exemplars/main/kdh_Arab.xml
+++ b/exemplars/main/kdh_Arab.xml
@@ -9,17 +9,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<identity>
 		<version number="$Revision$"/>
 		<language type="kdh"/>
-		<script type="Latn"/>
+		<script type="Arab"/>
 	</identity>
 	<layout>
 		<orientation>
-			<characterOrder>left-to-right</characterOrder>
+			<characterOrder>right-to-left</characterOrder>
 			<lineOrder>top-to-bottom</lineOrder>
 		</orientation>
 	</layout>
 	<characters>
-		<exemplarCharacters draft="unconfirmed">[a á b c d ɖ e é ɛ {ɛ\u0301} f g {gb} h i í ɩ {ɩ\u0301} j k {kp} l m ḿ n ń {ny} ŋ {ŋm} o ó ɔ {ɔ\u0301} p r s t u ú ʊ {ʊ\u0301} v w y z]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary" draft="unconfirmed">[q x]</exemplarCharacters>
-		<exemplarCharacters type="index" draft="unconfirmed">[A B C D Ɖ E Ɛ F G {Gb} H I Ɩ J K {Kp} L M N {Ny} Ŋ {Ŋm} O Ɔ P R S T U Ʊ V W Y Z]</exemplarCharacters>
+		<exemplarCharacters draft="unconfirmed">[\u06E4\u06EA \u064B \u064C \u064E \u064F \u0650 \u0652 ا ب پ ت ج چ د ر ز س ض غ ۼ ف ڢ ك ڮ ل م ن ڼ ڹ ه و ي]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary" draft="unconfirmed">[\u200C\u200D\u200E\u200F]</exemplarCharacters>
 	</characters>
 </ldml>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -141,7 +141,7 @@ public class GenerateMaximalLocales {
         "fub_Arab_CM",
         "fuf_Latn_GN",
         "kby_Arab_NE",
-        "kdh_Arab_TG",
+        "kdh_Latn_TG",
         "apd_Arab_TG",
         "zlm_Latn_TG",
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/langtags.json
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/external/langtags.json
@@ -51810,8 +51810,7 @@
         "regions": [ "BJ", "GH" ],
         "script": "Arab",
         "sldr": false,
-        "tag": "kdh",
-        "tags": [ "kdh-Arab", "kdh-TG" ],
+        "tag": "kdh-Arab",
         "windows": "kdh-Arab"
     },
     {
@@ -51826,7 +51825,8 @@
         "regions": [ "BJ", "GH" ],
         "script": "Latn",
         "sldr": false,
-        "tag": "kdh-Latn",
+        "tag": "kdh",
+        "tags": [ "kdh-Latn", "kdh-TG" ],
         "windows": "kdh-Latn"
     },
     {


### PR DESCRIPTION
CLDR-14846

- [X] This PR completes the ticket.

Note that git may tell you that 
- kdh.xml is modified
- kdh_Latn.xml renamed kdh_Arab.xml

In reality, two files were renamed without modification:
- kdh.xml renamed to kdh_Arab.xml
- kdh_Latn.xml renamed to kdh.xml

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
