### PR TITLE
CLDR-14898 Devanagari danda instead of pipe in emoji keywords

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -312,7 +312,11 @@ public class DisplayAndInputProcessor {
     static final UnicodeSet WHITESPACE = new UnicodeSet("[:whitespace:]").freeze();
     static final DateTimeCanonicalizer dtc = new DateTimeCanonicalizer(FIX_YEARS);
 
-    public static final Splitter SPLIT_BAR = Splitter.on(Pattern.compile("(\\||\\s+l\\s+)")).trimResults().omitEmptyStrings();
+    private static final String BAR_VL = "\\|"; // U+007C VERTICAL LINE (pipe, bar) literal
+    private static final String BAR_EL = "\\s+l\\s+"; // U+006C LATIN SMALL LETTER L with space
+    private static final String BAR_DANDA = "।"; // U+0964 DEVANAGARI DANDA
+    private static final String BAR_REGEX = "(" + BAR_VL + "|" + BAR_EL + "|" + BAR_DANDA + ")";
+    public static final Splitter SPLIT_BAR = Splitter.on(Pattern.compile(BAR_REGEX)).trimResults().omitEmptyStrings();
     static final Splitter SPLIT_SPACE = Splitter.on(' ').trimResults().omitEmptyStrings();
     static final Joiner JOIN_BAR = Joiner.on(" | ");
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -473,4 +473,24 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
             return a;
         }
     }
+
+    /**
+     * Test whether DisplayAndInputProcessor.processInput correctly normalizes annotations
+     * containing “|” = U+007C VERTICAL LINE or its variations
+     */
+    public void TestSplitBar() {
+        DisplayAndInputProcessor daip = new DisplayAndInputProcessor(info.getEnglish(), false);
+        String xpath = "//ldml/annotations/annotation[@cp=\"🆎\"]";
+        String val = daip.processInput(xpath, "a|b", null);
+        String normVal = "a | b";
+        assertEquals("Pipe gets spaces", normVal, val);
+        val = daip.processInput(xpath, "a   l   b", null);
+        assertEquals("Lowercase L with spaces becomes pipe", normVal, val);
+        val = daip.processInput(xpath, "alb", null);
+        assertEquals("Lowercase L without spaces does not become pipe", "alb", val);
+        val = daip.processInput(xpath, "a।b", null);
+        assertEquals("U+0964 DEVANAGARI DANDA without spaces becomes pipe", normVal, val);
+        val = daip.processInput(xpath, "a  ।  b", null);
+        assertEquals("U+0964 DEVANAGARI DANDA with spaces becomes pipe", normVal, val);
+    }
 }


### PR DESCRIPTION
-New unit test TestSplitBar for danda and lowercase l

-New BAR_REGEX used only by SPLIT_BAR, handles danda like pipe

-Construct regex from pieces for clarity and maintainability

-Comments

CLDR-14898

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
