### PR TITLE
CLDR-14966 clean up bal_Latn errors

### DIFF
--- a/seed/main/bal_Latn.xml
+++ b/seed/main/bal_Latn.xml
@@ -555,42 +555,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="provisional">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
-			<decimalFormatLength type="long">
-				<decimalFormat>
-					<pattern type="1000" count="one" draft="provisional">0 hazár</pattern>
-					<pattern type="1000" count="other" draft="provisional">0 hazár</pattern>
-					<pattern type="10000" count="one" draft="provisional">00 hazár</pattern>
-					<pattern type="10000" count="other" draft="provisional">00 hazár</pattern>
-					<pattern type="100000" count="one" draft="provisional">0 lakk</pattern>
-					<pattern type="100000" count="other" draft="provisional">0 lakk</pattern>
-					<pattern type="1000000" count="one" draft="provisional">0 milyun</pattern>
-					<pattern type="1000000" count="other" draft="provisional">0 milyun</pattern>
-					<pattern type="10000000" count="one" draft="provisional">0 korórh</pattern>
-					<pattern type="10000000" count="other" draft="provisional">0 korórh</pattern>
-					<pattern type="100000000" count="one" draft="provisional">00 korórh</pattern>
-					<pattern type="100000000" count="other" draft="provisional">00 korórh</pattern>
-					<pattern type="1000000000" count="one" draft="provisional">000 korórh</pattern>
-					<pattern type="1000000000" count="other" draft="provisional">000 korórh</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-			<decimalFormatLength type="short">
-				<decimalFormat>
-					<pattern type="1000" count="one" draft="provisional">0 h</pattern>
-					<pattern type="1000" count="other" draft="provisional">0 h</pattern>
-					<pattern type="10000" count="one" draft="provisional">00 h</pattern>
-					<pattern type="10000" count="other" draft="provisional">00 h</pattern>
-					<pattern type="100000" count="one" draft="provisional">0 l</pattern>
-					<pattern type="100000" count="other" draft="provisional">0 l</pattern>
-					<pattern type="1000000" count="one" draft="provisional">0 m</pattern>
-					<pattern type="1000000" count="other" draft="provisional">0 m</pattern>
-					<pattern type="10000000" count="one" draft="provisional">0 ko</pattern>
-					<pattern type="10000000" count="other" draft="provisional">0 ko</pattern>
-					<pattern type="100000000" count="one" draft="provisional">00 ko</pattern>
-					<pattern type="100000000" count="other" draft="provisional">00 ko</pattern>
-					<pattern type="1000000000" count="one" draft="provisional">000 ko</pattern>
-					<pattern type="1000000000" count="other" draft="provisional">000 ko</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="latn">
 			<scientificFormatLength>
@@ -618,11 +582,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="provisional">Brázili riál</displayName>
 				<symbol draft="provisional">R$</symbol>
 				<symbol alt="narrow" draft="provisional">R$</symbol>
-			</currency>
-			<currency type="CNY">
-				<displayName draft="provisional">Chini yuan</displayName>
-				<symbol draft="provisional">¥</symbol>
-				<symbol alt="narrow" draft="provisional">¥</symbol>
 			</currency>
 			<currency type="EUR">
 				<displayName draft="provisional">yuró</displayName>


### PR DESCRIPTION
CLDR-14966

- [ ] This PR completes the ticket.

This should correct 188 bal_Latn final testing errors (by removing incomplete decimalFormatLength elements, Chinese yuan currency element).

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
