### PR TITLE
CLDR-14408 improve FE test timeouts

### DIFF
--- a/tools/cldr-apps/js/package.json
+++ b/tools/cldr-apps/js/package.json
@@ -7,7 +7,7 @@
     "build-test": "webpack --config webpack-test.config.js",
     "test": "npm run nonbrowser-test && npm run browser-test",
     "nonbrowser-test": "mocha --require esm --reporter spec test/nonbrowser/test-*.js",
-    "browser-test": "npm run build-test && mocha-chrome test/Test.html",
+    "browser-test": "npm run build-test && mocha-chrome test/Test.html --chrome-launcher.connectionPollInterval=2000 --chrome-launcher.maxConnectionRetries=300",
     "lint": "exit 0",
     "build": "webpack",
     "watch": "webpack watch"


### PR DESCRIPTION
CLDR-14408

per https://github.com/shellscape/mocha-chrome/issues/32#issuecomment-539599328

- [ ] This PR completes the ticket.

Update timeouts to give the FE tests a better chance of running