### PR TITLE
CLDR-14952 remove triple up arrow in annotations

### DIFF
--- a/common/annotations/kab.xml
+++ b/common/annotations/kab.xml
@@ -364,7 +364,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤽" type="tts" draft="unconfirmed">amdan yetturare water polo</annotation>
 		<annotation cp="🤾" draft="unconfirmed">amdan yetturaren ddabex n ufus</annotation>
 		<annotation cp="🤾" type="tts" draft="unconfirmed">amdan yetturaren ddabex n ufus</annotation>
-		<annotation cp="🤹" draft="unconfirmed">↑↑↑</annotation>
 		<annotation cp="🛀" draft="unconfirmed">amdan yeccucufen</annotation>
 		<annotation cp="🛀" type="tts" draft="unconfirmed">amdan yeccucufen</annotation>
 		<annotation cp="🛌" draft="unconfirmed">amdan deg wusu</annotation>

--- a/common/annotations/zu.xml
+++ b/common/annotations/zu.xml
@@ -43,26 +43,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="・" type="tts">ichashazi lekatakana eliphakathi nendawo</annotation>
 		<annotation cp=",">ukhefana</annotation>
 		<annotation cp="," type="tts">ukhefana</annotation>
-		<annotation cp="،">↑↑↑</annotation>
 		<annotation cp="،" type="tts">ukhefana wama-arabic</annotation>
 		<annotation cp="、">ukhefana | umbono</annotation>
 		<annotation cp="、" type="tts">ukhefana we-ideographic</annotation>
-		<annotation cp=";">↑↑↑</annotation>
-		<annotation cp=";" type="tts">↑↑↑</annotation>
-		<annotation cp="؛">↑↑↑</annotation>
-		<annotation cp="؛" type="tts">↑↑↑</annotation>
-		<annotation cp=":">↑↑↑</annotation>
-		<annotation cp=":" type="tts">↑↑↑</annotation>
-		<annotation cp="!">↑↑↑</annotation>
-		<annotation cp="!" type="tts">↑↑↑</annotation>
-		<annotation cp="¡">↑↑↑</annotation>
-		<annotation cp="¡" type="tts">↑↑↑</annotation>
-		<annotation cp="?">↑↑↑</annotation>
-		<annotation cp="?" type="tts">↑↑↑</annotation>
-		<annotation cp="¿">↑↑↑</annotation>
-		<annotation cp="¿" type="tts">↑↑↑</annotation>
-		<annotation cp="؟">↑↑↑</annotation>
-		<annotation cp="؟" type="tts">↑↑↑</annotation>
 		<annotation cp="‽">i-interrobang</annotation>
 		<annotation cp="‽" type="tts">i-interrobang</annotation>
 		<annotation cp=".">ichashazi | isikhathi | ungqi</annotation>
@@ -129,24 +112,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="〗" type="tts">vala amalensi embobo kabakaki</annotation>
 		<annotation cp="§">i-section | ingxenye | isigaba | silcrow</annotation>
 		<annotation cp="§" type="tts">i-section</annotation>
-		<annotation cp="¶">↑↑↑</annotation>
-		<annotation cp="¶" type="tts">↑↑↑</annotation>
-		<annotation cp="@">↑↑↑</annotation>
-		<annotation cp="@" type="tts">↑↑↑</annotation>
-		<annotation cp="*">↑↑↑</annotation>
-		<annotation cp="*" type="tts">↑↑↑</annotation>
-		<annotation cp="/">↑↑↑</annotation>
-		<annotation cp="/" type="tts">↑↑↑</annotation>
-		<annotation cp="\">↑↑↑</annotation>
-		<annotation cp="\" type="tts">↑↑↑</annotation>
-		<annotation cp="&amp;">↑↑↑</annotation>
-		<annotation cp="&amp;" type="tts">↑↑↑</annotation>
-		<annotation cp="#">↑↑↑</annotation>
-		<annotation cp="#" type="tts">↑↑↑</annotation>
-		<annotation cp="%">↑↑↑</annotation>
-		<annotation cp="%" type="tts">↑↑↑</annotation>
-		<annotation cp="‰">↑↑↑</annotation>
-		<annotation cp="‰" type="tts">↑↑↑</annotation>
 		<annotation cp="†">dagger | obelisk | obelus | uphawu lwe-dagger</annotation>
 		<annotation cp="†" type="tts">uphawu lwe-dagger</annotation>
 		<annotation cp="‡">i-dagger | obelisk | obelus | phinda kabili | uphawu lwe-dagger oluphindeke kabili</annotation>
