### PR TITLE
CLDR-9895 change bo collation draft status from unconfirmed to contributed

### DIFF
--- a/common/collation/bo.xml
+++ b/common/collation/bo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2015 Unicode, Inc.
+Copyright © 1991-2021 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -11,7 +11,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<language type="bo" /> 
 	</identity>
 	<collations>
-		<collation type="standard" draft="unconfirmed">
+		<collation type="standard" draft="contributed">
 			<cr><![CDATA[
 				[normalization on]
 				[reorder Tibt]


### PR DESCRIPTION

CLDR-9895

- [x] This PR completes the ticket.

Per CLDR TC discussion, this PR changes the draft status of the Tibetan ("bo") collation from unconfirmed to contributed.