### PR TITLE
CLDR-14976 CLDR 40 a0, fix en_CA symbol for USD, make tarask uppercase

### DIFF
--- a/common/main/be_TARASK.xml
+++ b/common/main/be_TARASK.xml
@@ -11,7 +11,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<identity>
 		<version number="$Revision$"/>
 		<language type="be"/>
-		<variant type="tarask"/>
+		<variant type="TARASK"/>
 	</identity>
 	<localeDisplayNames>
 		<localeDisplayPattern>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -6565,8 +6565,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>U.S. Dollar</displayName>
 				<displayName count="one">U.S. dollar</displayName>
 				<displayName count="other">U.S. dollars</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol>US$</symbol>
+				<symbol alt="narrow">$</symbol>
 			</currency>
 			<currency type="UYU">
 				<displayName>↑↑↑</displayName>


### PR DESCRIPTION
CLDR-14976

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Two more fixes for CLDR alpha0 integration to ICU:
1. en_CA needs to specify USD symbol as "US$" which it used to inherit from en_001
2. For be_tarask, the variant needs to be uppercase 
