### PR TITLE
CLDR-14807 fix day-person collisions

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -259,6 +259,11 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
         addNonColliding(mapPathPartsToSets, "[@type=\"graphics-pixel-per-inch\"]", "[@type=\"graphics-dot-per-inch\"]");
         addNonColliding(mapPathPartsToSets, "[@type=\"graphics-dot-per-centimeter\"]", "[@type=\"graphics-pixel-per-centimeter\"]");
 
+        addNonColliding(mapPathPartsToSets, "[@type=\"duration-year-person\"]", "[@type=\"duration-year\"]");
+        addNonColliding(mapPathPartsToSets, "[@type=\"duration-month-person\"]", "[@type=\"duration-month\"]");
+        addNonColliding(mapPathPartsToSets, "[@type=\"duration-week-person\"]", "[@type=\"duration-week\"]");
+        addNonColliding(mapPathPartsToSets, "[@type=\"duration-day-person\"]", "[@type=\"duration-day\"]");
+
         // all done, return immutable version
         return ImmutableMap.copyOf(mapPathPartsToSets);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListSurveyToolStatus.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListSurveyToolStatus.java
@@ -1,0 +1,76 @@
+package org.unicode.cldr.tool;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.unicode.cldr.tool.Option.Options;
+import org.unicode.cldr.tool.Option.Params;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRFile.Status;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.PathHeader;
+
+public class ListSurveyToolStatus {
+    private enum MyOptions {
+        locale(new Params().setHelp("Regex for locales").setMatch(".*").setDefault("^root$")),
+        paths(new Params().setHelp("Regex for paths").setMatch(".+").setDefault("/unit.*day")),
+        verbose(new Params().setHelp("verbose debugging messages")),
+        ;
+
+        // BOILERPLATE TO COPY
+        final Option option;
+
+        private MyOptions(Params params) {
+            option = new Option(this, params);
+        }
+
+        private static Options myOptions = new Options();
+        static {
+            for (MyOptions option : MyOptions.values()) {
+                myOptions.add(option, option.option);
+            }
+        }
+
+        private static Set<String> parse(String[] args) {
+            return myOptions.parse(MyOptions.values()[0], args, true);
+        }
+    }
+
+    public static void main(String[] args) {
+        MyOptions.parse(args);
+        Matcher locales = Pattern.compile(MyOptions.locale.option.getValue()).matcher("");
+        Matcher paths = Pattern.compile(MyOptions.paths.option.getValue()).matcher("");
+        Factory factory = CLDRConfig.getInstance().getCldrFactory();
+        Status status = new Status();
+
+        for (String locale : factory.getAvailable()) {
+            if (locales.reset(locale).find()) {
+                CLDRFile cldrFile = factory.make(locale, true);
+                String testValue = cldrFile.getStringValue("//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-day-person\"]/displayName");
+                Set<PathHeader> sorted = new TreeSet<>();
+                for (String path : cldrFile.fullIterable()) {
+                    sorted.add(PathHeader.getFactory().fromPath(path));
+                }
+                for (PathHeader pathHeader : sorted) {
+                    // eg //ldml/units/unitLength[@type="long"]/unit[@type="duration-day-person"]/unitPattern[@count="one"][@case="accusative"]
+                    final String path = pathHeader.getOriginalPath();
+                    if (paths.reset(path).find()) {
+                        String value = cldrFile.getStringValue(path);
+                        String localeFound = cldrFile.getSourceLocaleID(path, status);
+                        System.out.println(locale
+                            + (locale.equals(localeFound) ? "" : "/" + localeFound)
+                            + "\t" + pathHeader
+                            + "\n\tvalue:\t" + value
+                            + "\n\tpath:\t" + path
+                            + (path.equals(status.pathWhereFound) ? "" : "\n\toPath:\t" + status.pathWhereFound)
+                            + "\n");
+                    }
+                }
+            }
+        }
+        System.out.println("DONE");
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -962,16 +962,17 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 // return the alias with the longest matching prefix since the
                 // hashmap is sorted according to xpath.
 
-                // We need to recurse, since we might have a chain of aliases
-                while (true) {
+//                // The following is a work in progress
+//                // We need to recurse, since we might have a chain of aliases
+//                while (true) {
                     String possibleSubpath = aliases.lowerKey(xpath);
                     if (possibleSubpath != null && xpath.startsWith(possibleSubpath)) {
                         aliasedPath = aliases.get(possibleSubpath) +
                             xpath.substring(possibleSubpath.length());
-                        xpath = aliasedPath;
-                    } else {
-                        break;
-                    }
+//                        xpath = aliasedPath;
+//                    } else {
+//                        break;
+//                    }
                 }
             }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -309,7 +309,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
         @Override
         public String toString() {
             return
-            "newLocaleID: " + newLocaleID + ",\t"
+                "newLocaleID: " + newLocaleID + ",\t"
                 +
                 "oldPath: " + oldPath + ",\n\t"
                 +
@@ -486,7 +486,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
      * @return the localeID
      */
     public String getSourceLocaleIdExtended(String path, CLDRFile.Status status,
-            @SuppressWarnings("unused") boolean skipInheritanceMarker) {
+        @SuppressWarnings("unused") boolean skipInheritanceMarker) {
         return getSourceLocaleID(path, status);
     }
 
@@ -961,10 +961,17 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 // If there are one or more matching aliases, lowerKey() will
                 // return the alias with the longest matching prefix since the
                 // hashmap is sorted according to xpath.
-                String possibleSubpath = aliases.lowerKey(xpath);
-                if (possibleSubpath != null && xpath.startsWith(possibleSubpath)) {
-                    aliasedPath = aliases.get(possibleSubpath) +
-                        xpath.substring(possibleSubpath.length());
+
+                // We need to recurse, since we might have a chain of aliases
+                while (true) {
+                    String possibleSubpath = aliases.lowerKey(xpath);
+                    if (possibleSubpath != null && xpath.startsWith(possibleSubpath)) {
+                        aliasedPath = aliases.get(possibleSubpath) +
+                            xpath.substring(possibleSubpath.length());
+                        xpath = aliasedPath;
+                    } else {
+                        break;
+                    }
                 }
             }
 
@@ -1397,7 +1404,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 "ro_MD",
                 "sw_CD",
                 "zh_Hans", "zh_Hant"
-                };
+            };
             for (String extraCode : extraCodes) {
                 addFallbackCode(CLDRFile.LANGUAGE_NAME, extraCode, extraCode);
             }
