### PR TITLE
CLDR-14957 include nn in dayPeriod rules for Norwegian

### DIFF
--- a/common/supplemental/dayPeriods.xml
+++ b/common/supplemental/dayPeriods.xml
@@ -59,7 +59,7 @@
 			<dayPeriodRule type="evening1" from="18:00" before="24:00"/>	<!-- aften -->
 			<dayPeriodRule type="night1" from="00:00" before="05:00"/>	<!-- nat -->
 		</dayPeriodRules>
-		<dayPeriodRules locales="nb no">
+		<dayPeriodRules locales="nb nn no">
 			<dayPeriodRule type="midnight" at="00:00"/>	<!-- midnatt -->
 			<dayPeriodRule type="morning1" from="06:00" before="10:00"/>	<!-- morgen -->
 			<dayPeriodRule type="morning2" from="10:00" before="12:00"/>	<!-- formiddag -->
@@ -702,7 +702,7 @@
 			<dayPeriodRule type="evening1" from="18:00" before="24:00"/>	<!-- aften -->
 			<dayPeriodRule type="night1" from="00:00" before="05:00"/>	<!-- nat -->
 		</dayPeriodRules>
-		<dayPeriodRules locales="nb no">
+		<dayPeriodRules locales="nb nn no">
 			<dayPeriodRule type="morning1" from="06:00" before="10:00"/>	<!-- morgen -->
 			<dayPeriodRule type="morning2" from="10:00" before="12:00"/>	<!-- formiddag -->
 			<dayPeriodRule type="afternoon1" from="12:00" before="18:00"/>	<!-- ettermiddag -->


### PR DESCRIPTION
CLDR-14957

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

The CLDR 40 Survey Tool phase added dayPeriods (besides just am/pm) for nn Nynorsk, but dayPeriods.xml did not actually specify the day period rules for nn, so just added nn to the list of locales for the Norwegian day period rules.