### PR TITLE
CLDR-14895 remove busstop

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -2397,7 +2397,7 @@ annotations.
 		<annotation cp="🛹" type="tts">skateboard</annotation>
 		<annotation cp="🛼">roller | skate</annotation>
 		<annotation cp="🛼" type="tts">roller skate</annotation>
-		<annotation cp="🚏">bus | busstop | stop</annotation>
+		<annotation cp="🚏">bus | stop</annotation>
 		<annotation cp="🚏" type="tts">bus stop</annotation>
 		<annotation cp="🛣">highway | motorway | road</annotation>
 		<annotation cp="🛣" type="tts">motorway</annotation>


### PR DESCRIPTION
Removing "busstop" due to spelling error.

CLDR-14895

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-14895)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