@@ -155,24 +120,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="•" type="tts">ichashaza</annotation>
 		<annotation cp="‧">i-hyphen | iphuzu | iphuzu le-hyphenation | udeshi</annotation>
 		<annotation cp="‧" type="tts">iphuzu le-hyphenation</annotation>
-		<annotation cp="′">↑↑↑</annotation>
-		<annotation cp="′" type="tts">↑↑↑</annotation>
-		<annotation cp="″">↑↑↑</annotation>
-		<annotation cp="″" type="tts">↑↑↑</annotation>
-		<annotation cp="‴">↑↑↑</annotation>
-		<annotation cp="‴" type="tts">↑↑↑</annotation>
 		<annotation cp="‸">i-caret</annotation>
 		<annotation cp="‸" type="tts">i-caret</annotation>
-		<annotation cp="※">↑↑↑</annotation>
-		<annotation cp="※" type="tts">↑↑↑</annotation>
 		<annotation cp="⁂">i-asterism | i-dinkus | izinkanyezi</annotation>
 		<annotation cp="⁂" type="tts">i-asterism</annotation>
-		<annotation cp="`">↑↑↑</annotation>
-		<annotation cp="`" type="tts">↑↑↑</annotation>
 		<annotation cp="´">i-acute | isimangalo | isimangalo esibi | ithoni</annotation>
 		<annotation cp="´" type="tts">isimangalo esibi</annotation>
 		<annotation cp="^">amandla | circumflex | control | I-chevron | inkomba | isibonakaliso se-xor | isigqoko | isimangalo | ukunakekelwa | wedge</annotation>
-		<annotation cp="^" type="tts">↑↑↑</annotation>
 		<annotation cp="¨">i-diaeresis | i-tréma | i-umlaut</annotation>
 		<annotation cp="¨" type="tts">i-diaeresis</annotation>
 		<annotation cp="°">i-degree | ihora | ubufakazi</annotation>
@@ -387,10 +341,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="◯" type="tts">indilinga enkulu engenalutho</annotation>
 		<annotation cp="♪">inothi | umculo | yesishiyagalombili</annotation>
 		<annotation cp="♪" type="tts">inothi yesishiyagalombili</annotation>
-		<annotation cp="♭">↑↑↑</annotation>
-		<annotation cp="♭" type="tts">↑↑↑</annotation>
-		<annotation cp="♯">↑↑↑</annotation>
-		<annotation cp="♯" type="tts">↑↑↑</annotation>
 		<annotation cp="😀">osinekile | ubuso obusinekile</annotation>
 		<annotation cp="😀" type="tts">ubuso obusinekile</annotation>
 		<annotation cp="😃">moyizela | ubuso | ubuso obumoyizelayo obuvule umlomo | umlomo | vula</annotation>
@@ -2411,8 +2361,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🧸" type="tts">u-teddy bear</annotation>
 		<annotation cp="🪅">i-piñata</annotation>
 		<annotation cp="🪅" type="tts">i-piñata</annotation>
-		<annotation cp="🪆">↑↑↑</annotation>
-		<annotation cp="🪆" type="tts">↑↑↑</annotation>
 		<annotation cp="♠">ikhadi | ispeyidi | umdlalo | uspeyidi</annotation>
 		<annotation cp="♠" type="tts">uspeyidi</annotation>
 		<annotation cp="♥">ikhadi | inhliziyo | izinhliziyo | umdlalo | unhliziyo</annotation>
@@ -2438,7 +2386,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🧵">E11:063</annotation>
 		<annotation cp="🧵" type="tts">E11:063</annotation>
 		<annotation cp="🪡">inaliti | izihlungo | izitishi | ukufeketha | ukuthunga</annotation>
-		<annotation cp="🪡" type="tts">↑↑↑</annotation>
 		<annotation cp="🧶">E11:064</annotation>
 		<annotation cp="🧶" type="tts">E11:064</annotation>
 		<annotation cp="🪢">bopha | hlanganisa | ifindo | intambo | ithandelwe | sonta</annotation>
@@ -3406,77 +3353,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="µ">i-micro sign | kala | micro sign</annotation>
 		<annotation cp="µ" type="tts">i-micro sign</annotation>
 		<annotation cp="🛝">dlala | ipaki yokuzijabulisa</annotation>
