### PR TITLE
CLDR-14286 Fix Interval format GyMMM for locale fa

### DIFF
--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -1601,7 +1601,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
 							<greatestDifference id="G">MMM y G تا MMM y G</greatestDifference>
-							<greatestDifference id="M">LLL تا MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM تا MMM y G</greatestDifference>
 							<greatestDifference id="y">MMM y تا MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">


### PR DESCRIPTION
The pattern for `<greatestDifference id="M">` has no repeating pattern
when TR35 indicates:

  The pattern is then designed to be broken up into two pieces by
  determining the first repeating field. For example, "MMM d-d, y"
  would be broken up into "MMM d-" and "d, y".

This PR replaces:

  <greatestDifference id="M">LLL تا MMM y G</greatestDifference>

with

  <greatestDifference id="M">MMM تا MMM y G</greatestDifference>

replacing LLL (standalone month) with MMM (month) thereby ensuring
there is a repeating pattern per the specification.

CLDR-14286

- [x] This PR completes the ticket.

