### PR TITLE
CLDR-14783 update ICU4J libs to version of 2021-08-11 with Unicode 14 beta

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -3382,6 +3382,10 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Chorasmian; ? } => { Chorasmian; Chorasmian; Uzbekistan }-->
 		<likelySubtag from="und_Copt" to="cop_Copt_EG"/>
 		<!--{ ?; Coptic; ? } => { Coptic; Coptic; Egypt }-->
+		<likelySubtag from="und_Cpmn" to="und_Cpmn_CY"/>
+		<!--{ ?; Cypro-Minoan; ? } => { ?; Cypro-Minoan; Cyprus }-->
+		<likelySubtag from="und_Cpmn_CY" to="und_Cpmn_CY"/>
+		<!--{ ?; Cypro-Minoan; Cyprus } => { ?; Cypro-Minoan; Cyprus }-->
 		<likelySubtag from="und_Cprt" to="grc_Cprt_CY"/>
 		<!--{ ?; Cypriot; ? } => { Ancient Greek; Cypriot; Cyprus }-->
 		<likelySubtag from="und_Cyrl" to="ru_Cyrl_RU"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -163,6 +163,7 @@ public class GenerateMaximalLocales {
         "rhg_Rohg_MM",
 
         "no_Latn_NO",
+        "und_Cpmn_CY",
     };
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -244,7 +244,7 @@ public class LikelySubtagsTest extends TestFmwk {
     }
 
     static Set<String> exceptions = new HashSet<>(Arrays.asList("Zyyy",
-        "Zinh", "Zzzz", "Brai"));
+        "Zinh", "Zzzz", "Brai", "Cpmn")); // scripts with no default language
 
     public void TestStability() {
         // when maximized must never change

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>70.0.1-SNAPSHOT-cldr-2021-06-15</icu4j.version>
+		<icu4j.version>70.0.1-SNAPSHOT-cldr-2021-08-11</icu4j.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-14783

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Update to use libs from latest ICU4J, tagged "cldr/2021-08-11", which adds Unicode 14 support. That requires likelySubtags & test/tool support for an additional ancient script Cpmn "Cypro-Minoan" (already have en name for it).