### PR TITLE
CLDR-14646 az_Cyrl Latin K to Cyrillic K

### DIFF
--- a/common/main/az_Cyrl.xml
+++ b/common/main/az_Cyrl.xml
@@ -482,7 +482,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG">Конго-Браззавил</territory>
 			<territory type="CG" alt="variant">Конго (Республика)</territory>
 			<territory type="CH">Исвечрә</territory>
-			<territory type="CI">Kотд’ивуар</territory>
+			<territory type="CI">Котд’ивуар</territory>
 			<territory type="CK">Кук адалары</territory>
 			<territory type="CL">Чили</territory>
 			<territory type="CM">Камерун</territory>


### PR DESCRIPTION
CLDR-14646

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

<territory type="CI">Kотд’ивуар</territory> was using a Latin K when all other cases used a Cyrillic K

Replaces https://github.com/unicode-org/cldr/pull/1183 which had a bad commit message