### PR TITLE
CLDR-13391 mt: Language and Region fixes

### DIFF
--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -452,7 +452,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="teo">Teso</language>
 			<language type="ter">Tereno</language>
 			<language type="tet">Tetum</language>
-			<language type="tg">Tajik</language>
+			<language type="tg">Taġik</language>
 			<language type="th">Tajlandiż</language>
 			<language type="ti">Tigrinya</language>
 			<language type="tig">Tigre</language>
@@ -648,7 +648,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FJ">Fiġi</territory>
 			<territory type="FK">il-Gżejjer Falkland</territory>
 			<territory type="FK" alt="variant">Il-Gżejjer Falkland (il-Gżejjer Malvinas)</territory>
-			<territory type="FM">Mikroneżja</territory>
+			<territory type="FM">il-Mikroneżja</territory>
 			<territory type="FO">il-Gżejjer Faeroe</territory>
 			<territory type="FR">Franza</territory>
 			<territory type="GA">il-Gabon</territory>
@@ -687,7 +687,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="IO">Territorju Brittaniku tal-Oċean Indjan</territory>
 			<territory type="IQ">l-Iraq</territory>
 			<territory type="IR">l-Iran</territory>
-			<territory type="IS">l-iżlanda</territory>
+			<territory type="IS">l-Iżlanda</territory>
 			<territory type="IT">l-Italja</territory>
 			<territory type="JE">Jersey</territory>
 			<territory type="JM">il-Ġamajka</territory>
@@ -773,7 +773,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="RS">is-Serbja</territory>
 			<territory type="RU">ir-Russja</territory>
 			<territory type="RW">ir-Rwanda</territory>
-			<territory type="SA">l-Arabia Sawdija</territory>
+			<territory type="SA">l-Arabja Sawdija</territory>
 			<territory type="SB">il-Gżejjer Solomon</territory>
 			<territory type="SC">is-Seychelles</territory>
 			<territory type="SD">is-Sudan</territory>
@@ -793,7 +793,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SV">El Salvador</territory>
 			<territory type="SX">Sint Maarten</territory>
 			<territory type="SY">is-Sirja</territory>
-			<territory type="SZ">is-Swaziland</territory>
+			<territory type="SZ">l-Eswatini</territory> <!-- ir-Renju tal-Eswatini -->
 			<territory type="TA">Tristan da Cunha</territory>
 			<territory type="TC">il-Gżejjer Turks u Caicos</territory>
 			<territory type="TD">iċ-Chad</territory>


### PR DESCRIPTION
- many per EU Annex A5 for Maltese

CLDR-13391

- [X] This PR completes the ticket.

Note: confirmed with Kunsil tal-Malti