### PR TITLE
CLDR-14952 v40 fixes

### DIFF
--- a/common/annotations/kab.xml
+++ b/common/annotations/kab.xml
@@ -375,8 +375,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👫" type="tts" draft="unconfirmed">tameṭṭut d urgaz myuṭṭafen ifassen</annotation>
 		<annotation cp="👬" draft="unconfirmed">irgazen myuṭṭafen ifassen</annotation>
 		<annotation cp="👬" type="tts" draft="unconfirmed">irgazen myuṭṭafen ifassen</annotation>
-		<annotation cp="💏" draft="unconfirmed">tasudent</annotation>
-		<annotation cp="💏" type="tts" draft="unconfirmed">tasudent</annotation>
 		<annotation cp="💑" draft="unconfirmed">tayuga s wul</annotation>
 		<annotation cp="💑" type="tts" draft="unconfirmed">tayuga s wul</annotation>
 		<annotation cp="👪" draft="unconfirmed">tawacult</annotation>
@@ -775,8 +773,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍣" type="tts" draft="unconfirmed">aṣuci</annotation>
 		<annotation cp="🦀" draft="unconfirmed">tifiraqest</annotation>
 		<annotation cp="🦀" type="tts" draft="unconfirmed">tifiraqest</annotation>
-		<annotation cp="🦞" draft="unconfirmed">tiɣirdemt</annotation>
-		<annotation cp="🦞" type="tts" draft="unconfirmed">tiɣirdemt</annotation>
 		<annotation cp="🦐" draft="unconfirmed">aqemrun</annotation>
 		<annotation cp="🦐" type="tts" draft="unconfirmed">aqemrun</annotation>
 		<annotation cp="🦪" draft="unconfirmed">idway</annotation>
@@ -1299,8 +1295,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="✒" type="tts" draft="unconfirmed">imru n tricet aberkan</annotation>
 		<annotation cp="🖋" draft="unconfirmed">imru n lmidad</annotation>
 		<annotation cp="🖋" type="tts" draft="unconfirmed">imru n lmidad</annotation>
-		<annotation cp="🖊" draft="unconfirmed">imru</annotation>
-		<annotation cp="🖊" type="tts" draft="unconfirmed">imru</annotation>
 		<annotation cp="🖍" draft="unconfirmed">akeryun</annotation>
 		<annotation cp="🖍" type="tts" draft="unconfirmed">akeryun</annotation>
 		<annotation cp="💼" draft="unconfirmed">aqrab</annotation>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -722,7 +722,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SS" draft="unconfirmed">Sudan n unẓul</territory>
 			<territory type="ST">Saw Tumi d Pransip</territory>
 			<territory type="SV">Salvadur</territory>
-			<territory type="SX" draft="unconfirmed">San Maṛtan</territory>
 			<territory type="SY">Surya</territory>
 			<territory type="SZ">Swazilund</territory>
 			<territory type="SZ" alt="variant" draft="unconfirmed">Swaziland</territory>


### PR DESCRIPTION
- common/annotations/kab: remove colliding strings
- common/main/kab: remove 'SX' translation as colliding with 'MF'

CLDR-14952

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
