### PR TITLE
CLDR-14781 en: add menu variants for Sami language names

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -513,6 +513,7 @@ annotations.
 			<language type="sdc">Sassarese Sardinian</language>
 			<language type="sdh">Southern Kurdish</language>
 			<language type="se">Northern Sami</language>
+			<language type="se" alt="menu">Sami, Northern</language>
 			<language type="see">Seneca</language>
 			<language type="seh">Sena</language>
 			<language type="sei">Seri</language>
@@ -533,9 +534,13 @@ annotations.
 			<language type="sly">Selayar</language>
 			<language type="sm">Samoan</language>
 			<language type="sma">Southern Sami</language>
+			<language type="sma" alt="menu">Sami, Southern</language>
 			<language type="smj">Lule Sami</language>
+			<language type="smj" alt="menu">Sami, Lule</language>
 			<language type="smn">Inari Sami</language>
+			<language type="smn" alt="menu">Sami, Inari</language>
 			<language type="sms">Skolt Sami</language>
+			<language type="sms" alt="menu">Sami, Skolt</language>
 			<language type="sn">Shona</language>
 			<language type="snk">Soninke</language>
 			<language type="so">Somali</language>


### PR DESCRIPTION
CLDR-14781

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

In English, add alt=menu variants for Sami language names.
Too late in CLDR 40 to collect these for other display languages.