@@ -1444,14 +1451,14 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 constructedItems.putValueAtPath(
                     "//ldml/localeDisplayNames/keys/key" +
                         "[@type=\"" + keyDisplayNames[i] + "\"]",
-                    keyDisplayNames[i]);
+                        keyDisplayNames[i]);
             }
             for (int i = 0; i < typeDisplayNames.length; ++i) {
                 constructedItems.putValueAtPath(
                     "//ldml/localeDisplayNames/types/type"
                         + "[@key=\"" + typeDisplayNames[i][1] + "\"]"
                         + "[@type=\"" + typeDisplayNames[i][0] + "\"]",
-                    typeDisplayNames[i][0]);
+                        typeDisplayNames[i][0]);
             }
             constructedItems.freeze();
             allowDuplicates = Collections.unmodifiableMap(allowDuplicates);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
@@ -38,7 +38,7 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
     private static final String deciNarrow = "//ldml/units/unitLength[@type=\"narrow\"]/compoundUnit[@type=\"10p-1\"]/unitPrefixPattern";
     private static final String deciShort = "//ldml/units/unitLength[@type=\"short\"]/compoundUnit[@type=\"10p-1\"]/unitPrefixPattern";
 
-        public static void main(String[] args) {
+    public static void main(String[] args) {
         new TestCheckDisplayCollisions().run(args);
     }
 
@@ -197,11 +197,11 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
 
     public void TestDotPixel14031 () {
         Map<String, String> pathValuePairs = ImmutableMap.of(
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot\"]/displayName", "Punkt",
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
-                    );
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot\"]/displayName", "Punkt",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
+            );
         TestFactory factory = makeFakeCldrFile("de", pathValuePairs);
         checkDisplayCollisions("de", pathValuePairs, factory);
     }
