### PR TITLE
CLDR-14966 clean up bal errors

### DIFF
--- a/seed/main/bal.xml
+++ b/seed/main/bal.xml
@@ -336,7 +336,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Argentina_Western">
 				<long>
-					<generic draft="provisional">ارجنتینائے ساهت</generic>
+					<generic draft="provisional">رۆنندی ارجنتینائے ساهت</generic>
 					<standard draft="provisional">رۆنندی ارجنتینائے گیشّتگێن ساهت</standard>
 					<daylight draft="provisional">رۆنندی ارجنتینائے گرماگی ساهت</daylight>
 				</long>
@@ -554,42 +554,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="provisional">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
-			<decimalFormatLength type="long">
-				<decimalFormat>
-					<pattern type="1000" count="one" draft="provisional">0 هزار</pattern>
-					<pattern type="1000" count="other" draft="provisional">0 هزار</pattern>
-					<pattern type="10000" count="one" draft="provisional">00 هزار</pattern>
-					<pattern type="10000" count="other" draft="provisional">00 هزار</pattern>
-					<pattern type="100000" count="one" draft="provisional">0 لکّ</pattern>
-					<pattern type="100000" count="other" draft="provisional">0 لکّ</pattern>
-					<pattern type="1000000" count="one" draft="provisional">0 میلیون</pattern>
-					<pattern type="1000000" count="other" draft="provisional">0 میلیون</pattern>
-					<pattern type="10000000" count="one" draft="provisional">0 کرۆڑ</pattern>
-					<pattern type="10000000" count="other" draft="provisional">0 کرۆڑ</pattern>
-					<pattern type="100000000" count="one" draft="provisional">00 کرۆڑ</pattern>
-					<pattern type="100000000" count="other" draft="provisional">00 کرۆڑ</pattern>
-					<pattern type="1000000000" count="one" draft="provisional">000 کرۆڑ</pattern>
-					<pattern type="1000000000" count="other" draft="provisional">000 کرۆڑ</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-			<decimalFormatLength type="short">
-				<decimalFormat>
-					<pattern type="1000" count="one" draft="provisional">0 ه</pattern>
-					<pattern type="1000" count="other" draft="provisional">0 ه</pattern>
-					<pattern type="10000" count="one" draft="provisional">00 ه</pattern>
-					<pattern type="10000" count="other" draft="provisional">00 ه</pattern>
-					<pattern type="100000" count="one" draft="provisional">0 ل</pattern>
-					<pattern type="100000" count="other" draft="provisional">0 ل</pattern>
-					<pattern type="1000000" count="one" draft="provisional">0 م</pattern>
-					<pattern type="1000000" count="other" draft="provisional">0 م</pattern>
-					<pattern type="10000000" count="one" draft="provisional">0 ک</pattern>
-					<pattern type="10000000" count="other" draft="provisional">0 ک</pattern>
-					<pattern type="100000000" count="one" draft="provisional">00 ک</pattern>
-					<pattern type="100000000" count="other" draft="provisional">00 ک</pattern>
-					<pattern type="1000000000" count="one" draft="provisional">000 ک</pattern>
-					<pattern type="1000000000" count="other" draft="provisional">000 ک</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="latn">
 			<scientificFormatLength>
@@ -617,11 +581,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="provisional">برازیلی ریال</displayName>
 				<symbol draft="provisional">R$</symbol>
 				<symbol alt="narrow" draft="provisional">R$</symbol>
-			</currency>
-			<currency type="CNY">
-				<displayName draft="provisional">چینی یوان</displayName>
-				<symbol draft="provisional">¥</symbol>
-				<symbol alt="narrow" draft="provisional">¥</symbol>
 			</currency>
 			<currency type="EUR">
 				<displayName draft="provisional">یورۆ</displayName>


### PR DESCRIPTION
CLDR-14966

- [ ] This PR completes the ticket.

Should resolve 8 bal final testing errors (by removing incomplete decimalFormatLength elements, Chinese yuan currency element, and correcting name of Western Argentina time zone).

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
