### PR TITLE
CLDR-14957 hy, rename emoji annotation for red hair to avoid conflict

### DIFF
--- a/common/annotations/hy.xml
+++ b/common/annotations/hy.xml
@@ -1635,8 +1635,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫂" type="tts">գրկախառնվող մարդիկ</annotation>
 		<annotation cp="👣">հագուստ | հետք | մարմին | ոտնահետք | ոտնահետքեր</annotation>
 		<annotation cp="👣" type="tts">ոտնահետքեր</annotation>
-		<annotation cp="🦰">հրագույն | շիկահեր | շիկամազ</annotation>
-		<annotation cp="🦰" type="tts">շիկահեր</annotation>
+		<annotation cp="🦰">հրագույն | շիկակարմիր | կարմրահեր</annotation>
+		<annotation cp="🦰" type="tts">կարմրահեր</annotation>
 		<annotation cp="🦱">աֆրո | գանգուր | գանգրահեր | գանգրամազ | խոպոպներ</annotation>
 		<annotation cp="🦱" type="tts">գանգրահեր</annotation>
 		<annotation cp="🦳">ալեհեր | ծեր | մազեր | սպիտակ | սպիտակահեր</annotation>


### PR DESCRIPTION
CLDR-14957

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

In hy Armenian, rename emoji annotation for red hair component to avoid conflict. Fixes all of the related conflicts.