### PR TITLE
CLDR-14780 Typo in ru-RU annotation for 👾 emoji

### DIFF
--- a/common/annotations/ru.xml
+++ b/common/annotations/ru.xml
@@ -652,7 +652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👻" type="tts">привидение</annotation>
 		<annotation cp="👽">инопланетянин | космос | пришелец | существо | фантастика | чужой</annotation>
 		<annotation cp="👽" type="tts">инопланетянин</annotation>
-		<annotation cp="👾">космический монстр | космос | лицо | нло | пришелец | фaнтастика | чужой</annotation>
+		<annotation cp="👾">космический монстр | космос | лицо | нло | пришелец | фантастика | чужой</annotation>
 		<annotation cp="👾" type="tts">космический монстр</annotation>
 		<annotation cp="🤖">лицо | монстр | робот | страх</annotation>
 		<annotation cp="🤖" type="tts">робот</annotation>


### PR DESCRIPTION
Fixing latin "a"

CLDR-14780

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-14780)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
