### PR TITLE
CLDR-14810 Suppress some same as English warnings

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -155,14 +155,12 @@ public class CheckForCopy extends FactoryCheckCLDR {
         }
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
             value = cldrFile.getConstructedBaileyValue(path, null, null);
-        }
-        if (value == null) {
-            return Failure.ok;
-        }
-        if ("en".equals(loc) || loc.startsWith("en_")) {
-            if ("year".equals(value) || "month".equals(value) || "day".equals(value) || "hour".equals(value)) {
+            if (value == null) {
                 return Failure.ok;
             }
+        }
+        if (sameAsEnglishOK(loc, path, value)) {
+            return Failure.ok;
         }
         String value2 = value;
         if (isExplicitBailey) {
@@ -191,6 +189,19 @@ public class CheckForCopy extends FactoryCheckCLDR {
             }
         }
         return failure;
+    }
+
+    private static boolean sameAsEnglishOK(String loc, String path, String value) {
+        if (path.startsWith("//ldml/units/unitLength")
+            || path.startsWith("//ldml/characters/parseLenients")) {
+            return true;
+        }
+        if ("en".equals(loc) || loc.startsWith("en_")) {
+            if ("year".equals(value) || "month".equals(value) || "day".equals(value) || "hour".equals(value)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
CLDR-14810

So many of the units are SI (and thus common across languages) or are English units (and thus ok to be copies) that all checks for same as units are disabled.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
