### PR TITLE
CLDR-14803 improve error message for TestNamesVsEmojiData

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -174,7 +174,7 @@ public class TestAnnotations extends TestFmwkPlus {
             String name = Emoji.getName(emoji);
             String annotationName = annotations.getShortName();
             if (!symbols.contains(emoji) && !emoji.contains("👲")) {
-                assertEquals(emoji, name, annotationName);
+                assertEquals(emoji + " (en.xml vs. emoji-test.txt)", name, annotationName);
             }
         }
     }


### PR DESCRIPTION
CLDR-14803

- [ ] This PR completes the ticket.

The source for the test says:

```java
    /** The English name should line up with the emoji-test.txt file */
```

…this change makes the test print out something to that effect.