### PR TITLE
CLDR-13595 ckb_IR, add Persian calendar month names

### DIFF
--- a/common/main/ckb_IR.xml
+++ b/common/main/ckb_IR.xml
@@ -42,6 +42,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 			</calendar>
 			<calendar type="persian">
+				<months>
+					<monthContext type="format">
+						<monthWidth type="wide">
+							<month type="1" draft="contributed">خاکەلێوە</month>
+							<month type="2" draft="contributed">گوڵان</month>
+							<month type="3" draft="contributed">جۆزەردان</month>
+							<month type="4" draft="contributed">پووشپەڕ</month>
+							<month type="5" draft="contributed">گەلاوێژ</month>
+							<month type="6" draft="contributed">خەرمانان</month>
+							<month type="7" draft="contributed">ڕەزبەر</month>
+							<month type="8" draft="contributed">گەڵاڕێزان</month>
+							<month type="9" draft="contributed">سەرماوەز</month>
+							<month type="10" draft="contributed">بەفرانبار</month>
+							<month type="11" draft="contributed">ڕێبەندان</month>
+							<month type="12" draft="contributed">ڕەشەمە</month>
+						</monthWidth>
+					</monthContext>
+				</months>
 				<timeFormats>
 					<timeFormatLength type="full">
 						<timeFormat>


### PR DESCRIPTION
CLDR-13595

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Compared the names requested in the bug to the Kurdish names in
https://en.wikipedia.org/wiki/Solar_Hijri_calendar#Months
and also to the unconfirmed names in ckb.

The bug had the names for months 5 and 6 swapped; compared to wikipedia it also added a space in month 3 and used a different final character for month 4. I went with the wikipedia data instead.

This completes the data changes for the bug, but in the ticket I also proposed a change to SupplementalDataInfo. getTargetTerritories which I will do in another PR.
