### PR TITLE
CLDR-14101 add examples for minimal pairs, units with grammar

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -75,8 +75,15 @@ public class GrammarInfo implements Freezable<GrammarInfo>{
         public CharSequence getSymbol() {
             return symbol;
         }
-        public String getDefault(Collection<String> values) {
-            return this == grammaticalGender && values != null && !values.contains("neuter") ? "masculine" : defaultValue;
+        /**
+         * Gets the default value. The parameter only needs to be set for grammaticalGender
+         */
+        public String getDefault(Collection<String> featureValuesFromGrammaticalInfo) {
+            return this == grammaticalGender
+                && featureValuesFromGrammaticalInfo != null
+                    && !featureValuesFromGrammaticalInfo.contains("neuter")
+                    ? "masculine"
+                        : defaultValue;
         }
         public static Matcher pathHasFeature(String path) {
             Matcher result = PATH_HAS_FEATURE.matcher(path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -811,7 +811,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 Set<String> grouping = new TreeSet<>(LogicalGrouping.getPaths(cldrFile, path));
                 final Multimap<String, String> deltaValue = delta(expected, grouping);
                 if (seen.add(deltaValue)) {
-                    assertEquals("Logical group for " + path, ImmutableListMultimap.of(), deltaValue);
+                    assertEquals("Logical group for " + locale + ", " + path, ImmutableListMultimap.of(), deltaValue);
                 }
                 PathType actualPathType = PathType.getPathTypeFromPath(path);
                 assertEquals("PathType", expectedPathType, actualPathType);


### PR DESCRIPTION
CLDR-14101

ExampleGenerator.java
I also did a bit of cleanup, moving the fields up to the top with statics before non-statics. supplementalDataInfo could be initialized statically also.
Main changes are
- private String handleMinimalPairs(XPathParts parts, String minimalPattern) - all new
- private String getBestUnitWithGender(String gender) - all new. Not quite sure about threading with the caching pattern used
- private String handleFormatUnit(XPathParts parts, String value) - adds use of minimal pairs for context

GrammarInfo.java - just some minor reformatting

TestExampleGenerator.java
- Added tests for the two additions (minimal pairs, units with minimal pairs)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
