### PR TITLE
CLDR-14408 build: timeout for JS tests

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -19,8 +19,12 @@ jobs:
       run: npx markdownlint-cli *.md {specs,docs}/*.md $(find .github -name '*.md') || (echo Warning, please fix these ; true)
     - name: Lint GitHub Actions
       run: npx yaml-lint .github/workflows/*.yml
+    - name: Prepare JS tests
+      run: (cd tools/cldr-apps/js && npm ci)
     - name: Run JS tests
-      run: (cd tools/cldr-apps/js && npm ci && npm t)
+      # stopgap: fail this if it takes too long
+      timeout-minutes: 10
+      run: (cd tools/cldr-apps/js && npm t)
   build:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
- this test has been hanging, as a stopgap fail fast after 10m
- test should take a few seconds to run

CLDR-14408