@@ -233,11 +233,12 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
 
     public void TestDurationPersonVariants () {
         Map<String, String> pathValuePairs = ImmutableMap.of(
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-day-person\"]/unitPattern[@count=\"other\"]", "Punkt",
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
-                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
-                    );
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-day-person\"]/unitPattern[@count=\"other\"]", "Punkt",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-day\"]/unitPattern[@count=\"other\"]", "Punkt",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
+            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
+            );
         TestFactory factory = makeFakeCldrFile("de", pathValuePairs);
         checkDisplayCollisions("de", pathValuePairs, factory);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
@@ -196,30 +196,50 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
     }
 
     public void TestDotPixel14031 () {
-        TestFactory factory = new TestFactory();
-        XMLSource rootSource = new SimpleXMLSource("root");
-        factory.addFile(new CLDRFile(rootSource));
+        Map<String, String> pathValuePairs = ImmutableMap.of(
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot\"]/displayName", "Punkt",
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
+                    );
+        TestFactory factory = makeFakeCldrFile("de", pathValuePairs);
+        checkDisplayCollisions("de", pathValuePairs, factory);
+    }
 
-        XMLSource localeSource = new SimpleXMLSource("de");
-        Map<String,String> m = ImmutableMap.of(
-            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot\"]/displayName", "Punkt",
-            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
-            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
-            "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
-            );
-        for (Entry<String, String> entry : m.entrySet()) {
-            localeSource.putValueAtPath(entry.getKey(), entry.getValue());
-        }
-        factory.addFile(new CLDRFile(localeSource));
-
+    public void checkDisplayCollisions(String locale, Map<String, String> pathValuePairs, TestFactory factory) {
         CheckDisplayCollisions cdc = new CheckDisplayCollisions(factory);
         cdc.setEnglishFile(CLDRConfig.getInstance().getEnglish());
 
         List<CheckStatus> possibleErrors = new ArrayList<>();
-        cdc.setCldrFileToCheck(factory.make("de", true), ImmutableMap.of(), possibleErrors);
-        for (Entry<String, String> entry : m.entrySet()) {
+        cdc.setCldrFileToCheck(factory.make(locale, true), ImmutableMap.of(), possibleErrors);
+        for (Entry<String, String> entry : pathValuePairs.entrySet()) {
             cdc.check(entry.getKey(), entry.getKey(), entry.getValue(), ImmutableMap.of(), possibleErrors);
             assertEquals(entry.toString(), Collections.emptyList(), possibleErrors);
         }
     }
+
+    public TestFactory makeFakeCldrFile(String locale, Map<String, String> pathValuePairs) {
+        TestFactory factory = new TestFactory();
+        XMLSource rootSource = new SimpleXMLSource("root");
+        factory.addFile(new CLDRFile(rootSource));
+
+        XMLSource localeSource = new SimpleXMLSource(locale);
+        for (Entry<String, String> entry : pathValuePairs.entrySet()) {
+            localeSource.putValueAtPath(entry.getKey(), entry.getValue());
+        }
+        factory.addFile(new CLDRFile(localeSource));
+        return factory;
+    }
+
+    public void TestDurationPersonVariants () {
+        Map<String, String> pathValuePairs = ImmutableMap.of(
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-day-person\"]/unitPattern[@count=\"other\"]", "Punkt",
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel\"]/displayName", "Punkt",
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-pixel-per-centimeter\"]/displayName", "Punkt pro Zentimeter",
+                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot-per-centimeter\"]/displayName", "Punkt pro Zentimeter"
+                    );
+        TestFactory factory = makeFakeCldrFile("de", pathValuePairs);
+        checkDisplayCollisions("de", pathValuePairs, factory);
+    }
+
 }


### PR DESCRIPTION
CLDR-14807 

The ticket will have 3 parts:

1. Make sure the special durations for persons don't collide.

2. Make the alias mechanism more robust where it could need recursion.
3. Make the iteration over aliases also more robust.

This PR should address the first item, but more work needs to be done on #2 and #3, which were encountered while doing #1. It is worth starting with #1, since it will unblock the vetters on fixing current errors.

The PR also adds a tool used in testing.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