-		<annotation cp="🛝" type="tts">↑↑↑</annotation>
-		<annotation cp="🛞">↑↑↑</annotation>
-		<annotation cp="🛞" type="tts">↑↑↑</annotation>
-		<annotation cp="🛟">↑↑↑</annotation>
-		<annotation cp="🛟" type="tts">↑↑↑</annotation>
-		<annotation cp="🟰">↑↑↑</annotation>
-		<annotation cp="🟰" type="tts">↑↑↑</annotation>
-		<annotation cp="🥹">↑↑↑</annotation>
-		<annotation cp="🥹" type="tts">↑↑↑</annotation>
-		<annotation cp="🧌" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🧌" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🩻">↑↑↑</annotation>
-		<annotation cp="🩻" type="tts">↑↑↑</annotation>
-		<annotation cp="🩼">↑↑↑</annotation>
-		<annotation cp="🩼" type="tts">↑↑↑</annotation>
-		<annotation cp="🪩">↑↑↑</annotation>
-		<annotation cp="🪩" type="tts">↑↑↑</annotation>
-		<annotation cp="🪪">↑↑↑</annotation>
-		<annotation cp="🪪" type="tts">↑↑↑</annotation>
-		<annotation cp="🪫">↑↑↑</annotation>
-		<annotation cp="🪫" type="tts">↑↑↑</annotation>
-		<annotation cp="🪬">↑↑↑</annotation>
-		<annotation cp="🪬" type="tts">↑↑↑</annotation>
-		<annotation cp="🪷">↑↑↑</annotation>
-		<annotation cp="🪷" type="tts">↑↑↑</annotation>
-		<annotation cp="🪸">↑↑↑</annotation>
-		<annotation cp="🪸" type="tts">↑↑↑</annotation>
 		<annotation cp="🪹">ukwakha isidleke</annotation>
 		<annotation cp="🪹" type="tts">isidleke esingenalutho</annotation>
 		<annotation cp="🪺">esidlekeni</annotation>
-		<annotation cp="🪺" type="tts">↑↑↑</annotation>
-		<annotation cp="🫃" draft="provisional">↑↑↑</annotation>
 		<annotation cp="🫃" type="tts">indoda ekhulelwe</annotation>
-		<annotation cp="🫄" draft="provisional">↑↑↑</annotation>
 		<annotation cp="🫄" type="tts">umuntu okhulelwe</annotation>
 		<annotation cp="🫅">inkosi | ohloniphekile | regal | ubukhosi</annotation>
-		<annotation cp="🫅" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫗" draft="provisional">↑↑↑</annotation>
 		<annotation cp="🫗" type="tts">uthela uketshezi</annotation>
-		<annotation cp="🫘" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫘" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫙" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫙" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫠">↑↑↑</annotation>
-		<annotation cp="🫠" type="tts">↑↑↑</annotation>
-		<annotation cp="🫡">↑↑↑</annotation>
-		<annotation cp="🫡" type="tts">↑↑↑</annotation>
-		<annotation cp="🫢">↑↑↑</annotation>
-		<annotation cp="🫢" type="tts">↑↑↑</annotation>
-		<annotation cp="🫣">↑↑↑</annotation>
-		<annotation cp="🫣" type="tts">↑↑↑</annotation>
-		<annotation cp="🫤">↑↑↑</annotation>
-		<annotation cp="🫤" type="tts">↑↑↑</annotation>
-		<annotation cp="🫥" draft="provisional">↑↑↑</annotation>
 		<annotation cp="🫥" type="tts">ubuso bomugqa onamachashazi</annotation>
-		<annotation cp="🫦" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫦" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫧">↑↑↑</annotation>
-		<annotation cp="🫧" type="tts">↑↑↑</annotation>
-		<annotation cp="🫰" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫰" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫱" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫱" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫲" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫲" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫳" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫳" type="tts" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫴" draft="provisional">↑↑↑</annotation>
-		<annotation cp="🫴" type="tts" draft="provisional">↑↑↑</annotation>
 		<annotation cp="🫵">iphoyinti | wena</annotation>
-		<annotation cp="🫵" type="tts" draft="provisional">↑↑↑</annotation>
 		<annotation cp="🫶">uthando</annotation>
 		<annotation cp="🫶" type="tts">thanda izandla</annotation>
 	</annotations>


### PR DESCRIPTION
annotations: votes for triple-up-arrow are causing "must be a real value" errors. Removed from:
- kab.xml
- zu.xml

CLDR-14952

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
