### PR TITLE
CLDR-14892 ar_AE should default to "latn" digits

### DIFF
--- a/common/main/ar_AE.xml
+++ b/common/main/ar_AE.xml
@@ -39,7 +39,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</fields>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>arab</defaultNumberingSystem>
+		<defaultNumberingSystem>latn</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>


### PR DESCRIPTION
CLDR-14892

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
