### PR TITLE
CLDR-14423 Use year marker " 'р'." consistently in uk

### DIFF
--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -1521,7 +1521,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>d MMM y G</pattern>
+							<pattern>d MMM y 'р'. G</pattern>
 							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
@@ -1568,9 +1568,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="EHms">E HH:mm:ss</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd" draft="contributed">dd-MM-y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">LLL y G</dateFormatItem>
-						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">LLL y 'р'. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y 'р'. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d MMM y 'р'. G</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
 						<dateFormatItem id="hm">h:mm a</dateFormatItem>
@@ -1591,10 +1591,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyM">MM.y G</dateFormatItem>
 						<dateFormatItem id="yyyyMd">dd.MM.y G</dateFormatItem>
 						<dateFormatItem id="yyyyMEd">E, dd.MM.y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">LLL y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">E, d MMM y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">LLLL y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">LLL y 'р'. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y 'р'. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM y 'р'. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y 'р'. G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQQ">QQQQ y 'р'. G</dateFormatItem>
 					</availableFormats>
@@ -1722,22 +1722,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">LLL–LLL y</greatestDifference>
-							<greatestDifference id="y">LLL y – LLL y</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y 'р'.</greatestDifference>
+							<greatestDifference id="y">LLL y – LLL y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d–d MMM y</greatestDifference>
-							<greatestDifference id="M">d MMM – d MMM y</greatestDifference>
-							<greatestDifference id="y">d MMM y – d MMM y</greatestDifference>
+							<greatestDifference id="d">d–d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d – E, d MMM y</greatestDifference>
-							<greatestDifference id="M">E, d MMM – E, d MMM y</greatestDifference>
-							<greatestDifference id="y">E, d MMM y – E, d MMM y</greatestDifference>
+							<greatestDifference id="d">E, d – E, d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="M">E, d MMM – E, d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="y">E, d MMM y – E, d MMM y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">LLLL – LLLL y</greatestDifference>
-							<greatestDifference id="y">LLLL y – LLLL y</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y 'р'.</greatestDifference>
+							<greatestDifference id="y">LLLL y – LLLL y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2125,9 +2125,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="EHms">E HH:mm:ss</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd" draft="contributed">dd-MM-y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">LLL y G</dateFormatItem>
-						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">LLL y 'р'. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y 'р'. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d MMM y 'р'. G</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
 						<dateFormatItem id="hm">h:mm a</dateFormatItem>
@@ -2155,10 +2155,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yM">MM.y</dateFormatItem>
 						<dateFormatItem id="yMd">dd.MM.y</dateFormatItem>
 						<dateFormatItem id="yMEd">E, dd.MM.y</dateFormatItem>
-						<dateFormatItem id="yMMM">LLL y</dateFormatItem>
-						<dateFormatItem id="yMMMd">d MMM y</dateFormatItem>
-						<dateFormatItem id="yMMMEd">E, d MMM y</dateFormatItem>
-						<dateFormatItem id="yMMMM">LLLL y</dateFormatItem>
+						<dateFormatItem id="yMMM">LLL y 'р'.</dateFormatItem>
+						<dateFormatItem id="yMMMd">d MMM y 'р'.</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, d MMM y 'р'.</dateFormatItem>
+						<dateFormatItem id="yMMMM">LLLL y 'р'.</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
 						<dateFormatItem id="yQQQQ">QQQQ y 'р'.</dateFormatItem>
 						<dateFormatItem id="yw" count="one">w-'й' 'тиж'. Y 'р'.</dateFormatItem>
@@ -2293,22 +2293,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">LLL–LLL y</greatestDifference>
-							<greatestDifference id="y">LLL y – LLL y</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y 'р'.</greatestDifference>
+							<greatestDifference id="y">LLL y – LLL y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d–d MMM y</greatestDifference>
-							<greatestDifference id="M">d MMM – d MMM y</greatestDifference>
-							<greatestDifference id="y">d MMM y – d MMM y</greatestDifference>
+							<greatestDifference id="d">d–d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d – E, d MMM y</greatestDifference>
-							<greatestDifference id="M">E, d MMM – E, d MMM y</greatestDifference>
-							<greatestDifference id="y">E, d MMM y – E, d MMM y</greatestDifference>
+							<greatestDifference id="d">E, d – E, d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="M">E, d MMM – E, d MMM y 'р'.</greatestDifference>
+							<greatestDifference id="y">E, d MMM y – E, d MMM y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">LLLL – LLLL y</greatestDifference>
-							<greatestDifference id="y">LLLL y – LLLL y</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y 'р'.</greatestDifference>
+							<greatestDifference id="y">LLLL y – LLLL y 'рр'.</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>


### PR DESCRIPTION
CLDR-14423 - Use the year marker 'р'." consistently in Ukrainian

Please check spreadsheet attached to issue for additional feedback from the linguist

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
