### PR TITLE
CLDR-14858 Yukon should not show DST strings

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -55,12 +55,7 @@
 		<!-- test -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -39,12 +39,7 @@
 		<!-- test -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckMetazones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckMetazones.java
@@ -39,20 +39,32 @@ public class CheckMetazones extends CheckCLDR {
             // MessageFormat with arguments
         }
 
-        if (path.indexOf("/long") >= 0) {
-            XPathParts parts = XPathParts.getFrozenInstance(path);
-            String metazoneName = parts.getAttributeValue(3, "type");
-            if (!metazoneUsesDST(metazoneName) && path.indexOf("/standard") < 0) {
-                result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.errorType)
-                    .setSubtype(Subtype.extraMetazoneString) // typically warningType or errorType
-                    .setMessage("Extra metazone string - should only contain standard value for a non-DST metazone"));
-                // the message can be MessageFormat with arguments
-            }
+        if (isDSTPathForNonDSTMetazone(path)) {
+            result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.errorType)
+            .setSubtype(Subtype.extraMetazoneString) // typically warningType or errorType
+            .setMessage("Extra metazone string - should only contain standard value for a non-DST metazone"));
         }
         return this;
     }
 
-    private boolean metazoneUsesDST(String name) {
+    /**
+     * True if this is a DST path, but a non DST metazone.
+     * Such an XPath should not be present in a CLDRFile.
+     * @param path (assumes it is a /metazone path)
+     * @return
+     */
+    public static boolean isDSTPathForNonDSTMetazone(String path) {
+        if (path.indexOf("/long") >= 0 || path.indexOf("/short") >= 0) {
+            XPathParts parts = XPathParts.getFrozenInstance(path);
+            String metazoneName = parts.getAttributeValue(3, "type");
+            if (!metazoneUsesDST(metazoneName) && path.indexOf("/standard") < 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean metazoneUsesDST(String name) {
         return LogicalGrouping.metazonesDSTSet.contains(name);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.unicode.cldr.test.CheckMetazones;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
@@ -3393,9 +3394,14 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         Set<String> zones = supplementalData.getAllMetazones();
 
         for (String zone : zones) {
+            final boolean metazoneUsesDST = CheckMetazones.metazoneUsesDST(zone);
             for (String width : new String[] { "long", "short" }) {
                 for (String type : new String[] { "generic", "standard", "daylight" }) {
-                    toAddTo.add("//ldml/dates/timeZoneNames/metazone[@type=\"" + zone + "\"]/" + width + "/" + type);
+                    if (metazoneUsesDST || type.equals("standard")) {
+                        // Only add /standard for non-DST metazones
+                        final String path = "//ldml/dates/timeZoneNames/metazone[@type=\"" + zone + "\"]/" + width + "/" + type;
+                        toAddTo.add(path);
+                    }
                 }
             }
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestCheckMetazones.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestCheckMetazones.java
@@ -1,0 +1,17 @@
+package org.unicode.cldr.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @see {@link CheckMetazones}
+ */
+public class TestCheckMetazones {
+    @Test
+    public void TestMetazoneUsesDST() {
+        assertFalse(CheckMetazones.metazoneUsesDST("Yukon"), "Yukon doesn't use DST");
+        assertTrue(CheckMetazones.metazoneUsesDST("America_Pacific"), "America_Pacific uses DST");
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -60,6 +60,11 @@ import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Output;
 
+/**
+ * This is the original TestFwmk test case for CLDRFile.
+ * @see {@link org.unicode.cldr.util.TestCLDRFile}
+ * @see {@link org.unicode.cldr.util.CLDRFile}
+ */
 public class TestCLDRFile extends TestFmwk {
     private static final boolean DISABLE_TIL_WORKS = false;
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -1,0 +1,43 @@
+package org.unicode.cldr.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.unicode.cldr.test.CheckMetazones;
+
+/**
+ * This contains additional tests in JUnit.
+ *
+ * @see {@link org.unicode.cldr.unittest.TestCLDRFile}
+ * @see {@link CLDRFile}
+ */
+public class TestCLDRFile {
+
+    static Factory factory = null;
+
+    @BeforeAll
+    public static void setUp() {
+        factory = CLDRConfig.getInstance().getFullCldrFactory();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"de","fr","root",})
+    public void TestExtraMetazonePaths(String locale) {
+        CLDRFile f = factory.make(locale, true);
+        assertNotNull(f, "CLDRFile for " + locale);
+        Set<String> rawExtraPaths = f.getRawExtraPaths();
+        assertNotNull(rawExtraPaths, "RawExtraPaths for " + locale);
+        for (final String path : rawExtraPaths) {
+            if (path.indexOf("/metazone") >= 0) {
+                assertFalse(CheckMetazones.isDSTPathForNonDSTMetazone(path), "DST path for non-DST zone: "+locale+":"+path);
+            }
+        }
+    }
+}

--- a/tools/cldr-rdf/pom.xml
+++ b/tools/cldr-rdf/pom.xml
@@ -60,12 +60,7 @@
         <!-- test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,6 @@
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
 		<icu4j.version>70.0.1-SNAPSHOT-cldr-2021-06-15</icu4j.version>
-		<junit.version>4.13.1</junit.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>
@@ -165,21 +164,8 @@
 
 			<!-- test -->
 			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>${junit.version}</version>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
 				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-api</artifactId>
-				<version>${junit.jupiter.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-engine</artifactId>
+				<artifactId>junit-jupiter</artifactId>
 				<version>${junit.jupiter.version}</version>
 				<scope>test</scope>
 			</dependency>


### PR DESCRIPTION
- add a check that CLDRFile.getRawExtraPaths() does
not show DST strings for non-DST metazones
- update getRawExtraPaths() to not include such paths
- include junit params for parameterized tests
- simplify junit pom dependencymanagement, remove an unneeded entry (bare "junit" not used anywhere)

CLDR-14858

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
