### PR TITLE
CLDR-14863 br: add \u02BC to collation-equivalent apostrophes between c,h e.g. cʼh

### DIFF
--- a/common/collation/br.xml
+++ b/common/collation/br.xml
@@ -14,7 +14,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	        <!-- References: https://en.wikipedia.org/wiki/Breton_language#Alphabet ; http://devri.bzh -->
 	        <collation type="standard">
 			<cr><![CDATA[
-				&C<ch<<<Ch<<<CH<c''h=c\u2019h<<<C''h=C\u2019h<<<C''H=C\u2019H
+				&C<ch<<<Ch<<<CH<c''h=c\u02BCh=c\u2019h<<<C''h=C\u02BCh=C\u2019h<<<C''H=C\u02BCH=C\u2019H
 			]]></cr>
 		</collation>
 	</collations>


### PR DESCRIPTION

CLDR-14863

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

I searched through all locales in common/main to see if any other exemplar sets included instances of u2019, u02BC or u0027 between a pair of letters, and did not find any other instance.