### PR TITLE
CLDR-14976 40a0 integration: handle brkitr lstm data, allow tarask variant, spelling fixes from ICU

### DIFF
--- a/common/dtd/ldmlICU.dtd
+++ b/common/dtd/ldmlICU.dtd
@@ -39,11 +39,17 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ATTLIST icu:ruleBasedNumberFormat type NMTOKEN #IMPLIED >
 
 <!-- RBBI data -->
-<!ELEMENT icu:breakIteratorData (alias | (icu:boundaries?, icu:dictionaries?)) >
+<!ELEMENT icu:breakIteratorData (alias | (icu:boundaries?, icu:dictionaries?, icu:lstm?)) >
 
 <!ELEMENT icu:boundaries (alias | (icu:grapheme?, icu:word?, icu:line*, icu:sentence?, icu:title?, icu:xgc?)) >
 
 <!ELEMENT icu:dictionaries (alias | (icu:dictionary*)) >
+
+<!ELEMENT icu:lstm (alias | (icu:lstmdata*)) >
+
+<!ELEMENT icu:lstmdata ( #PCDATA ) >
+<!ATTLIST icu:lstmdata icu:dependency NMTOKEN #IMPLIED >
+<!ATTLIST icu:lstmdata type NMTOKEN #REQUIRED >
 
 <!ELEMENT icu:dictionary ( #PCDATA ) >
 <!ATTLIST icu:dictionary icu:dependency NMTOKEN #IMPLIED >

--- a/common/testData/units/unitPreferencesTest.txt
+++ b/common/testData/units/unitPreferencesTest.txt
@@ -15,7 +15,7 @@
 #	 The Output amount and Unit are repeated for mixed units. In such a case, only the smallest unit will have
 #	 both a rational and decimal amount; the others will have a single integer value, such as:
 #	   length; person-height; CA; 3429 / 12500; 0.27432; meter; 2; foot; 54 / 5; 10.8; inch
-#	 The input and output units are unit identifers; in particular, the output does not have further processing:
+#	 The input and output units are unit identifiers; in particular, the output does not have further processing:
 #		 • no localization
 #		 • no adjustment for pluralization
 #		 • no formatted with the skeleton

--- a/common/transforms/Any-Accents.xml
+++ b/common/transforms/Any-Accents.xml
@@ -13,7 +13,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 :: NFD (NFC) ;
 # to do: make reversible
 # define special conversion characters.
-# varients of this could use different characters, or set one or the other to null.
+# variants of this could use different characters, or set one or the other to null.
 $pre = \← ;
 $post = \→ ;
 # Provide keyboard equivalents for common diacritics used in transliteration

--- a/common/transforms/Bulgarian-Latin-BGN.xml
+++ b/common/transforms/Bulgarian-Latin-BGN.xml
@@ -259,7 +259,7 @@ $bulgarian { [Ъъ]  } $wordBoundary > ;
 ѣ → ye ; # CYRILLIC SMALL LETTER YAT
 #
 #
-# Alternative rule where appropriate for local pronounciation. To apply
+# Alternative rule where appropriate for local pronunciation. To apply
 # uncomment the following by removing the '#' mark at the start of the
 # line and insert before the three rule lines above.
 #

--- a/common/transforms/Greek_Latin_UNGEGN.xml
+++ b/common/transforms/Greek_Latin_UNGEGN.xml
@@ -41,7 +41,7 @@ $caron = ̌;
 $afterLetter = [:L:] [\'$accent]* ;
 $beforeLetter = [\'$accent]* [:L:] ;
 # Fix punctuation
-# preserve orginal
+# preserve original
 \: ↔ \: $under ;
 \? ↔ \? $under ;
 \; ↔ \? ;

--- a/common/transforms/InterIndic-Gurmukhi.xml
+++ b/common/transforms/InterIndic-Gurmukhi.xml
@@ -16,7 +16,7 @@ $vowel = [ਅ-ਔ ਾ-੍];
 $consonant = [ਕ-ਹ];
 \uE001→ਁ;       # SIGN CHANDRABINDU
 #rules for BINDI
-# Anusvara is equivalent to BINDI when preceeded by a vowel
+# Anusvara is equivalent to BINDI when preceded by a vowel
 $vowel{\uE002→ਂ; # SIGN ANUSVARA (ਂ = SIGN BINDI)
 # else is equivalent to TIPPI
 $consonant{\uE002→ੰ; # SIGN TIPPI

--- a/common/transforms/InterIndic-Latin.xml
+++ b/common/transforms/InterIndic-Latin.xml
@@ -103,7 +103,7 @@ $om=\uE050; # OM
 $lm = \uE055;#  Telugu Length Mark
 $ailm=\uE056;#  AI Length Mark
 $aulm=\uE057;#  AU Length Mark
-#urdu compatibity forms
+#urdu compatibility forms
 $uka=\uE058;
 $ukha=\uE059;
 $ugha=\uE05A;
@@ -409,7 +409,7 @@ $wco} $x → ŏ̔;
 $wse} $x → e̔;
 $wso} $x → o̔;
 $om} $x → ''om̔;
-# independent vowels when preceeded by vowels
+# independent vowels when preceded by vowels
 $vowels{$waa  → ''ā;
 $vowels{$wai  → ''ai;
 $vowels{$wau  → ''au;

--- a/common/transforms/Latin-ConjoiningJamo.xml
+++ b/common/transforms/Latin-ConjoiningJamo.xml
@@ -53,7 +53,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 #    after it. Continue with the rest of the consonants.
 # -- If there is one consonant, attach to the following vowel
 # -- If there are two consonants and a following vowel, attach one to the
-#    preceeding vowel, and one to the following vowel.
+#    preceding vowel, and one to the following vowel.
 # -- If there are more than two consonants, join the first two together if you
 #    can: L + G =→ LG
 # -- If you still end up with more than 2 consonants, insert EU after the

--- a/common/transforms/Latin-InterIndic.xml
+++ b/common/transforms/Latin-InterIndic.xml
@@ -104,7 +104,7 @@ $om = \uE050; # OM
 $lm = \uE055;#  Telugu Length Mark
 $ailm=\uE056;#  AI Length Mark
 $aulm=\uE057;#  AU Length Mark
-#urdu compatibity forms
+#urdu compatibility forms
 $uka=\uE058;
 $ukha=\uE059;
 $ugha=\uE05A;
@@ -184,7 +184,7 @@ x→$ka$virama$sa;
 ̔ŏ→$co;
 ̔e→$se;
 ̔o→$so;
-# preceeded by consonants
+# preceded by consonants
 $consonants{ ā→$aa;
 $consonants{ ai→$ai;
 $consonants{ au→$au;

--- a/common/transforms/am-am_FONIPA.xml
+++ b/common/transforms/am-am_FONIPA.xml
@@ -621,7 +621,7 @@ $LABIALIZABLE_BEFORE_A = [p{pʼ}t{tʼ} {t͡ʃ}{t͡ʃʼ}{d͡ʒ}{d͡ʒʼ} s{sʼ}z�
 ፧ → ' ';  # U+1367 ETHIOPIC QUESTION MARK
 ፨ → ' ';  # U+1368 ETHIOPIC PARAGRAPH SEPARATOR
 
-# Likewise, Ethiopic numberals cannot be pronounced by these rules,
+# Likewise, Ethiopic numerals cannot be pronounced by these rules,
 # so we replace them by whitespace in the output IPA notation.
 # Applications will typically pre-process text before calling
 # the am → am_FONIPA transform.

--- a/common/transforms/cs-cs_FONIPA.xml
+++ b/common/transforms/cs-cs_FONIPA.xml
@@ -10,7 +10,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<transforms>
 		<transform source="cs" target="cs_FONIPA" direction="forward" alias="cs-fonipa-t-cs">
 			<tRule>
-# Tranformation from Czech to Czech in IPA transcription (cs_FONIPA).
+# Transformation from Czech to Czech in IPA transcription (cs_FONIPA).
 # The transcription is not fully phonemic since we mark allophonic variations
 # of /m/, /n/, /x/ and /ɦ/.
 #

--- a/common/transforms/es-es_FONIPA.xml
+++ b/common/transforms/es-es_FONIPA.xml
@@ -10,7 +10,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<transforms>
 		<transform source="es" target="es_FONIPA" direction="forward" alias="es-fonipa-t-es">
 			<tRule><![CDATA[
-# Tranformation from Spanish to Spanish in IPA transcription (es_FONIPA).
+# Transformation from Spanish to Spanish in IPA transcription (es_FONIPA).
 # Not fully phonemic, since we mark up allophonic variants of voiced stops,
 # e.g. we break down /b/ into [b] and [β].
 #

--- a/common/transforms/es_FONIPA-zh.xml
+++ b/common/transforms/es_FONIPA-zh.xml
@@ -10,7 +10,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<transforms>
 		<transform source="es_FONIPA" target="zh" direction="forward" alias="zh-t-es-fonipa">
 			<tRule><![CDATA[
-# Tranforms Spanish to Mandarin Chinese. The input Spanish string must be in
+# Transforms Spanish to Mandarin Chinese. The input Spanish string must be in
 # phonemic IPA transcription (es_FONIPA); the output is in Simplified Chinese.
 
 $word_boundary = [-\ $];
@@ -532,7 +532,7 @@ xwi → 惠 ;
 xwo → 霍 ;
 x → 赫 ;
 
-# 尔 simplification pass.  The idea is to drop most occurences of 尔
+# 尔 simplification pass.  The idea is to drop most occurrences of 尔
 # corresponding to <r> (not to <l> or <ll>) from a word if there is another /l/
 # sound nearby.  There is a vague pattern like this in the data, but the details
 # remain to be determined.  At the moment, this does nothing, it just puts 尔 in

--- a/common/transforms/it-ja.xml
+++ b/common/transforms/it-ja.xml
@@ -289,7 +289,7 @@ z → ツ;
 #
 # Latin hyphen should be transliterated to U+30A0 (KATAKANA-HIRAGANA
 # DOUBLE HYPHEN), ideally. But since the character isn't supported by
-# many fonts or softwares, we use U+FF1D (FULLWIDTH EQUALS SIGN),
+# many fonts or software, we use U+FF1D (FULLWIDTH EQUALS SIGN),
 # which is widely used as "double hyphen".
 #
 

--- a/common/transforms/sat_Olck-sat_FONIPA.xml
+++ b/common/transforms/sat_Olck-sat_FONIPA.xml
@@ -73,7 +73,7 @@ $inword = [[:L:][:M:]];
 # Some online texts use U+1C7C PHAARKAA instead of U+1C7B RELAA for indicating
 # long phonemes, presumably because the graphemes look similar in some fonts.
 # Since phaarkaa is used for voicing ejectives and plosives (which cannot
-# be lenghtened), we rewrite phaarkaa to relaa.
+# be lengthened), we rewrite phaarkaa to relaa.
 [ᱚᱟᱤᱩᱮᱳᱶᱢᱝᱞᱱ] [ᱹᱸᱺ]* {ᱼ} → ᱻ ;
 ::null();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/api/LocaleIds.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/api/LocaleIds.java
@@ -41,7 +41,7 @@ final class LocaleIds {
         Pattern.compile("(?:[a-z]{2,3})"
             + "(?:_(?:[A-Z][a-z]{3}))?"
             + "(?:_(?:[A-Z]{2}|[0-9]{3}))?"
-            + "(?:_(?:[A-Z]{5,}|[0-9][A-Z0-9]{3}))?");
+            + "(?:_(?:[A-Za-z]{5,}|[0-9][A-Za-z0-9]{3}))?");
 
     /**
      * Checks whether the given ID is valid for CLDR use (including case). Locale IDs for use in
@@ -56,8 +56,11 @@ final class LocaleIds {
      *     <li>Language subtag is lower-case, and is either 2 or 3 letters (i.e. "[a-z]{2,3}").
      *     <li>Script subtag is mixed-case and must match {@code "[A-Z][a-z]{3}"}.
      *     <li>Region subtag is upper-case and must match {@code "[A-Z]{2}} or {@code "[0-9]{3}"}.
-     *     <li>Variant subtag is upper-case and must match {@code "[A-Z]{5,}} or
+     *     <li>Variant subtag is upper- or lower-case and must match {@code "[A-Z]{5,}} or
      *         {@code "[0-9][A-Z0-9]{3}"}.
+     *         Note: The EBNF at https://www.unicode.org/reports/tr35/#unicode_variant_subtag
+     *         allows either lettercase, and the data at common/validity/variant.xml user lower.
+     *         CLDR 40 has be_tarask, ca_ES_VALENCIA, en_US_POSIX.
      *     <li>The special locale ID {@code "root"} is also permitted.
      * <ul>
      *

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ICUID.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ICUID.java
@@ -11,6 +11,8 @@ public final class ICUID {
     public static final String ICU_XGC = "icu:xgc";
     public static final String ICU_TITLE = "icu:title";
     public static final String ICU_DICTIONARY = "icu:dictionary";
+    public static final String ICU_LSTM = "icu:lstm";
+    public static final String ICU_LSTMDATA = "icu:lstmdata";
     // private static final String ICU_CLASS = "icu:class";
     // private static final String ICU_IMPORT = "icu:import";
     // private static final String ICU_APPEND = "icu:append";


### PR DESCRIPTION
CLDR-14976

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Misc fixes from integrating CLDR release-40-alpha0 to ICU:
- Support the lstm data for break iterators (special ICU type like dictionaries etc.)
- Handle the "tarask" variant in lower case (as in the filename, and in the validity data for example)
- Miscellaneous spelling fixes already made in the ICU copies of some CLDR-derived data