### PR TITLE
CLDR-14931 Change timing of automatic Survey Tool database backups

### DIFF
--- a/tools/scripts/ansible/backup-db-playbook.yml
+++ b/tools/scripts/ansible/backup-db-playbook.yml
@@ -71,6 +71,6 @@
       cron:
         name: "backup db"
         user: cldrbackup
-        minute: "37"
-        hour: "7"
+        minute: "53"
+        hour: "14" # 14:53 UTC = 7:53 PDT or 6:53 PST
         job: "sh /home/cldrbackup/backup.sh >/dev/null 2>&1"

--- a/tools/scripts/ansible/templates/cldrbackup/backup_sh.j2
+++ b/tools/scripts/ansible/templates/cldrbackup/backup_sh.j2
@@ -1,7 +1,12 @@
 #!/bin/bash
 #
 # A cron job may call this with a line such as:
-#     37 7 * * * sh /home/cldrbackup/backup.sh >/dev/null 2>&1
+#     53 14 * * * sh /home/cldrbackup/backup.sh >/dev/null 2>&1
+# It may be configured by an ansible script such as backup-db-playbook.yml
+#
+# The backups might be made faster by saving the sql file in a fast
+# temporary directory (mktemp? /mnt?) -- let's test that at a time
+# when Survey Tool is closed and daily backups aren't essential
 
 DATABASE_NAME={{ cldr_database_name }}
 FNAME={{ cldr_database_name }}-DUMP-`date +%Y-%m-%d`
@@ -9,5 +14,7 @@ RSYNC_DEST={{ cldr_db_backup_destination }}
 
 cd /home/cldrbackup
 mysqldump ${DATABASE_NAME} --add-drop-table --create-options --default-character-set=utf8mb4 > ${FNAME}.sql
+
+# Wait until mysqldump is finished before running xz, to minimize db disruption (don't use | pipe)
 xz ${FNAME}.sql
 rsync -q ${FNAME}.sql.xz ${RSYNC_DEST}


### PR DESCRIPTION
-Change backup starting time to 14:53 UTC = 7:53 PDT or 6:53 PST

-Comments in backup-db-playbook.yml and backup_sh.j2

CLDR-14931

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
