### PR TITLE
CLDR-14966 Fix kab errors

### DIFF
--- a/common/annotations/kab.xml
+++ b/common/annotations/kab.xml
@@ -32,8 +32,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="←" type="tts" draft="unconfirmed">aneccab s azelmaḍ</annotation>
 		<annotation cp="→" draft="unconfirmed">aneccab s ayeffus</annotation>
 		<annotation cp="→" type="tts" draft="unconfirmed">aneccab s ayeffus</annotation>
-		<annotation cp="↑" draft="unconfirmed">aneccab d asawen</annotation>
-		<annotation cp="↑" type="tts" draft="unconfirmed">aneccab d asawen</annotation>
 		<annotation cp="↓" draft="unconfirmed">aneccab d akesser</annotation>
 		<annotation cp="↓" type="tts" draft="unconfirmed">aneccab d akesser</annotation>
 		<annotation cp="⇅" draft="unconfirmed">aneccab d asawen d uneccab d akessar</annotation>
@@ -418,8 +416,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🐱" type="tts" draft="unconfirmed">udem n umcic</annotation>
 		<annotation cp="🐈" draft="unconfirmed">amcic</annotation>
 		<annotation cp="🐈" type="tts" draft="unconfirmed">amcic</annotation>
-		<annotation cp="🦁" draft="unconfirmed">izem | Leo | udem | zodiac</annotation>
-		<annotation cp="🦁" type="tts" draft="unconfirmed">izem</annotation>
 		<annotation cp="🐯" draft="unconfirmed">aɣilas | udem</annotation>
 		<annotation cp="🐯" type="tts" draft="unconfirmed">udem n uɣilas</annotation>
 		<annotation cp="🐅" draft="unconfirmed">aɣilas</annotation>
@@ -606,8 +602,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🕷" type="tts" draft="unconfirmed">tissist</annotation>
 		<annotation cp="🕸" draft="unconfirmed">azeṭṭa n tissist</annotation>
 		<annotation cp="🕸" type="tts" draft="unconfirmed">azeṭṭa n tissist</annotation>
-		<annotation cp="🦂" draft="unconfirmed">tiɣirdemt</annotation>
-		<annotation cp="🦂" type="tts" draft="unconfirmed">tiɣirdemt</annotation>
 		<annotation cp="🦟" draft="unconfirmed">aṭṭan | avirus | malarya | tawla | tizit | ṭṭaɛun</annotation>
 		<annotation cp="🦟" type="tts" draft="unconfirmed">tizit</annotation>
 		<annotation cp="🪰" draft="unconfirmed">izi</annotation>
@@ -720,8 +714,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🥬" type="tts" draft="unconfirmed">Tidelt n iferrawen izegzawen</annotation>
 		<annotation cp="🥦" draft="unconfirmed">brukuli</annotation>
 		<annotation cp="🥦" type="tts" draft="unconfirmed">brukuli</annotation>
-		<annotation cp="🧄" draft="unconfirmed">ticcert</annotation>
-		<annotation cp="🧄" type="tts" draft="unconfirmed">ticcert</annotation>
+		<annotation cp="🧄" draft="unconfirmed">tiskert</annotation>
+		<annotation cp="🧄" type="tts" draft="unconfirmed">tiskert</annotation>
 		<annotation cp="🧅" draft="unconfirmed">aẓalim</annotation>
 		<annotation cp="🧅" type="tts" draft="unconfirmed">aẓalim</annotation>
 		<annotation cp="🍄" draft="unconfirmed">tagerselt</annotation>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -6723,8 +6723,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-dot">
 				<displayName draft="unconfirmed">taneqqiḍt</displayName>
-				<unitPattern count="one" draft="unconfirmed">{0} n tneqqiḍt</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">{0} n tneqqiḍt</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} n tneqqiṭ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} n tneqqiṭ</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName draft="unconfirmed">ikilumitren</displayName>


### PR DESCRIPTION
CLDR-14966

Fixes kab errors. Kept consistent with 39 for where there were errors.

Note: Garlic appeared to have another term as well: https://polyglotclub.com/wiki/Language/Kabyle/Grammar/Noun-Gender

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
