### PR TITLE
CLDR-14966 Fix doi errors

### DIFF
--- a/common/main/doi.xml
+++ b/common/main/doi.xml
@@ -745,10 +745,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="weekday">
 				<displayName>हफ्ते दा दिन</displayName>
 			</field>
-			<field type="sun">
-				<relative type="-1">अखीरी ऐतबार</relative>
-				<relative type="1">औंदा ऐतबार</relative>
-			</field>
 			<field type="dayperiod">
 				<displayName>सवेर/बा.दपै.</displayName>
 			</field>


### PR DESCRIPTION
Delete relative Sunday value to fix doi error.

doi [Dogri]	error	▸Date_&_Time|Fields|Relative_Sunday|0◂	〈this Sunday〉	【】	〈this Sunday〉	«=»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [0]; level=modern❯	https://st.unicode.org/cldr-apps/v#/doi//34da11643c7613cf	root

https://gist.github.com/srl295/1b17f5b76b613ed75a82b16c31cc726a

CLDR-14966

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
