### PR TITLE
CLDR-14966 fixed various final_testing errs in be_tarask,ee,gu,sv,yo_BJ

### DIFF
--- a/common/main/be_tarask.xml
+++ b/common/main/be_tarask.xml
@@ -9530,6 +9530,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<styleName type="wdth" subtype="87.5" draft="provisional">напаўшчыльны</styleName>
 		<styleName type="wdth" subtype="87.5" alt="compressed" draft="provisional">напаўсьціснуты</styleName>
 		<styleName type="wdth" subtype="87.5" alt="narrow" draft="provisional">напаўвузкі</styleName>
+		<styleName type="wdth" subtype="100" draft="provisional">нармальны</styleName>
 		<styleName type="wdth" subtype="112.5" draft="provisional">напаўразгорнуты</styleName>
 		<styleName type="wdth" subtype="112.5" alt="extended" draft="provisional">напаўпашыраны</styleName>
 		<styleName type="wdth" subtype="112.5" alt="wide" draft="provisional">напаўшырокі</styleName>

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -6367,8 +6367,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-minute">
 				<displayName>aɖabaƒoƒowo</displayName>
-				<unitPattern count="one">aɖabaƒoƒo {0}</unitPattern>
-				<unitPattern count="other">aɖabaƒoƒo {0}</unitPattern>
+				<unitPattern count="one">a {0}</unitPattern>
+				<unitPattern count="other">a {0}</unitPattern>
 			</unit>
 			<unit type="duration-second">
 				<unitPattern count="one">sekend {0}</unitPattern>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -8842,8 +8842,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-radian">
 				<displayName>સમત્રિજ્યાકોણ</displayName>
-				<unitPattern count="one">{0} સમત્રિજ્યાકોણ</unitPattern>
-				<unitPattern count="other">{0} સમત્રિજ્યાકોણ</unitPattern>
+				<unitPattern count="one">{0} સમત્રિ.</unitPattern>
+				<unitPattern count="other">{0} સમત્રિ.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>અંશ</displayName>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -11428,7 +11428,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="provisional">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -3536,8 +3536,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} sídiì</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>àmì lumɛ́ɛ̀nì</displayName>
-				<unitPattern count="other">{0} àmi lumɛ́ɛ̀nì</unitPattern>
+				<displayName>lumɛ́ɛ̀nì</displayName>
+				<unitPattern count="other">{0} lumɛ́ɛ̀nì</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>gíréènì</displayName>


### PR DESCRIPTION
CLDR-14966

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

* be_tarask 
    * name for width/100 normal conflicts with weight/100 regular (which is same as in "be"); both important, so convert the "be" name for width/100 using tarask transliterator
* ee 
    * duration/minute/short too wide, copy value from narrow
* gu 
    * angle/radian/short too wide, copy value from narrow
* sv 
    * remove provisional status for narrow kilowatt-hour-per-100-kilometer/other, matches confirmed short & long
* yo_BJ 
    * light/lumen/short too wide, copy value from long (which is shorter!)
