### PR TITLE
CLDR-14487 doc: clarify legacy variant (en_US_POSIX)

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -351,7 +351,7 @@ A [`unicode_locale_id`](#unicode_locale_id) is _maximal_ when the [`unicode_lang
 
 > _Example:_ the maxmal form of ja-Kana-t-it is ja-Kana-JP-t-it-latn-it
 
-Note that the _latn_ and final _it_ don't use any uppercase characters, since they are not inside unicode_language_id.  
+Note that the _latn_ and final _it_ don't use any uppercase characters, since they are not inside unicode_language_id.
 
 Two [`unicode_locale_ids`](#unicode_locale_id) are _equivalent_ when their maximal canonical forms are identical.
 
@@ -606,7 +606,7 @@ For script codes, ISO 15924 supplies a mapping (however, the numeric codes are n
 | Script       | Numeric    |
 | ------------ | ---------- |
 | `Qaaa..Qabx` | `900..949` |
- 
+
 #### 3.5.3 <a name="Private_Use_Codes" href="#Private_Use_Codes">Private Use Codes</a>
 
 Private use codes fall into three groups.
@@ -850,11 +850,11 @@ Additional keys or types might be added in future versions. Implementations of L
 
 #### <a name="Numbering%20System%20Data" href="#Numbering%20System%20Data">3.6.2 Numbering System Data</a>
 
-LDML supports multiple numbering systems. The identifiers for those numbering systems are defined in the file **bcp47/number.xml**. For example, for the 'trunk' version of the data see [bcp47/number.xml](https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/number.xml).  
+LDML supports multiple numbering systems. The identifiers for those numbering systems are defined in the file **bcp47/number.xml**. For example, for the 'trunk' version of the data see [bcp47/number.xml](https://github.com/unicode-org/cldr/releases/tag/latest/common/bcp47/number.xml).
 
-Details about those numbering systems are defined in **supplemental/numberingSystems.xml**. For example, for the 'trunk' version of the data see [supplemental/numberingSystems.xml](https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/numberingSystems.xml).  
+Details about those numbering systems are defined in **supplemental/numberingSystems.xml**. For example, for the 'trunk' version of the data see [supplemental/numberingSystems.xml](https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/numberingSystems.xml).
 
-LDML makes certain stability guarantees on this data:   
+LDML makes certain stability guarantees on this data:
 
 1.  Like other BCP 47 identifiers, once a numeric identifier is added to **bcp47/number.xml** or **numberingSystems.xml**, it will never be removed from either of those files.
 2.  If an identifier has type="numeric" in numberingSystems.xml, then
@@ -894,29 +894,29 @@ The 't' extension data is stored in [common/bcp47/transform.xml](https://github.
 ```xml
 <!ELEMENT keyword ( key* )>
 
-<!ELEMENT key ( type* )>  
-<!ATTLIST key extension NMTOKEN #IMPLIED>  
-<!ATTLIST key name NMTOKEN #REQUIRED>  
-<!ATTLIST key description CDATA #IMPLIED>  
-<!ATTLIST key deprecated ( true | false ) "false">  
-<!ATTLIST key preferred NMTOKEN #IMPLIED>  
-<!ATTLIST key alias NMTOKEN #IMPLIED>  
-<!ATTLIST key valueType (single | multiple | incremental | any) #IMPLIED >  
+<!ELEMENT key ( type* )>
+<!ATTLIST key extension NMTOKEN #IMPLIED>
+<!ATTLIST key name NMTOKEN #REQUIRED>
+<!ATTLIST key description CDATA #IMPLIED>
+<!ATTLIST key deprecated ( true | false ) "false">
+<!ATTLIST key preferred NMTOKEN #IMPLIED>
+<!ATTLIST key alias NMTOKEN #IMPLIED>
+<!ATTLIST key valueType (single | multiple | incremental | any) #IMPLIED >
 <!ATTLIST key since CDATA #IMPLIED>
 
-<!ELEMENT type EMPTY>  
-<!ATTLIST type name NMTOKEN #REQUIRED>  
-<!ATTLIST type description CDATA #IMPLIED>  
-<!ATTLIST type deprecated ( true | false ) "false">  
-<!ATTLIST type preferred NMTOKEN #IMPLIED>  
-<!ATTLIST type alias CDATA #IMPLIED>  
+<!ELEMENT type EMPTY>
+<!ATTLIST type name NMTOKEN #REQUIRED>
+<!ATTLIST type description CDATA #IMPLIED>
+<!ATTLIST type deprecated ( true | false ) "false">
+<!ATTLIST type preferred NMTOKEN #IMPLIED>
+<!ATTLIST type alias CDATA #IMPLIED>
 <!ATTLIST type since CDATA #IMPLIED>
 
-<!ELEMENT attribute EMPTY>  
-<!ATTLIST attribute name NMTOKEN #REQUIRED>  
-<!ATTLIST attribute description CDATA #IMPLIED>  
-<!ATTLIST attribute deprecated ( true | false ) "false">  
-<!ATTLIST attribute preferred NMTOKEN #IMPLIED>  
+<!ELEMENT attribute EMPTY>
+<!ATTLIST attribute name NMTOKEN #REQUIRED>
+<!ATTLIST attribute description CDATA #IMPLIED>
+<!ATTLIST attribute deprecated ( true | false ) "false">
+<!ATTLIST attribute preferred NMTOKEN #IMPLIED>
 <!ATTLIST attribute since CDATA #IMPLIED>
 ```
 
@@ -927,46 +927,46 @@ In the Unicode locale extension 'u' and 't' data files, the common attributes fo
 **name**
 
 > The key or type name used by Unicode locale extension with ['u' extension syntax](#Unicode_locale_identifier) or the 't' extensions syntax. When _alias_ below is absent, this name can be also used with the old style ["@key=type" syntax](#Old_Locale_Extension_Syntax).
-> 
+>
 > Most type names are **literal type names**, which match exactly the same value. All of these have at least one lowercase letter, such as "buddhist". There are a small number of **indirect type names**, such as "RG_KEY_VALUE". These have no lowercase letters. The interpretation of each one is listed below.
-> 
+>
 > ##### <a name="CODEPOINTS" href="#CODEPOINTS">CODEPOINTS</a>
-> 
+>
 > The type name **"CODEPOINTS"** is reserved for a variable representing Unicode code point(s). The syntax is:
-> 
+>
 > |            | EBNF |
 > | ---------- | ---- |
 > | codepoints | `= codepoint (sep codepoint)?` |
 > | codepoint  | `= [0-9 A-F a-f]{4,6}` |
-> 
+>
 > In addition, no codepoint may exceed 10FFFF. For example, "00A0", "300b", "10D40C" and "00C1-00E1" are valid, but "A0", "U060C" and "110000" are not.
-> 
+>
 > In the current version of CLDR, the type "CODEPOINTS" is only used for the deprecated locale extension key "vt" (variableTop). The subtags forming the type for "vt" represent an arbitrary string of characters. There is no formal limit in the number of characters, although practically anything above 1 will be rare, and anything longer than 4 might be useless. Repetition is allowed, for example, 0061-0061 ("aa") is a Valid type value for "vt", since the sequence may be a collating element. Order is vital: 0061-0062 ("ab") is different than 0062-0061 ("ba"). Note that for variableTop any character sequence must be a contraction which yields exactly one primary weight.
-> 
+>
 > For example,
-> 
+>
 > > **en-u-vt-00A4** : this indicates English, with any characters sorting at or below " ¤" (at a primary level) considered Variable.
-> 
+>
 > By default in UCA, variable characters are ignored in sorting at a primary, secondary, and tertiary level. But in CLDR, they are not ignorable by default. For more information, see [Collation: Section 3.3 _Setting Options_](tr35-collation.md#Setting_Options) .
-> 
+>
 > ##### <a name="REORDER_CODE" href="#REORDER_CODE">REORDER_CODE</a>
-> 
+>
 > The type name **"REORDER_CODE"** is reserved for reordering block names (e.g. "latn", "digit" and "others") defined in the _[Root Collation](tr35-collation.md#Root_Collation)_. The type "REORDER_CODE" is used for locale extension key "kr" (colReorder). The value of type for "kr" is represented by one or more reordering block names such as "latn-digit". For more information, see [Collation: Section 3.12 _Collation Reordering_](tr35-collation.md#Script_Reordering) .
-> 
+>
 > ##### <a name="RG_KEY_VALUE" href="#RG_KEY_VALUE">RG_KEY_VALUE</a>
-> 
+>
 > The type name **"RG_KEY_VALUE"** is reserved for region codes in the format required by the "rg" key; this is a subdivision code with idStatus='unknown' or 'regular' from the idValidity data in common/validity/subdivision.xml.
-> 
+>
 > ##### <a name="SCRIPT_CODE" href="#SCRIPT_CODE">SCRIPT_CODE</a>
-> 
+>
 > The type name **"SCRIPT_CODE"** is reserved for [`unicode_script_subtag`](#unicode_script_subtag) values (e.g. "thai", "laoo"). The type "SCRIPT_CODE" is used for locale extension key "dx". The value of type for "dx" is represented by one or more SCRIPT_CODEs, such as "thai-laoo".
-> 
+>
 > ##### <a name="SUBDIVISION_CODE" href="#SUBDIVISION_CODE">SUBDIVISION_CODE</a>
-> 
+>
 > The type name **"SUBDIVISION_CODE"** is reserved for subdivision codes in the format required by the "sd" key; this is a subdivision code from the idValidity data in common/validity/subdivision.xml, excluding those with idStatus='unknown'. Codes with idStatus='deprecated' should not be generated, and those with idStatus='private_use' are only to be used with prior agreement.
-> 
+>
 > ##### <a name="PRIVATE_USE" href="#PRIVATE_USE">PRIVATE_USE</a>
-> 
+>
 > The type name **"PRIVATE_USE"** is reserved for private use types. A valid type value is composed of one or more subtags separated by hyphens and each subtag consists of three to eight ASCII alphanumeric characters. In the current version of CLDR, **"PRIVATE_USE"** is only used for transform extension "x0".
 
 **valueType**
@@ -995,15 +995,15 @@ In the Unicode locale extension 'u' and 't' data files, the common attributes fo
 **alias** (Not applicable to `<attribute>`)
 
 > The BCP 47 form is the canonical form, and recommended. Other aliases are included only for backwards compatibility.
-> 
+>
 > _Example:_
-> 
+>
 > ```xml
-> <type name="phonebk" alias="phonebook" description="Phonebook style ordering (such as in German)"/>  
+> <type name="phonebk" alias="phonebook" description="Phonebook style ordering (such as in German)"/>
 > ```
 >
-> The preferred term, and the only one to be used in BCP 47, is the name: in this example, "phonebk".  
-> 
+> The preferred term, and the only one to be used in BCP 47, is the name: in this example, "phonebk".
+>
 > The alias is a key or type name used by Unicode locale extensions with the old ["@key=type" syntax](#Old_Locale_Extension_Syntax). The attribute value for type may contain multiple names delimited by ASCII space characters. Of those aliases, the first name is the preferred value.
 
 **since**
@@ -1030,7 +1030,7 @@ For example,
   <type name="aumqi" alias="Antarctica/Macquarie" description="Macquarie Island Station, Macquarie Island" since="1.8.1"/>
   ...
 </key>
-```    
+```
 
 The data above indicates:
 
@@ -1065,11 +1065,11 @@ _Examples:_
 * **usca** is valid — there is an `id` element `<id type="subdivision"…>… usca …</id>`
 * **ussct** is invalid — there is no `id` element `<id type="subdivision"…>… ussct …</id>`
 
-If a [unicode_locale_id](#unicode_locale_id) contains both a [unicode_region_subtag](#unicode_region_subtag) and a [unicode_subdivision_id](#unicode_subdivision_id), it is only valid if the [unicode_subdivision_id](#unicode_subdivision_id) starts with the [unicode_region_subtag](#unicode_region_subtag) (case-insensitively).  
+If a [unicode_locale_id](#unicode_locale_id) contains both a [unicode_region_subtag](#unicode_region_subtag) and a [unicode_subdivision_id](#unicode_subdivision_id), it is only valid if the [unicode_subdivision_id](#unicode_subdivision_id) starts with the [unicode_region_subtag](#unicode_region_subtag) (case-insensitively).
 
 It is recommended that a [unicode_locale_id](#unicode_locale_id) contain a [unicode_region_subtag](#unicode_region_subtag) if it contains a [unicode_subdivision_id](#unicode_subdivision_id) and the region would not be added by adding likely subtags. That produces better behavior if the [unicode_subdivision_id](#unicode_subdivision_id) is ignored by an implementation or if the language tag is truncated.
 
-Examples:  
+Examples:
 
 * en-**US**-u-sd-**us**ca is valid — the region "US" matches the first part of "usca"
 * en-u-sd-**us**ca is valid — it still works after adding likely subtags.
@@ -1183,21 +1183,23 @@ Old LDML specification allowed codes other than registered [[BCP47](#BCP47)] var
 
 | Variant Code | Description |
 | ------------ | ----------- |
-| `AALAND`     | Åland, variant of "sv" Swedish used in Finland. Use "sv_AX" to indicate this. |
-| `BOKMAL`     | Bokmål, variant of "no" Norwegian. Use primary language subtag "nb" to indicate this. |
-| `NYNORSK`    | Nynorsk, variant of "no" Norwegian. Use primary language subtag "nn" to indicate this. |
-| `POSIX`      | POSIX variation of locale data. Use Unicode locale extension "-u-va-posix" to indicate this. |
-| `POLYTONI`   | Polytonic, variant of "el" Greek. Use [[BCP47](#BCP47)] variant subtag "polyton" to indicate this. |
-| `SAAHO`      | The Saaho variant of Afar. Use primary language subtag "ssy" to indicated this. |
+| `AALAND`     | Åland, variant of "`sv`" Swedish used in Finland. Use `sv_AX` to indicate this. |
+| `BOKMAL`     | Bokmål, variant of "`no`" Norwegian. Use primary language subtag "`nb`" to indicate this. |
+| `NYNORSK`    | Nynorsk, variant of "`no`" Norwegian. Use primary language subtag "`nn`" to indicate this. |
+| `POSIX`      | POSIX variation of locale data. Use Unicode locale extension `-u-va-posix` to indicate this. |
+| `POLYTONI`   | Polytonic, variant of "`el`" Greek. Use [[BCP47](#BCP47)] variant subtag `polyton` to indicate this. |
+| `SAAHO`      | The Saaho variant of Afar. Use primary language subtag "`ssy`" to indicated this. |
 
-When converting to old syntax, the Unicode locale extension "-u-va-posix" should be converted to the "POSIX" variant, _not_ to old extension syntax like "@va=posix". This is an exception: The other mappings above should not be reversed.
+When converting to old syntax, the Unicode locale extension "`-u-va-posix`" should be converted to the "`POSIX`" variant, _not_ to old extension syntax like "`@va=posix`". This is an exception: The other mappings above should not be reversed.
 
 Examples:
 
-* en_US_POSIX ↔ en-US-u-va-posix
-* en_US_POSIX@colNumeric=yes ↔ en-US-u-kn-va-posix
-* en-US-POSIX-u-kn-true → en-US-u-kn-va-posix
-* en-US-POSIX-u-kn-va-posix → en-US-u-kn-va-posix
+* `en_US_POSIX` ↔ `en-US-u-va-posix`
+* `en_US_POSIX@colNumeric=yes` ↔ `en-US-u-kn-va-posix`
+* `en-US-POSIX-u-kn-true` → `en-US-u-kn-va-posix`
+* `en-US-POSIX-u-kn-va-posix` → `en-US-u-kn-va-posix`
+
+> :point_right: Note that the mapping between `en_US_POSIX` and `en-US-u-va-posix` is a conversion process, not a canonicalization process.
 
 #### <a name="Relation_to_OpenI18n" href="#Relation_to_OpenI18n">3.8.3 Relation to OpenI18n</a>
 
@@ -1307,9 +1309,9 @@ Should there ever be strong need for hybrids of more than two languages or for o
 ### <a name="Validity_Data" href="#Validity_Data">3.11 Validity Data</a>
 
 ```xml
-<!ELEMENT idValidity (id*) >  
-<!ELEMENT id ( #PCDATA ) >  
-<!ATTLIST id type NMTOKEN #REQUIRED >  
+<!ELEMENT idValidity (id*) >
+<!ELEMENT id ( #PCDATA ) >
+<!ATTLIST id type NMTOKEN #REQUIRED >
 <!ATTLIST id idStatus NMTOKEN #REQUIRED >
 ```
 
@@ -1367,9 +1369,9 @@ For the relationship between Inheritance, DefaultContent, LikelySubtags, and Loc
 If a language has more than one script in customary modern use, then the CLDR file structure in common/main follows the following model:
 
 ```
-lang  
-lang_script  
-lang_script_region  
+lang
+lang_script
+lang_script_region
 lang_region (aliases to lang_script_region)
 ```
 
@@ -1554,8 +1556,8 @@ _Examples:_
 > Note that there may also be an alias in root that changes the path and starts again from the requested locale, such as:
 
 ```xml
-<unitLength type="narrow">  
-   <alias source="locale" path="../unitLength[@type='short']"/>  
+<unitLength type="narrow">
+   <alias source="locale" path="../unitLength[@type='short']"/>
 </unitLength>
 ```
 
@@ -1572,14 +1574,14 @@ _Examples:_
 | root  | `//ldml/numbers/currencies/currency[@type="CAD"]/displayName[@count="x"]`     |
 | root  | `//ldml/numbers/currencies/currency[@type="CAD"]/displayName[@count="other"]` |
 | root  | `//ldml/numbers/currencies/currency[@type="CAD"]/displayName`                 |
-  
+
 
 #### <a name="Parent_Locales" href="#Parent_Locales">4.1.3 Parent Locales</a>
 
 ```xml
-<!ELEMENT parentLocales ( parentLocale* ) >  
-<!ELEMENT parentLocale EMPTY >  
-<!ATTLIST parentLocale parent NMTOKEN #REQUIRED >  
+<!ELEMENT parentLocales ( parentLocale* ) >
+<!ELEMENT parentLocale EMPTY >
+<!ATTLIST parentLocale parent NMTOKEN #REQUIRED >
 <!ATTLIST parentLocale locales NMTOKENS #REQUIRED >
 ```
 
@@ -1661,12 +1663,12 @@ For example, some of those pairs would be the following. Notice that the first h
 * <`//ldml/localeDisplayNames/languages/language[@type="ar"]`, `"Αραβικά"`>
 
 > Note: There are two exceptions to this:
-> 
+>
 > 1. Blocking nodes and their contents are treated as a single end node.
 > 2. In terms of computing inheritance, the element pair consists of the element chain plus all distinguishing attributes; the value consists of the value (if any) plus any nondistinguishing attributes.
-> 
+>
 > > Thus instead of the element pair being (a) below, it is (b):
-> > 
+> >
 > > 1. <`//ldml/dates/calendars/calendar[@type='gregorian']/week/weekendStart[@day='sun'][@time='00:00']`,`""`>
 > > 2. <`//ldml/dates/calendars/calendar[@type='gregorian']/week/weekendStart`,`[@day='sun'][@time='00:00']`>
 
@@ -1705,29 +1707,29 @@ The attribute `draft="x"` in LDML means that the data has not been approved by t
 **Example 2.** Suppose that new locale data is added for af (Afrikaans). To indicate that all of the data is _unconfirmed_, the attribute can be added to the top level.
 
 ```xml
-<ldml version="1.1" draft="unconfirmed">  
-    <identity>  
-        <version number="1.1" />  
-        <language type="af" />  
-    </identity>  
-    <characters>...</characters>  
-    <localeDisplayNames>...</localeDisplayNames>  
+<ldml version="1.1" draft="unconfirmed">
+    <identity>
+        <version number="1.1" />
+        <language type="af" />
+    </identity>
+    <characters>...</characters>
+    <localeDisplayNames>...</localeDisplayNames>
 </ldml>
 ```
 
 Any data can be added to that file, and the status will all be `draft="unconfirmed"`. Once an item is vetted—_whether it is inherited or explicitly in the file_—then its status can be changed to _approved_. This can be done either by leaving `draft="unconfirmed"` on the enclosing element and marking the child with `draft="approved"`, such as:
 
 ```xml
-<ldml version="1.1" draft="unconfirmed">  
-    <identity>  
-        <version number="1.1" />  
-        <language type="af" />  
-    </identity>  
-    <characters draft="approved">...</characters>  
-    <localeDisplayNames>...</localeDisplayNames>  
-    <dates />  
-    <numbers />  
-    <collations />  
+<ldml version="1.1" draft="unconfirmed">
+    <identity>
+        <version number="1.1" />
+        <language type="af" />
+    </identity>
+    <characters draft="approved">...</characters>
+    <localeDisplayNames>...</localeDisplayNames>
+    <dates />
+    <numbers />
+    <collations />
 </ldml>
 ```
 
@@ -1820,14 +1822,14 @@ Examples of lookup for Chinese collation types. Note:
 <tr>                                                    <td>zh</td>                 <td>collation type=pinyin</td>      <td><i>found</i></td></tr>
 </tbody></table>
 
-> **Note:** It is an invariant that the default in root for a given element must  
+> **Note:** It is an invariant that the default in root for a given element must
 > always be a value that exists in root. So you can not have the following in root:
 
 ```
-<someElements>  
-    <default type='a'/>  
-    <someElement type='b'>...</someElement>  
-    <someElement type='c'>...</someElement>  
+<someElements>
+    <default type='a'/>
+    <someElement type='b'>...</someElement>
+    <someElement type='c'>...</someElement>
     <!-- no 'a' -->
 </someElements>
 ```
@@ -1883,8 +1885,8 @@ There are related types of data and processing that are easy to confuse:
 ### <a name="Likely_Subtags" href="#Likely_Subtags">4.3 Likely Subtags</a>
 
 ```xml
-<!ELEMENT likelySubtag EMPTY >  
-<!ATTLIST likelySubtag from NMTOKEN #REQUIRED>  
+<!ELEMENT likelySubtag EMPTY >
+<!ATTLIST likelySubtag from NMTOKEN #REQUIRED>
 <!ATTLIST likelySubtag to NMTOKEN #REQUIRED>
 ```
 
@@ -1899,11 +1901,11 @@ For the relationship between Inheritance, DefaultContent, LikelySubtags, and Loc
 To look up data in the table, see if a locale matches one of the `from` attribute values. If so, fetch the corresponding `to` attribute value. For example, the Chinese data looks like the following:
 
 ```xml
-<likelySubtag from="zh" to="zh_Hans_CN" />  
-<likelySubtag from="zh_HK" to="zh_Hant_HK" />  
-<likelySubtag from="zh_Hani" to="zh_Hani_CN" />  
-<likelySubtag from="zh_Hant" to="zh_Hant_TW" />  
-<likelySubtag from="zh_MO" to="zh_Hant_MO" />  
+<likelySubtag from="zh" to="zh_Hans_CN" />
+<likelySubtag from="zh_HK" to="zh_Hant_HK" />
+<likelySubtag from="zh_Hani" to="zh_Hani_CN" />
+<likelySubtag from="zh_Hant" to="zh_Hant_TW" />
+<likelySubtag from="zh_MO" to="zh_Hant_MO" />
 <likelySubtag from="zh_TW" to="zh_Hant_TW" />
 ```
 
@@ -1945,9 +1947,9 @@ The lookup can be optimized. For example, if any of the tags in Step 2 are the s
 
 _Example1:_
 
-* Input is ZH-ZZZZ-SG.    
-* Normalize to zh_SG.    
-* Lookup in table. No match.    
+* Input is ZH-ZZZZ-SG.
+* Normalize to zh_SG.
+* Lookup in table. No match.
 * Lookup zh, and get the match (zh_Hans_CN). Substitute SG, and return zh_Hans_SG.
 
 To find the most likely language for a country, or language for a script, use "und" as the language subtag. For example, looking up "und_TW" returns zh_Hant_TW.
@@ -1973,30 +1975,30 @@ The reverse operation removes fields that would be added by the first operation.
 
 Example:
 
-* Input is zh_Hant. Maximize to get zh_Hant_TW.    
-* zh => zh_Hans_CN. No match, so continue.    
+* Input is zh_Hant. Maximize to get zh_Hant_TW.
+* zh => zh_Hans_CN. No match, so continue.
 * zh_TW => zh_Hant_TW. Matches, so return zh_TW.
-    
+
 A variant of this favors the script over the region, thus using {language, language_script, language_region} in the above. If that variant is used, then the result in this example would be zh_Hant instead of zh_TW.
 
 ### <a name="LanguageMatching" href="#LanguageMatching">4.4 Language Matching</a>
 
 ```xml
-<!ELEMENT languageMatching ( languageMatches* ) >  
-<!ELEMENT languageMatches ( paradigmLocales*, matchVariable*, languageMatch* ) >  
+<!ELEMENT languageMatching ( languageMatches* ) >
+<!ELEMENT languageMatches ( paradigmLocales*, matchVariable*, languageMatch* ) >
 <!ATTLIST languageMatches type NMTOKEN #REQUIRED >
 
-<!ELEMENT languageMatch EMPTY >  
-<!ATTLIST languageMatch desired CDATA #REQUIRED >  
-<!ATTLIST languageMatch supported CDATA #REQUIRED >  
-<!ATTLIST languageMatch percent NMTOKEN #REQUIRED >  
-<!ATTLIST languageMatch distance NMTOKEN #IMPLIED >  
+<!ELEMENT languageMatch EMPTY >
+<!ATTLIST languageMatch desired CDATA #REQUIRED >
+<!ATTLIST languageMatch supported CDATA #REQUIRED >
+<!ATTLIST languageMatch percent NMTOKEN #REQUIRED >
+<!ATTLIST languageMatch distance NMTOKEN #IMPLIED >
 <!ATTLIST languageMatch oneway ( true | false ) #IMPLIED >
 
-<!ELEMENT languageMatches ( paradigmLocales*, matchVariable*, languageMatch* ) >  
+<!ELEMENT languageMatches ( paradigmLocales*, matchVariable*, languageMatch* ) >
 <!ATTLIST languageMatches type NMTOKEN #REQUIRED >
 
-<!ELEMENT paradigmLocales EMPTY >  
+<!ELEMENT paradigmLocales EMPTY >
 <!ATTLIST paradigmLocales locales NMTOKENS #REQUIRED >
 ```
 
@@ -2005,12 +2007,12 @@ Implementers are often faced with the issue of how to match the user's requested
 The standard truncation-fallback algorithm does not work well when faced with the complexities of natural language. The language matching data is designed to fill that gap. Stated in those terms, language matching can have the effect of a more complex fallback, such as:
 
 ```
-sr-Cyrl-RS  
-sr-Cyrl  
-sr-Latn-RS  
-sr-Latn  
-sr  
-hr-Latn  
+sr-Cyrl-RS
+sr-Cyrl
+sr-Latn-RS
+sr-Latn
+sr
+hr-Latn
 hr
 ```
 
@@ -2079,9 +2081,9 @@ To find the matching distance MD between any two languages, perform the followin
    4. Remove the subtag from each (logically)
 4. Return MD
 
-It is typically useful to set the discount factor between successive elements of the desired languages list to be slightly greater than the default region difference. That avoids the following problem:  
+It is typically useful to set the discount factor between successive elements of the desired languages list to be slightly greater than the default region difference. That avoids the following problem:
 
-_Supported languages:_ "de, fr, ja"  
+_Supported languages:_ "de, fr, ja"
 
 _User's desired languages:_ "de-AT, fr"
 
@@ -2091,9 +2093,9 @@ The base language subtag "und" is a special case. Suppose we have the following 
 
 * desired languages: \{und, it}
 * supported languages: \{en, it}
-* resulting language: en  
-    
-Part of this is because 'und' has a special function in BCP 47; it stands in for 'no supplied base language'. To prevent this from happening, if the desired base language is und, the language matcher should not apply likely subtags to it. 
+* resulting language: en
+
+Part of this is because 'und' has a special function in BCP 47; it stands in for 'no supplied base language'. To prevent this from happening, if the desired base language is und, the language matcher should not apply likely subtags to it.
 
 Examples:
 
@@ -2104,11 +2106,11 @@ Note that language matching is orthogonal to the how closely two languages are r
 The "\*" acts as a wild card, as shown in the following example:
 
 ```xml
-<languageMatch desired="es-*-ES" supported="es-*-ES" percent="100" />  
+<languageMatch desired="es-*-ES" supported="es-*-ES" percent="100" />
 <!-- Latin American Spanishes are closer to each other. Approximate by having es-ES be further from everything else. -->
 
 <languageMatch desired="es-*-ES" supported="es-*-*" percent="93" />
-  
+
 <languageMatch desired="*" supported="*" percent="1" />
 <!-- [Default value - must be at end!] Normally there is no comprehension of different languages. -->
 
@@ -2133,13 +2135,13 @@ _Example:_
     <matchVariable id="$enUS" value="AS+GU+MH+MP+PR+UM+US+VI" />
     <matchVariable id="$cnsar" value="HK+MO" />
     <matchVariable id="$americas" value="019" />
-    <matchVariable id="$maghreb" value="MA+DZ+TN+LY+MR+EH" />  
-    <languageMatch desired="no" supported="nb" distance="1" /><!-- no ⇒ nb -->  
+    <matchVariable id="$maghreb" value="MA+DZ+TN+LY+MR+EH" />
+    <languageMatch desired="no" supported="nb" distance="1" /><!-- no ⇒ nb -->
     …
     <languageMatch desired="ar_*_$maghreb" supported="ar_*_$maghreb" distance="4" />
-    <!-- ar; *; $maghreb ⇒ ar; *; $maghreb -->                        
+    <!-- ar; *; $maghreb ⇒ ar; *; $maghreb -->
     <languageMatch desired="ar_*_$!maghreb" supported="ar_*_$!maghreb" distance="4" />
-    <!-- ar; *; $!maghreb ⇒ ar; *; $!maghreb -->  
+    <!-- ar; *; $!maghreb ⇒ ar; *; $!maghreb -->
     …
 ```
 
@@ -2151,7 +2153,7 @@ In the rules, the percent value (100..0) is replaced by a **distance** value, wh
 
 These new variables and rules divide up the world into clusters, where items in the same clusters (for specific languages) get the normal regional difference, and items in different clusters get different weights.
 
-Each cluster can have one or more associated **paradigmLocales**. These are locales that are preferred within a cluster. So when matching desired=[en-SA] against [en-GU en en-IN en-GB], the value en-GB is returned. Both of \{en-GU en} are in a different cluster. While \{en-IN en-GB} are in the same cluster, and the same distance from en-SA, the preference is given to en-GB because it is in the paradigm locales. It would be possible to express this in rules, but using this mechanism handles these very common cases without bulking up the tables.  
+Each cluster can have one or more associated **paradigmLocales**. These are locales that are preferred within a cluster. So when matching desired=[en-SA] against [en-GU en en-IN en-GB], the value en-GB is returned. Both of \{en-GU en} are in a different cluster. While \{en-IN en-GB} are in the same cluster, and the same distance from en-SA, the preference is given to en-GB because it is in the paradigm locales. It would be possible to express this in rules, but using this mechanism handles these very common cases without bulking up the tables.
 
 The **paradigmLocales** also allow matching to macroregions. For example, desired=[es-419] should match to \{es-MX} more closely than to \{es}, and vice versa: \{es-MX} should match more closely to \{es-419} than to \{es}. But es-MX should match more closely to es-419 than to any of the other es-419 sublocales. In general, in the absence of other distance data, there is a ‘paradigm’ in each cluster that the others should match more closely to: en(-US), en-GB, es(-ES), es-419, ru(-RU)...
 
@@ -2176,8 +2178,8 @@ The status of the data is the same, whether or not data is split. That is, for t
 
 ```xml
 <ldml>
-    <identity>  
-    …  
+    <identity>
+    …
         <language type="pa" />
         <script type="Arab" />
         <territory type="PK" />
@@ -2205,8 +2207,8 @@ The following sections describe the structure of the XML format for language-dep
 To start with, the root element is `<ldml>`, with the following DTD entry:
 
 ```xml
-<!ELEMENT ldml (identity,(alias|(fallback*,localeDisplayNames?,layout?,contextTransforms?,characters?,  
-delimiters?,measurement?,dates?,numbers?,units?,listPatterns?,collations?,posix?,  
+<!ELEMENT ldml (identity,(alias|(fallback*,localeDisplayNames?,layout?,contextTransforms?,characters?,
+delimiters?,measurement?,dates?,numbers?,units?,listPatterns?,collations?,posix?,
 segmentations?,rbnf?,annotations?,metadata?,references?,special*)))>
 ```
 
@@ -2226,8 +2228,8 @@ Note that the data in examples given below is purely illustrative, and does not 
 In particular, all elements allow for draft versions to coexist in the file at the same time. Thus most elements are marked in the DTD as allowing multiple instances. However, unless an element is listed as a serialElement, or has a distinguishing attribute, it can only occur once as a subelement of a given element. Thus, for example, the following is illegal even though allowed by the DTD:
 
 ```xml
-<languages>  
-    <language type="aa">...</language>  
+<languages>
+    <language type="aa">...</language>
     <language type="aa">..</language>
 ```
 
@@ -2298,7 +2300,7 @@ Thus to include just the ICU DTD, one uses:
 ```
 
 > **Note:** A previous version of this document contained a special element for [ISO TR 14652](http://www.open-std.org/jtc1/sc22/wg20/docs/n897-14652w25.pdf) compatibility data. That element has been withdrawn, pending further investigation, since 14652 is a Type 1 TR: "when the required support cannot be obtained for the publication of an International Standard, despite repeated effort". See the ballot comments on [14652 Comments](http://www.open-std.org/jtc1/sc22/wg20/docs/n948-J1N6769-14652.pdf) for details on the 14652 defects. For example, most of these patterns make little provision for substantial changes in format when elements are empty, so are not particularly useful in practice. Compare, for example, the mail-merge capabilities of production software such as Microsoft Word or OpenOffice.
-> 
+>
 > **Note:** While the CLDR specification guarantees backwards compatibility, the definition of specials is up to other organizations. Any assurance of backwards compatibility is up to those organizations.
 
 A number of the elements above can have extra information for <a name="OpenOffice" href="#OpenOffice">openoffice.org</a>, such as the following example:
@@ -2316,8 +2318,8 @@ A number of the elements above can have extra information for <a name="OpenOffic
 #### <a name="Alias_Elements" href="#Alias_Elements">5.1.2 Element alias</a>
 
 ```xml
-<!ELEMENT alias (special*) >  
-<!ATTLIST alias source NMTOKEN #REQUIRED >  
+<!ELEMENT alias (special*) >
+<!ATTLIST alias source NMTOKEN #REQUIRED >
 <!ATTLIST alias path CDATA #IMPLIED>
 ```
 
@@ -2328,12 +2330,12 @@ Aliases will only ever appear in root with the form `//ldml/.../alias[@source="l
 Consider the following example in root:
 
 ```xml
-<calendar type="gregorian">  
-    <months>  
+<calendar type="gregorian">
+    <months>
         <default choice="format" />
         <monthContext type="format">
             <default choice="wide" />
-            <monthWidth type="abbreviated">  
+            <monthWidth type="abbreviated">
                 <alias source="locale" path="../monthWidth[@type='wide']"/>
             </monthWidth>
 ```
@@ -2549,17 +2551,17 @@ When attribute specify date ranges, it is usually done with attributes `from` an
 
 The data format is a restricted ISO 8601 format, restricted to the fields `year`, `month`, `day`, `hour`, `minute`, and `second` in that order, with "-" used as a separator between date fields, a space used as the separator between the date and the time fields, and `:` used as a separator between the time fields. If the `minute` or `minute` and `second` are absent, they are interpreted as zero. If the `hour` is also missing, then it is interpreted based on whether the attribute is `from` or `to`.
 
-* `from` defaults to "00:00:00" (midnight at the start of the day).    
+* `from` defaults to "00:00:00" (midnight at the start of the day).
 * `to` defaults to "24:00:00" (midnight at the end of the day).
-    
+
 That is, Friday at 24:00:00 is the same time as Saturday at 00:00:00. Thus when the `hour` is missing, the `from` and `to` are interpreted inclusively: the range includes all of the day mentioned.
 
 For example, the following are equivalent:
 
 ```xml
-<usesMetazone from="1991-10-27" to="2006-04-02" .../> 
-<usesMetazone from="1991-10-27 00:00:00" to="2006-04-02 24:00:00" .../> 
-<usesMetazone from="1991-10-26 24:00:00" to="2006-04-03 00:00:00" .../> 
+<usesMetazone from="1991-10-27" to="2006-04-02" .../>
+<usesMetazone from="1991-10-27 00:00:00" to="2006-04-02 24:00:00" .../>
+<usesMetazone from="1991-10-26 24:00:00" to="2006-04-03 00:00:00" .../>
 ```
 
 If the `from` element is missing, it is assumed to be as far backwards in time as there is data for; if the `to` element is missing, then it is from this point onwards, with no known end point.
@@ -2710,17 +2712,17 @@ A String Range is a compact format for specifying a list of strings.
 
 **Syntax:**
 
-> X _sep_ Y  
+> X _sep_ Y
 
 The separator and the format of strings X, Y may vary depending on the domain. For example,
 
 * for the validity files the separator is ~,
 * for UnicodeSet the separator is -, and any multi-codepoint string is enclosed in {…}.
 
-**Validity:** 
+**Validity:**
 
 > A string range X _sep_ Y is valid iff len(X) ≥ len(Y) > 0, where len(X) is the length of X in code points.
-> 
+>
 > _There may be additional, domain-specific requirements for validity of the expansion of the string range._
 
 **Interpretation:**
@@ -2758,7 +2760,7 @@ The `version` element provides, in an attribute, the version of this file.  The 
 > ```xml
 > <version number="1.1">Various notes and changes in version 1.1</version>
 > ```
-> 
+>
 > This is not to be confused with the `version` attribute on the `ldml` element, which tracks the dtd version.
 
 ```xml
@@ -2842,12 +2844,12 @@ Note that there was one case that had to be corrected in order to make this true
     * no `'&#x61;'`, it would be just `'a'`
 8.  All attributes with defaulted values are suppressed.
 9.  The draft and `alt="proposed.*"` attributes are only on leaf elements.
-10. The tzid are canonicalized in the following way:    
+10. The tzid are canonicalized in the following way:
     * All tzids as of as CLDR 1.1 (2004.06.08) in zone.tab are canonical.
     * After that point, the first time a tzid is introduced, that is the canonical form.
-    
+
     That is, new IDs are added, but existing ones keep the original form. The _TZ_ timezone database keeps a set of equivalences in the "backward" file. These are used to map other tzids to the canonical form. For example, when `America/Argentina/Catamarca` was introduced as the new name for the previous `America/Catamarca` , a link was added in the backward file.
-    
+
     `Link America/Argentina/Catamarca America/Catamarca`
 
 _Example:_
@@ -2906,7 +2908,7 @@ Any future additions to the DTD must be structured so as to allow compatibility 
 
 ### <a name="DTD_Annotations" href="#DTD_Annotations">5.7 DTD Annotations</a>
 
-The information in a standard DTD is insufficient for use in CLDR. To make up for that, DTD annotations are added. These are of the form  
+The information in a standard DTD is insufficient for use in CLDR. To make up for that, DTD annotations are added. These are of the form
 
 ```xml
 <!--@...-->
@@ -3050,16 +3052,16 @@ The `fallback` element is deprecated. Implementations should use instead the inf
 **Note:** _This structure is deprecated and replaced with [Section 3.6.4 U Extension Data Files](#Unicode_Locale_Extension_Data_Files)._
 
 ```xml
-<!ELEMENT bcp47KeywordMappings ( mapKeys?, mapTypes* ) >  
-<!ELEMENT mapKeys ( keyMap* ) >  
-<!ELEMENT keyMap EMPTY >  
-<!ATTLIST keyMap type NMTOKEN #REQUIRED >  
-<!ATTLIST keyMap bcp47 NMTOKEN #REQUIRED >  
-<!ELEMENT mapTypes ( typeMap* ) >  
-<!ATTLIST mapTypes type NMTOKEN #REQUIRED >  
-<!ELEMENT typeMap EMPTY >  
-<!ATTLIST typeMap type CDATA #REQUIRED >  
-<!ATTLIST typeMap bcp47 NMTOKEN #REQUIRED >  
+<!ELEMENT bcp47KeywordMappings ( mapKeys?, mapTypes* ) >
+<!ELEMENT mapKeys ( keyMap* ) >
+<!ELEMENT keyMap EMPTY >
+<!ATTLIST keyMap type NMTOKEN #REQUIRED >
+<!ATTLIST keyMap bcp47 NMTOKEN #REQUIRED >
+<!ELEMENT mapTypes ( typeMap* ) >
+<!ATTLIST mapTypes type NMTOKEN #REQUIRED >
+<!ELEMENT typeMap EMPTY >
+<!ATTLIST typeMap type CDATA #REQUIRED >
+<!ATTLIST typeMap bcp47 NMTOKEN #REQUIRED >
 ```
 
 This section defines mappings between old Unicode locale identifier key/type values and their BCP 47 'u' extension subtag representations. The 'u' extension syntax described in [Section 3.6 Unicode BCP 47 U Extension](#u_Extension) restricts a key to two ASCII alphanumerics and a type to three to eight ASCII alphanumerics. A key or a type which does not meet that syntax requirement is converted according to the mapping data defined by the `mapKeys` or `mapTypes` elements. For example, a keyword `"collation=phonebook"` is converted to BCP 47 'u' extension subtags "co-phonebk" by the mapping data below:
@@ -3084,9 +3086,9 @@ This section defines mappings between old Unicode locale identifier key/type val
 A choice pattern is a string that chooses among a number of strings, based on numeric value. It has the following form:
 
 ```
-<choice_pattern> = <choice> ( '|' <choice> )*  
-<choice> = <number><relation><string>  
-<number> = ('+' | '-')? ('∞' | [0-9]+ ('.' [0-9]+)?)  
+<choice_pattern> = <choice> ( '|' <choice> )*
+<choice> = <number><relation><string>
+<number> = ('+' | '-')? ('∞' | [0-9]+ ('.' [0-9]+)?)
 <relation> = '<' | ' ≤'
 ```
 
@@ -3151,7 +3153,7 @@ In that case, the default time format for fr_BE would be the inherited "long" re
         <pattern type="standard">...</pattern>
     </timeFormat>
 </timeFormatLength>
-```    
+```
 
 In this case, the `<default>` is inherited from fr, and has the value "medium". It thus refers to this new "medium" pattern in this resource bundle.
 
@@ -3164,8 +3166,8 @@ In this case, the `<default>` is inherited from fr, and has the value "medium". 
 The value of this attribute is a list of strings representing standards: international, national, organization, or vendor standards. The presence of this attribute indicates that the data in this element is compliant with the indicated standards. Where possible, for uniqueness, the string should be a URL that represents that standard. The strings are separated by commas; leading or trailing spaces on each string are not significant. Examples:
 
 ```xml
-<collation standard="MSA 200:2002">  
-    ...  
+<collation standard="MSA 200:2002">
+    ...
     <dateFormatStyle standard=”https://www.iso.org/iso/en/CatalogueDetailPage.CatalogueDetail?CSNUMBER=26780&amp;ICS1=1&amp;ICS2=140&amp;ICS3=30”>
 ```
 
@@ -3242,24 +3244,24 @@ The attribute `validSubLocales` allowed sublocales in a given tree to be treated
 **Example 1.** Suppose that in a particular LDML tree, there are no region locales for German, for example, there is a de.xml file, but no files for de_AT.xml, de_CH.xml, or de_DE.xml. Then no elements are valid for any of those region locales. If we want to mark one of those files as having valid elements, then we introduce an empty file, such as the following.
 
 ```xml
-<ldml version="1.1">  
-    <identity>  
-        <version number="1.1" />  
-        <language type="de" />  
-        <territory type="AT" />  
-    </identity>  
+<ldml version="1.1">
+    <identity>
+        <version number="1.1" />
+        <language type="de" />
+        <territory type="AT" />
+    </identity>
 </ldml>
 ```
 
 With the `validSubLocales` attribute, instead of adding the empty files for de_AT.xml, de_CH.xml, and de_DE.xml, in the de file we could add to the parent locale a list of the child locales that should behave as if files were present.
 
 ```xml
-<ldml version="1.1" validSubLocales="de_AT de_CH de_DE">  
-    <identity>  
-        <version number="1.1" />  
-        <language type="de" />  
-    </identity>  
-    ...  
+<ldml version="1.1" validSubLocales="de_AT de_CH de_DE">
+    <identity>
+        <version number="1.1" />
+        <language type="de" />
+    </identity>
+    ...
 </ldml>
 ```
 
@@ -3390,9 +3392,9 @@ Part 1 Links: Core (this document): No redirects needed.
 | C.8 <a name="Supplemental_Character_Fallback_Data" href="#Supplemental_Character_Fallback_Data">Supplemental Character Fallback Data</a> | 7 [Supplemental Character Fallback Data](tr35-info.md#Supplemental_Character_Fallback_Data) |
 | M <a name="Coverage_Levels" href="#Coverage_Levels">Coverage Levels</a>                                                                  | 8 [Coverage Levels](tr35-info.md#Coverage_Levels) |
 | 5.20 [Metadata Elements](tr35-info.md#Metadata_Elements)                                                                                 | 10 [Locale Metadata Element](tr35-info.md#Metadata_Elements) |
-| P [Supplemental Metadata](tr35-info.md#Appendix_Supplemental_Metadata)                                                                   | 9 [Supplemental Metadata](tr35-info.md#Appendix_Supplemental_Metadata)  
-| P.1 [Supplemental Alias Information](tr35-info.md#Supplemental_Alias_Information)                                                        | 9.1 [Supplemental Alias Information](tr35-info.md#Supplemental_Alias_Information)  
-| P.2 [Supplemental Deprecated Information](tr35-info.md#Supplemental_Deprecated_Information)                                              | 9.2 [Supplemental Deprecated Information](tr35-info.md#Supplemental_Deprecated_Information)   
+| P [Supplemental Metadata](tr35-info.md#Appendix_Supplemental_Metadata)                                                                   | 9 [Supplemental Metadata](tr35-info.md#Appendix_Supplemental_Metadata)
+| P.1 [Supplemental Alias Information](tr35-info.md#Supplemental_Alias_Information)                                                        | 9.1 [Supplemental Alias Information](tr35-info.md#Supplemental_Alias_Information)
+| P.2 [Supplemental Deprecated Information](tr35-info.md#Supplemental_Deprecated_Information)                                              | 9.2 [Supplemental Deprecated Information](tr35-info.md#Supplemental_Deprecated_Information)
 | P.3 [Default Content](tr35-info.md#Default_Content)                                                                                      | 9.3 [Default Content](tr35-info.md#Default_Content) |
 
 ##### <a name="Part_7_Links" href="#Part_7_Links">Part 7 Links</a>: [Keyboards](tr35-keyboards.md) (keyboard mappings)
@@ -3426,9 +3428,15 @@ Part 1 Links: Core (this document): No redirects needed.
 
 ## <a name="LocaleId_Canonicalization" href="#LocaleId_Canonicalization">Annex C. LocaleId Canonicalization</a>
 
-The `languageAlias`, `scriptAlias`, `territoryAlias`, and `variantAlias` elements are used as rules to transform an input _source localeId_. The first step is to transform the _languageId_ portion of the localeId.  
+The `languageAlias`, `scriptAlias`, `territoryAlias`, and `variantAlias` elements are used as rules to transform an input _source localeId_. The first step is to transform the _languageId_ portion of the localeId.
 
 > Note: in the following discussion, the separator '-' is used. That is also used in examples of XML alias data, even though for compatibility reasons that alias data actually uses '\_' as a separator. The processing can also be applied to syntax while maintaining the separator '\_', _mutatis mutandis_. CLDR also uses “territory” and “region” interchangeably.
+
+> Also note that the discussion of canonicalization assumes BCP47
+> input data. If input data is a CLDR or ICU locale ID such
+> as `en_US_POSIX`, a conversion step must be done prior to
+> canonicalization.
+>See §3.8.2 [Legacy Variants](#Legacy_Variants).
 
 ### Definitions
 
@@ -3506,11 +3514,11 @@ A matching rule can be used to transform the source fields as follows
 _Example:_
 
 > source=ja-Latn-fonipa-hepburn-heploc
-> 
+>
 > rule  =”\<languageAlias type="und-hepburn-heploc"
-> 
+>
 > replacement="und-alalc97">”
-> 
+>
 > result=”ja-Latn-alalc97-fonipa” // note that CLDR canonical order of variants is alphabetical
 
 ##### Territory Exception
@@ -3590,14 +3598,14 @@ The canonicalization of localeIds is done by first canonicalizing the languageId
 
 1. Replace any _tlang_ languageId value by its canonicalization.
 2. Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms. See **Section 3.6.4 U Extension Data Files** and **Section 3.7.1 T Extension Data Files**. The matches are in the `alias` attribute value, while the canonical replacement is in the `name` attribute value. For example:
-   1. Because of the following bcp47 data:  
+   1. Because of the following bcp47 data:
       `<key name="ms"…>…<type name="uksystem" … alias="imperial" … />…</key>`
-   2. We get the following transformation:  
+   2. We get the following transformation:
       `en-u-ms-imperial ⇒ en-u-ms-uksystem`
 3. Replace any unicode_subdivision_id that is a subdivision alias by its replacement value in the same way, using subdivisionAlias data. This applies, for example, to the values for the 'sd' and 'rg' keys. However, where the replacement value is a two-letter region code, also append zzzz so that the result is syntactically correct. For example:
-   1. Because of the following bcp47 data:  
+   1. Because of the following bcp47 data:
       `<subdivisionAlias type="fi01" replacement="AX"…`
-   2. We get the following transformation:  
+   2. We get the following transformation:
       `en-u-rg-fi01 ⇒ en-u-rg-axzzzz`
 
 ## Optimizations
@@ -3688,7 +3696,7 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
 **Revision 62**
-> TBD: The following is a list of changes that have yet to be incorporated into the Modifications. 
+> TBD: The following is a list of changes that have yet to be incorporated into the Modifications.
 > * Locales
 >    * The algorithm for generating display names for locales has been modified to handle aliased subtags **ALREADY INCLUDED BELOW**
 >    * The tvalues of true are not removed in canonicalization **Part 1, Core; Annex C. LocaleId Canonicalization**


### PR DESCRIPTION
- en_US_POSIX is not a bcp47 id, and so is not subject
to bcp47 locale canonicalization. Clarify that conversion from
a legacy format to bcp47 is a prerequisite to canonicalization.

CLDR-14487

- [X] This PR completes the ticket.
