### PR TITLE
CLDR-14635 change the en_CA data for the new inheritance

### DIFF
--- a/common/annotations/en_CA.xml
+++ b/common/annotations/en_CA.xml
@@ -12,3825 +12,401 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="CA"/>
 	</identity>
 	<annotations>
-		<annotation cp="{">↑↑↑</annotation>
-		<annotation cp="{" type="tts">↑↑↑</annotation>
-		<annotation cp="🏻">↑↑↑</annotation>
-		<annotation cp="🏻" type="tts">↑↑↑</annotation>
-		<annotation cp="🏼">↑↑↑</annotation>
-		<annotation cp="🏼" type="tts">↑↑↑</annotation>
-		<annotation cp="🏽">↑↑↑</annotation>
-		<annotation cp="🏽" type="tts">↑↑↑</annotation>
-		<annotation cp="🏾">↑↑↑</annotation>
-		<annotation cp="🏾" type="tts">↑↑↑</annotation>
-		<annotation cp="🏿">↑↑↑</annotation>
-		<annotation cp="🏿" type="tts">↑↑↑</annotation>
-		<annotation cp="‾">↑↑↑</annotation>
-		<annotation cp="‾" type="tts">↑↑↑</annotation>
-		<annotation cp="_">↑↑↑</annotation>
-		<annotation cp="_" type="tts">↑↑↑</annotation>
-		<annotation cp="-">↑↑↑</annotation>
-		<annotation cp="-" type="tts">↑↑↑</annotation>
-		<annotation cp="‐">↑↑↑</annotation>
-		<annotation cp="‐" type="tts">↑↑↑</annotation>
-		<annotation cp="–">↑↑↑</annotation>
-		<annotation cp="–" type="tts">↑↑↑</annotation>
-		<annotation cp="—">↑↑↑</annotation>
-		<annotation cp="—" type="tts">↑↑↑</annotation>
-		<annotation cp="―">↑↑↑</annotation>
-		<annotation cp="―" type="tts">↑↑↑</annotation>
-		<annotation cp="・">↑↑↑</annotation>
-		<annotation cp="・" type="tts">↑↑↑</annotation>
-		<annotation cp=",">↑↑↑</annotation>
-		<annotation cp="," type="tts">↑↑↑</annotation>
+		<annotation cp="{">brace | bracket | curly brace | curly bracket | gullwing | left curly bracket | open curly bracket</annotation>
+		<annotation cp="🏻">light skin tone | skin tone</annotation>
+		<annotation cp="🏼">medium-light skin tone | skin tone</annotation>
+		<annotation cp="🏽">medium skin tone | skin tone</annotation>
+		<annotation cp="🏾">medium-dark skin tone | skin tone</annotation>
+		<annotation cp="🏿">dark skin tone | skin tone</annotation>
 		<annotation cp="،">Arabic | comma</annotation>
 		<annotation cp="،" type="tts">Arabic comma</annotation>
-		<annotation cp="、">↑↑↑</annotation>
-		<annotation cp="、" type="tts">↑↑↑</annotation>
-		<annotation cp=";">↑↑↑</annotation>
-		<annotation cp=";" type="tts">↑↑↑</annotation>
 		<annotation cp="؛">Arabic | Arabic semicolon | semi-colon</annotation>
 		<annotation cp="؛" type="tts">Arabic semicolon</annotation>
-		<annotation cp=":">↑↑↑</annotation>
-		<annotation cp=":" type="tts">↑↑↑</annotation>
-		<annotation cp="!">↑↑↑</annotation>
-		<annotation cp="!" type="tts">↑↑↑</annotation>
-		<annotation cp="¡">↑↑↑</annotation>
-		<annotation cp="¡" type="tts">↑↑↑</annotation>
-		<annotation cp="?">↑↑↑</annotation>
-		<annotation cp="?" type="tts">↑↑↑</annotation>
-		<annotation cp="¿">↑↑↑</annotation>
-		<annotation cp="¿" type="tts">↑↑↑</annotation>
 		<annotation cp="؟">Arabic | Arabic question mark | question | question mark</annotation>
 		<annotation cp="؟" type="tts">Arabic question mark</annotation>
-		<annotation cp="‽">↑↑↑</annotation>
-		<annotation cp="‽" type="tts">↑↑↑</annotation>
-		<annotation cp=".">↑↑↑</annotation>
-		<annotation cp="." type="tts">↑↑↑</annotation>
-		<annotation cp="…">↑↑↑</annotation>
-		<annotation cp="…" type="tts">↑↑↑</annotation>
-		<annotation cp="。">↑↑↑</annotation>
-		<annotation cp="。" type="tts">↑↑↑</annotation>
-		<annotation cp="·">↑↑↑</annotation>
-		<annotation cp="·" type="tts">↑↑↑</annotation>
-		<annotation cp="'">↑↑↑</annotation>
-		<annotation cp="'" type="tts">↑↑↑</annotation>
-		<annotation cp="‘">↑↑↑</annotation>
-		<annotation cp="‘" type="tts">↑↑↑</annotation>
-		<annotation cp="’">↑↑↑</annotation>
-		<annotation cp="’" type="tts">↑↑↑</annotation>
-		<annotation cp="‚">↑↑↑</annotation>
-		<annotation cp="‚" type="tts">↑↑↑</annotation>
-		<annotation cp="“">↑↑↑</annotation>
-		<annotation cp="“" type="tts">↑↑↑</annotation>
-		<annotation cp="”">↑↑↑</annotation>
-		<annotation cp="”" type="tts">↑↑↑</annotation>
-		<annotation cp="„">↑↑↑</annotation>
-		<annotation cp="„" type="tts">↑↑↑</annotation>
-		<annotation cp="«">↑↑↑</annotation>
-		<annotation cp="«" type="tts">↑↑↑</annotation>
-		<annotation cp="»">↑↑↑</annotation>
-		<annotation cp="»" type="tts">↑↑↑</annotation>
-		<annotation cp=")">↑↑↑</annotation>
-		<annotation cp=")" type="tts">↑↑↑</annotation>
-		<annotation cp="[">↑↑↑</annotation>
-		<annotation cp="[" type="tts">↑↑↑</annotation>
-		<annotation cp="]">↑↑↑</annotation>
-		<annotation cp="]" type="tts">↑↑↑</annotation>
-		<annotation cp="}">↑↑↑</annotation>
-		<annotation cp="}" type="tts">↑↑↑</annotation>
-		<annotation cp="〈">↑↑↑</annotation>
-		<annotation cp="〈" type="tts">↑↑↑</annotation>
-		<annotation cp="〉">↑↑↑</annotation>
-		<annotation cp="〉" type="tts">↑↑↑</annotation>
-		<annotation cp="《">↑↑↑</annotation>
-		<annotation cp="《" type="tts">↑↑↑</annotation>
-		<annotation cp="》">↑↑↑</annotation>
-		<annotation cp="》" type="tts">↑↑↑</annotation>
-		<annotation cp="「">↑↑↑</annotation>
-		<annotation cp="「" type="tts">↑↑↑</annotation>
-		<annotation cp="」">↑↑↑</annotation>
-		<annotation cp="」" type="tts">↑↑↑</annotation>
-		<annotation cp="『">↑↑↑</annotation>
-		<annotation cp="『" type="tts">↑↑↑</annotation>
-		<annotation cp="』">↑↑↑</annotation>
-		<annotation cp="』" type="tts">↑↑↑</annotation>
-		<annotation cp="【">↑↑↑</annotation>
-		<annotation cp="【" type="tts">↑↑↑</annotation>
-		<annotation cp="】">↑↑↑</annotation>
-		<annotation cp="】" type="tts">↑↑↑</annotation>
-		<annotation cp="〔">↑↑↑</annotation>
-		<annotation cp="〔" type="tts">↑↑↑</annotation>
-		<annotation cp="〕">↑↑↑</annotation>
-		<annotation cp="〕" type="tts">↑↑↑</annotation>
-		<annotation cp="〖">↑↑↑</annotation>
-		<annotation cp="〖" type="tts">↑↑↑</annotation>
-		<annotation cp="〗">↑↑↑</annotation>
-		<annotation cp="〗" type="tts">↑↑↑</annotation>
-		<annotation cp="§">↑↑↑</annotation>
-		<annotation cp="§" type="tts">↑↑↑</annotation>
-		<annotation cp="¶">↑↑↑</annotation>
-		<annotation cp="¶" type="tts">↑↑↑</annotation>
+		<annotation cp="‘">apostrophe | curly quote | left apostrophe | quote | single quote | smart quote</annotation>
+		<annotation cp="’">apostrophe | curly quote | quote | right apostrophe | single quote | smart quote</annotation>
+		<annotation cp="“">curly quotes | double quote | left quotation mark | quotation | quote | smart quotation</annotation>
+		<annotation cp="”">curly quotes | double quote | quotation | quote | right quotation mark | smart quotation</annotation>
+		<annotation cp=")">bracket | close parenthesis | parens | parenthesis | round bracket</annotation>
+		<annotation cp="[">bracket | crotchet | left square bracket | open square bracket | square bracket</annotation>
+		<annotation cp="]">bracket | close square bracket | crotchet | right square bracket | square bracket</annotation>
+		<annotation cp="}">brace | bracket | close curly bracket | curly brace | curly bracket | gullwing | right curly bracket</annotation>
+		<annotation cp="〈">angle bracket | bracket | chevron | diamond brackets | left angle bracket | pointy bracket | tuple</annotation>
+		<annotation cp="〉">angle bracket | bracket | chevron | diamond brackets | pointy bracket | right angle bracket | tuple</annotation>
+		<annotation cp="《">bracket | double angle bracket | left double angle bracket</annotation>
+		<annotation cp="》">bracket | double angle bracket | right double angle bracket</annotation>
+		<annotation cp="「">bracket | corner bracket | left corner bracket</annotation>
+		<annotation cp="」">bracket | corner bracket | right corner bracket</annotation>
+		<annotation cp="『">bracket | hollow corner bracket | left hollow corner bracket</annotation>
+		<annotation cp="』">bracket | hollow corner bracket | right hollow corner bracket</annotation>
+		<annotation cp="【">bracket | left black lenticular bracket | lens bracket | lenticular bracket</annotation>
+		<annotation cp="】">bracket | lens bracket | lenticular bracket | right black lenticular bracket</annotation>
+		<annotation cp="〔">bracket | left tortoise shell bracket | open tortoise shell bracket | shell bracket | tortoise shell bracket</annotation>
+		<annotation cp="〕">bracket | close tortoise shell bracket | right tortoise shell bracket | shell bracket | tortoise shell bracket</annotation>
+		<annotation cp="〖">bracket | hollow lens bracket | hollow lenticular bracket | left hollow lenticular bracket</annotation>
+		<annotation cp="〗">bracket | hollow lens bracket | hollow lenticular bracket | right hollow lenticular bracket</annotation>
 		<annotation cp="@">ampersat | arobase | arroba | at mark | at-sign | commercial at | email | strudel</annotation>
 		<annotation cp="@" type="tts">at sign</annotation>
-		<annotation cp="*">↑↑↑</annotation>
-		<annotation cp="*" type="tts">↑↑↑</annotation>
-		<annotation cp="/">↑↑↑</annotation>
-		<annotation cp="/" type="tts">↑↑↑</annotation>
-		<annotation cp="\">↑↑↑</annotation>
-		<annotation cp="\" type="tts">↑↑↑</annotation>
-		<annotation cp="&amp;">↑↑↑</annotation>
-		<annotation cp="&amp;" type="tts">↑↑↑</annotation>
-		<annotation cp="#">↑↑↑</annotation>
-		<annotation cp="#" type="tts">↑↑↑</annotation>
 		<annotation cp="%">per cent | per-cent | percent | percentage</annotation>
-		<annotation cp="%" type="tts">↑↑↑</annotation>
-		<annotation cp="‰">↑↑↑</annotation>
-		<annotation cp="‰" type="tts">↑↑↑</annotation>
-		<annotation cp="†">↑↑↑</annotation>
-		<annotation cp="†" type="tts">↑↑↑</annotation>
-		<annotation cp="‡">↑↑↑</annotation>
-		<annotation cp="‡" type="tts">↑↑↑</annotation>
-		<annotation cp="•">↑↑↑</annotation>
-		<annotation cp="•" type="tts">↑↑↑</annotation>
-		<annotation cp="‧">↑↑↑</annotation>
-		<annotation cp="‧" type="tts">↑↑↑</annotation>
-		<annotation cp="′">↑↑↑</annotation>
-		<annotation cp="′" type="tts">↑↑↑</annotation>
-		<annotation cp="″">↑↑↑</annotation>
-		<annotation cp="″" type="tts">↑↑↑</annotation>
-		<annotation cp="‴">↑↑↑</annotation>
-		<annotation cp="‴" type="tts">↑↑↑</annotation>
-		<annotation cp="‸">↑↑↑</annotation>
-		<annotation cp="‸" type="tts">↑↑↑</annotation>
-		<annotation cp="※">↑↑↑</annotation>
-		<annotation cp="※" type="tts">↑↑↑</annotation>
-		<annotation cp="⁂">↑↑↑</annotation>
-		<annotation cp="⁂" type="tts">↑↑↑</annotation>
-		<annotation cp="`">↑↑↑</annotation>
-		<annotation cp="`" type="tts">↑↑↑</annotation>
-		<annotation cp="´">↑↑↑</annotation>
-		<annotation cp="´" type="tts">↑↑↑</annotation>
-		<annotation cp="^">↑↑↑</annotation>
-		<annotation cp="^" type="tts">↑↑↑</annotation>
-		<annotation cp="¨">↑↑↑</annotation>
-		<annotation cp="¨" type="tts">↑↑↑</annotation>
-		<annotation cp="°">↑↑↑</annotation>
-		<annotation cp="°" type="tts">↑↑↑</annotation>
-		<annotation cp="℗">↑↑↑</annotation>
-		<annotation cp="℗" type="tts">↑↑↑</annotation>
-		<annotation cp="←">↑↑↑</annotation>
-		<annotation cp="←" type="tts">↑↑↑</annotation>
-		<annotation cp="↚">↑↑↑</annotation>
-		<annotation cp="↚" type="tts">↑↑↑</annotation>
-		<annotation cp="→">↑↑↑</annotation>
-		<annotation cp="→" type="tts">↑↑↑</annotation>
-		<annotation cp="↛">↑↑↑</annotation>
-		<annotation cp="↛" type="tts">↑↑↑</annotation>
-		<annotation cp="↑">↑↑↑</annotation>
-		<annotation cp="↑" type="tts">↑↑↑</annotation>
-		<annotation cp="↓">↑↑↑</annotation>
-		<annotation cp="↓" type="tts">↑↑↑</annotation>
-		<annotation cp="↜">↑↑↑</annotation>
-		<annotation cp="↜" type="tts">↑↑↑</annotation>
-		<annotation cp="↝">↑↑↑</annotation>
-		<annotation cp="↝" type="tts">↑↑↑</annotation>
-		<annotation cp="↞">↑↑↑</annotation>
-		<annotation cp="↞" type="tts">↑↑↑</annotation>
-		<annotation cp="↟">↑↑↑</annotation>
-		<annotation cp="↟" type="tts">↑↑↑</annotation>
-		<annotation cp="↠">↑↑↑</annotation>
-		<annotation cp="↠" type="tts">↑↑↑</annotation>
-		<annotation cp="↡">↑↑↑</annotation>
-		<annotation cp="↡" type="tts">↑↑↑</annotation>
-		<annotation cp="↢">↑↑↑</annotation>
-		<annotation cp="↢" type="tts">↑↑↑</annotation>
-		<annotation cp="↣">↑↑↑</annotation>
-		<annotation cp="↣" type="tts">↑↑↑</annotation>
-		<annotation cp="↤">↑↑↑</annotation>
-		<annotation cp="↤" type="tts">↑↑↑</annotation>
-		<annotation cp="↥">↑↑↑</annotation>
-		<annotation cp="↥" type="tts">↑↑↑</annotation>
-		<annotation cp="↦">↑↑↑</annotation>
-		<annotation cp="↦" type="tts">↑↑↑</annotation>
-		<annotation cp="↧">↑↑↑</annotation>
-		<annotation cp="↧" type="tts">↑↑↑</annotation>
-		<annotation cp="↨">↑↑↑</annotation>
-		<annotation cp="↨" type="tts">↑↑↑</annotation>
-		<annotation cp="↫">↑↑↑</annotation>
-		<annotation cp="↫" type="tts">↑↑↑</annotation>
-		<annotation cp="↬">↑↑↑</annotation>
-		<annotation cp="↬" type="tts">↑↑↑</annotation>
-		<annotation cp="↭">↑↑↑</annotation>
-		<annotation cp="↭" type="tts">↑↑↑</annotation>
-		<annotation cp="↯">↑↑↑</annotation>
-		<annotation cp="↯" type="tts">↑↑↑</annotation>
-		<annotation cp="↰">↑↑↑</annotation>
-		<annotation cp="↰" type="tts">↑↑↑</annotation>
-		<annotation cp="↱">↑↑↑</annotation>
-		<annotation cp="↱" type="tts">↑↑↑</annotation>
-		<annotation cp="↲">↑↑↑</annotation>
-		<annotation cp="↲" type="tts">↑↑↑</annotation>
-		<annotation cp="↳">↑↑↑</annotation>
-		<annotation cp="↳" type="tts">↑↑↑</annotation>
-		<annotation cp="↴">↑↑↑</annotation>
-		<annotation cp="↴" type="tts">↑↑↑</annotation>
-		<annotation cp="↵">↑↑↑</annotation>
-		<annotation cp="↵" type="tts">↑↑↑</annotation>
-		<annotation cp="↶">↑↑↑</annotation>
-		<annotation cp="↶" type="tts">↑↑↑</annotation>
-		<annotation cp="↷">↑↑↑</annotation>
-		<annotation cp="↷" type="tts">↑↑↑</annotation>
-		<annotation cp="↸">↑↑↑</annotation>
-		<annotation cp="↸" type="tts">↑↑↑</annotation>
-		<annotation cp="↹">↑↑↑</annotation>
-		<annotation cp="↹" type="tts">↑↑↑</annotation>
-		<annotation cp="↺">↑↑↑</annotation>
-		<annotation cp="↺" type="tts">↑↑↑</annotation>
-		<annotation cp="↻">↑↑↑</annotation>
-		<annotation cp="↻" type="tts">↑↑↑</annotation>
-		<annotation cp="↼">↑↑↑</annotation>
-		<annotation cp="↼" type="tts">↑↑↑</annotation>
-		<annotation cp="↽">↑↑↑</annotation>
-		<annotation cp="↽" type="tts">↑↑↑</annotation>
-		<annotation cp="↾">↑↑↑</annotation>
-		<annotation cp="↾" type="tts">↑↑↑</annotation>
-		<annotation cp="↿">↑↑↑</annotation>
-		<annotation cp="↿" type="tts">↑↑↑</annotation>
-		<annotation cp="⇀">↑↑↑</annotation>
-		<annotation cp="⇀" type="tts">↑↑↑</annotation>
-		<annotation cp="⇁">↑↑↑</annotation>
-		<annotation cp="⇁" type="tts">↑↑↑</annotation>
-		<annotation cp="⇂">↑↑↑</annotation>
-		<annotation cp="⇂" type="tts">↑↑↑</annotation>
-		<annotation cp="⇃">↑↑↑</annotation>
-		<annotation cp="⇃" type="tts">↑↑↑</annotation>
-		<annotation cp="⇄">↑↑↑</annotation>
-		<annotation cp="⇄" type="tts">↑↑↑</annotation>
-		<annotation cp="⇅">↑↑↑</annotation>
-		<annotation cp="⇅" type="tts">↑↑↑</annotation>
-		<annotation cp="⇆">↑↑↑</annotation>
-		<annotation cp="⇆" type="tts">↑↑↑</annotation>
-		<annotation cp="⇇">↑↑↑</annotation>
-		<annotation cp="⇇" type="tts">↑↑↑</annotation>
-		<annotation cp="⇈">↑↑↑</annotation>
-		<annotation cp="⇈" type="tts">↑↑↑</annotation>
-		<annotation cp="⇉">↑↑↑</annotation>
-		<annotation cp="⇉" type="tts">↑↑↑</annotation>
-		<annotation cp="⇊">↑↑↑</annotation>
-		<annotation cp="⇊" type="tts">↑↑↑</annotation>
-		<annotation cp="⇋">↑↑↑</annotation>
-		<annotation cp="⇋" type="tts">↑↑↑</annotation>
-		<annotation cp="⇌">↑↑↑</annotation>
-		<annotation cp="⇌" type="tts">↑↑↑</annotation>
-		<annotation cp="⇐">↑↑↑</annotation>
-		<annotation cp="⇐" type="tts">↑↑↑</annotation>
-		<annotation cp="⇍">↑↑↑</annotation>
-		<annotation cp="⇍" type="tts">↑↑↑</annotation>
-		<annotation cp="⇑">↑↑↑</annotation>
-		<annotation cp="⇑" type="tts">↑↑↑</annotation>
-		<annotation cp="⇒">↑↑↑</annotation>
-		<annotation cp="⇒" type="tts">↑↑↑</annotation>
-		<annotation cp="⇏">↑↑↑</annotation>
-		<annotation cp="⇏" type="tts">↑↑↑</annotation>
-		<annotation cp="⇓">↑↑↑</annotation>
-		<annotation cp="⇓" type="tts">↑↑↑</annotation>
-		<annotation cp="⇔">↑↑↑</annotation>
-		<annotation cp="⇔" type="tts">↑↑↑</annotation>
-		<annotation cp="⇎">↑↑↑</annotation>
-		<annotation cp="⇎" type="tts">↑↑↑</annotation>
-		<annotation cp="⇖">↑↑↑</annotation>
-		<annotation cp="⇖" type="tts">↑↑↑</annotation>
-		<annotation cp="⇗">↑↑↑</annotation>
-		<annotation cp="⇗" type="tts">↑↑↑</annotation>
-		<annotation cp="⇘">↑↑↑</annotation>
-		<annotation cp="⇘" type="tts">↑↑↑</annotation>
-		<annotation cp="⇙">↑↑↑</annotation>
-		<annotation cp="⇙" type="tts">↑↑↑</annotation>
-		<annotation cp="⇚">↑↑↑</annotation>
-		<annotation cp="⇚" type="tts">↑↑↑</annotation>
-		<annotation cp="⇛">↑↑↑</annotation>
-		<annotation cp="⇛" type="tts">↑↑↑</annotation>
-		<annotation cp="⇜">↑↑↑</annotation>
-		<annotation cp="⇜" type="tts">↑↑↑</annotation>
-		<annotation cp="⇝">↑↑↑</annotation>
-		<annotation cp="⇝" type="tts">↑↑↑</annotation>
-		<annotation cp="⇞">↑↑↑</annotation>
-		<annotation cp="⇞" type="tts">↑↑↑</annotation>
-		<annotation cp="⇟">↑↑↑</annotation>
-		<annotation cp="⇟" type="tts">↑↑↑</annotation>
-		<annotation cp="⇠">↑↑↑</annotation>
-		<annotation cp="⇠" type="tts">↑↑↑</annotation>
-		<annotation cp="⇡">↑↑↑</annotation>
-		<annotation cp="⇡" type="tts">↑↑↑</annotation>
-		<annotation cp="⇢">↑↑↑</annotation>
-		<annotation cp="⇢" type="tts">↑↑↑</annotation>
-		<annotation cp="⇣">↑↑↑</annotation>
-		<annotation cp="⇣" type="tts">↑↑↑</annotation>
-		<annotation cp="⇤">↑↑↑</annotation>
-		<annotation cp="⇤" type="tts">↑↑↑</annotation>
-		<annotation cp="⇥">↑↑↑</annotation>
-		<annotation cp="⇥" type="tts">↑↑↑</annotation>
-		<annotation cp="⇦">↑↑↑</annotation>
-		<annotation cp="⇦" type="tts">↑↑↑</annotation>
-		<annotation cp="⇧">↑↑↑</annotation>
-		<annotation cp="⇧" type="tts">↑↑↑</annotation>
-		<annotation cp="⇨">↑↑↑</annotation>
-		<annotation cp="⇨" type="tts">↑↑↑</annotation>
-		<annotation cp="⇩">↑↑↑</annotation>
-		<annotation cp="⇩" type="tts">↑↑↑</annotation>
-		<annotation cp="⇪">↑↑↑</annotation>
-		<annotation cp="⇪" type="tts">↑↑↑</annotation>
-		<annotation cp="⇵">↑↑↑</annotation>
-		<annotation cp="⇵" type="tts">↑↑↑</annotation>
-		<annotation cp="∀">↑↑↑</annotation>
-		<annotation cp="∀" type="tts">↑↑↑</annotation>
-		<annotation cp="∂">↑↑↑</annotation>
-		<annotation cp="∂" type="tts">↑↑↑</annotation>
-		<annotation cp="∃">↑↑↑</annotation>
-		<annotation cp="∃" type="tts">↑↑↑</annotation>
-		<annotation cp="∅">↑↑↑</annotation>
-		<annotation cp="∅" type="tts">↑↑↑</annotation>
-		<annotation cp="∆">↑↑↑</annotation>
-		<annotation cp="∆" type="tts">↑↑↑</annotation>
-		<annotation cp="∇">↑↑↑</annotation>
-		<annotation cp="∇" type="tts">↑↑↑</annotation>
-		<annotation cp="∈">↑↑↑</annotation>
-		<annotation cp="∈" type="tts">↑↑↑</annotation>
-		<annotation cp="∉">↑↑↑</annotation>
-		<annotation cp="∉" type="tts">↑↑↑</annotation>
-		<annotation cp="∋">↑↑↑</annotation>
-		<annotation cp="∋" type="tts">↑↑↑</annotation>
-		<annotation cp="∎">↑↑↑</annotation>
-		<annotation cp="∎" type="tts">↑↑↑</annotation>
-		<annotation cp="∏">↑↑↑</annotation>
-		<annotation cp="∏" type="tts">↑↑↑</annotation>
-		<annotation cp="∑">↑↑↑</annotation>
-		<annotation cp="∑" type="tts">↑↑↑</annotation>
-		<annotation cp="+">↑↑↑</annotation>
-		<annotation cp="+" type="tts">↑↑↑</annotation>
-		<annotation cp="±">↑↑↑</annotation>
-		<annotation cp="±" type="tts">↑↑↑</annotation>
-		<annotation cp="÷">↑↑↑</annotation>
-		<annotation cp="÷" type="tts">↑↑↑</annotation>
-		<annotation cp="×">↑↑↑</annotation>
-		<annotation cp="×" type="tts">↑↑↑</annotation>
-		<annotation cp="&lt;">↑↑↑</annotation>
+		<annotation cp="↹">leftwards arrow to bar over rightwards arrow to bar</annotation>
+		<annotation cp="∂">differential | partial derivative | partial differential</annotation>
+		<annotation cp="∃">existential | mathematics | quantifier | there exists</annotation>
+		<annotation cp="∅">empty set | mathematics | null set | null sign | set operator</annotation>
+		<annotation cp="∉">element | not an element | set</annotation>
+		<annotation cp="∉" type="tts">not an element of</annotation>
+		<annotation cp="∎" type="tts">end of proof</annotation>
+		<annotation cp="∑">mathematics | n-ary summation | sigma | summation</annotation>
 		<annotation cp="&lt;" type="tts">less than</annotation>
-		<annotation cp="≮">↑↑↑</annotation>
-		<annotation cp="≮" type="tts">↑↑↑</annotation>
-		<annotation cp="=">↑↑↑</annotation>
-		<annotation cp="=" type="tts">↑↑↑</annotation>
-		<annotation cp="≠">↑↑↑</annotation>
-		<annotation cp="≠" type="tts">↑↑↑</annotation>
 		<annotation cp="&gt;">close tag | greater than | greater-than sign | tag</annotation>
 		<annotation cp="&gt;" type="tts">greater than</annotation>
-		<annotation cp="≯">↑↑↑</annotation>
-		<annotation cp="≯" type="tts">↑↑↑</annotation>
-		<annotation cp="¬">↑↑↑</annotation>
-		<annotation cp="¬" type="tts">↑↑↑</annotation>
-		<annotation cp="|">↑↑↑</annotation>
-		<annotation cp="|" type="tts">↑↑↑</annotation>
-		<annotation cp="~">↑↑↑</annotation>
-		<annotation cp="~" type="tts">↑↑↑</annotation>
-		<annotation cp="−">↑↑↑</annotation>
-		<annotation cp="−" type="tts">↑↑↑</annotation>
-		<annotation cp="⁻">↑↑↑</annotation>
-		<annotation cp="⁻" type="tts">↑↑↑</annotation>
-		<annotation cp="∓">↑↑↑</annotation>
-		<annotation cp="∓" type="tts">↑↑↑</annotation>
-		<annotation cp="∕">↑↑↑</annotation>
-		<annotation cp="∕" type="tts">↑↑↑</annotation>
-		<annotation cp="⁄">↑↑↑</annotation>
-		<annotation cp="⁄" type="tts">↑↑↑</annotation>
-		<annotation cp="∗">↑↑↑</annotation>
-		<annotation cp="∗" type="tts">↑↑↑</annotation>
-		<annotation cp="∘">↑↑↑</annotation>
-		<annotation cp="∘" type="tts">↑↑↑</annotation>
-		<annotation cp="∙">↑↑↑</annotation>
-		<annotation cp="∙" type="tts">↑↑↑</annotation>
-		<annotation cp="√">↑↑↑</annotation>
-		<annotation cp="√" type="tts">↑↑↑</annotation>
-		<annotation cp="∝">↑↑↑</annotation>
-		<annotation cp="∝" type="tts">↑↑↑</annotation>
-		<annotation cp="∞">↑↑↑</annotation>
-		<annotation cp="∞" type="tts">↑↑↑</annotation>
-		<annotation cp="∟">↑↑↑</annotation>
-		<annotation cp="∟" type="tts">↑↑↑</annotation>
-		<annotation cp="∠">↑↑↑</annotation>
-		<annotation cp="∠" type="tts">↑↑↑</annotation>
-		<annotation cp="∣">↑↑↑</annotation>
-		<annotation cp="∣" type="tts">↑↑↑</annotation>
-		<annotation cp="∥">↑↑↑</annotation>
-		<annotation cp="∥" type="tts">↑↑↑</annotation>
-		<annotation cp="∧">↑↑↑</annotation>
-		<annotation cp="∧" type="tts">↑↑↑</annotation>
-		<annotation cp="∩">↑↑↑</annotation>
-		<annotation cp="∩" type="tts">↑↑↑</annotation>
-		<annotation cp="∪">↑↑↑</annotation>
-		<annotation cp="∪" type="tts">↑↑↑</annotation>
-		<annotation cp="∫">↑↑↑</annotation>
-		<annotation cp="∫" type="tts">↑↑↑</annotation>
-		<annotation cp="∬">↑↑↑</annotation>
-		<annotation cp="∬" type="tts">↑↑↑</annotation>
-		<annotation cp="∮">↑↑↑</annotation>
-		<annotation cp="∮" type="tts">↑↑↑</annotation>
-		<annotation cp="∴">↑↑↑</annotation>
-		<annotation cp="∴" type="tts">↑↑↑</annotation>
-		<annotation cp="∵">↑↑↑</annotation>
-		<annotation cp="∵" type="tts">↑↑↑</annotation>
-		<annotation cp="∶">↑↑↑</annotation>
-		<annotation cp="∶" type="tts">↑↑↑</annotation>
-		<annotation cp="∷">↑↑↑</annotation>
-		<annotation cp="∷" type="tts">↑↑↑</annotation>
-		<annotation cp="∼">↑↑↑</annotation>
-		<annotation cp="∼" type="tts">↑↑↑</annotation>
-		<annotation cp="∽">↑↑↑</annotation>
-		<annotation cp="∽" type="tts">↑↑↑</annotation>
-		<annotation cp="∾">↑↑↑</annotation>
-		<annotation cp="∾" type="tts">↑↑↑</annotation>
-		<annotation cp="≃">↑↑↑</annotation>
-		<annotation cp="≃" type="tts">↑↑↑</annotation>
-		<annotation cp="≅">↑↑↑</annotation>
-		<annotation cp="≅" type="tts">↑↑↑</annotation>
+		<annotation cp="|">bar | line | pipe | sheffer stroke | vertical bar | vertical line</annotation>
+		<annotation cp="∓">minus-or-plus | minus-plus</annotation>
+		<annotation cp="∝" type="tts">is proportional</annotation>
+		<annotation cp="∣">divides | divisor | vertical bar</annotation>
+		<annotation cp="∥" type="tts">parallel to</annotation>
+		<annotation cp="∮">complex analysis | contour integral</annotation>
+		<annotation cp="≃" type="tts">asymptotically equal to</annotation>
+		<annotation cp="≅" type="tts">approximately equal to</annotation>
 		<annotation cp="≈">about | almost equal | approximate | approximation | around</annotation>
-		<annotation cp="≈" type="tts">↑↑↑</annotation>
-		<annotation cp="≌">↑↑↑</annotation>
-		<annotation cp="≌" type="tts">↑↑↑</annotation>
-		<annotation cp="≒">↑↑↑</annotation>
-		<annotation cp="≒" type="tts">↑↑↑</annotation>
-		<annotation cp="≖">↑↑↑</annotation>
-		<annotation cp="≖" type="tts">↑↑↑</annotation>
-		<annotation cp="≡">↑↑↑</annotation>
-		<annotation cp="≡" type="tts">↑↑↑</annotation>
-		<annotation cp="≣">↑↑↑</annotation>
-		<annotation cp="≣" type="tts">↑↑↑</annotation>
+		<annotation cp="≌" type="tts">all equal to</annotation>
+		<annotation cp="≣" type="tts">strictly equivalent to</annotation>
 		<annotation cp="≤">equal | equals | inequality | less than or equal to | less-than</annotation>
 		<annotation cp="≤" type="tts">less than or equal to</annotation>
 		<annotation cp="≥">equal | equals | greater than or equal to | greater-than | inequality</annotation>
 		<annotation cp="≥" type="tts">greater than or equal to</annotation>
-		<annotation cp="≦">↑↑↑</annotation>
-		<annotation cp="≦" type="tts">↑↑↑</annotation>
-		<annotation cp="≧">↑↑↑</annotation>
-		<annotation cp="≧" type="tts">↑↑↑</annotation>
-		<annotation cp="≪">↑↑↑</annotation>
-		<annotation cp="≪" type="tts">↑↑↑</annotation>
-		<annotation cp="≫">↑↑↑</annotation>
-		<annotation cp="≫" type="tts">↑↑↑</annotation>
-		<annotation cp="≬">↑↑↑</annotation>
-		<annotation cp="≬" type="tts">↑↑↑</annotation>
-		<annotation cp="≳">↑↑↑</annotation>
-		<annotation cp="≳" type="tts">↑↑↑</annotation>
-		<annotation cp="≺">↑↑↑</annotation>
-		<annotation cp="≺" type="tts">↑↑↑</annotation>
-		<annotation cp="≻">↑↑↑</annotation>
-		<annotation cp="≻" type="tts">↑↑↑</annotation>
-		<annotation cp="⊁">↑↑↑</annotation>
-		<annotation cp="⊁" type="tts">↑↑↑</annotation>
-		<annotation cp="⊂">↑↑↑</annotation>
-		<annotation cp="⊂" type="tts">↑↑↑</annotation>
-		<annotation cp="⊃">↑↑↑</annotation>
-		<annotation cp="⊃" type="tts">↑↑↑</annotation>
-		<annotation cp="⊆">↑↑↑</annotation>
-		<annotation cp="⊆" type="tts">↑↑↑</annotation>
-		<annotation cp="⊇">↑↑↑</annotation>
-		<annotation cp="⊇" type="tts">↑↑↑</annotation>
-		<annotation cp="⊕">↑↑↑</annotation>
-		<annotation cp="⊕" type="tts">↑↑↑</annotation>
-		<annotation cp="⊖">↑↑↑</annotation>
-		<annotation cp="⊖" type="tts">↑↑↑</annotation>
-		<annotation cp="⊗">↑↑↑</annotation>
-		<annotation cp="⊗" type="tts">↑↑↑</annotation>
-		<annotation cp="⊘">↑↑↑</annotation>
-		<annotation cp="⊘" type="tts">↑↑↑</annotation>
-		<annotation cp="⊙">↑↑↑</annotation>
-		<annotation cp="⊙" type="tts">↑↑↑</annotation>
-		<annotation cp="⊚">↑↑↑</annotation>
-		<annotation cp="⊚" type="tts">↑↑↑</annotation>
-		<annotation cp="⊛">↑↑↑</annotation>
-		<annotation cp="⊛" type="tts">↑↑↑</annotation>
-		<annotation cp="⊞">↑↑↑</annotation>
-		<annotation cp="⊞" type="tts">↑↑↑</annotation>
-		<annotation cp="⊟">↑↑↑</annotation>
-		<annotation cp="⊟" type="tts">↑↑↑</annotation>
-		<annotation cp="⊥">↑↑↑</annotation>
-		<annotation cp="⊥" type="tts">↑↑↑</annotation>
-		<annotation cp="⊮">↑↑↑</annotation>
-		<annotation cp="⊮" type="tts">↑↑↑</annotation>
-		<annotation cp="⊰">↑↑↑</annotation>
-		<annotation cp="⊰" type="tts">↑↑↑</annotation>
-		<annotation cp="⊱">↑↑↑</annotation>
-		<annotation cp="⊱" type="tts">↑↑↑</annotation>
-		<annotation cp="⋭">↑↑↑</annotation>
-		<annotation cp="⋭" type="tts">↑↑↑</annotation>
-		<annotation cp="⊶">↑↑↑</annotation>
-		<annotation cp="⊶" type="tts">↑↑↑</annotation>
-		<annotation cp="⊹">↑↑↑</annotation>
-		<annotation cp="⊹" type="tts">↑↑↑</annotation>
-		<annotation cp="⊿">↑↑↑</annotation>
-		<annotation cp="⊿" type="tts">↑↑↑</annotation>
-		<annotation cp="⋁">↑↑↑</annotation>
-		<annotation cp="⋁" type="tts">↑↑↑</annotation>
-		<annotation cp="⋂">↑↑↑</annotation>
-		<annotation cp="⋂" type="tts">↑↑↑</annotation>
-		<annotation cp="⋃">↑↑↑</annotation>
-		<annotation cp="⋃" type="tts">↑↑↑</annotation>
-		<annotation cp="⋅">↑↑↑</annotation>
-		<annotation cp="⋅" type="tts">↑↑↑</annotation>
-		<annotation cp="⋆">↑↑↑</annotation>
-		<annotation cp="⋆" type="tts">↑↑↑</annotation>
-		<annotation cp="⋈">↑↑↑</annotation>
-		<annotation cp="⋈" type="tts">↑↑↑</annotation>
-		<annotation cp="⋒">↑↑↑</annotation>
-		<annotation cp="⋒" type="tts">↑↑↑</annotation>
-		<annotation cp="⋘">↑↑↑</annotation>
-		<annotation cp="⋘" type="tts">↑↑↑</annotation>
-		<annotation cp="⋙">↑↑↑</annotation>
-		<annotation cp="⋙" type="tts">↑↑↑</annotation>
-		<annotation cp="⋮">↑↑↑</annotation>
-		<annotation cp="⋮" type="tts">↑↑↑</annotation>
-		<annotation cp="⋯">↑↑↑</annotation>
-		<annotation cp="⋯" type="tts">↑↑↑</annotation>
-		<annotation cp="⋰">↑↑↑</annotation>
-		<annotation cp="⋰" type="tts">↑↑↑</annotation>
-		<annotation cp="⋱">↑↑↑</annotation>
-		<annotation cp="⋱" type="tts">↑↑↑</annotation>
-		<annotation cp="■">↑↑↑</annotation>
-		<annotation cp="■" type="tts">↑↑↑</annotation>
-		<annotation cp="□">↑↑↑</annotation>
-		<annotation cp="□" type="tts">↑↑↑</annotation>
-		<annotation cp="▢">↑↑↑</annotation>
-		<annotation cp="▢" type="tts">↑↑↑</annotation>
-		<annotation cp="▣">↑↑↑</annotation>
-		<annotation cp="▣" type="tts">↑↑↑</annotation>
-		<annotation cp="▤">↑↑↑</annotation>
-		<annotation cp="▤" type="tts">↑↑↑</annotation>
-		<annotation cp="▥">↑↑↑</annotation>
-		<annotation cp="▥" type="tts">↑↑↑</annotation>
-		<annotation cp="▦">↑↑↑</annotation>
-		<annotation cp="▦" type="tts">↑↑↑</annotation>
-		<annotation cp="▧">↑↑↑</annotation>
-		<annotation cp="▧" type="tts">↑↑↑</annotation>
-		<annotation cp="▨">↑↑↑</annotation>
-		<annotation cp="▨" type="tts">↑↑↑</annotation>
-		<annotation cp="▩">↑↑↑</annotation>
-		<annotation cp="▩" type="tts">↑↑↑</annotation>
-		<annotation cp="▬">↑↑↑</annotation>
-		<annotation cp="▬" type="tts">↑↑↑</annotation>
-		<annotation cp="▭">↑↑↑</annotation>
-		<annotation cp="▭" type="tts">↑↑↑</annotation>
-		<annotation cp="▮">↑↑↑</annotation>
-		<annotation cp="▮" type="tts">↑↑↑</annotation>
-		<annotation cp="▰">↑↑↑</annotation>
-		<annotation cp="▰" type="tts">↑↑↑</annotation>
-		<annotation cp="▲">↑↑↑</annotation>
-		<annotation cp="▲" type="tts">↑↑↑</annotation>
-		<annotation cp="△">↑↑↑</annotation>
-		<annotation cp="△" type="tts">↑↑↑</annotation>
-		<annotation cp="▴">↑↑↑</annotation>
-		<annotation cp="▴" type="tts">↑↑↑</annotation>
-		<annotation cp="▵">↑↑↑</annotation>
-		<annotation cp="▵" type="tts">↑↑↑</annotation>
-		<annotation cp="▷">↑↑↑</annotation>
-		<annotation cp="▷" type="tts">↑↑↑</annotation>
-		<annotation cp="▸">↑↑↑</annotation>
-		<annotation cp="▸" type="tts">↑↑↑</annotation>
-		<annotation cp="▹">↑↑↑</annotation>
-		<annotation cp="▹" type="tts">↑↑↑</annotation>
-		<annotation cp="►">↑↑↑</annotation>
-		<annotation cp="►" type="tts">↑↑↑</annotation>
-		<annotation cp="▻">↑↑↑</annotation>
-		<annotation cp="▻" type="tts">↑↑↑</annotation>
-		<annotation cp="▼">↑↑↑</annotation>
-		<annotation cp="▼" type="tts">↑↑↑</annotation>
-		<annotation cp="▽">↑↑↑</annotation>
-		<annotation cp="▽" type="tts">↑↑↑</annotation>
-		<annotation cp="▾">↑↑↑</annotation>
-		<annotation cp="▾" type="tts">↑↑↑</annotation>
-		<annotation cp="▿">↑↑↑</annotation>
-		<annotation cp="▿" type="tts">↑↑↑</annotation>
-		<annotation cp="◁">↑↑↑</annotation>
-		<annotation cp="◁" type="tts">↑↑↑</annotation>
-		<annotation cp="◂">↑↑↑</annotation>
-		<annotation cp="◂" type="tts">↑↑↑</annotation>
-		<annotation cp="◃">↑↑↑</annotation>
-		<annotation cp="◃" type="tts">↑↑↑</annotation>
-		<annotation cp="◄">↑↑↑</annotation>
-		<annotation cp="◄" type="tts">↑↑↑</annotation>
-		<annotation cp="◅">↑↑↑</annotation>
-		<annotation cp="◅" type="tts">↑↑↑</annotation>
-		<annotation cp="◆">↑↑↑</annotation>
-		<annotation cp="◆" type="tts">↑↑↑</annotation>
-		<annotation cp="◇">↑↑↑</annotation>
-		<annotation cp="◇" type="tts">↑↑↑</annotation>
-		<annotation cp="◈">↑↑↑</annotation>
-		<annotation cp="◈" type="tts">↑↑↑</annotation>
-		<annotation cp="◉">↑↑↑</annotation>
-		<annotation cp="◉" type="tts">↑↑↑</annotation>
-		<annotation cp="◊">↑↑↑</annotation>
-		<annotation cp="◊" type="tts">↑↑↑</annotation>
-		<annotation cp="○">↑↑↑</annotation>
-		<annotation cp="○" type="tts">↑↑↑</annotation>
-		<annotation cp="◌">↑↑↑</annotation>
-		<annotation cp="◌" type="tts">↑↑↑</annotation>
-		<annotation cp="◍">↑↑↑</annotation>
-		<annotation cp="◍" type="tts">↑↑↑</annotation>
-		<annotation cp="◎">↑↑↑</annotation>
-		<annotation cp="◎" type="tts">↑↑↑</annotation>
-		<annotation cp="●">↑↑↑</annotation>
-		<annotation cp="●" type="tts">↑↑↑</annotation>
-		<annotation cp="◐">↑↑↑</annotation>
-		<annotation cp="◐" type="tts">↑↑↑</annotation>
-		<annotation cp="◑">↑↑↑</annotation>
-		<annotation cp="◑" type="tts">↑↑↑</annotation>
-		<annotation cp="◒">↑↑↑</annotation>
-		<annotation cp="◒" type="tts">↑↑↑</annotation>
-		<annotation cp="◓">↑↑↑</annotation>
-		<annotation cp="◓" type="tts">↑↑↑</annotation>
-		<annotation cp="◔">↑↑↑</annotation>
-		<annotation cp="◔" type="tts">↑↑↑</annotation>
-		<annotation cp="◕">↑↑↑</annotation>
-		<annotation cp="◕" type="tts">↑↑↑</annotation>
-		<annotation cp="◖">↑↑↑</annotation>
-		<annotation cp="◖" type="tts">↑↑↑</annotation>
-		<annotation cp="◗">↑↑↑</annotation>
-		<annotation cp="◗" type="tts">↑↑↑</annotation>
-		<annotation cp="◘">↑↑↑</annotation>
-		<annotation cp="◘" type="tts">↑↑↑</annotation>
-		<annotation cp="◙">↑↑↑</annotation>
-		<annotation cp="◙" type="tts">↑↑↑</annotation>
-		<annotation cp="◜">↑↑↑</annotation>
-		<annotation cp="◜" type="tts">↑↑↑</annotation>
-		<annotation cp="◝">↑↑↑</annotation>
-		<annotation cp="◝" type="tts">↑↑↑</annotation>
-		<annotation cp="◞">↑↑↑</annotation>
-		<annotation cp="◞" type="tts">↑↑↑</annotation>
-		<annotation cp="◟">↑↑↑</annotation>
-		<annotation cp="◟" type="tts">↑↑↑</annotation>
-		<annotation cp="◠">↑↑↑</annotation>
-		<annotation cp="◠" type="tts">↑↑↑</annotation>
-		<annotation cp="◡">↑↑↑</annotation>
-		<annotation cp="◡" type="tts">↑↑↑</annotation>
-		<annotation cp="◢">↑↑↑</annotation>
-		<annotation cp="◢" type="tts">↑↑↑</annotation>
-		<annotation cp="◣">↑↑↑</annotation>
-		<annotation cp="◣" type="tts">↑↑↑</annotation>
-		<annotation cp="◤">↑↑↑</annotation>
-		<annotation cp="◤" type="tts">↑↑↑</annotation>
-		<annotation cp="◥">↑↑↑</annotation>
-		<annotation cp="◥" type="tts">↑↑↑</annotation>
-		<annotation cp="◦">↑↑↑</annotation>
-		<annotation cp="◦" type="tts">↑↑↑</annotation>
-		<annotation cp="◯">↑↑↑</annotation>
-		<annotation cp="◯" type="tts">↑↑↑</annotation>
-		<annotation cp="◳">↑↑↑</annotation>
-		<annotation cp="◳" type="tts">↑↑↑</annotation>
-		<annotation cp="◷">↑↑↑</annotation>
-		<annotation cp="◷" type="tts">↑↑↑</annotation>
-		<annotation cp="◿">↑↑↑</annotation>
-		<annotation cp="◿" type="tts">↑↑↑</annotation>
-		<annotation cp="♪">↑↑↑</annotation>
-		<annotation cp="♪" type="tts">↑↑↑</annotation>
-		<annotation cp="⨧">↑↑↑</annotation>
-		<annotation cp="⨧" type="tts">↑↑↑</annotation>
-		<annotation cp="⨯">↑↑↑</annotation>
-		<annotation cp="⨯" type="tts">↑↑↑</annotation>
-		<annotation cp="⨼">↑↑↑</annotation>
-		<annotation cp="⨼" type="tts">↑↑↑</annotation>
-		<annotation cp="⩣">↑↑↑</annotation>
-		<annotation cp="⩣" type="tts">↑↑↑</annotation>
-		<annotation cp="⩽">↑↑↑</annotation>
-		<annotation cp="⩽" type="tts">↑↑↑</annotation>
-		<annotation cp="⪍">↑↑↑</annotation>
-		<annotation cp="⪍" type="tts">↑↑↑</annotation>
-		<annotation cp="⪚">↑↑↑</annotation>
-		<annotation cp="⪚" type="tts">↑↑↑</annotation>
-		<annotation cp="⪺">↑↑↑</annotation>
-		<annotation cp="⪺" type="tts">↑↑↑</annotation>
-		<annotation cp="♭">↑↑↑</annotation>
-		<annotation cp="♭" type="tts">↑↑↑</annotation>
-		<annotation cp="♯">↑↑↑</annotation>
-		<annotation cp="♯" type="tts">↑↑↑</annotation>
-		<annotation cp="🥹">↑↑↑</annotation>
-		<annotation cp="🥹" type="tts">↑↑↑</annotation>
-		<annotation cp="🧌">↑↑↑</annotation>
-		<annotation cp="🧌" type="tts">↑↑↑</annotation>
-		<annotation cp="🩻">↑↑↑</annotation>
-		<annotation cp="🩻" type="tts">↑↑↑</annotation>
-		<annotation cp="🩼">↑↑↑</annotation>
-		<annotation cp="🩼" type="tts">↑↑↑</annotation>
-		<annotation cp="🪩">↑↑↑</annotation>
-		<annotation cp="🪩" type="tts">↑↑↑</annotation>
+		<annotation cp="≳">equivalent | greater-than | inequality | mathematics</annotation>
+		<annotation cp="≳" type="tts">greater-than or equivalent to</annotation>
+		<annotation cp="≺">mathematics | ordered set | precedes | set operator</annotation>
+		<annotation cp="≻">follows | mathematics | ordered set | set operator | succeeds</annotation>
+		<annotation cp="⊁">does not succeed | mathematics | ordered set | set operator</annotation>
+		<annotation cp="⊃">mathematics | proper superset | set operator</annotation>
+		<annotation cp="⊃" type="tts">superset of</annotation>
+		<annotation cp="⊆">equal | mathematics | subset</annotation>
+		<annotation cp="⊆" type="tts">subset of or equal to</annotation>
+		<annotation cp="⊇">equal | mathematics | superset</annotation>
+		<annotation cp="⊇" type="tts">superset of or equal to</annotation>
+		<annotation cp="⊕">circled plus | direct sum | exclusive or | logic | mathematics</annotation>
+		<annotation cp="⊖">circled minus | erosion | mathematics | symmetric difference</annotation>
+		<annotation cp="⊗">circled times | Kronecker | product | tensor</annotation>
+		<annotation cp="⊙">circled dot operator | mathematics | vector | XNOR</annotation>
+		<annotation cp="⊛">circled asterisk operator</annotation>
+		<annotation cp="⊞">addition-like | free additive convolution | mathematics | squared plus</annotation>
+		<annotation cp="⊮">does not force | mathematics</annotation>
+		<annotation cp="⊰">mathematics | ordered set | precedes under relation | set operator</annotation>
+		<annotation cp="⊱">mathematics | ordered set | set operator | succeeds under relation</annotation>
+		<annotation cp="⋭" type="tts">does not contain as normal subgroup or equal</annotation>
+		<annotation cp="⊶" type="tts">original of</annotation>
+		<annotation cp="⋰">ellipsis | mathematics | upwards diagonal ellipsis</annotation>
+		<annotation cp="⋰" type="tts">upwards right diagonal ellipsis</annotation>
+		<annotation cp="⋱">downwards right diagonal ellipsis | ellipsis | mathematics</annotation>
+		<annotation cp="⋱" type="tts">downwards right diagonal ellipsis</annotation>
+		<annotation cp="■">black square | filled square</annotation>
+		<annotation cp="□">hollow square | white square</annotation>
+		<annotation cp="▢">hollow square with rounded corners | white square with rounded corners</annotation>
+		<annotation cp="▣">hollow square containing filled square | white square containing black small square</annotation>
+		<annotation cp="▦">square with orthogonal crosshatch fill</annotation>
+		<annotation cp="▦" type="tts">square with orthogonal crosshatch fill</annotation>
+		<annotation cp="▧">square with upper left to lower right fill</annotation>
+		<annotation cp="▧" type="tts">square with upper left to lower right fill</annotation>
+		<annotation cp="▨">square with upper right to lower left fill</annotation>
+		<annotation cp="▨" type="tts">square with upper right to lower left fill</annotation>
+		<annotation cp="▩">square with diagonal crosshatch fill</annotation>
+		<annotation cp="▩" type="tts">square with diagonal crosshatch fill</annotation>
+		<annotation cp="▬">black rectangle | filled rectangle</annotation>
+		<annotation cp="▭">hollow rectangle | white rectangle</annotation>
+		<annotation cp="▮">black vertical rectangle | filled vertical rectangle</annotation>
+		<annotation cp="▰">black parallelogram | filled parallelogram</annotation>
+		<annotation cp="▲">arrow | black up-pointing triangle | triangle | up</annotation>
+		<annotation cp="△">hollow up-pointing triangle | white up-pointing triangle</annotation>
+		<annotation cp="▴">black up-pointing small triangle | filled up-pointing small triangle</annotation>
+		<annotation cp="▵">hollow up-pointing small triangle | white up-pointing small triangle</annotation>
+		<annotation cp="▷">hollow right-pointing triangle | white right-pointing triangle</annotation>
+		<annotation cp="▸">black right-pointing triangle | filled right-pointing small triangle</annotation>
+		<annotation cp="▹">hollow right-pointing small triangle | white right-pointing small triangle</annotation>
+		<annotation cp="►">black right-pointing pointer | filled right-pointing pointer</annotation>
+		<annotation cp="▻">hollow right-pointing pointer | white right-pointing pointer</annotation>
+		<annotation cp="▼">arrow | black down-pointing triangle | down | triangle</annotation>
+		<annotation cp="▽">hollow down-pointing triangle | white down-pointing triangle</annotation>
+		<annotation cp="▾">black down-pointing small triangle | filled down-pointing small triangle</annotation>
+		<annotation cp="▿">hollow down-pointing small triangle | white down-pointing small triangle</annotation>
+		<annotation cp="◁">hollow left-pointing triangle | white left-pointing triangle</annotation>
+		<annotation cp="◂">black left-pointing small triangle | filled left-pointing small triangle</annotation>
+		<annotation cp="◃">hollow left-pointing small triangle | white left-pointing small triangle</annotation>
+		<annotation cp="◄">black left-pointing pointer | filled left-pointing pointer</annotation>
+		<annotation cp="◅">hollow left-pointing pointer | white left-pointing pointer</annotation>
+		<annotation cp="◆">black diamond | filled diamond</annotation>
+		<annotation cp="◇">hollow diamond | white diamond</annotation>
+		<annotation cp="◈">hollow diamond containing filled diamond | white diamond containing black small diamond</annotation>
+		<annotation cp="◉">circled dot | concentric circles filled | fisheye | hollow circle containing filled circle | white circle containing black small circle</annotation>
+		<annotation cp="○">circle | hollow circle | ring | white circle</annotation>
+		<annotation cp="●">black circle | circle | filled circle</annotation>
+		<annotation cp="◔">circle with upper-right quadrant filled</annotation>
+		<annotation cp="◔" type="tts">circle with upper-right quadrant filled</annotation>
+		<annotation cp="◕">circle with all but upper-left quadrant filled</annotation>
+		<annotation cp="◕" type="tts">circle with all but upper-left quadrant filled</annotation>
+		<annotation cp="◖">left half black circle | left half filled circle</annotation>
+		<annotation cp="◗">right half black circle | right half filled circle</annotation>
+		<annotation cp="◙">black square containing hollow circle | inverse hollow circle</annotation>
+		<annotation cp="◜">upper-left quadrant circular arc</annotation>
+		<annotation cp="◜" type="tts">upper-left quadrant circular arc</annotation>
+		<annotation cp="◝">upper-right quadrant circular arc</annotation>
+		<annotation cp="◝" type="tts">upper-right quadrant circular arc</annotation>
+		<annotation cp="◞">lower-right quadrant circular arc</annotation>
+		<annotation cp="◞" type="tts">lower-right quadrant circular arc</annotation>
+		<annotation cp="◟">lower-left quadrant circular arc</annotation>
+		<annotation cp="◟" type="tts">lower-left quadrant circular arc</annotation>
+		<annotation cp="◢">black lower-right triangle</annotation>
+		<annotation cp="◢" type="tts">filled lower-right triangle</annotation>
+		<annotation cp="◣">black lower-left triangle</annotation>
+		<annotation cp="◣" type="tts">filled lower-left triangle</annotation>
+		<annotation cp="◤">black upper-left triangle</annotation>
+		<annotation cp="◤" type="tts">filled upper-left triangle</annotation>
+		<annotation cp="◥">black upper-right triangle</annotation>
+		<annotation cp="◥" type="tts">filled upper-right triangle</annotation>
+		<annotation cp="◯">circle | large hollow circle | large white circle | ring</annotation>
+		<annotation cp="◳">white square with upper-right quadrant</annotation>
+		<annotation cp="◳" type="tts">hollow square with upper-right quadrant</annotation>
+		<annotation cp="◷">white circle with upper-right quadrant</annotation>
+		<annotation cp="◷" type="tts">hollow circle with upper-right quadrant</annotation>
+		<annotation cp="◿">lower-right triangle | white</annotation>
+		<annotation cp="◿" type="tts">lower-right triangle</annotation>
+		<annotation cp="⨧">plus sign with subscript two</annotation>
+		<annotation cp="⨧" type="tts">plus sign with subscript two</annotation>
+		<annotation cp="⨯">vector or cross product</annotation>
+		<annotation cp="⨯" type="tts">vector or cross product</annotation>
+		<annotation cp="⨼">interior product | mathematics</annotation>
+		<annotation cp="⩣">logical or with double underbar | mathematics</annotation>
+		<annotation cp="⩣" type="tts">logical or with double underbar</annotation>
+		<annotation cp="⩽">inequality | less-than or slanted equal to | mathematics</annotation>
+		<annotation cp="⩽" type="tts">less-than or slanted equal to</annotation>
+		<annotation cp="⪍">less-than above similar or equal</annotation>
+		<annotation cp="⪍" type="tts">less-than above similar or equal</annotation>
+		<annotation cp="⪚">double-line equal to or greater-than | inequality | mathematics</annotation>
+		<annotation cp="⪚" type="tts">double-line equal to or greater-than</annotation>
 		<annotation cp="🪪">credentials | ID | licence | security</annotation>
-		<annotation cp="🪪" type="tts">↑↑↑</annotation>
-		<annotation cp="🪫">↑↑↑</annotation>
-		<annotation cp="🪫" type="tts">↑↑↑</annotation>
-		<annotation cp="🪬">↑↑↑</annotation>
-		<annotation cp="🪬" type="tts">↑↑↑</annotation>
-		<annotation cp="🪷">↑↑↑</annotation>
-		<annotation cp="🪷" type="tts">↑↑↑</annotation>
-		<annotation cp="🪸">↑↑↑</annotation>
-		<annotation cp="🪸" type="tts">↑↑↑</annotation>
-		<annotation cp="🪹">↑↑↑</annotation>
-		<annotation cp="🪹" type="tts">↑↑↑</annotation>
-		<annotation cp="🪺">↑↑↑</annotation>
-		<annotation cp="🪺" type="tts">↑↑↑</annotation>
-		<annotation cp="🫃">↑↑↑</annotation>
-		<annotation cp="🫃" type="tts">↑↑↑</annotation>
-		<annotation cp="🫄">↑↑↑</annotation>
-		<annotation cp="🫄" type="tts">↑↑↑</annotation>
-		<annotation cp="🫅">↑↑↑</annotation>
-		<annotation cp="🫅" type="tts">↑↑↑</annotation>
-		<annotation cp="🫗">↑↑↑</annotation>
-		<annotation cp="🫗" type="tts">↑↑↑</annotation>
-		<annotation cp="🫘">↑↑↑</annotation>
-		<annotation cp="🫘" type="tts">↑↑↑</annotation>
-		<annotation cp="🫙">↑↑↑</annotation>
-		<annotation cp="🫙" type="tts">↑↑↑</annotation>
-		<annotation cp="🫠">↑↑↑</annotation>
-		<annotation cp="🫠" type="tts">↑↑↑</annotation>
-		<annotation cp="🫡">↑↑↑</annotation>
-		<annotation cp="🫡" type="tts">↑↑↑</annotation>
-		<annotation cp="🫢">↑↑↑</annotation>
-		<annotation cp="🫢" type="tts">↑↑↑</annotation>
-		<annotation cp="🫣">↑↑↑</annotation>
-		<annotation cp="🫣" type="tts">↑↑↑</annotation>
-		<annotation cp="🫤">↑↑↑</annotation>
-		<annotation cp="🫤" type="tts">↑↑↑</annotation>
-		<annotation cp="🫥">↑↑↑</annotation>
-		<annotation cp="🫥" type="tts">↑↑↑</annotation>
-		<annotation cp="🫦">↑↑↑</annotation>
-		<annotation cp="🫦" type="tts">↑↑↑</annotation>
-		<annotation cp="🫧">↑↑↑</annotation>
-		<annotation cp="🫧" type="tts">↑↑↑</annotation>
-		<annotation cp="🫰">↑↑↑</annotation>
-		<annotation cp="🫰" type="tts">↑↑↑</annotation>
+		<annotation cp="🫤">disappointed | meh | sceptical | unsure</annotation>
 		<annotation cp="🫱">hand | right | rightward | rightwards</annotation>
 		<annotation cp="🫱" type="tts">rightward hand</annotation>
 		<annotation cp="🫲">hand | left | leftward | leftwards</annotation>
 		<annotation cp="🫲" type="tts">leftward hand</annotation>
-		<annotation cp="🫳">↑↑↑</annotation>
-		<annotation cp="🫳" type="tts">↑↑↑</annotation>
-		<annotation cp="🫴">↑↑↑</annotation>
-		<annotation cp="🫴" type="tts">↑↑↑</annotation>
-		<annotation cp="🫵">↑↑↑</annotation>
-		<annotation cp="🫵" type="tts">↑↑↑</annotation>
-		<annotation cp="🫶">↑↑↑</annotation>
-		<annotation cp="🫶" type="tts">↑↑↑</annotation>
-		<annotation cp="🛝">↑↑↑</annotation>
-		<annotation cp="🛝" type="tts">↑↑↑</annotation>
-		<annotation cp="🛞">↑↑↑</annotation>
-		<annotation cp="🛞" type="tts">↑↑↑</annotation>
-		<annotation cp="🛟">↑↑↑</annotation>
-		<annotation cp="🛟" type="tts">↑↑↑</annotation>
-		<annotation cp="🟰">↑↑↑</annotation>
-		<annotation cp="🟰" type="tts">↑↑↑</annotation>
-		<annotation cp="😀">↑↑↑</annotation>
-		<annotation cp="😀" type="tts">↑↑↑</annotation>
-		<annotation cp="😃">↑↑↑</annotation>
-		<annotation cp="😃" type="tts">↑↑↑</annotation>
-		<annotation cp="😄">↑↑↑</annotation>
-		<annotation cp="😄" type="tts">↑↑↑</annotation>
-		<annotation cp="😁">↑↑↑</annotation>
-		<annotation cp="😁" type="tts">↑↑↑</annotation>
-		<annotation cp="😆">↑↑↑</annotation>
-		<annotation cp="😆" type="tts">↑↑↑</annotation>
-		<annotation cp="😅">↑↑↑</annotation>
-		<annotation cp="😅" type="tts">↑↑↑</annotation>
-		<annotation cp="🤣">↑↑↑</annotation>
-		<annotation cp="🤣" type="tts">↑↑↑</annotation>
-		<annotation cp="😂">↑↑↑</annotation>
-		<annotation cp="😂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙂">↑↑↑</annotation>
-		<annotation cp="🙂" type="tts">↑↑↑</annotation>
+		<annotation cp="🛞">circle | turn | tyre</annotation>
+		<annotation cp="🟰">equality | math | maths</annotation>
 		<annotation cp="🙃">face | upside down | upside-down face</annotation>
-		<annotation cp="🙃" type="tts">↑↑↑</annotation>
-		<annotation cp="😉">↑↑↑</annotation>
-		<annotation cp="😉" type="tts">↑↑↑</annotation>
-		<annotation cp="😊">↑↑↑</annotation>
-		<annotation cp="😊" type="tts">↑↑↑</annotation>
-		<annotation cp="😇">↑↑↑</annotation>
-		<annotation cp="😇" type="tts">↑↑↑</annotation>
-		<annotation cp="🥰">↑↑↑</annotation>
-		<annotation cp="🥰" type="tts">↑↑↑</annotation>
 		<annotation cp="😍">eye | face | love | smile | smiling face with heart eyes | smiling face with heart-eyes</annotation>
 		<annotation cp="😍" type="tts">smiling face with heart eyes</annotation>
-		<annotation cp="🤩">↑↑↑</annotation>
-		<annotation cp="🤩" type="tts">↑↑↑</annotation>
-		<annotation cp="😘">↑↑↑</annotation>
-		<annotation cp="😘" type="tts">↑↑↑</annotation>
-		<annotation cp="😗">↑↑↑</annotation>
-		<annotation cp="😗" type="tts">↑↑↑</annotation>
-		<annotation cp="☺">↑↑↑</annotation>
-		<annotation cp="☺" type="tts">↑↑↑</annotation>
-		<annotation cp="😚">↑↑↑</annotation>
-		<annotation cp="😚" type="tts">↑↑↑</annotation>
-		<annotation cp="😙">↑↑↑</annotation>
-		<annotation cp="😙" type="tts">↑↑↑</annotation>
-		<annotation cp="🥲">↑↑↑</annotation>
-		<annotation cp="🥲" type="tts">↑↑↑</annotation>
 		<annotation cp="😋">delicious | face | face savouring food | savoring | savouring | smile | yum</annotation>
-		<annotation cp="😋" type="tts">↑↑↑</annotation>
-		<annotation cp="😛">↑↑↑</annotation>
-		<annotation cp="😛" type="tts">↑↑↑</annotation>
-		<annotation cp="😜">↑↑↑</annotation>
-		<annotation cp="😜" type="tts">↑↑↑</annotation>
-		<annotation cp="🤪">↑↑↑</annotation>
-		<annotation cp="🤪" type="tts">↑↑↑</annotation>
-		<annotation cp="😝">↑↑↑</annotation>
-		<annotation cp="😝" type="tts">↑↑↑</annotation>
-		<annotation cp="🤑">↑↑↑</annotation>
-		<annotation cp="🤑" type="tts">↑↑↑</annotation>
-		<annotation cp="🤗">↑↑↑</annotation>
-		<annotation cp="🤗" type="tts">↑↑↑</annotation>
 		<annotation cp="🤭">face with hand over mouth | oops | whoops</annotation>
-		<annotation cp="🤭" type="tts">↑↑↑</annotation>
-		<annotation cp="🤫">↑↑↑</annotation>
-		<annotation cp="🤫" type="tts">↑↑↑</annotation>
-		<annotation cp="🤔">↑↑↑</annotation>
-		<annotation cp="🤔" type="tts">↑↑↑</annotation>
-		<annotation cp="🤐">↑↑↑</annotation>
-		<annotation cp="🤐" type="tts">↑↑↑</annotation>
-		<annotation cp="🤨">↑↑↑</annotation>
-		<annotation cp="🤨" type="tts">↑↑↑</annotation>
-		<annotation cp="😐">↑↑↑</annotation>
-		<annotation cp="😐" type="tts">↑↑↑</annotation>
-		<annotation cp="😑">↑↑↑</annotation>
-		<annotation cp="😑" type="tts">↑↑↑</annotation>
-		<annotation cp="😶">↑↑↑</annotation>
-		<annotation cp="😶" type="tts">↑↑↑</annotation>
-		<annotation cp="😶‍🌫">↑↑↑</annotation>
-		<annotation cp="😶‍🌫" type="tts">↑↑↑</annotation>
-		<annotation cp="😏">↑↑↑</annotation>
-		<annotation cp="😏" type="tts">↑↑↑</annotation>
-		<annotation cp="😒">↑↑↑</annotation>
-		<annotation cp="😒" type="tts">↑↑↑</annotation>
-		<annotation cp="🙄">↑↑↑</annotation>
-		<annotation cp="🙄" type="tts">↑↑↑</annotation>
-		<annotation cp="😬">↑↑↑</annotation>
-		<annotation cp="😬" type="tts">↑↑↑</annotation>
-		<annotation cp="😮‍💨">↑↑↑</annotation>
-		<annotation cp="😮‍💨" type="tts">↑↑↑</annotation>
-		<annotation cp="🤥">↑↑↑</annotation>
-		<annotation cp="🤥" type="tts">↑↑↑</annotation>
-		<annotation cp="😌">↑↑↑</annotation>
-		<annotation cp="😌" type="tts">↑↑↑</annotation>
-		<annotation cp="😔">↑↑↑</annotation>
-		<annotation cp="😔" type="tts">↑↑↑</annotation>
-		<annotation cp="😪">↑↑↑</annotation>
-		<annotation cp="😪" type="tts">↑↑↑</annotation>
-		<annotation cp="🤤">↑↑↑</annotation>
-		<annotation cp="🤤" type="tts">↑↑↑</annotation>
-		<annotation cp="😴">↑↑↑</annotation>
-		<annotation cp="😴" type="tts">↑↑↑</annotation>
 		<annotation cp="😷">cold | doctor | face | face with medical mask | ill | mask | sick</annotation>
-		<annotation cp="😷" type="tts">↑↑↑</annotation>
-		<annotation cp="🤒">face | face with thermometer | ill | sick | thermometer</annotation>
-		<annotation cp="🤒" type="tts">↑↑↑</annotation>
 		<annotation cp="🤕">bandage | face | face with head bandage | hurt | injury</annotation>
-		<annotation cp="🤕" type="tts">↑↑↑</annotation>
-		<annotation cp="🤢">↑↑↑</annotation>
-		<annotation cp="🤢" type="tts">↑↑↑</annotation>
-		<annotation cp="🤮">↑↑↑</annotation>
-		<annotation cp="🤮" type="tts">↑↑↑</annotation>
 		<annotation cp="🤧">bless you | face | gesundheit | sneeze | sneezing face</annotation>
-		<annotation cp="🤧" type="tts">↑↑↑</annotation>
-		<annotation cp="🥵">↑↑↑</annotation>
-		<annotation cp="🥵" type="tts">↑↑↑</annotation>
-		<annotation cp="🥶">↑↑↑</annotation>
-		<annotation cp="🥶" type="tts">↑↑↑</annotation>
-		<annotation cp="🥴">↑↑↑</annotation>
-		<annotation cp="🥴" type="tts">↑↑↑</annotation>
-		<annotation cp="😵">↑↑↑</annotation>
-		<annotation cp="😵" type="tts">↑↑↑</annotation>
-		<annotation cp="😵‍💫">↑↑↑</annotation>
-		<annotation cp="😵‍💫" type="tts">↑↑↑</annotation>
-		<annotation cp="🤯">↑↑↑</annotation>
-		<annotation cp="🤯" type="tts">↑↑↑</annotation>
-		<annotation cp="🤠">↑↑↑</annotation>
-		<annotation cp="🤠" type="tts">↑↑↑</annotation>
-		<annotation cp="🥳">↑↑↑</annotation>
-		<annotation cp="🥳" type="tts">↑↑↑</annotation>
-		<annotation cp="🥸">↑↑↑</annotation>
-		<annotation cp="🥸" type="tts">↑↑↑</annotation>
-		<annotation cp="😎">↑↑↑</annotation>
-		<annotation cp="😎" type="tts">↑↑↑</annotation>
-		<annotation cp="🤓">↑↑↑</annotation>
-		<annotation cp="🤓" type="tts">↑↑↑</annotation>
-		<annotation cp="🧐">↑↑↑</annotation>
-		<annotation cp="🧐" type="tts">↑↑↑</annotation>
-		<annotation cp="😕">↑↑↑</annotation>
-		<annotation cp="😕" type="tts">↑↑↑</annotation>
-		<annotation cp="😟">↑↑↑</annotation>
-		<annotation cp="😟" type="tts">↑↑↑</annotation>
-		<annotation cp="🙁">↑↑↑</annotation>
-		<annotation cp="🙁" type="tts">↑↑↑</annotation>
-		<annotation cp="☹">↑↑↑</annotation>
-		<annotation cp="☹" type="tts">↑↑↑</annotation>
-		<annotation cp="😮">↑↑↑</annotation>
-		<annotation cp="😮" type="tts">↑↑↑</annotation>
-		<annotation cp="😯">↑↑↑</annotation>
-		<annotation cp="😯" type="tts">↑↑↑</annotation>
-		<annotation cp="😲">↑↑↑</annotation>
-		<annotation cp="😲" type="tts">↑↑↑</annotation>
-		<annotation cp="😳">↑↑↑</annotation>
-		<annotation cp="😳" type="tts">↑↑↑</annotation>
-		<annotation cp="🥺">↑↑↑</annotation>
-		<annotation cp="🥺" type="tts">↑↑↑</annotation>
-		<annotation cp="😦">↑↑↑</annotation>
-		<annotation cp="😦" type="tts">↑↑↑</annotation>
-		<annotation cp="😧">↑↑↑</annotation>
-		<annotation cp="😧" type="tts">↑↑↑</annotation>
-		<annotation cp="😨">↑↑↑</annotation>
-		<annotation cp="😨" type="tts">↑↑↑</annotation>
-		<annotation cp="😰">↑↑↑</annotation>
-		<annotation cp="😰" type="tts">↑↑↑</annotation>
-		<annotation cp="😥">↑↑↑</annotation>
-		<annotation cp="😥" type="tts">↑↑↑</annotation>
-		<annotation cp="😢">↑↑↑</annotation>
-		<annotation cp="😢" type="tts">↑↑↑</annotation>
-		<annotation cp="😭">↑↑↑</annotation>
-		<annotation cp="😭" type="tts">↑↑↑</annotation>
-		<annotation cp="😱">↑↑↑</annotation>
-		<annotation cp="😱" type="tts">↑↑↑</annotation>
-		<annotation cp="😖">↑↑↑</annotation>
-		<annotation cp="😖" type="tts">↑↑↑</annotation>
-		<annotation cp="😣">↑↑↑</annotation>
-		<annotation cp="😣" type="tts">↑↑↑</annotation>
-		<annotation cp="😞">↑↑↑</annotation>
-		<annotation cp="😞" type="tts">↑↑↑</annotation>
-		<annotation cp="😓">↑↑↑</annotation>
-		<annotation cp="😓" type="tts">↑↑↑</annotation>
-		<annotation cp="😩">↑↑↑</annotation>
-		<annotation cp="😩" type="tts">↑↑↑</annotation>
-		<annotation cp="😫">↑↑↑</annotation>
-		<annotation cp="😫" type="tts">↑↑↑</annotation>
-		<annotation cp="🥱">↑↑↑</annotation>
-		<annotation cp="🥱" type="tts">↑↑↑</annotation>
-		<annotation cp="😤">↑↑↑</annotation>
-		<annotation cp="😤" type="tts">↑↑↑</annotation>
-		<annotation cp="😡">↑↑↑</annotation>
-		<annotation cp="😡" type="tts">↑↑↑</annotation>
-		<annotation cp="😠">↑↑↑</annotation>
-		<annotation cp="😠" type="tts">↑↑↑</annotation>
-		<annotation cp="🤬">↑↑↑</annotation>
-		<annotation cp="🤬" type="tts">↑↑↑</annotation>
-		<annotation cp="😈">↑↑↑</annotation>
-		<annotation cp="😈" type="tts">↑↑↑</annotation>
-		<annotation cp="👿">↑↑↑</annotation>
-		<annotation cp="👿" type="tts">↑↑↑</annotation>
-		<annotation cp="💀">↑↑↑</annotation>
-		<annotation cp="💀" type="tts">↑↑↑</annotation>
-		<annotation cp="☠">↑↑↑</annotation>
-		<annotation cp="☠" type="tts">↑↑↑</annotation>
-		<annotation cp="💩">↑↑↑</annotation>
-		<annotation cp="💩" type="tts">↑↑↑</annotation>
-		<annotation cp="🤡">↑↑↑</annotation>
-		<annotation cp="🤡" type="tts">↑↑↑</annotation>
-		<annotation cp="👹">↑↑↑</annotation>
-		<annotation cp="👹" type="tts">↑↑↑</annotation>
-		<annotation cp="👺">↑↑↑</annotation>
-		<annotation cp="👺" type="tts">↑↑↑</annotation>
-		<annotation cp="👻">↑↑↑</annotation>
-		<annotation cp="👻" type="tts">↑↑↑</annotation>
-		<annotation cp="👽">↑↑↑</annotation>
-		<annotation cp="👽" type="tts">↑↑↑</annotation>
-		<annotation cp="👾">↑↑↑</annotation>
-		<annotation cp="👾" type="tts">↑↑↑</annotation>
-		<annotation cp="🤖">↑↑↑</annotation>
-		<annotation cp="🤖" type="tts">↑↑↑</annotation>
-		<annotation cp="😺">↑↑↑</annotation>
-		<annotation cp="😺" type="tts">↑↑↑</annotation>
-		<annotation cp="😸">↑↑↑</annotation>
-		<annotation cp="😸" type="tts">↑↑↑</annotation>
-		<annotation cp="😹">↑↑↑</annotation>
-		<annotation cp="😹" type="tts">↑↑↑</annotation>
+		<annotation cp="😵‍💫">dizzy | face with spiral eyes | hypnotised | spiral | trouble | whoa</annotation>
+		<annotation cp="😤">angry | face | face with steam from nose | frustration | triumph | won</annotation>
 		<annotation cp="😻">cat | eye | face | heart | love | smile | smiling cat face with heart-eyes</annotation>
 		<annotation cp="😻" type="tts">smiling cat face with heart eyes</annotation>
-		<annotation cp="😼">cat | cat with wry smile | face | ironic | smile | wry</annotation>
-		<annotation cp="😼" type="tts">↑↑↑</annotation>
-		<annotation cp="😽">↑↑↑</annotation>
-		<annotation cp="😽" type="tts">↑↑↑</annotation>
-		<annotation cp="🙀">↑↑↑</annotation>
-		<annotation cp="🙀" type="tts">↑↑↑</annotation>
-		<annotation cp="😿">↑↑↑</annotation>
-		<annotation cp="😿" type="tts">↑↑↑</annotation>
-		<annotation cp="😾">↑↑↑</annotation>
-		<annotation cp="😾" type="tts">↑↑↑</annotation>
-		<annotation cp="🙈">↑↑↑</annotation>
-		<annotation cp="🙈" type="tts">↑↑↑</annotation>
-		<annotation cp="🙉">↑↑↑</annotation>
-		<annotation cp="🙉" type="tts">↑↑↑</annotation>
-		<annotation cp="🙊">↑↑↑</annotation>
-		<annotation cp="🙊" type="tts">↑↑↑</annotation>
-		<annotation cp="💋">↑↑↑</annotation>
-		<annotation cp="💋" type="tts">↑↑↑</annotation>
-		<annotation cp="💌">↑↑↑</annotation>
-		<annotation cp="💌" type="tts">↑↑↑</annotation>
-		<annotation cp="💘">↑↑↑</annotation>
-		<annotation cp="💘" type="tts">↑↑↑</annotation>
-		<annotation cp="💝">↑↑↑</annotation>
-		<annotation cp="💝" type="tts">↑↑↑</annotation>
-		<annotation cp="💖">↑↑↑</annotation>
-		<annotation cp="💖" type="tts">↑↑↑</annotation>
-		<annotation cp="💗">↑↑↑</annotation>
-		<annotation cp="💗" type="tts">↑↑↑</annotation>
-		<annotation cp="💓">↑↑↑</annotation>
-		<annotation cp="💓" type="tts">↑↑↑</annotation>
-		<annotation cp="💞">↑↑↑</annotation>
-		<annotation cp="💞" type="tts">↑↑↑</annotation>
-		<annotation cp="💕">↑↑↑</annotation>
-		<annotation cp="💕" type="tts">↑↑↑</annotation>
-		<annotation cp="💟">↑↑↑</annotation>
-		<annotation cp="💟" type="tts">↑↑↑</annotation>
-		<annotation cp="❣">↑↑↑</annotation>
-		<annotation cp="❣" type="tts">↑↑↑</annotation>
-		<annotation cp="💔">↑↑↑</annotation>
-		<annotation cp="💔" type="tts">↑↑↑</annotation>
-		<annotation cp="❤‍🔥">↑↑↑</annotation>
-		<annotation cp="❤‍🔥" type="tts">↑↑↑</annotation>
-		<annotation cp="❤‍🩹">↑↑↑</annotation>
-		<annotation cp="❤‍🩹" type="tts">↑↑↑</annotation>
-		<annotation cp="❤">↑↑↑</annotation>
-		<annotation cp="❤" type="tts">↑↑↑</annotation>
-		<annotation cp="🧡">↑↑↑</annotation>
-		<annotation cp="🧡" type="tts">↑↑↑</annotation>
-		<annotation cp="💛">↑↑↑</annotation>
-		<annotation cp="💛" type="tts">↑↑↑</annotation>
-		<annotation cp="💚">↑↑↑</annotation>
-		<annotation cp="💚" type="tts">↑↑↑</annotation>
-		<annotation cp="💙">↑↑↑</annotation>
-		<annotation cp="💙" type="tts">↑↑↑</annotation>
-		<annotation cp="💜">↑↑↑</annotation>
-		<annotation cp="💜" type="tts">↑↑↑</annotation>
-		<annotation cp="🤎">↑↑↑</annotation>
-		<annotation cp="🤎" type="tts">↑↑↑</annotation>
-		<annotation cp="🖤">↑↑↑</annotation>
-		<annotation cp="🖤" type="tts">↑↑↑</annotation>
-		<annotation cp="🤍">↑↑↑</annotation>
-		<annotation cp="🤍" type="tts">↑↑↑</annotation>
-		<annotation cp="💯">↑↑↑</annotation>
-		<annotation cp="💯" type="tts">↑↑↑</annotation>
-		<annotation cp="💢">↑↑↑</annotation>
-		<annotation cp="💢" type="tts">↑↑↑</annotation>
-		<annotation cp="💥">↑↑↑</annotation>
-		<annotation cp="💥" type="tts">↑↑↑</annotation>
-		<annotation cp="💫">↑↑↑</annotation>
-		<annotation cp="💫" type="tts">↑↑↑</annotation>
-		<annotation cp="💦">↑↑↑</annotation>
-		<annotation cp="💦" type="tts">↑↑↑</annotation>
-		<annotation cp="💨">↑↑↑</annotation>
-		<annotation cp="💨" type="tts">↑↑↑</annotation>
-		<annotation cp="🕳">↑↑↑</annotation>
-		<annotation cp="🕳" type="tts">↑↑↑</annotation>
-		<annotation cp="💣">↑↑↑</annotation>
-		<annotation cp="💣" type="tts">↑↑↑</annotation>
-		<annotation cp="💬">↑↑↑</annotation>
-		<annotation cp="💬" type="tts">↑↑↑</annotation>
-		<annotation cp="👁‍🗨">↑↑↑</annotation>
-		<annotation cp="👁‍🗨" type="tts">↑↑↑</annotation>
 		<annotation cp="🗨">dialogue | left speech bubble | speech</annotation>
-		<annotation cp="🗨" type="tts">↑↑↑</annotation>
-		<annotation cp="🗯">↑↑↑</annotation>
-		<annotation cp="🗯" type="tts">↑↑↑</annotation>
-		<annotation cp="💭">↑↑↑</annotation>
-		<annotation cp="💭" type="tts">↑↑↑</annotation>
-		<annotation cp="💤">↑↑↑</annotation>
-		<annotation cp="💤" type="tts">↑↑↑</annotation>
-		<annotation cp="👋">↑↑↑</annotation>
-		<annotation cp="👋" type="tts">↑↑↑</annotation>
-		<annotation cp="🤚">↑↑↑</annotation>
-		<annotation cp="🤚" type="tts">↑↑↑</annotation>
-		<annotation cp="🖐">↑↑↑</annotation>
-		<annotation cp="🖐" type="tts">↑↑↑</annotation>
-		<annotation cp="✋">↑↑↑</annotation>
-		<annotation cp="✋" type="tts">↑↑↑</annotation>
-		<annotation cp="🖖">↑↑↑</annotation>
-		<annotation cp="🖖" type="tts">↑↑↑</annotation>
 		<annotation cp="👌">hand | OK | perfect</annotation>
-		<annotation cp="👌" type="tts">↑↑↑</annotation>
-		<annotation cp="🤌">↑↑↑</annotation>
-		<annotation cp="🤌" type="tts">↑↑↑</annotation>
-		<annotation cp="🤏">↑↑↑</annotation>
-		<annotation cp="🤏" type="tts">↑↑↑</annotation>
-		<annotation cp="✌">↑↑↑</annotation>
-		<annotation cp="✌" type="tts">↑↑↑</annotation>
 		<annotation cp="🤞">cross | crossed fingers | finger | good luck | hand | luck</annotation>
-		<annotation cp="🤞" type="tts">↑↑↑</annotation>
 		<annotation cp="🤟">hand | ILY | love you gesture | love-you gesture</annotation>
-		<annotation cp="🤟" type="tts">↑↑↑</annotation>
 		<annotation cp="🤘">finger | hand | horns | rock on | sign of the horns</annotation>
-		<annotation cp="🤘" type="tts">↑↑↑</annotation>
 		<annotation cp="🤙">call | call me hand | call-me hand | hand</annotation>
-		<annotation cp="🤙" type="tts">↑↑↑</annotation>
-		<annotation cp="👈">↑↑↑</annotation>
-		<annotation cp="👈" type="tts">↑↑↑</annotation>
-		<annotation cp="👉">↑↑↑</annotation>
-		<annotation cp="👉" type="tts">↑↑↑</annotation>
-		<annotation cp="👆">↑↑↑</annotation>
-		<annotation cp="👆" type="tts">↑↑↑</annotation>
-		<annotation cp="🖕">↑↑↑</annotation>
-		<annotation cp="🖕" type="tts">↑↑↑</annotation>
-		<annotation cp="👇">↑↑↑</annotation>
-		<annotation cp="👇" type="tts">↑↑↑</annotation>
-		<annotation cp="☝">↑↑↑</annotation>
-		<annotation cp="☝" type="tts">↑↑↑</annotation>
-		<annotation cp="👍">↑↑↑</annotation>
-		<annotation cp="👍" type="tts">↑↑↑</annotation>
-		<annotation cp="👎">↑↑↑</annotation>
-		<annotation cp="👎" type="tts">↑↑↑</annotation>
-		<annotation cp="✊">↑↑↑</annotation>
-		<annotation cp="✊" type="tts">↑↑↑</annotation>
-		<annotation cp="👊">↑↑↑</annotation>
-		<annotation cp="👊" type="tts">↑↑↑</annotation>
 		<annotation cp="🤛">fist | left-facing fist | leftward</annotation>
-		<annotation cp="🤛" type="tts">↑↑↑</annotation>
 		<annotation cp="🤜">fist | right-facing fist | rightward</annotation>
-		<annotation cp="🤜" type="tts">↑↑↑</annotation>
-		<annotation cp="👏">↑↑↑</annotation>
-		<annotation cp="👏" type="tts">↑↑↑</annotation>
-		<annotation cp="🙌">celebration | gesture | hand | hooray | raised | raising hands</annotation>
-		<annotation cp="🙌" type="tts">↑↑↑</annotation>
-		<annotation cp="👐">↑↑↑</annotation>
-		<annotation cp="👐" type="tts">↑↑↑</annotation>
-		<annotation cp="🤲">↑↑↑</annotation>
-		<annotation cp="🤲" type="tts">↑↑↑</annotation>
-		<annotation cp="🤝">↑↑↑</annotation>
-		<annotation cp="🤝" type="tts">↑↑↑</annotation>
 		<annotation cp="🙏">ask | folded hands | hand | high five | please | pray | thanks</annotation>
-		<annotation cp="🙏" type="tts">↑↑↑</annotation>
-		<annotation cp="✍">↑↑↑</annotation>
-		<annotation cp="✍" type="tts">↑↑↑</annotation>
-		<annotation cp="💅">↑↑↑</annotation>
-		<annotation cp="💅" type="tts">↑↑↑</annotation>
-		<annotation cp="🤳">↑↑↑</annotation>
-		<annotation cp="🤳" type="tts">↑↑↑</annotation>
-		<annotation cp="💪">↑↑↑</annotation>
-		<annotation cp="💪" type="tts">↑↑↑</annotation>
-		<annotation cp="🦾">↑↑↑</annotation>
-		<annotation cp="🦾" type="tts">↑↑↑</annotation>
-		<annotation cp="🦿">↑↑↑</annotation>
-		<annotation cp="🦿" type="tts">↑↑↑</annotation>
-		<annotation cp="🦵">↑↑↑</annotation>
-		<annotation cp="🦵" type="tts">↑↑↑</annotation>
-		<annotation cp="🦶">↑↑↑</annotation>
-		<annotation cp="🦶" type="tts">↑↑↑</annotation>
-		<annotation cp="👂">↑↑↑</annotation>
-		<annotation cp="👂" type="tts">↑↑↑</annotation>
 		<annotation cp="🦻">accessibility | ear with hearing aid | hard of hearing | hearing impaired</annotation>
-		<annotation cp="🦻" type="tts">↑↑↑</annotation>
-		<annotation cp="👃">↑↑↑</annotation>
-		<annotation cp="👃" type="tts">↑↑↑</annotation>
-		<annotation cp="🧠">↑↑↑</annotation>
-		<annotation cp="🧠" type="tts">↑↑↑</annotation>
-		<annotation cp="🫀">↑↑↑</annotation>
-		<annotation cp="🫀" type="tts">↑↑↑</annotation>
-		<annotation cp="🫁">↑↑↑</annotation>
-		<annotation cp="🫁" type="tts">↑↑↑</annotation>
-		<annotation cp="🦷">↑↑↑</annotation>
-		<annotation cp="🦷" type="tts">↑↑↑</annotation>
-		<annotation cp="🦴">↑↑↑</annotation>
-		<annotation cp="🦴" type="tts">↑↑↑</annotation>
-		<annotation cp="👀">↑↑↑</annotation>
-		<annotation cp="👀" type="tts">↑↑↑</annotation>
-		<annotation cp="👁">↑↑↑</annotation>
-		<annotation cp="👁" type="tts">↑↑↑</annotation>
-		<annotation cp="👅">↑↑↑</annotation>
-		<annotation cp="👅" type="tts">↑↑↑</annotation>
-		<annotation cp="👄">↑↑↑</annotation>
-		<annotation cp="👄" type="tts">↑↑↑</annotation>
-		<annotation cp="👶">↑↑↑</annotation>
-		<annotation cp="👶" type="tts">↑↑↑</annotation>
-		<annotation cp="🧒">child | gender-neutral | unspecified gender | young</annotation>
-		<annotation cp="🧒" type="tts">↑↑↑</annotation>
-		<annotation cp="👦">↑↑↑</annotation>
-		<annotation cp="👦" type="tts">↑↑↑</annotation>
 		<annotation cp="👧">girl | young</annotation>
-		<annotation cp="👧" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑">↑↑↑</annotation>
-		<annotation cp="🧑" type="tts">↑↑↑</annotation>
-		<annotation cp="👱">↑↑↑</annotation>
-		<annotation cp="👱" type="tts">↑↑↑</annotation>
-		<annotation cp="👨">↑↑↑</annotation>
-		<annotation cp="👨" type="tts">↑↑↑</annotation>
-		<annotation cp="🧔">↑↑↑</annotation>
-		<annotation cp="🧔" type="tts">↑↑↑</annotation>
-		<annotation cp="🧔‍♂">↑↑↑</annotation>
-		<annotation cp="🧔‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👱‍♂">↑↑↑</annotation>
-		<annotation cp="👱‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👩">↑↑↑</annotation>
-		<annotation cp="👩" type="tts">↑↑↑</annotation>
-		<annotation cp="🧔‍♀">↑↑↑</annotation>
-		<annotation cp="🧔‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="👱‍♀">↑↑↑</annotation>
-		<annotation cp="👱‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧓">↑↑↑</annotation>
-		<annotation cp="🧓" type="tts">↑↑↑</annotation>
-		<annotation cp="👴">↑↑↑</annotation>
-		<annotation cp="👴" type="tts">↑↑↑</annotation>
-		<annotation cp="👵">↑↑↑</annotation>
-		<annotation cp="👵" type="tts">↑↑↑</annotation>
-		<annotation cp="🙍">↑↑↑</annotation>
-		<annotation cp="🙍" type="tts">↑↑↑</annotation>
-		<annotation cp="🙍‍♂">↑↑↑</annotation>
-		<annotation cp="🙍‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙍‍♀">↑↑↑</annotation>
-		<annotation cp="🙍‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🙎">↑↑↑</annotation>
-		<annotation cp="🙎" type="tts">↑↑↑</annotation>
-		<annotation cp="🙎‍♂">↑↑↑</annotation>
-		<annotation cp="🙎‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙎‍♀">↑↑↑</annotation>
-		<annotation cp="🙎‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🙅">↑↑↑</annotation>
-		<annotation cp="🙅" type="tts">↑↑↑</annotation>
-		<annotation cp="🙅‍♂">↑↑↑</annotation>
-		<annotation cp="🙅‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙅‍♀">↑↑↑</annotation>
-		<annotation cp="🙅‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🙆">↑↑↑</annotation>
-		<annotation cp="🙆" type="tts">↑↑↑</annotation>
-		<annotation cp="🙆‍♂">↑↑↑</annotation>
-		<annotation cp="🙆‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙆‍♀">↑↑↑</annotation>
-		<annotation cp="🙆‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="💁">↑↑↑</annotation>
-		<annotation cp="💁" type="tts">↑↑↑</annotation>
-		<annotation cp="💁‍♂">↑↑↑</annotation>
-		<annotation cp="💁‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="💁‍♀">↑↑↑</annotation>
-		<annotation cp="💁‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🙋">↑↑↑</annotation>
-		<annotation cp="🙋" type="tts">↑↑↑</annotation>
-		<annotation cp="🙋‍♂">↑↑↑</annotation>
-		<annotation cp="🙋‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙋‍♀">↑↑↑</annotation>
-		<annotation cp="🙋‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="🧏">accessibility | deaf | deaf person | ear | hear | hearing impaired</annotation>
-		<annotation cp="🧏" type="tts">↑↑↑</annotation>
-		<annotation cp="🧏‍♂">↑↑↑</annotation>
-		<annotation cp="🧏‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧏‍♀">↑↑↑</annotation>
-		<annotation cp="🧏‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🙇">↑↑↑</annotation>
-		<annotation cp="🙇" type="tts">↑↑↑</annotation>
-		<annotation cp="🙇‍♂">↑↑↑</annotation>
-		<annotation cp="🙇‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🙇‍♀">↑↑↑</annotation>
-		<annotation cp="🙇‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤦">↑↑↑</annotation>
-		<annotation cp="🤦" type="tts">↑↑↑</annotation>
-		<annotation cp="🤦‍♂">↑↑↑</annotation>
-		<annotation cp="🤦‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤦‍♀">↑↑↑</annotation>
-		<annotation cp="🤦‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤷">↑↑↑</annotation>
-		<annotation cp="🤷" type="tts">↑↑↑</annotation>
-		<annotation cp="🤷‍♂">↑↑↑</annotation>
-		<annotation cp="🤷‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤷‍♀">↑↑↑</annotation>
-		<annotation cp="🤷‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="🧑‍⚕">care | doctor | health | health worker | healthcare | nurse | therapist</annotation>
-		<annotation cp="🧑‍⚕" type="tts">↑↑↑</annotation>
 		<annotation cp="👨‍⚕">doctor | health care | man | man health worker | nurse | therapist</annotation>
-		<annotation cp="👨‍⚕" type="tts">↑↑↑</annotation>
 		<annotation cp="👩‍⚕">doctor | health care | nurse | therapist | woman | woman health worker</annotation>
-		<annotation cp="👩‍⚕" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🎓">↑↑↑</annotation>
-		<annotation cp="🧑‍🎓" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🎓">↑↑↑</annotation>
-		<annotation cp="👨‍🎓" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🎓">↑↑↑</annotation>
-		<annotation cp="👩‍🎓" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🏫">↑↑↑</annotation>
-		<annotation cp="🧑‍🏫" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🏫">↑↑↑</annotation>
-		<annotation cp="👨‍🏫" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🏫">↑↑↑</annotation>
-		<annotation cp="👩‍🏫" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍⚖">↑↑↑</annotation>
-		<annotation cp="🧑‍⚖" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍⚖">↑↑↑</annotation>
-		<annotation cp="👨‍⚖" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍⚖">↑↑↑</annotation>
-		<annotation cp="👩‍⚖" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🌾">↑↑↑</annotation>
-		<annotation cp="🧑‍🌾" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🌾">↑↑↑</annotation>
-		<annotation cp="👨‍🌾" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🌾">↑↑↑</annotation>
-		<annotation cp="👩‍🌾" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🍳">↑↑↑</annotation>
-		<annotation cp="🧑‍🍳" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🍳">↑↑↑</annotation>
-		<annotation cp="👨‍🍳" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🍳">↑↑↑</annotation>
-		<annotation cp="👩‍🍳" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🔧">↑↑↑</annotation>
-		<annotation cp="🧑‍🔧" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🔧">↑↑↑</annotation>
-		<annotation cp="👨‍🔧" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🔧">↑↑↑</annotation>
-		<annotation cp="👩‍🔧" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🏭">↑↑↑</annotation>
-		<annotation cp="🧑‍🏭" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🏭">↑↑↑</annotation>
-		<annotation cp="👨‍🏭" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🏭">↑↑↑</annotation>
-		<annotation cp="👩‍🏭" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍💼">↑↑↑</annotation>
-		<annotation cp="🧑‍💼" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍💼">↑↑↑</annotation>
-		<annotation cp="👨‍💼" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍💼">↑↑↑</annotation>
-		<annotation cp="👩‍💼" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🔬">↑↑↑</annotation>
-		<annotation cp="🧑‍🔬" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🔬">↑↑↑</annotation>
-		<annotation cp="👨‍🔬" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🔬">↑↑↑</annotation>
-		<annotation cp="👩‍🔬" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍💻">↑↑↑</annotation>
-		<annotation cp="🧑‍💻" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍💻">↑↑↑</annotation>
-		<annotation cp="👨‍💻" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍💻">↑↑↑</annotation>
-		<annotation cp="👩‍💻" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🎤">↑↑↑</annotation>
-		<annotation cp="🧑‍🎤" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🎤">↑↑↑</annotation>
-		<annotation cp="👨‍🎤" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🎤">↑↑↑</annotation>
-		<annotation cp="👩‍🎤" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🎨">↑↑↑</annotation>
-		<annotation cp="🧑‍🎨" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🎨">↑↑↑</annotation>
-		<annotation cp="👨‍🎨" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🎨">↑↑↑</annotation>
-		<annotation cp="👩‍🎨" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍✈">↑↑↑</annotation>
-		<annotation cp="🧑‍✈" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍✈">↑↑↑</annotation>
-		<annotation cp="👨‍✈" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍✈">↑↑↑</annotation>
-		<annotation cp="👩‍✈" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🚀">↑↑↑</annotation>
-		<annotation cp="🧑‍🚀" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🚀">↑↑↑</annotation>
-		<annotation cp="👨‍🚀" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🚀">↑↑↑</annotation>
-		<annotation cp="👩‍🚀" type="tts">↑↑↑</annotation>
 		<annotation cp="🧑‍🚒">engine | fire | firefighter | firetruck | truck</annotation>
-		<annotation cp="🧑‍🚒" type="tts">↑↑↑</annotation>
 		<annotation cp="👨‍🚒">fire truck | firefighter | fireman | man</annotation>
-		<annotation cp="👨‍🚒" type="tts">↑↑↑</annotation>
 		<annotation cp="👩‍🚒">engine | fire | firefighter | firetruck | firewoman | truck | woman</annotation>
-		<annotation cp="👩‍🚒" type="tts">↑↑↑</annotation>
-		<annotation cp="👮">↑↑↑</annotation>
-		<annotation cp="👮" type="tts">↑↑↑</annotation>
-		<annotation cp="👮‍♂">↑↑↑</annotation>
-		<annotation cp="👮‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👮‍♀">↑↑↑</annotation>
-		<annotation cp="👮‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🕵">↑↑↑</annotation>
-		<annotation cp="🕵" type="tts">↑↑↑</annotation>
-		<annotation cp="🕵‍♂">↑↑↑</annotation>
-		<annotation cp="🕵‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🕵‍♀">↑↑↑</annotation>
-		<annotation cp="🕵‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="💂">↑↑↑</annotation>
-		<annotation cp="💂" type="tts">↑↑↑</annotation>
-		<annotation cp="💂‍♂">↑↑↑</annotation>
-		<annotation cp="💂‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="💂‍♀">↑↑↑</annotation>
-		<annotation cp="💂‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🥷">↑↑↑</annotation>
-		<annotation cp="🥷" type="tts">↑↑↑</annotation>
-		<annotation cp="👷">↑↑↑</annotation>
-		<annotation cp="👷" type="tts">↑↑↑</annotation>
-		<annotation cp="👷‍♂">↑↑↑</annotation>
-		<annotation cp="👷‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👷‍♀">↑↑↑</annotation>
-		<annotation cp="👷‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤴">↑↑↑</annotation>
-		<annotation cp="🤴" type="tts">↑↑↑</annotation>
-		<annotation cp="👸">↑↑↑</annotation>
-		<annotation cp="👸" type="tts">↑↑↑</annotation>
-		<annotation cp="👳">↑↑↑</annotation>
-		<annotation cp="👳" type="tts">↑↑↑</annotation>
-		<annotation cp="👳‍♂">↑↑↑</annotation>
-		<annotation cp="👳‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👳‍♀">↑↑↑</annotation>
-		<annotation cp="👳‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="👲">↑↑↑</annotation>
-		<annotation cp="👲" type="tts">↑↑↑</annotation>
-		<annotation cp="🧕">↑↑↑</annotation>
-		<annotation cp="🧕" type="tts">↑↑↑</annotation>
-		<annotation cp="🤵">↑↑↑</annotation>
-		<annotation cp="🤵" type="tts">↑↑↑</annotation>
-		<annotation cp="🤵‍♂">↑↑↑</annotation>
-		<annotation cp="🤵‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤵‍♀">↑↑↑</annotation>
-		<annotation cp="🤵‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="👰">↑↑↑</annotation>
-		<annotation cp="👰" type="tts">↑↑↑</annotation>
-		<annotation cp="👰‍♂">↑↑↑</annotation>
-		<annotation cp="👰‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👰‍♀">↑↑↑</annotation>
-		<annotation cp="👰‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤰">↑↑↑</annotation>
-		<annotation cp="🤰" type="tts">↑↑↑</annotation>
-		<annotation cp="🤱">↑↑↑</annotation>
-		<annotation cp="🤱" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🍼">↑↑↑</annotation>
-		<annotation cp="👩‍🍼" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🍼">↑↑↑</annotation>
-		<annotation cp="👨‍🍼" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🍼">↑↑↑</annotation>
-		<annotation cp="🧑‍🍼" type="tts">↑↑↑</annotation>
-		<annotation cp="👼">↑↑↑</annotation>
-		<annotation cp="👼" type="tts">↑↑↑</annotation>
 		<annotation cp="🎅">celebration | Christmas | Claus | Father | Santa</annotation>
-		<annotation cp="🎅" type="tts">↑↑↑</annotation>
 		<annotation cp="🤶">celebration | Christmas | Claus | Mother | Mrs.</annotation>
-		<annotation cp="🤶" type="tts">Mrs. Claus</annotation>
 		<annotation cp="🧑‍🎄">Claus, Christmas | Mx. Claus</annotation>
 		<annotation cp="🧑‍🎄" type="tts">Mx. Claus</annotation>
-		<annotation cp="🦸">↑↑↑</annotation>
-		<annotation cp="🦸" type="tts">↑↑↑</annotation>
-		<annotation cp="🦸‍♂">↑↑↑</annotation>
-		<annotation cp="🦸‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🦸‍♀">↑↑↑</annotation>
-		<annotation cp="🦸‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🦹">↑↑↑</annotation>
-		<annotation cp="🦹" type="tts">↑↑↑</annotation>
-		<annotation cp="🦹‍♂">↑↑↑</annotation>
-		<annotation cp="🦹‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🦹‍♀">↑↑↑</annotation>
-		<annotation cp="🦹‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧙">↑↑↑</annotation>
-		<annotation cp="🧙" type="tts">↑↑↑</annotation>
-		<annotation cp="🧙‍♂">↑↑↑</annotation>
-		<annotation cp="🧙‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧙‍♀">↑↑↑</annotation>
-		<annotation cp="🧙‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧚">↑↑↑</annotation>
-		<annotation cp="🧚" type="tts">↑↑↑</annotation>
-		<annotation cp="🧚‍♂">↑↑↑</annotation>
-		<annotation cp="🧚‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧚‍♀">↑↑↑</annotation>
-		<annotation cp="🧚‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧛">↑↑↑</annotation>
-		<annotation cp="🧛" type="tts">↑↑↑</annotation>
-		<annotation cp="🧛‍♂">↑↑↑</annotation>
-		<annotation cp="🧛‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧛‍♀">↑↑↑</annotation>
-		<annotation cp="🧛‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧜">↑↑↑</annotation>
-		<annotation cp="🧜" type="tts">↑↑↑</annotation>
-		<annotation cp="🧜‍♂">↑↑↑</annotation>
-		<annotation cp="🧜‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧜‍♀">↑↑↑</annotation>
-		<annotation cp="🧜‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧝">↑↑↑</annotation>
-		<annotation cp="🧝" type="tts">↑↑↑</annotation>
-		<annotation cp="🧝‍♂">↑↑↑</annotation>
-		<annotation cp="🧝‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧝‍♀">↑↑↑</annotation>
-		<annotation cp="🧝‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧞">↑↑↑</annotation>
-		<annotation cp="🧞" type="tts">↑↑↑</annotation>
-		<annotation cp="🧞‍♂">↑↑↑</annotation>
-		<annotation cp="🧞‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧞‍♀">↑↑↑</annotation>
-		<annotation cp="🧞‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧟">↑↑↑</annotation>
-		<annotation cp="🧟" type="tts">↑↑↑</annotation>
-		<annotation cp="🧟‍♂">↑↑↑</annotation>
-		<annotation cp="🧟‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧟‍♀">↑↑↑</annotation>
-		<annotation cp="🧟‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="💆">↑↑↑</annotation>
-		<annotation cp="💆" type="tts">↑↑↑</annotation>
-		<annotation cp="💆‍♂">↑↑↑</annotation>
-		<annotation cp="💆‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="💆‍♀">↑↑↑</annotation>
-		<annotation cp="💆‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="💇">barber | beauty | haircut | parlour | person getting haircut</annotation>
-		<annotation cp="💇" type="tts">↑↑↑</annotation>
-		<annotation cp="💇‍♂">↑↑↑</annotation>
-		<annotation cp="💇‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="💇‍♀">↑↑↑</annotation>
-		<annotation cp="💇‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🚶">↑↑↑</annotation>
-		<annotation cp="🚶" type="tts">↑↑↑</annotation>
-		<annotation cp="🚶‍♂">↑↑↑</annotation>
-		<annotation cp="🚶‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🚶‍♀">↑↑↑</annotation>
-		<annotation cp="🚶‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧍">↑↑↑</annotation>
-		<annotation cp="🧍" type="tts">↑↑↑</annotation>
-		<annotation cp="🧍‍♂">↑↑↑</annotation>
-		<annotation cp="🧍‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧍‍♀">↑↑↑</annotation>
-		<annotation cp="🧍‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧎">↑↑↑</annotation>
-		<annotation cp="🧎" type="tts">↑↑↑</annotation>
-		<annotation cp="🧎‍♂">↑↑↑</annotation>
-		<annotation cp="🧎‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧎‍♀">↑↑↑</annotation>
-		<annotation cp="🧎‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🦯">↑↑↑</annotation>
-		<annotation cp="🧑‍🦯" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🦯">↑↑↑</annotation>
-		<annotation cp="👨‍🦯" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🦯">↑↑↑</annotation>
-		<annotation cp="👩‍🦯" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🦼">↑↑↑</annotation>
-		<annotation cp="🧑‍🦼" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🦼">↑↑↑</annotation>
-		<annotation cp="👨‍🦼" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🦼">↑↑↑</annotation>
-		<annotation cp="👩‍🦼" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🦽">↑↑↑</annotation>
-		<annotation cp="🧑‍🦽" type="tts">↑↑↑</annotation>
-		<annotation cp="👨‍🦽">↑↑↑</annotation>
-		<annotation cp="👨‍🦽" type="tts">↑↑↑</annotation>
-		<annotation cp="👩‍🦽">↑↑↑</annotation>
-		<annotation cp="👩‍🦽" type="tts">↑↑↑</annotation>
-		<annotation cp="🏃">↑↑↑</annotation>
-		<annotation cp="🏃" type="tts">↑↑↑</annotation>
-		<annotation cp="🏃‍♂">↑↑↑</annotation>
-		<annotation cp="🏃‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🏃‍♀">↑↑↑</annotation>
-		<annotation cp="🏃‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="💃">↑↑↑</annotation>
-		<annotation cp="💃" type="tts">↑↑↑</annotation>
-		<annotation cp="🕺">↑↑↑</annotation>
-		<annotation cp="🕺" type="tts">↑↑↑</annotation>
-		<annotation cp="🕴">↑↑↑</annotation>
-		<annotation cp="🕴" type="tts">↑↑↑</annotation>
-		<annotation cp="👯">↑↑↑</annotation>
-		<annotation cp="👯" type="tts">↑↑↑</annotation>
-		<annotation cp="👯‍♂">↑↑↑</annotation>
-		<annotation cp="👯‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="👯‍♀">↑↑↑</annotation>
-		<annotation cp="👯‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧖">↑↑↑</annotation>
-		<annotation cp="🧖" type="tts">↑↑↑</annotation>
-		<annotation cp="🧖‍♂">↑↑↑</annotation>
-		<annotation cp="🧖‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧖‍♀">↑↑↑</annotation>
-		<annotation cp="🧖‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧗">↑↑↑</annotation>
-		<annotation cp="🧗" type="tts">↑↑↑</annotation>
-		<annotation cp="🧗‍♂">↑↑↑</annotation>
-		<annotation cp="🧗‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧗‍♀">↑↑↑</annotation>
-		<annotation cp="🧗‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤺">↑↑↑</annotation>
-		<annotation cp="🤺" type="tts">↑↑↑</annotation>
-		<annotation cp="🏇">↑↑↑</annotation>
-		<annotation cp="🏇" type="tts">↑↑↑</annotation>
-		<annotation cp="⛷">↑↑↑</annotation>
-		<annotation cp="⛷" type="tts">↑↑↑</annotation>
-		<annotation cp="🏂">↑↑↑</annotation>
-		<annotation cp="🏂" type="tts">↑↑↑</annotation>
-		<annotation cp="🏌">↑↑↑</annotation>
-		<annotation cp="🏌" type="tts">↑↑↑</annotation>
-		<annotation cp="🏌‍♂">↑↑↑</annotation>
-		<annotation cp="🏌‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🏌‍♀">↑↑↑</annotation>
-		<annotation cp="🏌‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🏄">↑↑↑</annotation>
-		<annotation cp="🏄" type="tts">↑↑↑</annotation>
-		<annotation cp="🏄‍♂">↑↑↑</annotation>
-		<annotation cp="🏄‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🏄‍♀">↑↑↑</annotation>
-		<annotation cp="🏄‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🚣">↑↑↑</annotation>
-		<annotation cp="🚣" type="tts">↑↑↑</annotation>
-		<annotation cp="🚣‍♂">↑↑↑</annotation>
-		<annotation cp="🚣‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🚣‍♀">↑↑↑</annotation>
-		<annotation cp="🚣‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🏊">↑↑↑</annotation>
-		<annotation cp="🏊" type="tts">↑↑↑</annotation>
-		<annotation cp="🏊‍♂">↑↑↑</annotation>
-		<annotation cp="🏊‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🏊‍♀">↑↑↑</annotation>
-		<annotation cp="🏊‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="⛹">↑↑↑</annotation>
-		<annotation cp="⛹" type="tts">↑↑↑</annotation>
-		<annotation cp="⛹‍♂">↑↑↑</annotation>
-		<annotation cp="⛹‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="⛹‍♀">↑↑↑</annotation>
-		<annotation cp="⛹‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="🏋">lifter | person lifting weights | weight | weightlifter</annotation>
-		<annotation cp="🏋" type="tts">↑↑↑</annotation>
-		<annotation cp="🏋‍♂">↑↑↑</annotation>
-		<annotation cp="🏋‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🏋‍♀">↑↑↑</annotation>
-		<annotation cp="🏋‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🚴">↑↑↑</annotation>
-		<annotation cp="🚴" type="tts">↑↑↑</annotation>
-		<annotation cp="🚴‍♂">↑↑↑</annotation>
-		<annotation cp="🚴‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🚴‍♀">↑↑↑</annotation>
-		<annotation cp="🚴‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🚵">↑↑↑</annotation>
-		<annotation cp="🚵" type="tts">↑↑↑</annotation>
-		<annotation cp="🚵‍♂">↑↑↑</annotation>
-		<annotation cp="🚵‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🚵‍♀">↑↑↑</annotation>
-		<annotation cp="🚵‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤸">↑↑↑</annotation>
-		<annotation cp="🤸" type="tts">↑↑↑</annotation>
-		<annotation cp="🤸‍♂">↑↑↑</annotation>
-		<annotation cp="🤸‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤸‍♀">↑↑↑</annotation>
-		<annotation cp="🤸‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤼">↑↑↑</annotation>
-		<annotation cp="🤼" type="tts">↑↑↑</annotation>
-		<annotation cp="🤼‍♂">↑↑↑</annotation>
-		<annotation cp="🤼‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤼‍♀">↑↑↑</annotation>
-		<annotation cp="🤼‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤽">↑↑↑</annotation>
-		<annotation cp="🤽" type="tts">↑↑↑</annotation>
-		<annotation cp="🤽‍♂">↑↑↑</annotation>
-		<annotation cp="🤽‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤽‍♀">↑↑↑</annotation>
-		<annotation cp="🤽‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🤾">↑↑↑</annotation>
-		<annotation cp="🤾" type="tts">↑↑↑</annotation>
-		<annotation cp="🤾‍♂">↑↑↑</annotation>
-		<annotation cp="🤾‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🤾‍♀">↑↑↑</annotation>
-		<annotation cp="🤾‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="🤹">balance | juggle | multi-task | multitask | person juggling | skill</annotation>
-		<annotation cp="🤹" type="tts">↑↑↑</annotation>
 		<annotation cp="🤹‍♂">juggling | man | multi-task | multitask</annotation>
-		<annotation cp="🤹‍♂" type="tts">↑↑↑</annotation>
 		<annotation cp="🤹‍♀">juggling | multi-task | multitask | woman</annotation>
-		<annotation cp="🤹‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧘">↑↑↑</annotation>
-		<annotation cp="🧘" type="tts">↑↑↑</annotation>
-		<annotation cp="🧘‍♂">↑↑↑</annotation>
-		<annotation cp="🧘‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧘‍♀">↑↑↑</annotation>
-		<annotation cp="🧘‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🛀">↑↑↑</annotation>
-		<annotation cp="🛀" type="tts">↑↑↑</annotation>
-		<annotation cp="🛌">↑↑↑</annotation>
-		<annotation cp="🛌" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🤝‍🧑">↑↑↑</annotation>
-		<annotation cp="🧑‍🤝‍🧑" type="tts">↑↑↑</annotation>
 		<annotation cp="👭">couple | hand | holding hands | two women holding hands | women</annotation>
-		<annotation cp="👭" type="tts">↑↑↑</annotation>
-		<annotation cp="👫">↑↑↑</annotation>
-		<annotation cp="👫" type="tts">↑↑↑</annotation>
 		<annotation cp="👬">couple | Gemini | holding hands | men | twins | two men holding hands | zodiac</annotation>
-		<annotation cp="👬" type="tts">↑↑↑</annotation>
-		<annotation cp="💏">↑↑↑</annotation>
-		<annotation cp="💏" type="tts">↑↑↑</annotation>
-		<annotation cp="💑">↑↑↑</annotation>
-		<annotation cp="💑" type="tts">↑↑↑</annotation>
-		<annotation cp="👪">↑↑↑</annotation>
-		<annotation cp="👪" type="tts">↑↑↑</annotation>
-		<annotation cp="🗣">↑↑↑</annotation>
-		<annotation cp="🗣" type="tts">↑↑↑</annotation>
-		<annotation cp="👤">↑↑↑</annotation>
-		<annotation cp="👤" type="tts">↑↑↑</annotation>
-		<annotation cp="👥">↑↑↑</annotation>
-		<annotation cp="👥" type="tts">↑↑↑</annotation>
-		<annotation cp="🫂">↑↑↑</annotation>
-		<annotation cp="🫂" type="tts">↑↑↑</annotation>
-		<annotation cp="👣">↑↑↑</annotation>
-		<annotation cp="👣" type="tts">↑↑↑</annotation>
-		<annotation cp="🦰">↑↑↑</annotation>
-		<annotation cp="🦰" type="tts">↑↑↑</annotation>
-		<annotation cp="🦱">↑↑↑</annotation>
-		<annotation cp="🦱" type="tts">↑↑↑</annotation>
 		<annotation cp="🦳">gray | grey | hair | old | white</annotation>
-		<annotation cp="🦳" type="tts">↑↑↑</annotation>
-		<annotation cp="🦲">↑↑↑</annotation>
-		<annotation cp="🦲" type="tts">↑↑↑</annotation>
-		<annotation cp="🐵">↑↑↑</annotation>
-		<annotation cp="🐵" type="tts">↑↑↑</annotation>
-		<annotation cp="🐒">↑↑↑</annotation>
-		<annotation cp="🐒" type="tts">↑↑↑</annotation>
-		<annotation cp="🦍">↑↑↑</annotation>
-		<annotation cp="🦍" type="tts">↑↑↑</annotation>
-		<annotation cp="🦧">↑↑↑</annotation>
-		<annotation cp="🦧" type="tts">↑↑↑</annotation>
-		<annotation cp="🐶">↑↑↑</annotation>
-		<annotation cp="🐶" type="tts">↑↑↑</annotation>
-		<annotation cp="🐕">↑↑↑</annotation>
-		<annotation cp="🐕" type="tts">↑↑↑</annotation>
-		<annotation cp="🦮">↑↑↑</annotation>
-		<annotation cp="🦮" type="tts">↑↑↑</annotation>
-		<annotation cp="🐕‍🦺">↑↑↑</annotation>
-		<annotation cp="🐕‍🦺" type="tts">↑↑↑</annotation>
-		<annotation cp="🐩">↑↑↑</annotation>
-		<annotation cp="🐩" type="tts">↑↑↑</annotation>
-		<annotation cp="🐺">↑↑↑</annotation>
-		<annotation cp="🐺" type="tts">↑↑↑</annotation>
-		<annotation cp="🦊">↑↑↑</annotation>
-		<annotation cp="🦊" type="tts">↑↑↑</annotation>
-		<annotation cp="🦝">↑↑↑</annotation>
-		<annotation cp="🦝" type="tts">↑↑↑</annotation>
-		<annotation cp="🐱">↑↑↑</annotation>
-		<annotation cp="🐱" type="tts">↑↑↑</annotation>
-		<annotation cp="🐈">↑↑↑</annotation>
-		<annotation cp="🐈" type="tts">↑↑↑</annotation>
-		<annotation cp="🐈‍⬛">↑↑↑</annotation>
-		<annotation cp="🐈‍⬛" type="tts">↑↑↑</annotation>
-		<annotation cp="🦁">↑↑↑</annotation>
-		<annotation cp="🦁" type="tts">↑↑↑</annotation>
-		<annotation cp="🐯">↑↑↑</annotation>
-		<annotation cp="🐯" type="tts">↑↑↑</annotation>
-		<annotation cp="🐅">↑↑↑</annotation>
-		<annotation cp="🐅" type="tts">↑↑↑</annotation>
-		<annotation cp="🐆">↑↑↑</annotation>
-		<annotation cp="🐆" type="tts">↑↑↑</annotation>
-		<annotation cp="🐴">↑↑↑</annotation>
-		<annotation cp="🐴" type="tts">↑↑↑</annotation>
-		<annotation cp="🐎">↑↑↑</annotation>
-		<annotation cp="🐎" type="tts">↑↑↑</annotation>
-		<annotation cp="🦄">↑↑↑</annotation>
-		<annotation cp="🦄" type="tts">↑↑↑</annotation>
-		<annotation cp="🦓">↑↑↑</annotation>
-		<annotation cp="🦓" type="tts">↑↑↑</annotation>
-		<annotation cp="🦌">↑↑↑</annotation>
-		<annotation cp="🦌" type="tts">↑↑↑</annotation>
-		<annotation cp="🦬">↑↑↑</annotation>
-		<annotation cp="🦬" type="tts">↑↑↑</annotation>
-		<annotation cp="🐮">↑↑↑</annotation>
-		<annotation cp="🐮" type="tts">↑↑↑</annotation>
-		<annotation cp="🐂">↑↑↑</annotation>
-		<annotation cp="🐂" type="tts">↑↑↑</annotation>
-		<annotation cp="🐃">↑↑↑</annotation>
-		<annotation cp="🐃" type="tts">↑↑↑</annotation>
-		<annotation cp="🐄">↑↑↑</annotation>
-		<annotation cp="🐄" type="tts">↑↑↑</annotation>
-		<annotation cp="🐷">↑↑↑</annotation>
-		<annotation cp="🐷" type="tts">↑↑↑</annotation>
-		<annotation cp="🐖">↑↑↑</annotation>
-		<annotation cp="🐖" type="tts">↑↑↑</annotation>
-		<annotation cp="🐗">↑↑↑</annotation>
-		<annotation cp="🐗" type="tts">↑↑↑</annotation>
-		<annotation cp="🐽">↑↑↑</annotation>
-		<annotation cp="🐽" type="tts">↑↑↑</annotation>
-		<annotation cp="🐏">↑↑↑</annotation>
-		<annotation cp="🐏" type="tts">↑↑↑</annotation>
-		<annotation cp="🐑">↑↑↑</annotation>
-		<annotation cp="🐑" type="tts">↑↑↑</annotation>
-		<annotation cp="🐐">↑↑↑</annotation>
-		<annotation cp="🐐" type="tts">↑↑↑</annotation>
-		<annotation cp="🐪">↑↑↑</annotation>
-		<annotation cp="🐪" type="tts">↑↑↑</annotation>
 		<annotation cp="🐫">Bactrian | camel | hump | two-hump camel</annotation>
-		<annotation cp="🐫" type="tts">↑↑↑</annotation>
-		<annotation cp="🦙">↑↑↑</annotation>
-		<annotation cp="🦙" type="tts">↑↑↑</annotation>
-		<annotation cp="🦒">↑↑↑</annotation>
-		<annotation cp="🦒" type="tts">↑↑↑</annotation>
-		<annotation cp="🐘">↑↑↑</annotation>
-		<annotation cp="🐘" type="tts">↑↑↑</annotation>
-		<annotation cp="🦣">↑↑↑</annotation>
-		<annotation cp="🦣" type="tts">↑↑↑</annotation>
-		<annotation cp="🦏">↑↑↑</annotation>
-		<annotation cp="🦏" type="tts">↑↑↑</annotation>
-		<annotation cp="🦛">↑↑↑</annotation>
-		<annotation cp="🦛" type="tts">↑↑↑</annotation>
-		<annotation cp="🐭">↑↑↑</annotation>
-		<annotation cp="🐭" type="tts">↑↑↑</annotation>
-		<annotation cp="🐁">↑↑↑</annotation>
-		<annotation cp="🐁" type="tts">↑↑↑</annotation>
-		<annotation cp="🐀">↑↑↑</annotation>
-		<annotation cp="🐀" type="tts">↑↑↑</annotation>
-		<annotation cp="🐹">↑↑↑</annotation>
-		<annotation cp="🐹" type="tts">↑↑↑</annotation>
-		<annotation cp="🐰">↑↑↑</annotation>
-		<annotation cp="🐰" type="tts">↑↑↑</annotation>
-		<annotation cp="🐇">↑↑↑</annotation>
-		<annotation cp="🐇" type="tts">↑↑↑</annotation>
-		<annotation cp="🐿">↑↑↑</annotation>
-		<annotation cp="🐿" type="tts">↑↑↑</annotation>
-		<annotation cp="🦫">↑↑↑</annotation>
-		<annotation cp="🦫" type="tts">↑↑↑</annotation>
-		<annotation cp="🦔">↑↑↑</annotation>
-		<annotation cp="🦔" type="tts">↑↑↑</annotation>
-		<annotation cp="🦇">↑↑↑</annotation>
-		<annotation cp="🦇" type="tts">↑↑↑</annotation>
-		<annotation cp="🐻">↑↑↑</annotation>
-		<annotation cp="🐻" type="tts">↑↑↑</annotation>
-		<annotation cp="🐻‍❄">↑↑↑</annotation>
-		<annotation cp="🐻‍❄" type="tts">↑↑↑</annotation>
-		<annotation cp="🐨">↑↑↑</annotation>
-		<annotation cp="🐨" type="tts">↑↑↑</annotation>
-		<annotation cp="🐼">↑↑↑</annotation>
-		<annotation cp="🐼" type="tts">↑↑↑</annotation>
-		<annotation cp="🦥">↑↑↑</annotation>
-		<annotation cp="🦥" type="tts">↑↑↑</annotation>
-		<annotation cp="🦦">↑↑↑</annotation>
-		<annotation cp="🦦" type="tts">↑↑↑</annotation>
-		<annotation cp="🦨">↑↑↑</annotation>
-		<annotation cp="🦨" type="tts">↑↑↑</annotation>
-		<annotation cp="🦘">↑↑↑</annotation>
-		<annotation cp="🦘" type="tts">↑↑↑</annotation>
-		<annotation cp="🦡">↑↑↑</annotation>
-		<annotation cp="🦡" type="tts">↑↑↑</annotation>
-		<annotation cp="🐾">↑↑↑</annotation>
-		<annotation cp="🐾" type="tts">↑↑↑</annotation>
-		<annotation cp="🦃">↑↑↑</annotation>
-		<annotation cp="🦃" type="tts">↑↑↑</annotation>
-		<annotation cp="🐔">↑↑↑</annotation>
-		<annotation cp="🐔" type="tts">↑↑↑</annotation>
-		<annotation cp="🐓">↑↑↑</annotation>
-		<annotation cp="🐓" type="tts">↑↑↑</annotation>
-		<annotation cp="🐣">↑↑↑</annotation>
-		<annotation cp="🐣" type="tts">↑↑↑</annotation>
-		<annotation cp="🐤">↑↑↑</annotation>
-		<annotation cp="🐤" type="tts">↑↑↑</annotation>
-		<annotation cp="🐥">↑↑↑</annotation>
-		<annotation cp="🐥" type="tts">↑↑↑</annotation>
-		<annotation cp="🐦">↑↑↑</annotation>
-		<annotation cp="🐦" type="tts">↑↑↑</annotation>
-		<annotation cp="🐧">↑↑↑</annotation>
-		<annotation cp="🐧" type="tts">↑↑↑</annotation>
-		<annotation cp="🕊">↑↑↑</annotation>
-		<annotation cp="🕊" type="tts">↑↑↑</annotation>
-		<annotation cp="🦅">↑↑↑</annotation>
-		<annotation cp="🦅" type="tts">↑↑↑</annotation>
-		<annotation cp="🦆">↑↑↑</annotation>
-		<annotation cp="🦆" type="tts">↑↑↑</annotation>
-		<annotation cp="🦢">↑↑↑</annotation>
-		<annotation cp="🦢" type="tts">↑↑↑</annotation>
-		<annotation cp="🦉">↑↑↑</annotation>
-		<annotation cp="🦉" type="tts">↑↑↑</annotation>
-		<annotation cp="🦤">↑↑↑</annotation>
-		<annotation cp="🦤" type="tts">↑↑↑</annotation>
-		<annotation cp="🪶">↑↑↑</annotation>
-		<annotation cp="🪶" type="tts">↑↑↑</annotation>
-		<annotation cp="🦩">↑↑↑</annotation>
-		<annotation cp="🦩" type="tts">↑↑↑</annotation>
-		<annotation cp="🦚">↑↑↑</annotation>
-		<annotation cp="🦚" type="tts">↑↑↑</annotation>
-		<annotation cp="🦜">↑↑↑</annotation>
-		<annotation cp="🦜" type="tts">↑↑↑</annotation>
-		<annotation cp="🐸">↑↑↑</annotation>
-		<annotation cp="🐸" type="tts">↑↑↑</annotation>
-		<annotation cp="🐊">↑↑↑</annotation>
-		<annotation cp="🐊" type="tts">↑↑↑</annotation>
-		<annotation cp="🐢">↑↑↑</annotation>
-		<annotation cp="🐢" type="tts">↑↑↑</annotation>
-		<annotation cp="🦎">↑↑↑</annotation>
-		<annotation cp="🦎" type="tts">↑↑↑</annotation>
-		<annotation cp="🐍">↑↑↑</annotation>
-		<annotation cp="🐍" type="tts">↑↑↑</annotation>
-		<annotation cp="🐲">↑↑↑</annotation>
-		<annotation cp="🐲" type="tts">↑↑↑</annotation>
-		<annotation cp="🐉">↑↑↑</annotation>
-		<annotation cp="🐉" type="tts">↑↑↑</annotation>
-		<annotation cp="🦕">↑↑↑</annotation>
-		<annotation cp="🦕" type="tts">↑↑↑</annotation>
-		<annotation cp="🦖">↑↑↑</annotation>
-		<annotation cp="🦖" type="tts">↑↑↑</annotation>
-		<annotation cp="🐳">↑↑↑</annotation>
-		<annotation cp="🐳" type="tts">↑↑↑</annotation>
-		<annotation cp="🐋">↑↑↑</annotation>
-		<annotation cp="🐋" type="tts">↑↑↑</annotation>
-		<annotation cp="🐬">↑↑↑</annotation>
-		<annotation cp="🐬" type="tts">↑↑↑</annotation>
-		<annotation cp="🦭">↑↑↑</annotation>
-		<annotation cp="🦭" type="tts">↑↑↑</annotation>
-		<annotation cp="🐟">↑↑↑</annotation>
-		<annotation cp="🐟" type="tts">↑↑↑</annotation>
-		<annotation cp="🐠">↑↑↑</annotation>
-		<annotation cp="🐠" type="tts">↑↑↑</annotation>
-		<annotation cp="🐡">↑↑↑</annotation>
-		<annotation cp="🐡" type="tts">↑↑↑</annotation>
-		<annotation cp="🦈">↑↑↑</annotation>
-		<annotation cp="🦈" type="tts">↑↑↑</annotation>
-		<annotation cp="🐙">↑↑↑</annotation>
-		<annotation cp="🐙" type="tts">↑↑↑</annotation>
-		<annotation cp="🐚">↑↑↑</annotation>
-		<annotation cp="🐚" type="tts">↑↑↑</annotation>
-		<annotation cp="🐌">↑↑↑</annotation>
-		<annotation cp="🐌" type="tts">↑↑↑</annotation>
-		<annotation cp="🦋">↑↑↑</annotation>
-		<annotation cp="🦋" type="tts">↑↑↑</annotation>
-		<annotation cp="🐛">↑↑↑</annotation>
-		<annotation cp="🐛" type="tts">↑↑↑</annotation>
-		<annotation cp="🐜">↑↑↑</annotation>
-		<annotation cp="🐜" type="tts">↑↑↑</annotation>
-		<annotation cp="🐝">↑↑↑</annotation>
-		<annotation cp="🐝" type="tts">↑↑↑</annotation>
-		<annotation cp="🪲">↑↑↑</annotation>
-		<annotation cp="🪲" type="tts">↑↑↑</annotation>
-		<annotation cp="🐞">beetle | insect | lady beetle | ladybird | ladybug</annotation>
 		<annotation cp="🐞" type="tts">ladybug</annotation>
-		<annotation cp="🦗">↑↑↑</annotation>
-		<annotation cp="🦗" type="tts">↑↑↑</annotation>
-		<annotation cp="🪳">↑↑↑</annotation>
-		<annotation cp="🪳" type="tts">↑↑↑</annotation>
-		<annotation cp="🕷">↑↑↑</annotation>
-		<annotation cp="🕷" type="tts">↑↑↑</annotation>
-		<annotation cp="🕸">spider | web</annotation>
-		<annotation cp="🕸" type="tts">spider web</annotation>
-		<annotation cp="🦂">↑↑↑</annotation>
-		<annotation cp="🦂" type="tts">↑↑↑</annotation>
-		<annotation cp="🦟">↑↑↑</annotation>
-		<annotation cp="🦟" type="tts">↑↑↑</annotation>
-		<annotation cp="🪰">↑↑↑</annotation>
-		<annotation cp="🪰" type="tts">↑↑↑</annotation>
-		<annotation cp="🪱">↑↑↑</annotation>
-		<annotation cp="🪱" type="tts">↑↑↑</annotation>
-		<annotation cp="🦠">↑↑↑</annotation>
-		<annotation cp="🦠" type="tts">↑↑↑</annotation>
-		<annotation cp="💐">↑↑↑</annotation>
-		<annotation cp="💐" type="tts">↑↑↑</annotation>
-		<annotation cp="🌸">↑↑↑</annotation>
-		<annotation cp="🌸" type="tts">↑↑↑</annotation>
-		<annotation cp="💮">↑↑↑</annotation>
-		<annotation cp="💮" type="tts">↑↑↑</annotation>
-		<annotation cp="🏵">↑↑↑</annotation>
-		<annotation cp="🏵" type="tts">↑↑↑</annotation>
-		<annotation cp="🌹">↑↑↑</annotation>
-		<annotation cp="🌹" type="tts">↑↑↑</annotation>
-		<annotation cp="🥀">↑↑↑</annotation>
-		<annotation cp="🥀" type="tts">↑↑↑</annotation>
-		<annotation cp="🌺">↑↑↑</annotation>
-		<annotation cp="🌺" type="tts">↑↑↑</annotation>
-		<annotation cp="🌻">↑↑↑</annotation>
-		<annotation cp="🌻" type="tts">↑↑↑</annotation>
-		<annotation cp="🌼">↑↑↑</annotation>
-		<annotation cp="🌼" type="tts">↑↑↑</annotation>
-		<annotation cp="🌷">↑↑↑</annotation>
-		<annotation cp="🌷" type="tts">↑↑↑</annotation>
-		<annotation cp="🌱">↑↑↑</annotation>
-		<annotation cp="🌱" type="tts">↑↑↑</annotation>
-		<annotation cp="🪴">↑↑↑</annotation>
-		<annotation cp="🪴" type="tts">↑↑↑</annotation>
-		<annotation cp="🌲">↑↑↑</annotation>
-		<annotation cp="🌲" type="tts">↑↑↑</annotation>
-		<annotation cp="🌳">↑↑↑</annotation>
-		<annotation cp="🌳" type="tts">↑↑↑</annotation>
-		<annotation cp="🌴">↑↑↑</annotation>
-		<annotation cp="🌴" type="tts">↑↑↑</annotation>
-		<annotation cp="🌵">↑↑↑</annotation>
-		<annotation cp="🌵" type="tts">↑↑↑</annotation>
 		<annotation cp="🌾">ear | grain | rice | sheaf | sheaf of rice</annotation>
-		<annotation cp="🌾" type="tts">sheaf of rice</annotation>
-		<annotation cp="🌿">↑↑↑</annotation>
-		<annotation cp="🌿" type="tts">↑↑↑</annotation>
-		<annotation cp="☘">↑↑↑</annotation>
-		<annotation cp="☘" type="tts">↑↑↑</annotation>
-		<annotation cp="🍀">↑↑↑</annotation>
-		<annotation cp="🍀" type="tts">↑↑↑</annotation>
-		<annotation cp="🍁">↑↑↑</annotation>
-		<annotation cp="🍁" type="tts">↑↑↑</annotation>
-		<annotation cp="🍂">↑↑↑</annotation>
-		<annotation cp="🍂" type="tts">↑↑↑</annotation>
-		<annotation cp="🍃">↑↑↑</annotation>
-		<annotation cp="🍃" type="tts">↑↑↑</annotation>
-		<annotation cp="🍇">↑↑↑</annotation>
-		<annotation cp="🍇" type="tts">↑↑↑</annotation>
-		<annotation cp="🍈">↑↑↑</annotation>
-		<annotation cp="🍈" type="tts">↑↑↑</annotation>
-		<annotation cp="🍉">↑↑↑</annotation>
-		<annotation cp="🍉" type="tts">↑↑↑</annotation>
-		<annotation cp="🍊">↑↑↑</annotation>
-		<annotation cp="🍊" type="tts">↑↑↑</annotation>
-		<annotation cp="🍋">↑↑↑</annotation>
-		<annotation cp="🍋" type="tts">↑↑↑</annotation>
-		<annotation cp="🍌">↑↑↑</annotation>
-		<annotation cp="🍌" type="tts">↑↑↑</annotation>
-		<annotation cp="🍍">↑↑↑</annotation>
-		<annotation cp="🍍" type="tts">↑↑↑</annotation>
-		<annotation cp="🥭">↑↑↑</annotation>
-		<annotation cp="🥭" type="tts">↑↑↑</annotation>
-		<annotation cp="🍎">↑↑↑</annotation>
-		<annotation cp="🍎" type="tts">↑↑↑</annotation>
-		<annotation cp="🍏">↑↑↑</annotation>
-		<annotation cp="🍏" type="tts">↑↑↑</annotation>
-		<annotation cp="🍐">↑↑↑</annotation>
-		<annotation cp="🍐" type="tts">↑↑↑</annotation>
-		<annotation cp="🍑">↑↑↑</annotation>
-		<annotation cp="🍑" type="tts">↑↑↑</annotation>
-		<annotation cp="🍒">↑↑↑</annotation>
-		<annotation cp="🍒" type="tts">↑↑↑</annotation>
-		<annotation cp="🍓">↑↑↑</annotation>
-		<annotation cp="🍓" type="tts">↑↑↑</annotation>
-		<annotation cp="🫐">↑↑↑</annotation>
-		<annotation cp="🫐" type="tts">↑↑↑</annotation>
-		<annotation cp="🥝">↑↑↑</annotation>
-		<annotation cp="🥝" type="tts">↑↑↑</annotation>
-		<annotation cp="🍅">↑↑↑</annotation>
-		<annotation cp="🍅" type="tts">↑↑↑</annotation>
-		<annotation cp="🫒">↑↑↑</annotation>
-		<annotation cp="🫒" type="tts">↑↑↑</annotation>
-		<annotation cp="🥥">↑↑↑</annotation>
-		<annotation cp="🥥" type="tts">↑↑↑</annotation>
-		<annotation cp="🥑">↑↑↑</annotation>
-		<annotation cp="🥑" type="tts">↑↑↑</annotation>
-		<annotation cp="🍆">↑↑↑</annotation>
-		<annotation cp="🍆" type="tts">↑↑↑</annotation>
-		<annotation cp="🥔">↑↑↑</annotation>
-		<annotation cp="🥔" type="tts">↑↑↑</annotation>
-		<annotation cp="🥕">↑↑↑</annotation>
-		<annotation cp="🥕" type="tts">↑↑↑</annotation>
-		<annotation cp="🌽">↑↑↑</annotation>
-		<annotation cp="🌽" type="tts">↑↑↑</annotation>
-		<annotation cp="🌶">↑↑↑</annotation>
-		<annotation cp="🌶" type="tts">↑↑↑</annotation>
-		<annotation cp="🫑">↑↑↑</annotation>
-		<annotation cp="🫑" type="tts">↑↑↑</annotation>
-		<annotation cp="🥒">↑↑↑</annotation>
-		<annotation cp="🥒" type="tts">↑↑↑</annotation>
-		<annotation cp="🥬">↑↑↑</annotation>
-		<annotation cp="🥬" type="tts">↑↑↑</annotation>
-		<annotation cp="🥦">↑↑↑</annotation>
-		<annotation cp="🥦" type="tts">↑↑↑</annotation>
-		<annotation cp="🧄">↑↑↑</annotation>
-		<annotation cp="🧄" type="tts">↑↑↑</annotation>
-		<annotation cp="🧅">↑↑↑</annotation>
-		<annotation cp="🧅" type="tts">↑↑↑</annotation>
-		<annotation cp="🍄">↑↑↑</annotation>
-		<annotation cp="🍄" type="tts">↑↑↑</annotation>
-		<annotation cp="🥜">food | nut | peanut | peanuts | vegetable</annotation>
-		<annotation cp="🥜" type="tts">↑↑↑</annotation>
 		<annotation cp="🌰">chestnut | nut | plant</annotation>
-		<annotation cp="🌰" type="tts">↑↑↑</annotation>
-		<annotation cp="🍞">↑↑↑</annotation>
-		<annotation cp="🍞" type="tts">↑↑↑</annotation>
 		<annotation cp="🥐">bread | crescent roll | croissant | food | French</annotation>
-		<annotation cp="🥐" type="tts">↑↑↑</annotation>
 		<annotation cp="🥖">baguette | bread | food | French</annotation>
-		<annotation cp="🥖" type="tts">↑↑↑</annotation>
-		<annotation cp="🫓">↑↑↑</annotation>
-		<annotation cp="🫓" type="tts">↑↑↑</annotation>
-		<annotation cp="🥨">↑↑↑</annotation>
-		<annotation cp="🥨" type="tts">↑↑↑</annotation>
-		<annotation cp="🥯">↑↑↑</annotation>
-		<annotation cp="🥯" type="tts">↑↑↑</annotation>
-		<annotation cp="🥞">↑↑↑</annotation>
-		<annotation cp="🥞" type="tts">↑↑↑</annotation>
-		<annotation cp="🧇">↑↑↑</annotation>
-		<annotation cp="🧇" type="tts">↑↑↑</annotation>
-		<annotation cp="🧀">↑↑↑</annotation>
-		<annotation cp="🧀" type="tts">↑↑↑</annotation>
-		<annotation cp="🍖">↑↑↑</annotation>
-		<annotation cp="🍖" type="tts">↑↑↑</annotation>
-		<annotation cp="🍗">↑↑↑</annotation>
-		<annotation cp="🍗" type="tts">↑↑↑</annotation>
-		<annotation cp="🥩">↑↑↑</annotation>
-		<annotation cp="🥩" type="tts">↑↑↑</annotation>
-		<annotation cp="🥓">↑↑↑</annotation>
-		<annotation cp="🥓" type="tts">↑↑↑</annotation>
-		<annotation cp="🍔">burger | hamburger</annotation>
-		<annotation cp="🍔" type="tts">hamburger</annotation>
+		<annotation cp="🧇">breakfast | iron | unclear | vague | waffle</annotation>
+		<annotation cp="🥩">chop | cut of meat | lamb chop | pork chop | steak</annotation>
 		<annotation cp="🍟">French | fries</annotation>
 		<annotation cp="🍟" type="tts">French fries</annotation>
-		<annotation cp="🍕">↑↑↑</annotation>
-		<annotation cp="🍕" type="tts">↑↑↑</annotation>
-		<annotation cp="🌭">↑↑↑</annotation>
-		<annotation cp="🌭" type="tts">↑↑↑</annotation>
-		<annotation cp="🥪">↑↑↑</annotation>
-		<annotation cp="🥪" type="tts">↑↑↑</annotation>
 		<annotation cp="🌮">Mexican | taco</annotation>
-		<annotation cp="🌮" type="tts">↑↑↑</annotation>
 		<annotation cp="🌯">burrito | Mexican | wrap</annotation>
-		<annotation cp="🌯" type="tts">↑↑↑</annotation>
-		<annotation cp="🫔">↑↑↑</annotation>
-		<annotation cp="🫔" type="tts">↑↑↑</annotation>
-		<annotation cp="🥙">↑↑↑</annotation>
-		<annotation cp="🥙" type="tts">↑↑↑</annotation>
 		<annotation cp="🧆">chick pea | chickpea | falafel | meatball</annotation>
-		<annotation cp="🧆" type="tts">↑↑↑</annotation>
-		<annotation cp="🥚">↑↑↑</annotation>
-		<annotation cp="🥚" type="tts">↑↑↑</annotation>
-		<annotation cp="🍳">↑↑↑</annotation>
-		<annotation cp="🍳" type="tts">↑↑↑</annotation>
-		<annotation cp="🥘">↑↑↑</annotation>
-		<annotation cp="🥘" type="tts">↑↑↑</annotation>
-		<annotation cp="🍲">↑↑↑</annotation>
-		<annotation cp="🍲" type="tts">↑↑↑</annotation>
-		<annotation cp="🫕">↑↑↑</annotation>
-		<annotation cp="🫕" type="tts">↑↑↑</annotation>
-		<annotation cp="🥣">↑↑↑</annotation>
-		<annotation cp="🥣" type="tts">↑↑↑</annotation>
-		<annotation cp="🥗">↑↑↑</annotation>
-		<annotation cp="🥗" type="tts">↑↑↑</annotation>
-		<annotation cp="🍿">↑↑↑</annotation>
-		<annotation cp="🍿" type="tts">↑↑↑</annotation>
-		<annotation cp="🧈">↑↑↑</annotation>
-		<annotation cp="🧈" type="tts">↑↑↑</annotation>
-		<annotation cp="🧂">↑↑↑</annotation>
-		<annotation cp="🧂" type="tts">↑↑↑</annotation>
-		<annotation cp="🥫">↑↑↑</annotation>
-		<annotation cp="🥫" type="tts">canned food</annotation>
-		<annotation cp="🍱">↑↑↑</annotation>
-		<annotation cp="🍱" type="tts">↑↑↑</annotation>
-		<annotation cp="🍘">↑↑↑</annotation>
-		<annotation cp="🍘" type="tts">↑↑↑</annotation>
-		<annotation cp="🍙">↑↑↑</annotation>
-		<annotation cp="🍙" type="tts">↑↑↑</annotation>
-		<annotation cp="🍚">↑↑↑</annotation>
-		<annotation cp="🍚" type="tts">↑↑↑</annotation>
-		<annotation cp="🍛">↑↑↑</annotation>
-		<annotation cp="🍛" type="tts">↑↑↑</annotation>
-		<annotation cp="🍜">↑↑↑</annotation>
-		<annotation cp="🍜" type="tts">↑↑↑</annotation>
-		<annotation cp="🍝">↑↑↑</annotation>
-		<annotation cp="🍝" type="tts">↑↑↑</annotation>
-		<annotation cp="🍠">↑↑↑</annotation>
-		<annotation cp="🍠" type="tts">↑↑↑</annotation>
-		<annotation cp="🍢">↑↑↑</annotation>
-		<annotation cp="🍢" type="tts">↑↑↑</annotation>
-		<annotation cp="🍣">↑↑↑</annotation>
-		<annotation cp="🍣" type="tts">↑↑↑</annotation>
-		<annotation cp="🍤">↑↑↑</annotation>
-		<annotation cp="🍤" type="tts">↑↑↑</annotation>
-		<annotation cp="🍥">↑↑↑</annotation>
-		<annotation cp="🍥" type="tts">↑↑↑</annotation>
-		<annotation cp="🥮">↑↑↑</annotation>
-		<annotation cp="🥮" type="tts">↑↑↑</annotation>
-		<annotation cp="🍡">↑↑↑</annotation>
-		<annotation cp="🍡" type="tts">↑↑↑</annotation>
-		<annotation cp="🥟">↑↑↑</annotation>
-		<annotation cp="🥟" type="tts">↑↑↑</annotation>
-		<annotation cp="🥠">↑↑↑</annotation>
-		<annotation cp="🥠" type="tts">↑↑↑</annotation>
-		<annotation cp="🥡">oyster pail | takeout box</annotation>
-		<annotation cp="🥡" type="tts">↑↑↑</annotation>
-		<annotation cp="🦀">↑↑↑</annotation>
-		<annotation cp="🦀" type="tts">↑↑↑</annotation>
-		<annotation cp="🦞">↑↑↑</annotation>
-		<annotation cp="🦞" type="tts">↑↑↑</annotation>
-		<annotation cp="🦐">↑↑↑</annotation>
-		<annotation cp="🦐" type="tts">↑↑↑</annotation>
-		<annotation cp="🦑">↑↑↑</annotation>
-		<annotation cp="🦑" type="tts">↑↑↑</annotation>
-		<annotation cp="🦪">↑↑↑</annotation>
-		<annotation cp="🦪" type="tts">↑↑↑</annotation>
+		<annotation cp="🍥">cake | fish | fish cake with swirl | narutomaki | pastry | swirl</annotation>
 		<annotation cp="🍦">cream | dessert | ice | soft | sweet</annotation>
-		<annotation cp="🍦" type="tts">↑↑↑</annotation>
-		<annotation cp="🍧">↑↑↑</annotation>
-		<annotation cp="🍧" type="tts">↑↑↑</annotation>
-		<annotation cp="🍨">↑↑↑</annotation>
-		<annotation cp="🍨" type="tts">↑↑↑</annotation>
-		<annotation cp="🍩">↑↑↑</annotation>
-		<annotation cp="🍩" type="tts">↑↑↑</annotation>
-		<annotation cp="🍪">cookie | dessert | sweet</annotation>
-		<annotation cp="🍪" type="tts">cookie</annotation>
-		<annotation cp="🎂">↑↑↑</annotation>
-		<annotation cp="🎂" type="tts">↑↑↑</annotation>
-		<annotation cp="🍰">↑↑↑</annotation>
-		<annotation cp="🍰" type="tts">↑↑↑</annotation>
-		<annotation cp="🧁">↑↑↑</annotation>
-		<annotation cp="🧁" type="tts">↑↑↑</annotation>
-		<annotation cp="🥧">↑↑↑</annotation>
-		<annotation cp="🥧" type="tts">↑↑↑</annotation>
-		<annotation cp="🍫">↑↑↑</annotation>
-		<annotation cp="🍫" type="tts">↑↑↑</annotation>
 		<annotation cp="🍬">candy | dessert | sweet | sweets</annotation>
-		<annotation cp="🍬" type="tts">candy</annotation>
-		<annotation cp="🍭">candy | dessert | lollipop | sweet</annotation>
-		<annotation cp="🍭" type="tts">↑↑↑</annotation>
-		<annotation cp="🍮">↑↑↑</annotation>
-		<annotation cp="🍮" type="tts">↑↑↑</annotation>
-		<annotation cp="🍯">↑↑↑</annotation>
-		<annotation cp="🍯" type="tts">↑↑↑</annotation>
-		<annotation cp="🍼">↑↑↑</annotation>
-		<annotation cp="🍼" type="tts">↑↑↑</annotation>
-		<annotation cp="🥛">↑↑↑</annotation>
-		<annotation cp="🥛" type="tts">↑↑↑</annotation>
-		<annotation cp="☕">↑↑↑</annotation>
-		<annotation cp="☕" type="tts">↑↑↑</annotation>
-		<annotation cp="🫖">↑↑↑</annotation>
-		<annotation cp="🫖" type="tts">↑↑↑</annotation>
-		<annotation cp="🍵">↑↑↑</annotation>
-		<annotation cp="🍵" type="tts">↑↑↑</annotation>
-		<annotation cp="🍶">↑↑↑</annotation>
-		<annotation cp="🍶" type="tts">↑↑↑</annotation>
-		<annotation cp="🍾">↑↑↑</annotation>
-		<annotation cp="🍾" type="tts">↑↑↑</annotation>
-		<annotation cp="🍷">↑↑↑</annotation>
-		<annotation cp="🍷" type="tts">↑↑↑</annotation>
-		<annotation cp="🍸">↑↑↑</annotation>
-		<annotation cp="🍸" type="tts">↑↑↑</annotation>
-		<annotation cp="🍹">↑↑↑</annotation>
-		<annotation cp="🍹" type="tts">↑↑↑</annotation>
-		<annotation cp="🍺">↑↑↑</annotation>
-		<annotation cp="🍺" type="tts">↑↑↑</annotation>
-		<annotation cp="🍻">↑↑↑</annotation>
-		<annotation cp="🍻" type="tts">↑↑↑</annotation>
-		<annotation cp="🥂">↑↑↑</annotation>
-		<annotation cp="🥂" type="tts">↑↑↑</annotation>
-		<annotation cp="🥃">↑↑↑</annotation>
-		<annotation cp="🥃" type="tts">↑↑↑</annotation>
-		<annotation cp="🥤">↑↑↑</annotation>
-		<annotation cp="🥤" type="tts">↑↑↑</annotation>
-		<annotation cp="🧋">↑↑↑</annotation>
-		<annotation cp="🧋" type="tts">↑↑↑</annotation>
-		<annotation cp="🧃">↑↑↑</annotation>
-		<annotation cp="🧃" type="tts">↑↑↑</annotation>
-		<annotation cp="🧉">↑↑↑</annotation>
-		<annotation cp="🧉" type="tts">↑↑↑</annotation>
-		<annotation cp="🧊">↑↑↑</annotation>
-		<annotation cp="🧊" type="tts">↑↑↑</annotation>
-		<annotation cp="🥢">↑↑↑</annotation>
-		<annotation cp="🥢" type="tts">↑↑↑</annotation>
-		<annotation cp="🍽">↑↑↑</annotation>
-		<annotation cp="🍽" type="tts">↑↑↑</annotation>
+		<annotation cp="🍶">bar | beverage | bottle | cup | drink | sake | saké</annotation>
 		<annotation cp="🍴">cooking | cutlery | fork | fork and knife | knife | knife and fork</annotation>
-		<annotation cp="🍴" type="tts">fork and knife</annotation>
-		<annotation cp="🥄">↑↑↑</annotation>
-		<annotation cp="🥄" type="tts">↑↑↑</annotation>
-		<annotation cp="🔪">↑↑↑</annotation>
-		<annotation cp="🔪" type="tts">↑↑↑</annotation>
-		<annotation cp="🏺">↑↑↑</annotation>
-		<annotation cp="🏺" type="tts">↑↑↑</annotation>
-		<annotation cp="🌍">↑↑↑</annotation>
-		<annotation cp="🌍" type="tts">↑↑↑</annotation>
-		<annotation cp="🌎">↑↑↑</annotation>
-		<annotation cp="🌎" type="tts">↑↑↑</annotation>
-		<annotation cp="🌏">↑↑↑</annotation>
-		<annotation cp="🌏" type="tts">↑↑↑</annotation>
-		<annotation cp="🌐">↑↑↑</annotation>
-		<annotation cp="🌐" type="tts">↑↑↑</annotation>
-		<annotation cp="🗺">↑↑↑</annotation>
-		<annotation cp="🗺" type="tts">↑↑↑</annotation>
-		<annotation cp="🗾">↑↑↑</annotation>
-		<annotation cp="🗾" type="tts">↑↑↑</annotation>
-		<annotation cp="🧭">↑↑↑</annotation>
-		<annotation cp="🧭" type="tts">↑↑↑</annotation>
-		<annotation cp="🏔">↑↑↑</annotation>
-		<annotation cp="🏔" type="tts">↑↑↑</annotation>
-		<annotation cp="⛰">↑↑↑</annotation>
-		<annotation cp="⛰" type="tts">↑↑↑</annotation>
-		<annotation cp="🌋">↑↑↑</annotation>
-		<annotation cp="🌋" type="tts">↑↑↑</annotation>
 		<annotation cp="🗻">Fuji | mount Fuji | mountain</annotation>
 		<annotation cp="🗻" type="tts">mount Fuji</annotation>
-		<annotation cp="🏕">↑↑↑</annotation>
-		<annotation cp="🏕" type="tts">↑↑↑</annotation>
-		<annotation cp="🏖">↑↑↑</annotation>
-		<annotation cp="🏖" type="tts">↑↑↑</annotation>
-		<annotation cp="🏜">↑↑↑</annotation>
-		<annotation cp="🏜" type="tts">↑↑↑</annotation>
-		<annotation cp="🏝">↑↑↑</annotation>
-		<annotation cp="🏝" type="tts">↑↑↑</annotation>
-		<annotation cp="🏞">↑↑↑</annotation>
-		<annotation cp="🏞" type="tts">↑↑↑</annotation>
-		<annotation cp="🏟">↑↑↑</annotation>
-		<annotation cp="🏟" type="tts">↑↑↑</annotation>
-		<annotation cp="🏛">↑↑↑</annotation>
-		<annotation cp="🏛" type="tts">↑↑↑</annotation>
-		<annotation cp="🏗">↑↑↑</annotation>
-		<annotation cp="🏗" type="tts">↑↑↑</annotation>
-		<annotation cp="🧱">↑↑↑</annotation>
-		<annotation cp="🧱" type="tts">↑↑↑</annotation>
-		<annotation cp="🪨">↑↑↑</annotation>
-		<annotation cp="🪨" type="tts">↑↑↑</annotation>
-		<annotation cp="🪵">↑↑↑</annotation>
-		<annotation cp="🪵" type="tts">↑↑↑</annotation>
-		<annotation cp="🛖">↑↑↑</annotation>
-		<annotation cp="🛖" type="tts">↑↑↑</annotation>
-		<annotation cp="🏘">↑↑↑</annotation>
-		<annotation cp="🏘" type="tts">↑↑↑</annotation>
-		<annotation cp="🏚">↑↑↑</annotation>
-		<annotation cp="🏚" type="tts">↑↑↑</annotation>
-		<annotation cp="🏠">↑↑↑</annotation>
-		<annotation cp="🏠" type="tts">↑↑↑</annotation>
-		<annotation cp="🏡">↑↑↑</annotation>
-		<annotation cp="🏡" type="tts">↑↑↑</annotation>
-		<annotation cp="🏢">↑↑↑</annotation>
-		<annotation cp="🏢" type="tts">↑↑↑</annotation>
-		<annotation cp="🏣">↑↑↑</annotation>
-		<annotation cp="🏣" type="tts">↑↑↑</annotation>
-		<annotation cp="🏤">↑↑↑</annotation>
-		<annotation cp="🏤" type="tts">↑↑↑</annotation>
-		<annotation cp="🏥">↑↑↑</annotation>
-		<annotation cp="🏥" type="tts">↑↑↑</annotation>
-		<annotation cp="🏦">↑↑↑</annotation>
-		<annotation cp="🏦" type="tts">↑↑↑</annotation>
-		<annotation cp="🏨">↑↑↑</annotation>
-		<annotation cp="🏨" type="tts">↑↑↑</annotation>
-		<annotation cp="🏩">↑↑↑</annotation>
-		<annotation cp="🏩" type="tts">↑↑↑</annotation>
+		<annotation cp="🏛">classical | classical building | column</annotation>
 		<annotation cp="🏪">convenience | dépanneur | store</annotation>
-		<annotation cp="🏪" type="tts">↑↑↑</annotation>
-		<annotation cp="🏫">↑↑↑</annotation>
-		<annotation cp="🏫" type="tts">↑↑↑</annotation>
-		<annotation cp="🏬">↑↑↑</annotation>
-		<annotation cp="🏬" type="tts">↑↑↑</annotation>
-		<annotation cp="🏭">↑↑↑</annotation>
-		<annotation cp="🏭" type="tts">↑↑↑</annotation>
-		<annotation cp="🏯">↑↑↑</annotation>
-		<annotation cp="🏯" type="tts">↑↑↑</annotation>
-		<annotation cp="🏰">↑↑↑</annotation>
-		<annotation cp="🏰" type="tts">↑↑↑</annotation>
-		<annotation cp="💒">↑↑↑</annotation>
-		<annotation cp="💒" type="tts">↑↑↑</annotation>
 		<annotation cp="🗼">Tokyo | Tower</annotation>
 		<annotation cp="🗼" type="tts">Tokyo Tower</annotation>
 		<annotation cp="🗽">Liberty | Statue | Statue of Liberty</annotation>
-		<annotation cp="🗽" type="tts">↑↑↑</annotation>
-		<annotation cp="⛪">↑↑↑</annotation>
-		<annotation cp="⛪" type="tts">↑↑↑</annotation>
 		<annotation cp="🕌">Islam | mosque | Muslim | religion</annotation>
-		<annotation cp="🕌" type="tts">↑↑↑</annotation>
 		<annotation cp="🛕">Hindu | temple</annotation>
 		<annotation cp="🛕" type="tts">Hindu temple</annotation>
 		<annotation cp="🕍">Jew | Jewish | religion | shul | synagogue | temple</annotation>
-		<annotation cp="🕍" type="tts">↑↑↑</annotation>
 		<annotation cp="⛩">religion | Shinto | shrine</annotation>
 		<annotation cp="⛩" type="tts">Shinto shrine</annotation>
 		<annotation cp="🕋">Islam | kaaba | Kaaba | Muslim | religion</annotation>
-		<annotation cp="🕋" type="tts">↑↑↑</annotation>
-		<annotation cp="⛲">↑↑↑</annotation>
-		<annotation cp="⛲" type="tts">↑↑↑</annotation>
-		<annotation cp="⛺">↑↑↑</annotation>
-		<annotation cp="⛺" type="tts">↑↑↑</annotation>
-		<annotation cp="🌁">↑↑↑</annotation>
-		<annotation cp="🌁" type="tts">↑↑↑</annotation>
-		<annotation cp="🌃">↑↑↑</annotation>
-		<annotation cp="🌃" type="tts">↑↑↑</annotation>
-		<annotation cp="🏙">↑↑↑</annotation>
-		<annotation cp="🏙" type="tts">↑↑↑</annotation>
-		<annotation cp="🌄">↑↑↑</annotation>
-		<annotation cp="🌄" type="tts">↑↑↑</annotation>
-		<annotation cp="🌅">↑↑↑</annotation>
-		<annotation cp="🌅" type="tts">↑↑↑</annotation>
-		<annotation cp="🌆">↑↑↑</annotation>
-		<annotation cp="🌆" type="tts">↑↑↑</annotation>
-		<annotation cp="🌇">↑↑↑</annotation>
-		<annotation cp="🌇" type="tts">↑↑↑</annotation>
-		<annotation cp="🌉">↑↑↑</annotation>
-		<annotation cp="🌉" type="tts">↑↑↑</annotation>
-		<annotation cp="♨">↑↑↑</annotation>
-		<annotation cp="♨" type="tts">↑↑↑</annotation>
-		<annotation cp="🎠">↑↑↑</annotation>
-		<annotation cp="🎠" type="tts">↑↑↑</annotation>
+		<annotation cp="🕋" type="tts">Kaaba</annotation>
 		<annotation cp="🎡">amusement park | Ferris | theme park | wheel</annotation>
 		<annotation cp="🎡" type="tts">Ferris wheel</annotation>
-		<annotation cp="🎢">↑↑↑</annotation>
-		<annotation cp="🎢" type="tts">↑↑↑</annotation>
-		<annotation cp="💈">↑↑↑</annotation>
-		<annotation cp="💈" type="tts">barber pole</annotation>
-		<annotation cp="🎪">↑↑↑</annotation>
-		<annotation cp="🎪" type="tts">↑↑↑</annotation>
-		<annotation cp="🚂">↑↑↑</annotation>
-		<annotation cp="🚂" type="tts">↑↑↑</annotation>
 		<annotation cp="🚃">car | electric | railway | train | tram | trolley bus | trolleybus</annotation>
-		<annotation cp="🚃" type="tts">railway car</annotation>
 		<annotation cp="🚄">high-speed train | railway | Shinkansen | speed | train</annotation>
-		<annotation cp="🚄" type="tts">↑↑↑</annotation>
 		<annotation cp="🚅">bullet | railway | Shinkansen | speed | train</annotation>
-		<annotation cp="🚅" type="tts">↑↑↑</annotation>
-		<annotation cp="🚆">↑↑↑</annotation>
-		<annotation cp="🚆" type="tts">↑↑↑</annotation>
-		<annotation cp="🚇">↑↑↑</annotation>
 		<annotation cp="🚇" type="tts">subway</annotation>
-		<annotation cp="🚈">↑↑↑</annotation>
-		<annotation cp="🚈" type="tts">↑↑↑</annotation>
-		<annotation cp="🚉">↑↑↑</annotation>
-		<annotation cp="🚉" type="tts">↑↑↑</annotation>
 		<annotation cp="🚊">car | streetcar | tram | tramcar | trolley | trolley bus | trolleybus</annotation>
-		<annotation cp="🚊" type="tts">↑↑↑</annotation>
-		<annotation cp="🚝">↑↑↑</annotation>
-		<annotation cp="🚝" type="tts">↑↑↑</annotation>
-		<annotation cp="🚞">↑↑↑</annotation>
-		<annotation cp="🚞" type="tts">↑↑↑</annotation>
 		<annotation cp="🚋">car | streetcar | tram | tramcar | trolley | trolley bus | trolleybus</annotation>
 		<annotation cp="🚋" type="tts">streetcar</annotation>
-		<annotation cp="🚌">↑↑↑</annotation>
-		<annotation cp="🚌" type="tts">↑↑↑</annotation>
-		<annotation cp="🚍">↑↑↑</annotation>
-		<annotation cp="🚍" type="tts">↑↑↑</annotation>
 		<annotation cp="🚎">bus | streetcar | tram | trolley | trolleybus</annotation>
 		<annotation cp="🚎" type="tts">trolley bus</annotation>
-		<annotation cp="🚐">↑↑↑</annotation>
-		<annotation cp="🚐" type="tts">↑↑↑</annotation>
-		<annotation cp="🚑">↑↑↑</annotation>
-		<annotation cp="🚑" type="tts">↑↑↑</annotation>
-		<annotation cp="🚒">↑↑↑</annotation>
 		<annotation cp="🚒" type="tts">fire truck</annotation>
-		<annotation cp="🚓">↑↑↑</annotation>
-		<annotation cp="🚓" type="tts">↑↑↑</annotation>
-		<annotation cp="🚔">↑↑↑</annotation>
-		<annotation cp="🚔" type="tts">↑↑↑</annotation>
-		<annotation cp="🚕">↑↑↑</annotation>
-		<annotation cp="🚕" type="tts">↑↑↑</annotation>
-		<annotation cp="🚖">↑↑↑</annotation>
-		<annotation cp="🚖" type="tts">↑↑↑</annotation>
-		<annotation cp="🚗">↑↑↑</annotation>
-		<annotation cp="🚗" type="tts">↑↑↑</annotation>
-		<annotation cp="🚘">↑↑↑</annotation>
-		<annotation cp="🚘" type="tts">↑↑↑</annotation>
 		<annotation cp="🚙">recreational | sport utility | sport utility vehicle | SUV</annotation>
-		<annotation cp="🚙" type="tts">↑↑↑</annotation>
-		<annotation cp="🛻">↑↑↑</annotation>
-		<annotation cp="🛻" type="tts">↑↑↑</annotation>
-		<annotation cp="🚚">↑↑↑</annotation>
-		<annotation cp="🚚" type="tts">↑↑↑</annotation>
-		<annotation cp="🚛">↑↑↑</annotation>
 		<annotation cp="🚛" type="tts">semi</annotation>
-		<annotation cp="🚜">↑↑↑</annotation>
-		<annotation cp="🚜" type="tts">↑↑↑</annotation>
-		<annotation cp="🏎">↑↑↑</annotation>
-		<annotation cp="🏎" type="tts">↑↑↑</annotation>
-		<annotation cp="🏍">↑↑↑</annotation>
-		<annotation cp="🏍" type="tts">↑↑↑</annotation>
-		<annotation cp="🛵">↑↑↑</annotation>
-		<annotation cp="🛵" type="tts">↑↑↑</annotation>
-		<annotation cp="🦽">↑↑↑</annotation>
-		<annotation cp="🦽" type="tts">↑↑↑</annotation>
-		<annotation cp="🦼">↑↑↑</annotation>
-		<annotation cp="🦼" type="tts">↑↑↑</annotation>
 		<annotation cp="🛺">auto rickshaw | tuk tuk | tuk-tuk | tuktuk</annotation>
-		<annotation cp="🛺" type="tts">↑↑↑</annotation>
-		<annotation cp="🚲">↑↑↑</annotation>
-		<annotation cp="🚲" type="tts">↑↑↑</annotation>
-		<annotation cp="🛴">↑↑↑</annotation>
-		<annotation cp="🛴" type="tts">↑↑↑</annotation>
-		<annotation cp="🛹">↑↑↑</annotation>
-		<annotation cp="🛹" type="tts">↑↑↑</annotation>
-		<annotation cp="🛼">↑↑↑</annotation>
-		<annotation cp="🛼" type="tts">↑↑↑</annotation>
 		<annotation cp="🚏">bus | busstop | stop</annotation>
-		<annotation cp="🚏" type="tts">↑↑↑</annotation>
-		<annotation cp="🛣">↑↑↑</annotation>
 		<annotation cp="🛣" type="tts">highway</annotation>
-		<annotation cp="🛤">↑↑↑</annotation>
-		<annotation cp="🛤" type="tts">↑↑↑</annotation>
-		<annotation cp="🛢">↑↑↑</annotation>
-		<annotation cp="🛢" type="tts">↑↑↑</annotation>
-		<annotation cp="⛽">diesel | fuel | fuelpump | gas | pump | station</annotation>
 		<annotation cp="⛽" type="tts">gas pump</annotation>
-		<annotation cp="🚨">↑↑↑</annotation>
-		<annotation cp="🚨" type="tts">↑↑↑</annotation>
-		<annotation cp="🚥">↑↑↑</annotation>
-		<annotation cp="🚥" type="tts">↑↑↑</annotation>
-		<annotation cp="🚦">↑↑↑</annotation>
-		<annotation cp="🚦" type="tts">↑↑↑</annotation>
-		<annotation cp="🛑">↑↑↑</annotation>
-		<annotation cp="🛑" type="tts">↑↑↑</annotation>
-		<annotation cp="🚧">↑↑↑</annotation>
-		<annotation cp="🚧" type="tts">↑↑↑</annotation>
-		<annotation cp="⚓">↑↑↑</annotation>
-		<annotation cp="⚓" type="tts">↑↑↑</annotation>
-		<annotation cp="⛵">↑↑↑</annotation>
-		<annotation cp="⛵" type="tts">↑↑↑</annotation>
-		<annotation cp="🛶">↑↑↑</annotation>
-		<annotation cp="🛶" type="tts">↑↑↑</annotation>
-		<annotation cp="🚤">↑↑↑</annotation>
-		<annotation cp="🚤" type="tts">↑↑↑</annotation>
-		<annotation cp="🛳">↑↑↑</annotation>
-		<annotation cp="🛳" type="tts">↑↑↑</annotation>
-		<annotation cp="⛴">↑↑↑</annotation>
-		<annotation cp="⛴" type="tts">↑↑↑</annotation>
-		<annotation cp="🛥">↑↑↑</annotation>
 		<annotation cp="🛥" type="tts">motorboat</annotation>
-		<annotation cp="🚢">↑↑↑</annotation>
-		<annotation cp="🚢" type="tts">↑↑↑</annotation>
-		<annotation cp="✈">↑↑↑</annotation>
-		<annotation cp="✈" type="tts">↑↑↑</annotation>
-		<annotation cp="🛩">↑↑↑</annotation>
-		<annotation cp="🛩" type="tts">↑↑↑</annotation>
-		<annotation cp="🛫">aeroplane | airplane | check-in | departure | departures</annotation>
-		<annotation cp="🛫" type="tts">↑↑↑</annotation>
-		<annotation cp="🛬">↑↑↑</annotation>
-		<annotation cp="🛬" type="tts">↑↑↑</annotation>
-		<annotation cp="🪂">↑↑↑</annotation>
-		<annotation cp="🪂" type="tts">↑↑↑</annotation>
-		<annotation cp="💺">↑↑↑</annotation>
-		<annotation cp="💺" type="tts">↑↑↑</annotation>
-		<annotation cp="🚁">↑↑↑</annotation>
-		<annotation cp="🚁" type="tts">↑↑↑</annotation>
-		<annotation cp="🚟">↑↑↑</annotation>
-		<annotation cp="🚟" type="tts">↑↑↑</annotation>
-		<annotation cp="🚠">↑↑↑</annotation>
-		<annotation cp="🚠" type="tts">↑↑↑</annotation>
-		<annotation cp="🚡">↑↑↑</annotation>
-		<annotation cp="🚡" type="tts">↑↑↑</annotation>
-		<annotation cp="🛰">↑↑↑</annotation>
-		<annotation cp="🛰" type="tts">↑↑↑</annotation>
-		<annotation cp="🚀">↑↑↑</annotation>
-		<annotation cp="🚀" type="tts">↑↑↑</annotation>
-		<annotation cp="🛸">↑↑↑</annotation>
-		<annotation cp="🛸" type="tts">↑↑↑</annotation>
-		<annotation cp="🛎">↑↑↑</annotation>
-		<annotation cp="🛎" type="tts">↑↑↑</annotation>
-		<annotation cp="🧳">↑↑↑</annotation>
-		<annotation cp="🧳" type="tts">↑↑↑</annotation>
-		<annotation cp="⌛">↑↑↑</annotation>
-		<annotation cp="⌛" type="tts">↑↑↑</annotation>
-		<annotation cp="⏳">↑↑↑</annotation>
-		<annotation cp="⏳" type="tts">↑↑↑</annotation>
-		<annotation cp="⌚">↑↑↑</annotation>
-		<annotation cp="⌚" type="tts">↑↑↑</annotation>
-		<annotation cp="⏰">↑↑↑</annotation>
-		<annotation cp="⏰" type="tts">↑↑↑</annotation>
-		<annotation cp="⏱">↑↑↑</annotation>
-		<annotation cp="⏱" type="tts">↑↑↑</annotation>
-		<annotation cp="⏲">↑↑↑</annotation>
-		<annotation cp="⏲" type="tts">↑↑↑</annotation>
-		<annotation cp="🕰">↑↑↑</annotation>
-		<annotation cp="🕰" type="tts">↑↑↑</annotation>
-		<annotation cp="🕛">↑↑↑</annotation>
-		<annotation cp="🕛" type="tts">↑↑↑</annotation>
 		<annotation cp="🕧">12 | 12:30 | clock | half past twelve | thirty | twelve | twelve-thirty</annotation>
 		<annotation cp="🕧" type="tts">twelve thirty</annotation>
-		<annotation cp="🕐">↑↑↑</annotation>
-		<annotation cp="🕐" type="tts">↑↑↑</annotation>
 		<annotation cp="🕜">1 | 1:30 | clock | half past one | one | one-thirty | thirty</annotation>
 		<annotation cp="🕜" type="tts">one thirty</annotation>
-		<annotation cp="🕑">↑↑↑</annotation>
-		<annotation cp="🕑" type="tts">↑↑↑</annotation>
 		<annotation cp="🕝">2 | 2:30 | clock | half past two | thirty | two | two-thirty</annotation>
 		<annotation cp="🕝" type="tts">two thirty</annotation>
-		<annotation cp="🕒">↑↑↑</annotation>
-		<annotation cp="🕒" type="tts">↑↑↑</annotation>
 		<annotation cp="🕞">3 | 3:30 | clock | half past three | thirty | three | three-thirty</annotation>
 		<annotation cp="🕞" type="tts">three thirty</annotation>
-		<annotation cp="🕓">↑↑↑</annotation>
-		<annotation cp="🕓" type="tts">↑↑↑</annotation>
 		<annotation cp="🕟">4 | 4:30 | clock | four | four-thirty | half past four | thirty</annotation>
 		<annotation cp="🕟" type="tts">four thirty</annotation>
-		<annotation cp="🕔">↑↑↑</annotation>
-		<annotation cp="🕔" type="tts">↑↑↑</annotation>
 		<annotation cp="🕠">5 | 5:30 | clock | five | five-thirty | half past five | thirty</annotation>
 		<annotation cp="🕠" type="tts">five thirty</annotation>
-		<annotation cp="🕕">↑↑↑</annotation>
-		<annotation cp="🕕" type="tts">↑↑↑</annotation>
 		<annotation cp="🕡">6 | 6:30 | clock | half past six | six | six-thirty | thirty</annotation>
 		<annotation cp="🕡" type="tts">six thirty</annotation>
-		<annotation cp="🕖">↑↑↑</annotation>
-		<annotation cp="🕖" type="tts">↑↑↑</annotation>
 		<annotation cp="🕢">7 | 7:30 | clock | half past seven | seven | seven-thirty | thirty</annotation>
 		<annotation cp="🕢" type="tts">seven thirty</annotation>
-		<annotation cp="🕗">↑↑↑</annotation>
-		<annotation cp="🕗" type="tts">↑↑↑</annotation>
 		<annotation cp="🕣">8 | 8:30 | clock | eight | eight-thirty | half past eight | thirty</annotation>
 		<annotation cp="🕣" type="tts">eight thirty</annotation>
-		<annotation cp="🕘">↑↑↑</annotation>
-		<annotation cp="🕘" type="tts">↑↑↑</annotation>
 		<annotation cp="🕤">9 | 9:30 | clock | half past nine | nine | nine-thirty | thirty</annotation>
 		<annotation cp="🕤" type="tts">nine thirty</annotation>
-		<annotation cp="🕙">↑↑↑</annotation>
-		<annotation cp="🕙" type="tts">↑↑↑</annotation>
 		<annotation cp="🕥">10 | 10:30 | clock | half past ten | ten | ten-thirty | thirty</annotation>
 		<annotation cp="🕥" type="tts">ten thirty</annotation>
-		<annotation cp="🕚">↑↑↑</annotation>
-		<annotation cp="🕚" type="tts">↑↑↑</annotation>
 		<annotation cp="🕦">11 | 11:30 | clock | eleven | eleven-thirty | half past eleven | thirty</annotation>
 		<annotation cp="🕦" type="tts">eleven thirty</annotation>
-		<annotation cp="🌑">↑↑↑</annotation>
-		<annotation cp="🌑" type="tts">↑↑↑</annotation>
-		<annotation cp="🌒">↑↑↑</annotation>
-		<annotation cp="🌒" type="tts">↑↑↑</annotation>
-		<annotation cp="🌓">↑↑↑</annotation>
-		<annotation cp="🌓" type="tts">↑↑↑</annotation>
-		<annotation cp="🌔">↑↑↑</annotation>
-		<annotation cp="🌔" type="tts">↑↑↑</annotation>
-		<annotation cp="🌕">↑↑↑</annotation>
-		<annotation cp="🌕" type="tts">↑↑↑</annotation>
-		<annotation cp="🌖">↑↑↑</annotation>
-		<annotation cp="🌖" type="tts">↑↑↑</annotation>
-		<annotation cp="🌗">↑↑↑</annotation>
-		<annotation cp="🌗" type="tts">↑↑↑</annotation>
-		<annotation cp="🌘">↑↑↑</annotation>
-		<annotation cp="🌘" type="tts">↑↑↑</annotation>
-		<annotation cp="🌙">↑↑↑</annotation>
-		<annotation cp="🌙" type="tts">↑↑↑</annotation>
-		<annotation cp="🌚">↑↑↑</annotation>
-		<annotation cp="🌚" type="tts">↑↑↑</annotation>
-		<annotation cp="🌛">↑↑↑</annotation>
-		<annotation cp="🌛" type="tts">↑↑↑</annotation>
-		<annotation cp="🌜">↑↑↑</annotation>
-		<annotation cp="🌜" type="tts">↑↑↑</annotation>
-		<annotation cp="🌡">↑↑↑</annotation>
-		<annotation cp="🌡" type="tts">↑↑↑</annotation>
-		<annotation cp="☀">↑↑↑</annotation>
-		<annotation cp="☀" type="tts">↑↑↑</annotation>
 		<annotation cp="🌝">bright | face | full | full-moon face | moon</annotation>
 		<annotation cp="🌝" type="tts">full-moon face</annotation>
-		<annotation cp="🌞">↑↑↑</annotation>
-		<annotation cp="🌞" type="tts">↑↑↑</annotation>
-		<annotation cp="🪐">↑↑↑</annotation>
-		<annotation cp="🪐" type="tts">↑↑↑</annotation>
-		<annotation cp="⭐">↑↑↑</annotation>
-		<annotation cp="⭐" type="tts">↑↑↑</annotation>
-		<annotation cp="🌟">↑↑↑</annotation>
-		<annotation cp="🌟" type="tts">↑↑↑</annotation>
-		<annotation cp="🌠">↑↑↑</annotation>
-		<annotation cp="🌠" type="tts">↑↑↑</annotation>
 		<annotation cp="🌌">Milky | space | Way</annotation>
 		<annotation cp="🌌" type="tts">Milky Way</annotation>
-		<annotation cp="☁">↑↑↑</annotation>
-		<annotation cp="☁" type="tts">↑↑↑</annotation>
-		<annotation cp="⛅">↑↑↑</annotation>
-		<annotation cp="⛅" type="tts">↑↑↑</annotation>
-		<annotation cp="⛈">↑↑↑</annotation>
-		<annotation cp="⛈" type="tts">↑↑↑</annotation>
-		<annotation cp="🌤">↑↑↑</annotation>
-		<annotation cp="🌤" type="tts">↑↑↑</annotation>
-		<annotation cp="🌥">↑↑↑</annotation>
-		<annotation cp="🌥" type="tts">↑↑↑</annotation>
-		<annotation cp="🌦">↑↑↑</annotation>
-		<annotation cp="🌦" type="tts">↑↑↑</annotation>
-		<annotation cp="🌧">↑↑↑</annotation>
-		<annotation cp="🌧" type="tts">↑↑↑</annotation>
-		<annotation cp="🌨">↑↑↑</annotation>
-		<annotation cp="🌨" type="tts">↑↑↑</annotation>
-		<annotation cp="🌩">↑↑↑</annotation>
-		<annotation cp="🌩" type="tts">↑↑↑</annotation>
-		<annotation cp="🌪">↑↑↑</annotation>
-		<annotation cp="🌪" type="tts">↑↑↑</annotation>
-		<annotation cp="🌫">↑↑↑</annotation>
-		<annotation cp="🌫" type="tts">↑↑↑</annotation>
-		<annotation cp="🌬">↑↑↑</annotation>
-		<annotation cp="🌬" type="tts">↑↑↑</annotation>
-		<annotation cp="🌀">↑↑↑</annotation>
-		<annotation cp="🌀" type="tts">↑↑↑</annotation>
-		<annotation cp="🌈">↑↑↑</annotation>
-		<annotation cp="🌈" type="tts">↑↑↑</annotation>
-		<annotation cp="🌂">↑↑↑</annotation>
-		<annotation cp="🌂" type="tts">↑↑↑</annotation>
-		<annotation cp="☂">↑↑↑</annotation>
-		<annotation cp="☂" type="tts">↑↑↑</annotation>
-		<annotation cp="☔">↑↑↑</annotation>
-		<annotation cp="☔" type="tts">↑↑↑</annotation>
-		<annotation cp="⛱">↑↑↑</annotation>
-		<annotation cp="⛱" type="tts">↑↑↑</annotation>
-		<annotation cp="⚡">↑↑↑</annotation>
-		<annotation cp="⚡" type="tts">↑↑↑</annotation>
-		<annotation cp="❄">↑↑↑</annotation>
-		<annotation cp="❄" type="tts">↑↑↑</annotation>
-		<annotation cp="☃">↑↑↑</annotation>
-		<annotation cp="☃" type="tts">↑↑↑</annotation>
-		<annotation cp="⛄">↑↑↑</annotation>
-		<annotation cp="⛄" type="tts">↑↑↑</annotation>
-		<annotation cp="☄">↑↑↑</annotation>
-		<annotation cp="☄" type="tts">↑↑↑</annotation>
-		<annotation cp="🔥">↑↑↑</annotation>
-		<annotation cp="🔥" type="tts">↑↑↑</annotation>
-		<annotation cp="💧">↑↑↑</annotation>
-		<annotation cp="💧" type="tts">↑↑↑</annotation>
-		<annotation cp="🌊">↑↑↑</annotation>
-		<annotation cp="🌊" type="tts">↑↑↑</annotation>
 		<annotation cp="🎃">celebration | Halloween | jack | jack-o-lantern | jack-o’-lantern | lantern</annotation>
-		<annotation cp="🎃" type="tts">↑↑↑</annotation>
-		<annotation cp="🎄">↑↑↑</annotation>
-		<annotation cp="🎄" type="tts">↑↑↑</annotation>
-		<annotation cp="🎆">↑↑↑</annotation>
-		<annotation cp="🎆" type="tts">↑↑↑</annotation>
-		<annotation cp="🎇">↑↑↑</annotation>
-		<annotation cp="🎇" type="tts">↑↑↑</annotation>
-		<annotation cp="🧨">↑↑↑</annotation>
-		<annotation cp="🧨" type="tts">↑↑↑</annotation>
-		<annotation cp="✨">↑↑↑</annotation>
-		<annotation cp="✨" type="tts">↑↑↑</annotation>
-		<annotation cp="🎈">↑↑↑</annotation>
-		<annotation cp="🎈" type="tts">↑↑↑</annotation>
-		<annotation cp="🎉">↑↑↑</annotation>
-		<annotation cp="🎉" type="tts">↑↑↑</annotation>
-		<annotation cp="🎊">↑↑↑</annotation>
-		<annotation cp="🎊" type="tts">↑↑↑</annotation>
 		<annotation cp="🎋">banner | celebration | Japanese | Tanabata tree | tree</annotation>
 		<annotation cp="🎋" type="tts">Tanabata tree</annotation>
-		<annotation cp="🎍">↑↑↑</annotation>
-		<annotation cp="🎍" type="tts">↑↑↑</annotation>
-		<annotation cp="🎎">↑↑↑</annotation>
-		<annotation cp="🎎" type="tts">↑↑↑</annotation>
-		<annotation cp="🎏">↑↑↑</annotation>
-		<annotation cp="🎏" type="tts">↑↑↑</annotation>
-		<annotation cp="🎐">↑↑↑</annotation>
-		<annotation cp="🎐" type="tts">↑↑↑</annotation>
 		<annotation cp="🎑">celebration | ceremony | moon | moon viewing ceremony | moon-viewing ceremony</annotation>
 		<annotation cp="🎑" type="tts">moon-viewing ceremony</annotation>
-		<annotation cp="🧧">↑↑↑</annotation>
-		<annotation cp="🧧" type="tts">↑↑↑</annotation>
-		<annotation cp="🎀">↑↑↑</annotation>
-		<annotation cp="🎀" type="tts">↑↑↑</annotation>
-		<annotation cp="🎁">↑↑↑</annotation>
-		<annotation cp="🎁" type="tts">↑↑↑</annotation>
-		<annotation cp="🎗">↑↑↑</annotation>
-		<annotation cp="🎗" type="tts">↑↑↑</annotation>
-		<annotation cp="🎟">↑↑↑</annotation>
-		<annotation cp="🎟" type="tts">↑↑↑</annotation>
-		<annotation cp="🎫">↑↑↑</annotation>
-		<annotation cp="🎫" type="tts">↑↑↑</annotation>
-		<annotation cp="🎖">↑↑↑</annotation>
-		<annotation cp="🎖" type="tts">↑↑↑</annotation>
-		<annotation cp="🏆">↑↑↑</annotation>
-		<annotation cp="🏆" type="tts">↑↑↑</annotation>
-		<annotation cp="🏅">↑↑↑</annotation>
-		<annotation cp="🏅" type="tts">↑↑↑</annotation>
-		<annotation cp="🥇">↑↑↑</annotation>
-		<annotation cp="🥇" type="tts">↑↑↑</annotation>
-		<annotation cp="🥈">↑↑↑</annotation>
-		<annotation cp="🥈" type="tts">↑↑↑</annotation>
-		<annotation cp="🥉">↑↑↑</annotation>
-		<annotation cp="🥉" type="tts">↑↑↑</annotation>
-		<annotation cp="⚽">ball | football | soccer</annotation>
-		<annotation cp="⚽" type="tts">soccer ball</annotation>
-		<annotation cp="⚾">↑↑↑</annotation>
-		<annotation cp="⚾" type="tts">↑↑↑</annotation>
-		<annotation cp="🥎">↑↑↑</annotation>
-		<annotation cp="🥎" type="tts">↑↑↑</annotation>
-		<annotation cp="🏀">↑↑↑</annotation>
-		<annotation cp="🏀" type="tts">↑↑↑</annotation>
-		<annotation cp="🏐">↑↑↑</annotation>
-		<annotation cp="🏐" type="tts">↑↑↑</annotation>
-		<annotation cp="🏈">↑↑↑</annotation>
 		<annotation cp="🏈" type="tts">football</annotation>
-		<annotation cp="🏉">↑↑↑</annotation>
 		<annotation cp="🏉" type="tts">rugby</annotation>
-		<annotation cp="🎾">↑↑↑</annotation>
-		<annotation cp="🎾" type="tts">↑↑↑</annotation>
 		<annotation cp="🥏">flying disc | Frisbee | ultimate</annotation>
-		<annotation cp="🥏" type="tts">↑↑↑</annotation>
-		<annotation cp="🎳">↑↑↑</annotation>
-		<annotation cp="🎳" type="tts">↑↑↑</annotation>
 		<annotation cp="🏏">ball | bat | cricket | cricket match | game</annotation>
-		<annotation cp="🏏" type="tts">↑↑↑</annotation>
-		<annotation cp="🏑">ball | field | game | hockey | stick</annotation>
-		<annotation cp="🏑" type="tts">field hockey</annotation>
-		<annotation cp="🏒">↑↑↑</annotation>
 		<annotation cp="🏒" type="tts">hockey</annotation>
-		<annotation cp="🥍">↑↑↑</annotation>
-		<annotation cp="🥍" type="tts">↑↑↑</annotation>
-		<annotation cp="🏓">ball | bat | game | paddle | ping pong | table tennis</annotation>
-		<annotation cp="🏓" type="tts">↑↑↑</annotation>
-		<annotation cp="🏸">↑↑↑</annotation>
-		<annotation cp="🏸" type="tts">↑↑↑</annotation>
-		<annotation cp="🥊">↑↑↑</annotation>
-		<annotation cp="🥊" type="tts">↑↑↑</annotation>
-		<annotation cp="🥋">↑↑↑</annotation>
-		<annotation cp="🥋" type="tts">↑↑↑</annotation>
-		<annotation cp="🥅">↑↑↑</annotation>
-		<annotation cp="🥅" type="tts">↑↑↑</annotation>
-		<annotation cp="⛳">↑↑↑</annotation>
-		<annotation cp="⛳" type="tts">↑↑↑</annotation>
-		<annotation cp="⛸">↑↑↑</annotation>
-		<annotation cp="⛸" type="tts">↑↑↑</annotation>
-		<annotation cp="🎣">↑↑↑</annotation>
-		<annotation cp="🎣" type="tts">↑↑↑</annotation>
 		<annotation cp="🤿">diving | diving mask | scuba | snorkelling</annotation>
-		<annotation cp="🤿" type="tts">↑↑↑</annotation>
-		<annotation cp="🎽">↑↑↑</annotation>
-		<annotation cp="🎽" type="tts">↑↑↑</annotation>
-		<annotation cp="🎿">↑↑↑</annotation>
-		<annotation cp="🎿" type="tts">↑↑↑</annotation>
-		<annotation cp="🛷">↑↑↑</annotation>
-		<annotation cp="🛷" type="tts">sled</annotation>
 		<annotation cp="🥌">curling rock | curling stone | game | rock</annotation>
 		<annotation cp="🥌" type="tts">curling rock</annotation>
-		<annotation cp="🎯">↑↑↑</annotation>
-		<annotation cp="🎯" type="tts">↑↑↑</annotation>
-		<annotation cp="🪀">↑↑↑</annotation>
-		<annotation cp="🪀" type="tts">↑↑↑</annotation>
-		<annotation cp="🪁">↑↑↑</annotation>
-		<annotation cp="🪁" type="tts">↑↑↑</annotation>
-		<annotation cp="🎱">↑↑↑</annotation>
-		<annotation cp="🎱" type="tts">↑↑↑</annotation>
-		<annotation cp="🔮">↑↑↑</annotation>
-		<annotation cp="🔮" type="tts">↑↑↑</annotation>
-		<annotation cp="🪄">↑↑↑</annotation>
-		<annotation cp="🪄" type="tts">↑↑↑</annotation>
 		<annotation cp="🧿">bead | charm | evil eye | nazar | nazar amulet | talisman</annotation>
-		<annotation cp="🧿" type="tts">↑↑↑</annotation>
-		<annotation cp="🎮">↑↑↑</annotation>
-		<annotation cp="🎮" type="tts">↑↑↑</annotation>
-		<annotation cp="🕹">↑↑↑</annotation>
-		<annotation cp="🕹" type="tts">↑↑↑</annotation>
-		<annotation cp="🎰">↑↑↑</annotation>
-		<annotation cp="🎰" type="tts">↑↑↑</annotation>
-		<annotation cp="🎲">↑↑↑</annotation>
-		<annotation cp="🎲" type="tts">↑↑↑</annotation>
-		<annotation cp="🧩">↑↑↑</annotation>
-		<annotation cp="🧩" type="tts">↑↑↑</annotation>
-		<annotation cp="🧸">↑↑↑</annotation>
-		<annotation cp="🧸" type="tts">↑↑↑</annotation>
-		<annotation cp="🪅">↑↑↑</annotation>
-		<annotation cp="🪅" type="tts">↑↑↑</annotation>
-		<annotation cp="🪆">↑↑↑</annotation>
-		<annotation cp="🪆" type="tts">↑↑↑</annotation>
-		<annotation cp="♠">↑↑↑</annotation>
-		<annotation cp="♠" type="tts">↑↑↑</annotation>
-		<annotation cp="♥">↑↑↑</annotation>
-		<annotation cp="♥" type="tts">↑↑↑</annotation>
-		<annotation cp="♦">↑↑↑</annotation>
-		<annotation cp="♦" type="tts">↑↑↑</annotation>
-		<annotation cp="♣">↑↑↑</annotation>
-		<annotation cp="♣" type="tts">↑↑↑</annotation>
-		<annotation cp="♟">↑↑↑</annotation>
-		<annotation cp="♟" type="tts">↑↑↑</annotation>
-		<annotation cp="🃏">↑↑↑</annotation>
-		<annotation cp="🃏" type="tts">↑↑↑</annotation>
 		<annotation cp="🀄">game | Mahjong | Mahjong red dragon | red</annotation>
 		<annotation cp="🀄" type="tts">Mahjong red dragon</annotation>
-		<annotation cp="🎴">↑↑↑</annotation>
-		<annotation cp="🎴" type="tts">↑↑↑</annotation>
-		<annotation cp="🎭">↑↑↑</annotation>
-		<annotation cp="🎭" type="tts">↑↑↑</annotation>
-		<annotation cp="🖼">↑↑↑</annotation>
-		<annotation cp="🖼" type="tts">↑↑↑</annotation>
-		<annotation cp="🎨">↑↑↑</annotation>
-		<annotation cp="🎨" type="tts">↑↑↑</annotation>
-		<annotation cp="🧵">↑↑↑</annotation>
-		<annotation cp="🧵" type="tts">↑↑↑</annotation>
-		<annotation cp="🪡">↑↑↑</annotation>
-		<annotation cp="🪡" type="tts">↑↑↑</annotation>
-		<annotation cp="🧶">↑↑↑</annotation>
-		<annotation cp="🧶" type="tts">↑↑↑</annotation>
-		<annotation cp="🪢">↑↑↑</annotation>
-		<annotation cp="🪢" type="tts">↑↑↑</annotation>
-		<annotation cp="👓">↑↑↑</annotation>
-		<annotation cp="👓" type="tts">↑↑↑</annotation>
-		<annotation cp="🕶">↑↑↑</annotation>
-		<annotation cp="🕶" type="tts">↑↑↑</annotation>
-		<annotation cp="🥽">↑↑↑</annotation>
-		<annotation cp="🥽" type="tts">↑↑↑</annotation>
-		<annotation cp="🥼">↑↑↑</annotation>
-		<annotation cp="🥼" type="tts">↑↑↑</annotation>
-		<annotation cp="🦺">↑↑↑</annotation>
-		<annotation cp="🦺" type="tts">↑↑↑</annotation>
-		<annotation cp="👔">↑↑↑</annotation>
-		<annotation cp="👔" type="tts">↑↑↑</annotation>
 		<annotation cp="👕">clothing | shirt | t-shirt | T-shirt | tee-shirt | tshirt</annotation>
-		<annotation cp="👕" type="tts">↑↑↑</annotation>
-		<annotation cp="👖">↑↑↑</annotation>
-		<annotation cp="👖" type="tts">↑↑↑</annotation>
-		<annotation cp="🧣">↑↑↑</annotation>
-		<annotation cp="🧣" type="tts">↑↑↑</annotation>
-		<annotation cp="🧤">↑↑↑</annotation>
-		<annotation cp="🧤" type="tts">↑↑↑</annotation>
-		<annotation cp="🧥">↑↑↑</annotation>
-		<annotation cp="🧥" type="tts">↑↑↑</annotation>
-		<annotation cp="🧦">↑↑↑</annotation>
-		<annotation cp="🧦" type="tts">↑↑↑</annotation>
-		<annotation cp="👗">↑↑↑</annotation>
-		<annotation cp="👗" type="tts">↑↑↑</annotation>
-		<annotation cp="👘">↑↑↑</annotation>
-		<annotation cp="👘" type="tts">↑↑↑</annotation>
-		<annotation cp="🥻">↑↑↑</annotation>
-		<annotation cp="🥻" type="tts">↑↑↑</annotation>
-		<annotation cp="🩱">↑↑↑</annotation>
-		<annotation cp="🩱" type="tts">↑↑↑</annotation>
-		<annotation cp="🩲">↑↑↑</annotation>
-		<annotation cp="🩲" type="tts">↑↑↑</annotation>
-		<annotation cp="🩳">↑↑↑</annotation>
-		<annotation cp="🩳" type="tts">↑↑↑</annotation>
-		<annotation cp="👙">↑↑↑</annotation>
-		<annotation cp="👙" type="tts">↑↑↑</annotation>
-		<annotation cp="👚">↑↑↑</annotation>
-		<annotation cp="👚" type="tts">↑↑↑</annotation>
-		<annotation cp="👛">↑↑↑</annotation>
-		<annotation cp="👛" type="tts">↑↑↑</annotation>
-		<annotation cp="👜">↑↑↑</annotation>
-		<annotation cp="👜" type="tts">↑↑↑</annotation>
-		<annotation cp="👝">↑↑↑</annotation>
-		<annotation cp="👝" type="tts">↑↑↑</annotation>
-		<annotation cp="🛍">↑↑↑</annotation>
-		<annotation cp="🛍" type="tts">↑↑↑</annotation>
-		<annotation cp="🎒">↑↑↑</annotation>
-		<annotation cp="🎒" type="tts">backpack</annotation>
+		<annotation cp="🩱">bathing suit | one-piece swimsuit | swimming costume</annotation>
 		<annotation cp="🩴">beach sandal | flip-flop | sandal | thong | zōri</annotation>
 		<annotation cp="🩴" type="tts">flip-flop</annotation>
-		<annotation cp="👞">↑↑↑</annotation>
-		<annotation cp="👞" type="tts">↑↑↑</annotation>
-		<annotation cp="👟">↑↑↑</annotation>
-		<annotation cp="👟" type="tts">↑↑↑</annotation>
-		<annotation cp="🥾">↑↑↑</annotation>
-		<annotation cp="🥾" type="tts">↑↑↑</annotation>
-		<annotation cp="🥿">↑↑↑</annotation>
-		<annotation cp="🥿" type="tts">↑↑↑</annotation>
-		<annotation cp="👠">↑↑↑</annotation>
-		<annotation cp="👠" type="tts">↑↑↑</annotation>
-		<annotation cp="👡">↑↑↑</annotation>
-		<annotation cp="👡" type="tts">↑↑↑</annotation>
-		<annotation cp="🩰">↑↑↑</annotation>
-		<annotation cp="🩰" type="tts">↑↑↑</annotation>
-		<annotation cp="👢">↑↑↑</annotation>
-		<annotation cp="👢" type="tts">↑↑↑</annotation>
-		<annotation cp="👑">↑↑↑</annotation>
-		<annotation cp="👑" type="tts">↑↑↑</annotation>
-		<annotation cp="👒">↑↑↑</annotation>
-		<annotation cp="👒" type="tts">↑↑↑</annotation>
-		<annotation cp="🎩">↑↑↑</annotation>
-		<annotation cp="🎩" type="tts">↑↑↑</annotation>
-		<annotation cp="🎓">cap | celebration | clothing | graduation | hat</annotation>
-		<annotation cp="🎓" type="tts">↑↑↑</annotation>
-		<annotation cp="🧢">↑↑↑</annotation>
+		<annotation cp="🥿">ballet flat | flat shoe | pump | slip-on | slipper</annotation>
 		<annotation cp="🧢" type="tts">baseball cap</annotation>
-		<annotation cp="🪖">↑↑↑</annotation>
-		<annotation cp="🪖" type="tts">↑↑↑</annotation>
-		<annotation cp="⛑">↑↑↑</annotation>
-		<annotation cp="⛑" type="tts">↑↑↑</annotation>
-		<annotation cp="📿">↑↑↑</annotation>
-		<annotation cp="📿" type="tts">↑↑↑</annotation>
-		<annotation cp="💄">↑↑↑</annotation>
-		<annotation cp="💄" type="tts">↑↑↑</annotation>
-		<annotation cp="💍">↑↑↑</annotation>
-		<annotation cp="💍" type="tts">↑↑↑</annotation>
 		<annotation cp="💎">diamond | gem | gem stone | gemstone | jewel</annotation>
 		<annotation cp="💎" type="tts">gemstone</annotation>
-		<annotation cp="🔇">↑↑↑</annotation>
-		<annotation cp="🔇" type="tts">↑↑↑</annotation>
-		<annotation cp="🔈">↑↑↑</annotation>
-		<annotation cp="🔈" type="tts">↑↑↑</annotation>
-		<annotation cp="🔉">↑↑↑</annotation>
-		<annotation cp="🔉" type="tts">↑↑↑</annotation>
-		<annotation cp="🔊">↑↑↑</annotation>
-		<annotation cp="🔊" type="tts">↑↑↑</annotation>
-		<annotation cp="📢">↑↑↑</annotation>
-		<annotation cp="📢" type="tts">↑↑↑</annotation>
-		<annotation cp="📣">↑↑↑</annotation>
-		<annotation cp="📣" type="tts">↑↑↑</annotation>
-		<annotation cp="📯">↑↑↑</annotation>
-		<annotation cp="📯" type="tts">↑↑↑</annotation>
-		<annotation cp="🔔">↑↑↑</annotation>
-		<annotation cp="🔔" type="tts">↑↑↑</annotation>
-		<annotation cp="🔕">↑↑↑</annotation>
-		<annotation cp="🔕" type="tts">↑↑↑</annotation>
-		<annotation cp="🎼">↑↑↑</annotation>
-		<annotation cp="🎼" type="tts">↑↑↑</annotation>
-		<annotation cp="🎵">↑↑↑</annotation>
-		<annotation cp="🎵" type="tts">↑↑↑</annotation>
-		<annotation cp="🎶">↑↑↑</annotation>
-		<annotation cp="🎶" type="tts">↑↑↑</annotation>
-		<annotation cp="🎙">↑↑↑</annotation>
-		<annotation cp="🎙" type="tts">↑↑↑</annotation>
-		<annotation cp="🎚">↑↑↑</annotation>
-		<annotation cp="🎚" type="tts">↑↑↑</annotation>
-		<annotation cp="🎛">↑↑↑</annotation>
-		<annotation cp="🎛" type="tts">↑↑↑</annotation>
-		<annotation cp="🎤">↑↑↑</annotation>
-		<annotation cp="🎤" type="tts">↑↑↑</annotation>
-		<annotation cp="🎧">↑↑↑</annotation>
-		<annotation cp="🎧" type="tts">↑↑↑</annotation>
-		<annotation cp="📻">↑↑↑</annotation>
-		<annotation cp="📻" type="tts">↑↑↑</annotation>
-		<annotation cp="🎷">↑↑↑</annotation>
-		<annotation cp="🎷" type="tts">↑↑↑</annotation>
-		<annotation cp="🪗">↑↑↑</annotation>
-		<annotation cp="🪗" type="tts">↑↑↑</annotation>
-		<annotation cp="🎸">↑↑↑</annotation>
-		<annotation cp="🎸" type="tts">↑↑↑</annotation>
-		<annotation cp="🎹">↑↑↑</annotation>
-		<annotation cp="🎹" type="tts">↑↑↑</annotation>
-		<annotation cp="🎺">↑↑↑</annotation>
-		<annotation cp="🎺" type="tts">↑↑↑</annotation>
-		<annotation cp="🎻">↑↑↑</annotation>
-		<annotation cp="🎻" type="tts">↑↑↑</annotation>
-		<annotation cp="🪕">↑↑↑</annotation>
-		<annotation cp="🪕" type="tts">↑↑↑</annotation>
-		<annotation cp="🥁">↑↑↑</annotation>
-		<annotation cp="🥁" type="tts">↑↑↑</annotation>
-		<annotation cp="🪘">↑↑↑</annotation>
-		<annotation cp="🪘" type="tts">↑↑↑</annotation>
-		<annotation cp="📱">↑↑↑</annotation>
-		<annotation cp="📱" type="tts">↑↑↑</annotation>
-		<annotation cp="📲">↑↑↑</annotation>
-		<annotation cp="📲" type="tts">↑↑↑</annotation>
-		<annotation cp="☎">↑↑↑</annotation>
-		<annotation cp="☎" type="tts">↑↑↑</annotation>
-		<annotation cp="📞">↑↑↑</annotation>
-		<annotation cp="📞" type="tts">↑↑↑</annotation>
-		<annotation cp="📟">↑↑↑</annotation>
-		<annotation cp="📟" type="tts">↑↑↑</annotation>
-		<annotation cp="📠">↑↑↑</annotation>
-		<annotation cp="📠" type="tts">↑↑↑</annotation>
-		<annotation cp="🔋">↑↑↑</annotation>
-		<annotation cp="🔋" type="tts">↑↑↑</annotation>
-		<annotation cp="🔌">↑↑↑</annotation>
-		<annotation cp="🔌" type="tts">↑↑↑</annotation>
-		<annotation cp="💻">↑↑↑</annotation>
-		<annotation cp="💻" type="tts">↑↑↑</annotation>
-		<annotation cp="🖥">↑↑↑</annotation>
-		<annotation cp="🖥" type="tts">↑↑↑</annotation>
-		<annotation cp="🖨">↑↑↑</annotation>
-		<annotation cp="🖨" type="tts">↑↑↑</annotation>
-		<annotation cp="⌨">↑↑↑</annotation>
-		<annotation cp="⌨" type="tts">↑↑↑</annotation>
-		<annotation cp="🖱">↑↑↑</annotation>
-		<annotation cp="🖱" type="tts">↑↑↑</annotation>
-		<annotation cp="🖲">↑↑↑</annotation>
-		<annotation cp="🖲" type="tts">↑↑↑</annotation>
-		<annotation cp="💽">↑↑↑</annotation>
-		<annotation cp="💽" type="tts">↑↑↑</annotation>
+		<annotation cp="📯" type="tts">post horn</annotation>
 		<annotation cp="💾">computer | disk | diskette | floppy</annotation>
-		<annotation cp="💾" type="tts">↑↑↑</annotation>
-		<annotation cp="💿">↑↑↑</annotation>
-		<annotation cp="💿" type="tts">↑↑↑</annotation>
-		<annotation cp="📀">↑↑↑</annotation>
-		<annotation cp="📀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧮">↑↑↑</annotation>
-		<annotation cp="🧮" type="tts">↑↑↑</annotation>
-		<annotation cp="🎥">↑↑↑</annotation>
-		<annotation cp="🎥" type="tts">movie camera</annotation>
-		<annotation cp="🎞">↑↑↑</annotation>
-		<annotation cp="🎞" type="tts">↑↑↑</annotation>
-		<annotation cp="📽">↑↑↑</annotation>
-		<annotation cp="📽" type="tts">↑↑↑</annotation>
-		<annotation cp="🎬">↑↑↑</annotation>
-		<annotation cp="🎬" type="tts">↑↑↑</annotation>
-		<annotation cp="📺">television | tv | video</annotation>
-		<annotation cp="📺" type="tts">↑↑↑</annotation>
-		<annotation cp="📷">↑↑↑</annotation>
-		<annotation cp="📷" type="tts">↑↑↑</annotation>
-		<annotation cp="📸">↑↑↑</annotation>
-		<annotation cp="📸" type="tts">↑↑↑</annotation>
-		<annotation cp="📹">↑↑↑</annotation>
-		<annotation cp="📹" type="tts">↑↑↑</annotation>
-		<annotation cp="📼">↑↑↑</annotation>
-		<annotation cp="📼" type="tts">↑↑↑</annotation>
-		<annotation cp="🔍">↑↑↑</annotation>
-		<annotation cp="🔍" type="tts">↑↑↑</annotation>
-		<annotation cp="🔎">↑↑↑</annotation>
-		<annotation cp="🔎" type="tts">↑↑↑</annotation>
-		<annotation cp="🕯">↑↑↑</annotation>
-		<annotation cp="🕯" type="tts">↑↑↑</annotation>
-		<annotation cp="💡">↑↑↑</annotation>
-		<annotation cp="💡" type="tts">↑↑↑</annotation>
-		<annotation cp="🔦">electric | flashlight | light | tool | torch</annotation>
-		<annotation cp="🔦" type="tts">flashlight</annotation>
-		<annotation cp="🏮">↑↑↑</annotation>
-		<annotation cp="🏮" type="tts">↑↑↑</annotation>
-		<annotation cp="🪔">↑↑↑</annotation>
-		<annotation cp="🪔" type="tts">↑↑↑</annotation>
-		<annotation cp="📔">↑↑↑</annotation>
-		<annotation cp="📔" type="tts">↑↑↑</annotation>
-		<annotation cp="📕">↑↑↑</annotation>
-		<annotation cp="📕" type="tts">↑↑↑</annotation>
-		<annotation cp="📖">↑↑↑</annotation>
-		<annotation cp="📖" type="tts">↑↑↑</annotation>
-		<annotation cp="📗">↑↑↑</annotation>
-		<annotation cp="📗" type="tts">↑↑↑</annotation>
-		<annotation cp="📘">↑↑↑</annotation>
-		<annotation cp="📘" type="tts">↑↑↑</annotation>
-		<annotation cp="📙">↑↑↑</annotation>
-		<annotation cp="📙" type="tts">↑↑↑</annotation>
-		<annotation cp="📚">↑↑↑</annotation>
-		<annotation cp="📚" type="tts">↑↑↑</annotation>
-		<annotation cp="📓">↑↑↑</annotation>
-		<annotation cp="📓" type="tts">↑↑↑</annotation>
-		<annotation cp="📒">↑↑↑</annotation>
-		<annotation cp="📒" type="tts">↑↑↑</annotation>
-		<annotation cp="📃">↑↑↑</annotation>
-		<annotation cp="📃" type="tts">↑↑↑</annotation>
-		<annotation cp="📜">↑↑↑</annotation>
-		<annotation cp="📜" type="tts">↑↑↑</annotation>
-		<annotation cp="📄">↑↑↑</annotation>
-		<annotation cp="📄" type="tts">↑↑↑</annotation>
-		<annotation cp="📰">↑↑↑</annotation>
-		<annotation cp="📰" type="tts">↑↑↑</annotation>
-		<annotation cp="🗞">↑↑↑</annotation>
-		<annotation cp="🗞" type="tts">↑↑↑</annotation>
-		<annotation cp="📑">↑↑↑</annotation>
-		<annotation cp="📑" type="tts">↑↑↑</annotation>
-		<annotation cp="🔖">↑↑↑</annotation>
-		<annotation cp="🔖" type="tts">↑↑↑</annotation>
-		<annotation cp="🏷">↑↑↑</annotation>
-		<annotation cp="🏷" type="tts">↑↑↑</annotation>
-		<annotation cp="💰">↑↑↑</annotation>
-		<annotation cp="💰" type="tts">↑↑↑</annotation>
-		<annotation cp="🪙">↑↑↑</annotation>
-		<annotation cp="🪙" type="tts">↑↑↑</annotation>
-		<annotation cp="💴">↑↑↑</annotation>
-		<annotation cp="💴" type="tts">↑↑↑</annotation>
-		<annotation cp="💵">↑↑↑</annotation>
-		<annotation cp="💵" type="tts">↑↑↑</annotation>
-		<annotation cp="💶">↑↑↑</annotation>
-		<annotation cp="💶" type="tts">↑↑↑</annotation>
-		<annotation cp="💷">↑↑↑</annotation>
-		<annotation cp="💷" type="tts">↑↑↑</annotation>
-		<annotation cp="💸">↑↑↑</annotation>
-		<annotation cp="💸" type="tts">↑↑↑</annotation>
-		<annotation cp="💳">↑↑↑</annotation>
-		<annotation cp="💳" type="tts">↑↑↑</annotation>
-		<annotation cp="🧾">↑↑↑</annotation>
-		<annotation cp="🧾" type="tts">↑↑↑</annotation>
-		<annotation cp="💹">↑↑↑</annotation>
-		<annotation cp="💹" type="tts">↑↑↑</annotation>
+		<annotation cp="💷">banknote | bill | currency | money | note | pound | sterling</annotation>
 		<annotation cp="✉">e-mail | email | envelope | letter</annotation>
-		<annotation cp="✉" type="tts">↑↑↑</annotation>
-		<annotation cp="📧">e-mail | email | letter | mail</annotation>
-		<annotation cp="📧" type="tts">↑↑↑</annotation>
-		<annotation cp="📨">↑↑↑</annotation>
-		<annotation cp="📨" type="tts">↑↑↑</annotation>
-		<annotation cp="📩">↑↑↑</annotation>
-		<annotation cp="📩" type="tts">↑↑↑</annotation>
-		<annotation cp="📤">↑↑↑</annotation>
-		<annotation cp="📤" type="tts">↑↑↑</annotation>
-		<annotation cp="📥">↑↑↑</annotation>
-		<annotation cp="📥" type="tts">↑↑↑</annotation>
-		<annotation cp="📦">↑↑↑</annotation>
-		<annotation cp="📦" type="tts">↑↑↑</annotation>
 		<annotation cp="📫">closed | closed postbox with raised flag | mail | mailbox | post | post box | postbox</annotation>
-		<annotation cp="📫" type="tts">↑↑↑</annotation>
 		<annotation cp="📪">closed | closed postbox with lowered flag | mail | mailbox | post | post box | postbox</annotation>
-		<annotation cp="📪" type="tts">↑↑↑</annotation>
 		<annotation cp="📬">mail | mailbox | open | open postbox with raised flag | post | post box | postbox</annotation>
-		<annotation cp="📬" type="tts">↑↑↑</annotation>
 		<annotation cp="📭">mail | mailbox | open | open postbox with lowered flag | post | post box | postbox</annotation>
-		<annotation cp="📭" type="tts">↑↑↑</annotation>
 		<annotation cp="📮">mail | mailbox | post | post box | postbox</annotation>
 		<annotation cp="📮" type="tts">mailbox</annotation>
-		<annotation cp="🗳">↑↑↑</annotation>
-		<annotation cp="🗳" type="tts">↑↑↑</annotation>
-		<annotation cp="✏">↑↑↑</annotation>
-		<annotation cp="✏" type="tts">↑↑↑</annotation>
-		<annotation cp="✒">↑↑↑</annotation>
-		<annotation cp="✒" type="tts">↑↑↑</annotation>
-		<annotation cp="🖋">↑↑↑</annotation>
-		<annotation cp="🖋" type="tts">↑↑↑</annotation>
-		<annotation cp="🖊">↑↑↑</annotation>
-		<annotation cp="🖊" type="tts">↑↑↑</annotation>
-		<annotation cp="🖌">↑↑↑</annotation>
-		<annotation cp="🖌" type="tts">↑↑↑</annotation>
-		<annotation cp="🖍">↑↑↑</annotation>
-		<annotation cp="🖍" type="tts">↑↑↑</annotation>
-		<annotation cp="📝">↑↑↑</annotation>
-		<annotation cp="📝" type="tts">↑↑↑</annotation>
-		<annotation cp="💼">↑↑↑</annotation>
-		<annotation cp="💼" type="tts">↑↑↑</annotation>
-		<annotation cp="📁">↑↑↑</annotation>
-		<annotation cp="📁" type="tts">↑↑↑</annotation>
-		<annotation cp="📂">↑↑↑</annotation>
-		<annotation cp="📂" type="tts">↑↑↑</annotation>
-		<annotation cp="🗂">↑↑↑</annotation>
-		<annotation cp="🗂" type="tts">↑↑↑</annotation>
-		<annotation cp="📅">↑↑↑</annotation>
-		<annotation cp="📅" type="tts">↑↑↑</annotation>
-		<annotation cp="📆">↑↑↑</annotation>
-		<annotation cp="📆" type="tts">↑↑↑</annotation>
-		<annotation cp="🗒">↑↑↑</annotation>
-		<annotation cp="🗒" type="tts">↑↑↑</annotation>
-		<annotation cp="🗓">↑↑↑</annotation>
-		<annotation cp="🗓" type="tts">↑↑↑</annotation>
-		<annotation cp="📇">↑↑↑</annotation>
-		<annotation cp="📇" type="tts">↑↑↑</annotation>
-		<annotation cp="📈">↑↑↑</annotation>
-		<annotation cp="📈" type="tts">↑↑↑</annotation>
-		<annotation cp="📉">↑↑↑</annotation>
-		<annotation cp="📉" type="tts">↑↑↑</annotation>
-		<annotation cp="📊">↑↑↑</annotation>
-		<annotation cp="📊" type="tts">↑↑↑</annotation>
-		<annotation cp="📋">↑↑↑</annotation>
-		<annotation cp="📋" type="tts">↑↑↑</annotation>
-		<annotation cp="📌">↑↑↑</annotation>
-		<annotation cp="📌" type="tts">↑↑↑</annotation>
-		<annotation cp="📍">↑↑↑</annotation>
-		<annotation cp="📍" type="tts">↑↑↑</annotation>
-		<annotation cp="📎">↑↑↑</annotation>
-		<annotation cp="📎" type="tts">↑↑↑</annotation>
-		<annotation cp="🖇">↑↑↑</annotation>
-		<annotation cp="🖇" type="tts">↑↑↑</annotation>
-		<annotation cp="📏">↑↑↑</annotation>
-		<annotation cp="📏" type="tts">↑↑↑</annotation>
 		<annotation cp="📐">ruler | set | set square | triangle | triangular ruler</annotation>
-		<annotation cp="📐" type="tts">triangular ruler</annotation>
-		<annotation cp="✂">↑↑↑</annotation>
-		<annotation cp="✂" type="tts">↑↑↑</annotation>
-		<annotation cp="🗃">↑↑↑</annotation>
-		<annotation cp="🗃" type="tts">↑↑↑</annotation>
-		<annotation cp="🗄">↑↑↑</annotation>
-		<annotation cp="🗄" type="tts">↑↑↑</annotation>
-		<annotation cp="🗑">↑↑↑</annotation>
-		<annotation cp="🗑" type="tts">wastebasket</annotation>
-		<annotation cp="🔒">↑↑↑</annotation>
-		<annotation cp="🔒" type="tts">↑↑↑</annotation>
-		<annotation cp="🔓">↑↑↑</annotation>
-		<annotation cp="🔓" type="tts">↑↑↑</annotation>
-		<annotation cp="🔏">↑↑↑</annotation>
-		<annotation cp="🔏" type="tts">↑↑↑</annotation>
-		<annotation cp="🔐">↑↑↑</annotation>
-		<annotation cp="🔐" type="tts">↑↑↑</annotation>
-		<annotation cp="🔑">↑↑↑</annotation>
-		<annotation cp="🔑" type="tts">↑↑↑</annotation>
-		<annotation cp="🗝">↑↑↑</annotation>
-		<annotation cp="🗝" type="tts">↑↑↑</annotation>
-		<annotation cp="🔨">↑↑↑</annotation>
-		<annotation cp="🔨" type="tts">↑↑↑</annotation>
-		<annotation cp="🪓">↑↑↑</annotation>
-		<annotation cp="🪓" type="tts">↑↑↑</annotation>
-		<annotation cp="⛏">↑↑↑</annotation>
-		<annotation cp="⛏" type="tts">↑↑↑</annotation>
-		<annotation cp="⚒">↑↑↑</annotation>
-		<annotation cp="⚒" type="tts">↑↑↑</annotation>
-		<annotation cp="🛠">hammer | hammer and wrench | spanner | tool | wrench</annotation>
-		<annotation cp="🛠" type="tts">hammer and wrench</annotation>
-		<annotation cp="🗡">↑↑↑</annotation>
-		<annotation cp="🗡" type="tts">↑↑↑</annotation>
-		<annotation cp="⚔">↑↑↑</annotation>
-		<annotation cp="⚔" type="tts">↑↑↑</annotation>
-		<annotation cp="🔫">↑↑↑</annotation>
-		<annotation cp="🔫" type="tts">↑↑↑</annotation>
-		<annotation cp="🪃">↑↑↑</annotation>
-		<annotation cp="🪃" type="tts">↑↑↑</annotation>
-		<annotation cp="🏹">↑↑↑</annotation>
-		<annotation cp="🏹" type="tts">↑↑↑</annotation>
-		<annotation cp="🛡">↑↑↑</annotation>
-		<annotation cp="🛡" type="tts">↑↑↑</annotation>
-		<annotation cp="🪚">↑↑↑</annotation>
-		<annotation cp="🪚" type="tts">↑↑↑</annotation>
-		<annotation cp="🔧">spanner | tool | wrench</annotation>
-		<annotation cp="🔧" type="tts">wrench</annotation>
-		<annotation cp="🪛">↑↑↑</annotation>
-		<annotation cp="🪛" type="tts">↑↑↑</annotation>
-		<annotation cp="🔩">↑↑↑</annotation>
-		<annotation cp="🔩" type="tts">↑↑↑</annotation>
-		<annotation cp="⚙">↑↑↑</annotation>
-		<annotation cp="⚙" type="tts">↑↑↑</annotation>
-		<annotation cp="🗜">↑↑↑</annotation>
-		<annotation cp="🗜" type="tts">↑↑↑</annotation>
-		<annotation cp="⚖">↑↑↑</annotation>
-		<annotation cp="⚖" type="tts">↑↑↑</annotation>
-		<annotation cp="🦯">↑↑↑</annotation>
-		<annotation cp="🦯" type="tts">↑↑↑</annotation>
-		<annotation cp="🔗">↑↑↑</annotation>
-		<annotation cp="🔗" type="tts">↑↑↑</annotation>
-		<annotation cp="⛓">↑↑↑</annotation>
-		<annotation cp="⛓" type="tts">↑↑↑</annotation>
-		<annotation cp="🪝">↑↑↑</annotation>
-		<annotation cp="🪝" type="tts">↑↑↑</annotation>
-		<annotation cp="🧰">↑↑↑</annotation>
-		<annotation cp="🧰" type="tts">↑↑↑</annotation>
-		<annotation cp="🧲">↑↑↑</annotation>
-		<annotation cp="🧲" type="tts">↑↑↑</annotation>
-		<annotation cp="🪜">↑↑↑</annotation>
-		<annotation cp="🪜" type="tts">↑↑↑</annotation>
-		<annotation cp="⚗">↑↑↑</annotation>
-		<annotation cp="⚗" type="tts">↑↑↑</annotation>
-		<annotation cp="🧪">↑↑↑</annotation>
-		<annotation cp="🧪" type="tts">↑↑↑</annotation>
-		<annotation cp="🧫">↑↑↑</annotation>
-		<annotation cp="🧫" type="tts">↑↑↑</annotation>
-		<annotation cp="🧬">↑↑↑</annotation>
-		<annotation cp="🧬" type="tts">↑↑↑</annotation>
-		<annotation cp="🔬">↑↑↑</annotation>
-		<annotation cp="🔬" type="tts">↑↑↑</annotation>
-		<annotation cp="🔭">↑↑↑</annotation>
-		<annotation cp="🔭" type="tts">↑↑↑</annotation>
-		<annotation cp="📡">↑↑↑</annotation>
-		<annotation cp="📡" type="tts">↑↑↑</annotation>
-		<annotation cp="💉">↑↑↑</annotation>
-		<annotation cp="💉" type="tts">↑↑↑</annotation>
-		<annotation cp="🩸">↑↑↑</annotation>
-		<annotation cp="🩸" type="tts">↑↑↑</annotation>
-		<annotation cp="💊">↑↑↑</annotation>
-		<annotation cp="💊" type="tts">↑↑↑</annotation>
-		<annotation cp="🩹">↑↑↑</annotation>
-		<annotation cp="🩹" type="tts">↑↑↑</annotation>
-		<annotation cp="🩺">↑↑↑</annotation>
-		<annotation cp="🩺" type="tts">↑↑↑</annotation>
-		<annotation cp="🚪">↑↑↑</annotation>
-		<annotation cp="🚪" type="tts">↑↑↑</annotation>
-		<annotation cp="🛗">↑↑↑</annotation>
-		<annotation cp="🛗" type="tts">↑↑↑</annotation>
-		<annotation cp="🪞">↑↑↑</annotation>
-		<annotation cp="🪞" type="tts">↑↑↑</annotation>
-		<annotation cp="🪟">↑↑↑</annotation>
-		<annotation cp="🪟" type="tts">↑↑↑</annotation>
-		<annotation cp="🛏">↑↑↑</annotation>
-		<annotation cp="🛏" type="tts">↑↑↑</annotation>
+		<annotation cp="🔒">closed | locked | padlock</annotation>
+		<annotation cp="🔓">lock | open | padlock | unlock | unlocked</annotation>
+		<annotation cp="🦯">accessibility | blind | guide cane</annotation>
+		<annotation cp="🩹">injury | plaster | sticking plaster</annotation>
 		<annotation cp="🛋">couch | couch and lamp | hotel | lamp | sofa | sofa and lamp</annotation>
-		<annotation cp="🛋" type="tts">couch and lamp</annotation>
-		<annotation cp="🪑">↑↑↑</annotation>
-		<annotation cp="🪑" type="tts">↑↑↑</annotation>
 		<annotation cp="🚽">lavatory | toilet</annotation>
-		<annotation cp="🚽" type="tts">↑↑↑</annotation>
-		<annotation cp="🪠">↑↑↑</annotation>
-		<annotation cp="🪠" type="tts">↑↑↑</annotation>
-		<annotation cp="🚿">↑↑↑</annotation>
-		<annotation cp="🚿" type="tts">↑↑↑</annotation>
-		<annotation cp="🛁">↑↑↑</annotation>
-		<annotation cp="🛁" type="tts">↑↑↑</annotation>
 		<annotation cp="🪤">bait | mouse | mousetrap | snare | trap</annotation>
 		<annotation cp="🪤" type="tts">mousetrap</annotation>
-		<annotation cp="🪒">↑↑↑</annotation>
-		<annotation cp="🪒" type="tts">↑↑↑</annotation>
-		<annotation cp="🧴">↑↑↑</annotation>
-		<annotation cp="🧴" type="tts">↑↑↑</annotation>
-		<annotation cp="🧷">↑↑↑</annotation>
-		<annotation cp="🧷" type="tts">↑↑↑</annotation>
-		<annotation cp="🧹">↑↑↑</annotation>
-		<annotation cp="🧹" type="tts">↑↑↑</annotation>
-		<annotation cp="🧺">↑↑↑</annotation>
-		<annotation cp="🧺" type="tts">↑↑↑</annotation>
-		<annotation cp="🧻">↑↑↑</annotation>
-		<annotation cp="🧻" type="tts">↑↑↑</annotation>
-		<annotation cp="🪣">↑↑↑</annotation>
-		<annotation cp="🪣" type="tts">↑↑↑</annotation>
-		<annotation cp="🧼">↑↑↑</annotation>
-		<annotation cp="🧼" type="tts">↑↑↑</annotation>
-		<annotation cp="🪥">↑↑↑</annotation>
-		<annotation cp="🪥" type="tts">↑↑↑</annotation>
-		<annotation cp="🧽">↑↑↑</annotation>
-		<annotation cp="🧽" type="tts">↑↑↑</annotation>
-		<annotation cp="🧯">↑↑↑</annotation>
-		<annotation cp="🧯" type="tts">↑↑↑</annotation>
+		<annotation cp="🪒">cut-throat | razor | sharp | shave</annotation>
 		<annotation cp="🛒">basket | cart | shopping | trolley</annotation>
-		<annotation cp="🛒" type="tts">shopping cart</annotation>
-		<annotation cp="🚬">↑↑↑</annotation>
-		<annotation cp="🚬" type="tts">↑↑↑</annotation>
-		<annotation cp="⚰">↑↑↑</annotation>
-		<annotation cp="⚰" type="tts">↑↑↑</annotation>
-		<annotation cp="🪦">↑↑↑</annotation>
-		<annotation cp="🪦" type="tts">↑↑↑</annotation>
-		<annotation cp="⚱">↑↑↑</annotation>
-		<annotation cp="⚱" type="tts">↑↑↑</annotation>
-		<annotation cp="🗿">↑↑↑</annotation>
-		<annotation cp="🗿" type="tts">↑↑↑</annotation>
-		<annotation cp="🪧">↑↑↑</annotation>
-		<annotation cp="🪧" type="tts">↑↑↑</annotation>
-		<annotation cp="🏧">↑↑↑</annotation>
-		<annotation cp="🏧" type="tts">↑↑↑</annotation>
 		<annotation cp="🚮">garbage | litter | litter bin | litter in bin sign | trash</annotation>
-		<annotation cp="🚮" type="tts">↑↑↑</annotation>
-		<annotation cp="🚰">↑↑↑</annotation>
-		<annotation cp="🚰" type="tts">↑↑↑</annotation>
-		<annotation cp="♿">↑↑↑</annotation>
-		<annotation cp="♿" type="tts">↑↑↑</annotation>
 		<annotation cp="🚹">bathroom | lavatory | men’s | men’s room | restroom | washroom | wc</annotation>
-		<annotation cp="🚹" type="tts">men’s room</annotation>
 		<annotation cp="🚺">bathroom | lavatory | restroom | washroom | wc | women’s | women’s room</annotation>
 		<annotation cp="🚺" type="tts">ladies’ room</annotation>
 		<annotation cp="🚻">bathroom | lavatory | restroom | washroom | WC</annotation>
 		<annotation cp="🚻" type="tts">washroom</annotation>
-		<annotation cp="🚼">↑↑↑</annotation>
-		<annotation cp="🚼" type="tts">↑↑↑</annotation>
-		<annotation cp="🚾">↑↑↑</annotation>
-		<annotation cp="🚾" type="tts">↑↑↑</annotation>
-		<annotation cp="🛂">↑↑↑</annotation>
-		<annotation cp="🛂" type="tts">↑↑↑</annotation>
-		<annotation cp="🛃">↑↑↑</annotation>
-		<annotation cp="🛃" type="tts">↑↑↑</annotation>
-		<annotation cp="🛄">↑↑↑</annotation>
-		<annotation cp="🛄" type="tts">↑↑↑</annotation>
-		<annotation cp="🛅">↑↑↑</annotation>
-		<annotation cp="🛅" type="tts">↑↑↑</annotation>
-		<annotation cp="⚠">↑↑↑</annotation>
-		<annotation cp="⚠" type="tts">↑↑↑</annotation>
-		<annotation cp="🚸">↑↑↑</annotation>
-		<annotation cp="🚸" type="tts">↑↑↑</annotation>
-		<annotation cp="⛔">↑↑↑</annotation>
-		<annotation cp="⛔" type="tts">↑↑↑</annotation>
-		<annotation cp="🚫">↑↑↑</annotation>
-		<annotation cp="🚫" type="tts">↑↑↑</annotation>
-		<annotation cp="🚳">↑↑↑</annotation>
-		<annotation cp="🚳" type="tts">↑↑↑</annotation>
-		<annotation cp="🚭">↑↑↑</annotation>
-		<annotation cp="🚭" type="tts">↑↑↑</annotation>
-		<annotation cp="🚯">↑↑↑</annotation>
-		<annotation cp="🚯" type="tts">↑↑↑</annotation>
-		<annotation cp="🚱">↑↑↑</annotation>
-		<annotation cp="🚱" type="tts">↑↑↑</annotation>
-		<annotation cp="🚷">↑↑↑</annotation>
-		<annotation cp="🚷" type="tts">↑↑↑</annotation>
-		<annotation cp="📵">↑↑↑</annotation>
-		<annotation cp="📵" type="tts">↑↑↑</annotation>
-		<annotation cp="🔞">↑↑↑</annotation>
-		<annotation cp="🔞" type="tts">↑↑↑</annotation>
-		<annotation cp="☢">↑↑↑</annotation>
-		<annotation cp="☢" type="tts">↑↑↑</annotation>
-		<annotation cp="☣">↑↑↑</annotation>
-		<annotation cp="☣" type="tts">↑↑↑</annotation>
-		<annotation cp="⬆">↑↑↑</annotation>
-		<annotation cp="⬆" type="tts">↑↑↑</annotation>
-		<annotation cp="↗">↑↑↑</annotation>
-		<annotation cp="↗" type="tts">↑↑↑</annotation>
-		<annotation cp="➡">↑↑↑</annotation>
-		<annotation cp="➡" type="tts">↑↑↑</annotation>
-		<annotation cp="↘">↑↑↑</annotation>
-		<annotation cp="↘" type="tts">↑↑↑</annotation>
-		<annotation cp="⬇">↑↑↑</annotation>
-		<annotation cp="⬇" type="tts">↑↑↑</annotation>
-		<annotation cp="↙">↑↑↑</annotation>
-		<annotation cp="↙" type="tts">↑↑↑</annotation>
-		<annotation cp="⬅">↑↑↑</annotation>
-		<annotation cp="⬅" type="tts">↑↑↑</annotation>
-		<annotation cp="↖">↑↑↑</annotation>
-		<annotation cp="↖" type="tts">↑↑↑</annotation>
-		<annotation cp="↕">↑↑↑</annotation>
-		<annotation cp="↕" type="tts">↑↑↑</annotation>
-		<annotation cp="↔">↑↑↑</annotation>
-		<annotation cp="↔" type="tts">↑↑↑</annotation>
-		<annotation cp="↮">↑↑↑</annotation>
-		<annotation cp="↮" type="tts">↑↑↑</annotation>
-		<annotation cp="↩">↑↑↑</annotation>
-		<annotation cp="↩" type="tts">↑↑↑</annotation>
-		<annotation cp="↪">↑↑↑</annotation>
-		<annotation cp="↪" type="tts">↑↑↑</annotation>
-		<annotation cp="⤴">↑↑↑</annotation>
-		<annotation cp="⤴" type="tts">↑↑↑</annotation>
-		<annotation cp="⤵">↑↑↑</annotation>
-		<annotation cp="⤵" type="tts">↑↑↑</annotation>
-		<annotation cp="🔃">↑↑↑</annotation>
-		<annotation cp="🔃" type="tts">↑↑↑</annotation>
-		<annotation cp="🔄">anticlockwise | arrow | counterclockwise | counterclockwise arrows button | withershins</annotation>
-		<annotation cp="🔄" type="tts">counterclockwise arrows button</annotation>
-		<annotation cp="🔙">↑↑↑</annotation>
-		<annotation cp="🔙" type="tts">↑↑↑</annotation>
-		<annotation cp="🔚">↑↑↑</annotation>
-		<annotation cp="🔚" type="tts">↑↑↑</annotation>
-		<annotation cp="🔛">↑↑↑</annotation>
-		<annotation cp="🔛" type="tts">↑↑↑</annotation>
-		<annotation cp="🔜">↑↑↑</annotation>
-		<annotation cp="🔜" type="tts">↑↑↑</annotation>
-		<annotation cp="🔝">↑↑↑</annotation>
-		<annotation cp="🔝" type="tts">↑↑↑</annotation>
-		<annotation cp="🛐">↑↑↑</annotation>
-		<annotation cp="🛐" type="tts">↑↑↑</annotation>
-		<annotation cp="⚛">↑↑↑</annotation>
-		<annotation cp="⚛" type="tts">↑↑↑</annotation>
-		<annotation cp="🕉">↑↑↑</annotation>
-		<annotation cp="🕉" type="tts">↑↑↑</annotation>
-		<annotation cp="✡">↑↑↑</annotation>
-		<annotation cp="✡" type="tts">↑↑↑</annotation>
-		<annotation cp="☸">↑↑↑</annotation>
-		<annotation cp="☸" type="tts">↑↑↑</annotation>
+		<annotation cp="🚾">closet | lavatory | restroom | toilet | water | wc</annotation>
+		<annotation cp="✡">David | Jewish | Judaism | religion | star | Star of David</annotation>
+		<annotation cp="✡" type="tts">Star of David</annotation>
 		<annotation cp="☯">religion | Tao | Taoist | yang | yin</annotation>
-		<annotation cp="☯" type="tts">↑↑↑</annotation>
 		<annotation cp="✝">Christian | cross | Latin cross | religion</annotation>
 		<annotation cp="✝" type="tts">Latin cross</annotation>
 		<annotation cp="☦">Christian | cross | Orthodox cross | religion</annotation>
 		<annotation cp="☦" type="tts">Orthodox cross</annotation>
 		<annotation cp="☪">Islam | Muslim | religion | star and crescent</annotation>
-		<annotation cp="☪" type="tts">↑↑↑</annotation>
-		<annotation cp="☮">↑↑↑</annotation>
-		<annotation cp="☮" type="tts">↑↑↑</annotation>
-		<annotation cp="🕎">↑↑↑</annotation>
-		<annotation cp="🕎" type="tts">↑↑↑</annotation>
-		<annotation cp="🔯">↑↑↑</annotation>
-		<annotation cp="🔯" type="tts">↑↑↑</annotation>
-		<annotation cp="♈">↑↑↑</annotation>
-		<annotation cp="♈" type="tts">↑↑↑</annotation>
-		<annotation cp="♉">↑↑↑</annotation>
-		<annotation cp="♉" type="tts">↑↑↑</annotation>
-		<annotation cp="♊">↑↑↑</annotation>
-		<annotation cp="♊" type="tts">↑↑↑</annotation>
-		<annotation cp="♋">↑↑↑</annotation>
-		<annotation cp="♋" type="tts">↑↑↑</annotation>
-		<annotation cp="♌">↑↑↑</annotation>
-		<annotation cp="♌" type="tts">↑↑↑</annotation>
-		<annotation cp="♍">↑↑↑</annotation>
-		<annotation cp="♍" type="tts">↑↑↑</annotation>
-		<annotation cp="♎">↑↑↑</annotation>
-		<annotation cp="♎" type="tts">↑↑↑</annotation>
 		<annotation cp="♏">Scorpio | scorpion | Scorpius | zodiac</annotation>
-		<annotation cp="♏" type="tts">Scorpio</annotation>
-		<annotation cp="♐">↑↑↑</annotation>
-		<annotation cp="♐" type="tts">↑↑↑</annotation>
-		<annotation cp="♑">↑↑↑</annotation>
-		<annotation cp="♑" type="tts">↑↑↑</annotation>
-		<annotation cp="♒">↑↑↑</annotation>
-		<annotation cp="♒" type="tts">↑↑↑</annotation>
-		<annotation cp="♓">↑↑↑</annotation>
-		<annotation cp="♓" type="tts">↑↑↑</annotation>
-		<annotation cp="⛎">↑↑↑</annotation>
-		<annotation cp="⛎" type="tts">↑↑↑</annotation>
-		<annotation cp="🔀">↑↑↑</annotation>
-		<annotation cp="🔀" type="tts">↑↑↑</annotation>
-		<annotation cp="🔁">↑↑↑</annotation>
-		<annotation cp="🔁" type="tts">↑↑↑</annotation>
-		<annotation cp="🔂">↑↑↑</annotation>
-		<annotation cp="🔂" type="tts">↑↑↑</annotation>
-		<annotation cp="▶">↑↑↑</annotation>
-		<annotation cp="▶" type="tts">↑↑↑</annotation>
-		<annotation cp="⏩">↑↑↑</annotation>
-		<annotation cp="⏩" type="tts">↑↑↑</annotation>
-		<annotation cp="⏭">↑↑↑</annotation>
-		<annotation cp="⏭" type="tts">↑↑↑</annotation>
-		<annotation cp="⏯">↑↑↑</annotation>
-		<annotation cp="⏯" type="tts">↑↑↑</annotation>
-		<annotation cp="◀">↑↑↑</annotation>
-		<annotation cp="◀" type="tts">↑↑↑</annotation>
-		<annotation cp="⏪">↑↑↑</annotation>
-		<annotation cp="⏪" type="tts">↑↑↑</annotation>
-		<annotation cp="⏮">↑↑↑</annotation>
-		<annotation cp="⏮" type="tts">↑↑↑</annotation>
 		<annotation cp="🔼">arrow | button | red | upward button | upwards button</annotation>
 		<annotation cp="🔼" type="tts">upward button</annotation>
-		<annotation cp="⏫">↑↑↑</annotation>
-		<annotation cp="⏫" type="tts">↑↑↑</annotation>
 		<annotation cp="🔽">arrow | button | down | downward button | downwards button | red</annotation>
 		<annotation cp="🔽" type="tts">downward button</annotation>
-		<annotation cp="⏬">↑↑↑</annotation>
-		<annotation cp="⏬" type="tts">↑↑↑</annotation>
-		<annotation cp="⏸">↑↑↑</annotation>
-		<annotation cp="⏸" type="tts">↑↑↑</annotation>
-		<annotation cp="⏹">↑↑↑</annotation>
-		<annotation cp="⏹" type="tts">↑↑↑</annotation>
-		<annotation cp="⏺">↑↑↑</annotation>
-		<annotation cp="⏺" type="tts">↑↑↑</annotation>
-		<annotation cp="⏏">↑↑↑</annotation>
-		<annotation cp="⏏" type="tts">↑↑↑</annotation>
-		<annotation cp="🎦">↑↑↑</annotation>
-		<annotation cp="🎦" type="tts">↑↑↑</annotation>
-		<annotation cp="🔅">↑↑↑</annotation>
-		<annotation cp="🔅" type="tts">↑↑↑</annotation>
-		<annotation cp="🔆">↑↑↑</annotation>
-		<annotation cp="🔆" type="tts">↑↑↑</annotation>
-		<annotation cp="📶">↑↑↑</annotation>
-		<annotation cp="📶" type="tts">↑↑↑</annotation>
 		<annotation cp="📳">cell | mobile | mode | phone | telephone | vibrate | vibration</annotation>
-		<annotation cp="📳" type="tts">↑↑↑</annotation>
-		<annotation cp="📴">↑↑↑</annotation>
-		<annotation cp="📴" type="tts">↑↑↑</annotation>
-		<annotation cp="♀">↑↑↑</annotation>
-		<annotation cp="♀" type="tts">↑↑↑</annotation>
-		<annotation cp="♂">↑↑↑</annotation>
-		<annotation cp="♂" type="tts">↑↑↑</annotation>
-		<annotation cp="⚧">↑↑↑</annotation>
-		<annotation cp="⚧" type="tts">↑↑↑</annotation>
-		<annotation cp="✖">↑↑↑</annotation>
-		<annotation cp="✖" type="tts">↑↑↑</annotation>
-		<annotation cp="➕">+ | math | plus | sign</annotation>
-		<annotation cp="➕" type="tts">↑↑↑</annotation>
-		<annotation cp="➖">- | − | math | minus | sign</annotation>
-		<annotation cp="➖" type="tts">↑↑↑</annotation>
-		<annotation cp="➗">÷ | divide | division | math | sign</annotation>
-		<annotation cp="➗" type="tts">↑↑↑</annotation>
-		<annotation cp="♾">↑↑↑</annotation>
-		<annotation cp="♾" type="tts">↑↑↑</annotation>
-		<annotation cp="‼">↑↑↑</annotation>
-		<annotation cp="‼" type="tts">↑↑↑</annotation>
-		<annotation cp="⁉">↑↑↑</annotation>
-		<annotation cp="⁉" type="tts">↑↑↑</annotation>
-		<annotation cp="❓">↑↑↑</annotation>
-		<annotation cp="❓" type="tts">↑↑↑</annotation>
-		<annotation cp="❔">↑↑↑</annotation>
-		<annotation cp="❔" type="tts">↑↑↑</annotation>
-		<annotation cp="❕">↑↑↑</annotation>
-		<annotation cp="❕" type="tts">↑↑↑</annotation>
-		<annotation cp="❗">↑↑↑</annotation>
-		<annotation cp="❗" type="tts">↑↑↑</annotation>
-		<annotation cp="〰">↑↑↑</annotation>
-		<annotation cp="〰" type="tts">↑↑↑</annotation>
-		<annotation cp="💱">↑↑↑</annotation>
-		<annotation cp="💱" type="tts">↑↑↑</annotation>
-		<annotation cp="💲">↑↑↑</annotation>
-		<annotation cp="💲" type="tts">↑↑↑</annotation>
-		<annotation cp="⚕">↑↑↑</annotation>
-		<annotation cp="⚕" type="tts">↑↑↑</annotation>
-		<annotation cp="♻">↑↑↑</annotation>
-		<annotation cp="♻" type="tts">↑↑↑</annotation>
-		<annotation cp="⚜">↑↑↑</annotation>
-		<annotation cp="⚜" type="tts">↑↑↑</annotation>
-		<annotation cp="🔱">↑↑↑</annotation>
-		<annotation cp="🔱" type="tts">↑↑↑</annotation>
-		<annotation cp="📛">↑↑↑</annotation>
-		<annotation cp="📛" type="tts">↑↑↑</annotation>
-		<annotation cp="🔰">↑↑↑</annotation>
-		<annotation cp="🔰" type="tts">↑↑↑</annotation>
-		<annotation cp="⭕">↑↑↑</annotation>
-		<annotation cp="⭕" type="tts">↑↑↑</annotation>
+		<annotation cp="✖">× | cancel | heavy multiplication sign | multiplication | sign | x</annotation>
+		<annotation cp="⁉">! | !? | ? | interrobang | mark | punctuation | question</annotation>
 		<annotation cp="✅">✓ | button | check | mark | tick</annotation>
-		<annotation cp="✅" type="tts">check mark button</annotation>
 		<annotation cp="☑">✓ | box | check | check box with check | tick | tick box with tick</annotation>
-		<annotation cp="☑" type="tts">check box with check</annotation>
-		<annotation cp="✔">✓ | check | mark</annotation>
-		<annotation cp="✔" type="tts">check mark</annotation>
-		<annotation cp="❌">↑↑↑</annotation>
-		<annotation cp="❌" type="tts">↑↑↑</annotation>
-		<annotation cp="❎">↑↑↑</annotation>
-		<annotation cp="❎" type="tts">↑↑↑</annotation>
-		<annotation cp="➰">↑↑↑</annotation>
-		<annotation cp="➰" type="tts">↑↑↑</annotation>
-		<annotation cp="➿">↑↑↑</annotation>
-		<annotation cp="➿" type="tts">↑↑↑</annotation>
-		<annotation cp="〽">↑↑↑</annotation>
-		<annotation cp="〽" type="tts">↑↑↑</annotation>
-		<annotation cp="✳">↑↑↑</annotation>
-		<annotation cp="✳" type="tts">↑↑↑</annotation>
-		<annotation cp="✴">↑↑↑</annotation>
-		<annotation cp="✴" type="tts">↑↑↑</annotation>
-		<annotation cp="❇">↑↑↑</annotation>
-		<annotation cp="❇" type="tts">↑↑↑</annotation>
-		<annotation cp="©">↑↑↑</annotation>
-		<annotation cp="©" type="tts">↑↑↑</annotation>
-		<annotation cp="®">↑↑↑</annotation>
-		<annotation cp="®" type="tts">↑↑↑</annotation>
-		<annotation cp="™">mark | tm | trade mark | trademark</annotation>
-		<annotation cp="™" type="tts">↑↑↑</annotation>
+		<annotation cp="®">r | registered | trademark</annotation>
 		<annotation cp="🔠">ABCD | input | Latin | letters | uppercase</annotation>
 		<annotation cp="🔠" type="tts">input Latin uppercase</annotation>
 		<annotation cp="🔡">abcd | input | Latin | letters | lowercase</annotation>
 		<annotation cp="🔡" type="tts">input Latin lowercase</annotation>
-		<annotation cp="🔢">↑↑↑</annotation>
-		<annotation cp="🔢" type="tts">↑↑↑</annotation>
-		<annotation cp="🔣">↑↑↑</annotation>
-		<annotation cp="🔣" type="tts">↑↑↑</annotation>
 		<annotation cp="🔤">abc | alphabet | input | Latin | letters</annotation>
 		<annotation cp="🔤" type="tts">input Latin letters</annotation>
-		<annotation cp="🅰">↑↑↑</annotation>
-		<annotation cp="🅰" type="tts">↑↑↑</annotation>
-		<annotation cp="🆎">↑↑↑</annotation>
-		<annotation cp="🆎" type="tts">↑↑↑</annotation>
-		<annotation cp="🅱">↑↑↑</annotation>
-		<annotation cp="🅱" type="tts">↑↑↑</annotation>
-		<annotation cp="🆑">↑↑↑</annotation>
-		<annotation cp="🆑" type="tts">↑↑↑</annotation>
-		<annotation cp="🆒">↑↑↑</annotation>
-		<annotation cp="🆒" type="tts">↑↑↑</annotation>
-		<annotation cp="🆓">↑↑↑</annotation>
-		<annotation cp="🆓" type="tts">↑↑↑</annotation>
-		<annotation cp="ℹ">↑↑↑</annotation>
-		<annotation cp="ℹ" type="tts">↑↑↑</annotation>
-		<annotation cp="🆔">↑↑↑</annotation>
-		<annotation cp="🆔" type="tts">↑↑↑</annotation>
-		<annotation cp="Ⓜ">↑↑↑</annotation>
-		<annotation cp="Ⓜ" type="tts">↑↑↑</annotation>
-		<annotation cp="🆕">↑↑↑</annotation>
-		<annotation cp="🆕" type="tts">↑↑↑</annotation>
-		<annotation cp="🆖">↑↑↑</annotation>
-		<annotation cp="🆖" type="tts">↑↑↑</annotation>
-		<annotation cp="🅾">↑↑↑</annotation>
-		<annotation cp="🅾" type="tts">↑↑↑</annotation>
-		<annotation cp="🆗">↑↑↑</annotation>
-		<annotation cp="🆗" type="tts">↑↑↑</annotation>
-		<annotation cp="🅿">↑↑↑</annotation>
-		<annotation cp="🅿" type="tts">↑↑↑</annotation>
-		<annotation cp="🆘">↑↑↑</annotation>
-		<annotation cp="🆘" type="tts">↑↑↑</annotation>
-		<annotation cp="🆙">↑↑↑</annotation>
-		<annotation cp="🆙" type="tts">↑↑↑</annotation>
-		<annotation cp="🆚">↑↑↑</annotation>
-		<annotation cp="🆚" type="tts">↑↑↑</annotation>
-		<annotation cp="🈁">↑↑↑</annotation>
-		<annotation cp="🈁" type="tts">↑↑↑</annotation>
-		<annotation cp="🈂">↑↑↑</annotation>
-		<annotation cp="🈂" type="tts">↑↑↑</annotation>
-		<annotation cp="🈷">↑↑↑</annotation>
-		<annotation cp="🈷" type="tts">↑↑↑</annotation>
-		<annotation cp="🈶">↑↑↑</annotation>
-		<annotation cp="🈶" type="tts">↑↑↑</annotation>
-		<annotation cp="🈯">↑↑↑</annotation>
-		<annotation cp="🈯" type="tts">↑↑↑</annotation>
-		<annotation cp="🉐">↑↑↑</annotation>
-		<annotation cp="🉐" type="tts">↑↑↑</annotation>
-		<annotation cp="🈹">↑↑↑</annotation>
-		<annotation cp="🈹" type="tts">↑↑↑</annotation>
-		<annotation cp="🈚">↑↑↑</annotation>
-		<annotation cp="🈚" type="tts">↑↑↑</annotation>
-		<annotation cp="🈲">↑↑↑</annotation>
-		<annotation cp="🈲" type="tts">↑↑↑</annotation>
-		<annotation cp="🉑">↑↑↑</annotation>
-		<annotation cp="🉑" type="tts">↑↑↑</annotation>
-		<annotation cp="🈸">↑↑↑</annotation>
-		<annotation cp="🈸" type="tts">↑↑↑</annotation>
-		<annotation cp="🈴">↑↑↑</annotation>
-		<annotation cp="🈴" type="tts">↑↑↑</annotation>
-		<annotation cp="🈳">↑↑↑</annotation>
-		<annotation cp="🈳" type="tts">↑↑↑</annotation>
-		<annotation cp="㊗">↑↑↑</annotation>
-		<annotation cp="㊗" type="tts">↑↑↑</annotation>
-		<annotation cp="㊙">↑↑↑</annotation>
-		<annotation cp="㊙" type="tts">↑↑↑</annotation>
-		<annotation cp="🈺">↑↑↑</annotation>
-		<annotation cp="🈺" type="tts">↑↑↑</annotation>
-		<annotation cp="🈵">↑↑↑</annotation>
-		<annotation cp="🈵" type="tts">↑↑↑</annotation>
-		<annotation cp="🔴">↑↑↑</annotation>
-		<annotation cp="🔴" type="tts">↑↑↑</annotation>
-		<annotation cp="🟠">↑↑↑</annotation>
-		<annotation cp="🟠" type="tts">↑↑↑</annotation>
-		<annotation cp="🟡">↑↑↑</annotation>
-		<annotation cp="🟡" type="tts">↑↑↑</annotation>
-		<annotation cp="🟢">↑↑↑</annotation>
-		<annotation cp="🟢" type="tts">↑↑↑</annotation>
-		<annotation cp="🔵">↑↑↑</annotation>
-		<annotation cp="🔵" type="tts">↑↑↑</annotation>
-		<annotation cp="🟣">↑↑↑</annotation>
-		<annotation cp="🟣" type="tts">↑↑↑</annotation>
-		<annotation cp="🟤">↑↑↑</annotation>
-		<annotation cp="🟤" type="tts">↑↑↑</annotation>
-		<annotation cp="⚫">↑↑↑</annotation>
-		<annotation cp="⚫" type="tts">↑↑↑</annotation>
-		<annotation cp="⚪">↑↑↑</annotation>
-		<annotation cp="⚪" type="tts">↑↑↑</annotation>
-		<annotation cp="🟥">↑↑↑</annotation>
-		<annotation cp="🟥" type="tts">↑↑↑</annotation>
-		<annotation cp="🟧">↑↑↑</annotation>
-		<annotation cp="🟧" type="tts">↑↑↑</annotation>
-		<annotation cp="🟨">↑↑↑</annotation>
-		<annotation cp="🟨" type="tts">↑↑↑</annotation>
-		<annotation cp="🟩">↑↑↑</annotation>
-		<annotation cp="🟩" type="tts">↑↑↑</annotation>
-		<annotation cp="🟦">↑↑↑</annotation>
-		<annotation cp="🟦" type="tts">↑↑↑</annotation>
-		<annotation cp="🟪">↑↑↑</annotation>
-		<annotation cp="🟪" type="tts">↑↑↑</annotation>
-		<annotation cp="🟫">↑↑↑</annotation>
-		<annotation cp="🟫" type="tts">↑↑↑</annotation>
-		<annotation cp="⬛">↑↑↑</annotation>
-		<annotation cp="⬛" type="tts">↑↑↑</annotation>
-		<annotation cp="⬜">↑↑↑</annotation>
-		<annotation cp="⬜" type="tts">↑↑↑</annotation>
-		<annotation cp="◼">↑↑↑</annotation>
-		<annotation cp="◼" type="tts">↑↑↑</annotation>
-		<annotation cp="◻">↑↑↑</annotation>
-		<annotation cp="◻" type="tts">↑↑↑</annotation>
-		<annotation cp="◾">↑↑↑</annotation>
-		<annotation cp="◾" type="tts">↑↑↑</annotation>
-		<annotation cp="◽">↑↑↑</annotation>
-		<annotation cp="◽" type="tts">↑↑↑</annotation>
-		<annotation cp="▪">↑↑↑</annotation>
-		<annotation cp="▪" type="tts">↑↑↑</annotation>
-		<annotation cp="▫">↑↑↑</annotation>
-		<annotation cp="▫" type="tts">↑↑↑</annotation>
-		<annotation cp="🔶">↑↑↑</annotation>
-		<annotation cp="🔶" type="tts">↑↑↑</annotation>
-		<annotation cp="🔷">↑↑↑</annotation>
-		<annotation cp="🔷" type="tts">↑↑↑</annotation>
-		<annotation cp="🔸">↑↑↑</annotation>
-		<annotation cp="🔸" type="tts">↑↑↑</annotation>
-		<annotation cp="🔹">↑↑↑</annotation>
-		<annotation cp="🔹" type="tts">↑↑↑</annotation>
-		<annotation cp="🔺">↑↑↑</annotation>
-		<annotation cp="🔺" type="tts">↑↑↑</annotation>
-		<annotation cp="🔻">↑↑↑</annotation>
-		<annotation cp="🔻" type="tts">↑↑↑</annotation>
-		<annotation cp="💠">↑↑↑</annotation>
-		<annotation cp="💠" type="tts">↑↑↑</annotation>
-		<annotation cp="🔘">↑↑↑</annotation>
-		<annotation cp="🔘" type="tts">↑↑↑</annotation>
-		<annotation cp="🔳">↑↑↑</annotation>
-		<annotation cp="🔳" type="tts">↑↑↑</annotation>
-		<annotation cp="🔲">↑↑↑</annotation>
-		<annotation cp="🔲" type="tts">↑↑↑</annotation>
 		<annotation cp="🏁">checkered | checkered flag | chequered | chequered flag | racing</annotation>
 		<annotation cp="🏁" type="tts">checkered flag</annotation>
-		<annotation cp="🚩">↑↑↑</annotation>
-		<annotation cp="🚩" type="tts">↑↑↑</annotation>
-		<annotation cp="🎌">↑↑↑</annotation>
-		<annotation cp="🎌" type="tts">↑↑↑</annotation>
-		<annotation cp="🏴">↑↑↑</annotation>
-		<annotation cp="🏴" type="tts">↑↑↑</annotation>
-		<annotation cp="🏳">↑↑↑</annotation>
-		<annotation cp="🏳" type="tts">↑↑↑</annotation>
-		<annotation cp="🏳‍🌈">↑↑↑</annotation>
-		<annotation cp="🏳‍🌈" type="tts">↑↑↑</annotation>
-		<annotation cp="🏳‍⚧">↑↑↑</annotation>
-		<annotation cp="🏳‍⚧" type="tts">↑↑↑</annotation>
-		<annotation cp="🏴‍☠">↑↑↑</annotation>
-		<annotation cp="🏴‍☠" type="tts">↑↑↑</annotation>
+		<annotation cp="🚩">post | red flag | triangular flag</annotation>
+		<annotation cp="🏳">surrender | waving | white flag</annotation>
 		<annotation cp="¢">cent | cents</annotation>
-		<annotation cp="¢" type="tts">↑↑↑</annotation>
 		<annotation cp="$">CAD | cash | dollar | dollars | money | peso | USD</annotation>
-		<annotation cp="$" type="tts">↑↑↑</annotation>
-		<annotation cp="£">↑↑↑</annotation>
-		<annotation cp="£" type="tts">↑↑↑</annotation>
-		<annotation cp="¥">↑↑↑</annotation>
-		<annotation cp="¥" type="tts">↑↑↑</annotation>
-		<annotation cp="₢">↑↑↑</annotation>
-		<annotation cp="₢" type="tts">↑↑↑</annotation>
-		<annotation cp="₣">↑↑↑</annotation>
-		<annotation cp="₣" type="tts">↑↑↑</annotation>
-		<annotation cp="₤">↑↑↑</annotation>
-		<annotation cp="₤" type="tts">↑↑↑</annotation>
-		<annotation cp="₥">↑↑↑</annotation>
-		<annotation cp="₥" type="tts">↑↑↑</annotation>
-		<annotation cp="₩">↑↑↑</annotation>
-		<annotation cp="₩" type="tts">↑↑↑</annotation>
-		<annotation cp="€">↑↑↑</annotation>
-		<annotation cp="€" type="tts">↑↑↑</annotation>
-		<annotation cp="₰">↑↑↑</annotation>
-		<annotation cp="₰" type="tts">↑↑↑</annotation>
+		<annotation cp="₢">Brazil | BRB | cruzeiro | currency</annotation>
+		<annotation cp="₣">currency | franc | France | French franc</annotation>
+		<annotation cp="₣" type="tts">French franc</annotation>
+		<annotation cp="₤">currency | Italy | lira</annotation>
+		<annotation cp="₰">currency | German penny | pfennig</annotation>
+		<annotation cp="₰" type="tts">German penny</annotation>
 		<annotation cp="₱">peso | pesos</annotation>
-		<annotation cp="₱" type="tts">↑↑↑</annotation>
-		<annotation cp="₳">↑↑↑</annotation>
-		<annotation cp="₳" type="tts">↑↑↑</annotation>
-		<annotation cp="₶">↑↑↑</annotation>
-		<annotation cp="₶" type="tts">↑↑↑</annotation>
-		<annotation cp="₷">↑↑↑</annotation>
-		<annotation cp="₷" type="tts">↑↑↑</annotation>
+		<annotation cp="₳">ARA | Argentina | austral | currency</annotation>
+		<annotation cp="₶">currency | France | livre tournois</annotation>
 		<annotation cp="₹">currency | Indian rupee | rupee</annotation>
 		<annotation cp="₹" type="tts">Indian rupee</annotation>
-		<annotation cp="₽">↑↑↑</annotation>
-		<annotation cp="₽" type="tts">↑↑↑</annotation>
-		<annotation cp="₿">↑↑↑</annotation>
-		<annotation cp="₿" type="tts">↑↑↑</annotation>
-		<annotation cp="₨">↑↑↑</annotation>
-		<annotation cp="₨" type="tts">↑↑↑</annotation>
-		<annotation cp="﷼">↑↑↑</annotation>
-		<annotation cp="﷼" type="tts">↑↑↑</annotation>
-		<annotation cp="¹">↑↑↑</annotation>
-		<annotation cp="¹" type="tts">↑↑↑</annotation>
-		<annotation cp="²">↑↑↑</annotation>
-		<annotation cp="²" type="tts">↑↑↑</annotation>
-		<annotation cp="³">↑↑↑</annotation>
-		<annotation cp="³" type="tts">↑↑↑</annotation>
-		<annotation cp="µ">↑↑↑</annotation>
-		<annotation cp="µ" type="tts">↑↑↑</annotation>
 	</annotations>
 </ldml>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -12,1346 +12,93 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="CA"/>
 	</identity>
 	<localeDisplayNames>
-		<localeDisplayPattern>
-			<localePattern>↑↑↑</localePattern>
-			<localeSeparator>↑↑↑</localeSeparator>
-			<localeKeyTypePattern>↑↑↑</localeKeyTypePattern>
-		</localeDisplayPattern>
 		<languages>
-			<language type="aa">↑↑↑</language>
-			<language type="ab">↑↑↑</language>
-			<language type="ace">↑↑↑</language>
-			<language type="ach" draft="contributed">↑↑↑</language>
-			<language type="ada">↑↑↑</language>
-			<language type="ady">↑↑↑</language>
-			<language type="ae" draft="contributed">↑↑↑</language>
-			<language type="aeb" draft="contributed">↑↑↑</language>
-			<language type="af">↑↑↑</language>
-			<language type="afh" draft="contributed">↑↑↑</language>
-			<language type="agq">↑↑↑</language>
-			<language type="ain">↑↑↑</language>
-			<language type="ak">↑↑↑</language>
-			<language type="akk" draft="contributed">↑↑↑</language>
-			<language type="akz" draft="contributed">↑↑↑</language>
-			<language type="ale">↑↑↑</language>
-			<language type="aln" draft="contributed">↑↑↑</language>
-			<language type="alt">↑↑↑</language>
-			<language type="am">↑↑↑</language>
-			<language type="an">↑↑↑</language>
-			<language type="ang" draft="contributed">↑↑↑</language>
-			<language type="anp">↑↑↑</language>
-			<language type="ar">↑↑↑</language>
-			<language type="ar_001">Modern Standard Arabic</language>
-			<language type="arc" draft="contributed">↑↑↑</language>
-			<language type="arn">↑↑↑</language>
-			<language type="aro" draft="contributed">↑↑↑</language>
-			<language type="arp">↑↑↑</language>
-			<language type="arq" draft="contributed">↑↑↑</language>
-			<language type="ars">↑↑↑</language>
-			<language type="arw" draft="contributed">↑↑↑</language>
-			<language type="ary" draft="contributed">↑↑↑</language>
-			<language type="arz" draft="contributed">↑↑↑</language>
-			<language type="as">↑↑↑</language>
-			<language type="asa">↑↑↑</language>
-			<language type="ase" draft="contributed">↑↑↑</language>
-			<language type="ast">↑↑↑</language>
-			<language type="av">↑↑↑</language>
-			<language type="avk" draft="contributed">↑↑↑</language>
-			<language type="awa">↑↑↑</language>
-			<language type="ay">↑↑↑</language>
-			<language type="az">↑↑↑</language>
-			<language type="az" alt="short">↑↑↑</language>
-			<language type="ba">↑↑↑</language>
-			<language type="bal" draft="contributed">↑↑↑</language>
-			<language type="ban">↑↑↑</language>
-			<language type="bar" draft="contributed">↑↑↑</language>
-			<language type="bas">↑↑↑</language>
-			<language type="bax">↑↑↑</language>
-			<language type="bbc" draft="contributed">↑↑↑</language>
-			<language type="bbj">↑↑↑</language>
-			<language type="be">↑↑↑</language>
-			<language type="bej" draft="contributed">↑↑↑</language>
-			<language type="bem">↑↑↑</language>
-			<language type="bew" draft="contributed">↑↑↑</language>
-			<language type="bez">↑↑↑</language>
-			<language type="bfd">↑↑↑</language>
-			<language type="bfq" draft="contributed">↑↑↑</language>
-			<language type="bg">↑↑↑</language>
-			<language type="bgn" draft="contributed">↑↑↑</language>
-			<language type="bho">↑↑↑</language>
-			<language type="bi">↑↑↑</language>
-			<language type="bik" draft="contributed">↑↑↑</language>
-			<language type="bin">↑↑↑</language>
-			<language type="bjn" draft="contributed">↑↑↑</language>
-			<language type="bkm">↑↑↑</language>
-			<language type="bla">↑↑↑</language>
-			<language type="bm">↑↑↑</language>
 			<language type="bn">Bengali</language>
-			<language type="bo">↑↑↑</language>
-			<language type="bpy" draft="contributed">↑↑↑</language>
-			<language type="bqi" draft="contributed">↑↑↑</language>
-			<language type="br">↑↑↑</language>
-			<language type="bra" draft="contributed">↑↑↑</language>
-			<language type="brh" draft="contributed">↑↑↑</language>
-			<language type="brx">↑↑↑</language>
-			<language type="bs">↑↑↑</language>
-			<language type="bss">↑↑↑</language>
-			<language type="bua" draft="contributed">↑↑↑</language>
-			<language type="bug">↑↑↑</language>
-			<language type="bum">↑↑↑</language>
-			<language type="byn">↑↑↑</language>
-			<language type="byv">↑↑↑</language>
-			<language type="ca">↑↑↑</language>
-			<language type="cad" draft="contributed">↑↑↑</language>
-			<language type="car" draft="contributed">↑↑↑</language>
-			<language type="cay" draft="contributed">↑↑↑</language>
-			<language type="cch" draft="contributed">↑↑↑</language>
-			<language type="ccp">↑↑↑</language>
-			<language type="ce">↑↑↑</language>
-			<language type="ceb">↑↑↑</language>
-			<language type="cgg">↑↑↑</language>
-			<language type="ch">↑↑↑</language>
-			<language type="chb" draft="contributed">↑↑↑</language>
-			<language type="chg" draft="contributed">↑↑↑</language>
-			<language type="chk">↑↑↑</language>
-			<language type="chm">↑↑↑</language>
-			<language type="chn" draft="contributed">↑↑↑</language>
-			<language type="cho">↑↑↑</language>
-			<language type="chp" draft="contributed">↑↑↑</language>
-			<language type="chr">↑↑↑</language>
-			<language type="chy">↑↑↑</language>
-			<language type="ckb">↑↑↑</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
-			<language type="co">↑↑↑</language>
-			<language type="cop" draft="contributed">↑↑↑</language>
-			<language type="cps" draft="contributed">↑↑↑</language>
-			<language type="cr" draft="contributed">↑↑↑</language>
-			<language type="crh" draft="contributed">↑↑↑</language>
-			<language type="crs">↑↑↑</language>
-			<language type="cs">↑↑↑</language>
-			<language type="csb" draft="contributed">↑↑↑</language>
-			<language type="cu">↑↑↑</language>
-			<language type="cv">↑↑↑</language>
-			<language type="cy">↑↑↑</language>
-			<language type="da">↑↑↑</language>
-			<language type="dak">↑↑↑</language>
-			<language type="dar">↑↑↑</language>
-			<language type="dav">↑↑↑</language>
-			<language type="de">↑↑↑</language>
-			<language type="de_AT">Austrian German</language>
-			<language type="de_CH">Swiss High German</language>
-			<language type="del" draft="contributed">↑↑↑</language>
-			<language type="den" draft="contributed">↑↑↑</language>
-			<language type="dgr">↑↑↑</language>
-			<language type="din" draft="contributed">↑↑↑</language>
-			<language type="dje">↑↑↑</language>
-			<language type="doi">↑↑↑</language>
-			<language type="dsb">↑↑↑</language>
-			<language type="dtp" draft="contributed">↑↑↑</language>
-			<language type="dua">↑↑↑</language>
-			<language type="dum" draft="contributed">↑↑↑</language>
-			<language type="dv">↑↑↑</language>
-			<language type="dyo">↑↑↑</language>
-			<language type="dyu" draft="contributed">↑↑↑</language>
-			<language type="dz">↑↑↑</language>
-			<language type="dzg">↑↑↑</language>
-			<language type="ebu">↑↑↑</language>
-			<language type="ee">↑↑↑</language>
-			<language type="efi">↑↑↑</language>
-			<language type="egl" draft="contributed">↑↑↑</language>
-			<language type="egy" draft="contributed">↑↑↑</language>
-			<language type="eka">↑↑↑</language>
-			<language type="el">↑↑↑</language>
-			<language type="elx" draft="contributed">↑↑↑</language>
-			<language type="en">↑↑↑</language>
-			<language type="en_AU">Australian English</language>
-			<language type="en_CA">Canadian English</language>
-			<language type="en_GB">British English</language>
-			<language type="en_GB" alt="short">UK English</language>
-			<language type="en_US">American English</language>
 			<language type="en_US" alt="short">U.S. English</language>
-			<language type="enm" draft="contributed">↑↑↑</language>
-			<language type="eo">↑↑↑</language>
-			<language type="es">↑↑↑</language>
-			<language type="es_419">Latin American Spanish</language>
-			<language type="es_ES">European Spanish</language>
-			<language type="es_MX">Mexican Spanish</language>
-			<language type="esu" draft="contributed">↑↑↑</language>
-			<language type="et">↑↑↑</language>
-			<language type="eu">↑↑↑</language>
-			<language type="ewo">↑↑↑</language>
-			<language type="ext" draft="contributed">↑↑↑</language>
-			<language type="fa">↑↑↑</language>
-			<language type="fa_AF">Dari</language>
-			<language type="fan" draft="contributed">↑↑↑</language>
-			<language type="fat" draft="contributed">↑↑↑</language>
-			<language type="ff">↑↑↑</language>
-			<language type="fi">↑↑↑</language>
-			<language type="fil">↑↑↑</language>
-			<language type="fit" draft="contributed">↑↑↑</language>
-			<language type="fj">↑↑↑</language>
-			<language type="fo">↑↑↑</language>
-			<language type="fon">↑↑↑</language>
-			<language type="fr">↑↑↑</language>
-			<language type="fr_CA">Canadian French</language>
-			<language type="fr_CH">Swiss French</language>
-			<language type="frc" draft="contributed">↑↑↑</language>
-			<language type="frm" draft="contributed">↑↑↑</language>
-			<language type="fro" draft="contributed">↑↑↑</language>
-			<language type="frp" draft="contributed">↑↑↑</language>
-			<language type="frr" draft="contributed">↑↑↑</language>
-			<language type="frs" draft="contributed">↑↑↑</language>
-			<language type="fur">↑↑↑</language>
-			<language type="fy">↑↑↑</language>
-			<language type="ga">↑↑↑</language>
-			<language type="gaa">↑↑↑</language>
-			<language type="gag" draft="contributed">↑↑↑</language>
-			<language type="gan" draft="contributed">↑↑↑</language>
-			<language type="gay" draft="contributed">↑↑↑</language>
-			<language type="gba" draft="contributed">↑↑↑</language>
-			<language type="gbz" draft="contributed">↑↑↑</language>
-			<language type="gd">↑↑↑</language>
-			<language type="gez">↑↑↑</language>
-			<language type="gil">↑↑↑</language>
-			<language type="gl">↑↑↑</language>
-			<language type="glk" draft="contributed">↑↑↑</language>
-			<language type="gmh" draft="contributed">↑↑↑</language>
-			<language type="gn">↑↑↑</language>
-			<language type="goh" draft="contributed">↑↑↑</language>
-			<language type="gom" draft="contributed">↑↑↑</language>
-			<language type="gon" draft="contributed">↑↑↑</language>
-			<language type="gor">↑↑↑</language>
-			<language type="got" draft="contributed">↑↑↑</language>
-			<language type="grb" draft="contributed">↑↑↑</language>
-			<language type="grc" draft="contributed">↑↑↑</language>
-			<language type="gsw">↑↑↑</language>
-			<language type="gu">↑↑↑</language>
-			<language type="guc" draft="contributed">↑↑↑</language>
-			<language type="gur" draft="contributed">↑↑↑</language>
-			<language type="guz">↑↑↑</language>
-			<language type="gv">↑↑↑</language>
-			<language type="gwi">↑↑↑</language>
-			<language type="ha">↑↑↑</language>
-			<language type="hai" draft="contributed">↑↑↑</language>
-			<language type="hak" draft="contributed">↑↑↑</language>
-			<language type="haw">↑↑↑</language>
-			<language type="he">↑↑↑</language>
-			<language type="hi">↑↑↑</language>
-			<language type="hif" draft="contributed">↑↑↑</language>
-			<language type="hil">↑↑↑</language>
-			<language type="hit" draft="contributed">↑↑↑</language>
-			<language type="hmn">↑↑↑</language>
-			<language type="ho" draft="contributed">↑↑↑</language>
-			<language type="hr">↑↑↑</language>
-			<language type="hsb">↑↑↑</language>
-			<language type="hsn" draft="contributed">↑↑↑</language>
-			<language type="ht">↑↑↑</language>
-			<language type="hu">↑↑↑</language>
-			<language type="hup">↑↑↑</language>
-			<language type="hy">↑↑↑</language>
-			<language type="hz">↑↑↑</language>
-			<language type="ia">↑↑↑</language>
-			<language type="iba">↑↑↑</language>
-			<language type="ibb">↑↑↑</language>
-			<language type="id">↑↑↑</language>
-			<language type="ie" draft="contributed">↑↑↑</language>
-			<language type="ig">↑↑↑</language>
-			<language type="ii">↑↑↑</language>
-			<language type="ik" draft="contributed">↑↑↑</language>
-			<language type="ilo">↑↑↑</language>
-			<language type="inh">↑↑↑</language>
-			<language type="io">↑↑↑</language>
-			<language type="is">↑↑↑</language>
-			<language type="it">↑↑↑</language>
-			<language type="iu">↑↑↑</language>
-			<language type="izh" draft="contributed">↑↑↑</language>
-			<language type="ja">↑↑↑</language>
-			<language type="jam" draft="contributed">↑↑↑</language>
-			<language type="jbo">↑↑↑</language>
-			<language type="jgo">↑↑↑</language>
-			<language type="jmc">↑↑↑</language>
-			<language type="jpr" draft="contributed">↑↑↑</language>
-			<language type="jrb" draft="contributed">↑↑↑</language>
-			<language type="jut" draft="contributed">↑↑↑</language>
-			<language type="jv">↑↑↑</language>
-			<language type="ka">↑↑↑</language>
-			<language type="kaa" draft="contributed">↑↑↑</language>
-			<language type="kab">↑↑↑</language>
-			<language type="kac">↑↑↑</language>
-			<language type="kaj">↑↑↑</language>
-			<language type="kam">↑↑↑</language>
-			<language type="kaw" draft="contributed">↑↑↑</language>
-			<language type="kbd">↑↑↑</language>
-			<language type="kbl" draft="contributed">↑↑↑</language>
-			<language type="kcg">↑↑↑</language>
-			<language type="kde">↑↑↑</language>
-			<language type="kea">↑↑↑</language>
-			<language type="ken" draft="contributed">↑↑↑</language>
-			<language type="kfo">↑↑↑</language>
-			<language type="kg" draft="contributed">↑↑↑</language>
-			<language type="kgp" draft="contributed">↑↑↑</language>
-			<language type="kha">↑↑↑</language>
-			<language type="kho" draft="contributed">↑↑↑</language>
-			<language type="khq">↑↑↑</language>
-			<language type="khw" draft="contributed">↑↑↑</language>
-			<language type="ki">↑↑↑</language>
-			<language type="kiu" draft="contributed">↑↑↑</language>
-			<language type="kj">↑↑↑</language>
-			<language type="kk">↑↑↑</language>
-			<language type="kkj">↑↑↑</language>
-			<language type="kl">↑↑↑</language>
-			<language type="kln">↑↑↑</language>
-			<language type="km">↑↑↑</language>
-			<language type="kmb">↑↑↑</language>
-			<language type="kn">↑↑↑</language>
-			<language type="ko">↑↑↑</language>
-			<language type="koi" draft="contributed">↑↑↑</language>
-			<language type="kok">↑↑↑</language>
-			<language type="kos" draft="contributed">↑↑↑</language>
-			<language type="kpe">↑↑↑</language>
-			<language type="kr">↑↑↑</language>
-			<language type="krc">↑↑↑</language>
-			<language type="kri" draft="contributed">↑↑↑</language>
-			<language type="krj" draft="contributed">↑↑↑</language>
-			<language type="krl">↑↑↑</language>
-			<language type="kru">↑↑↑</language>
-			<language type="ks">↑↑↑</language>
-			<language type="ksb">↑↑↑</language>
-			<language type="ksf">↑↑↑</language>
-			<language type="ksh">↑↑↑</language>
-			<language type="ku">↑↑↑</language>
-			<language type="kum">↑↑↑</language>
-			<language type="kut" draft="contributed">↑↑↑</language>
-			<language type="kv">↑↑↑</language>
-			<language type="kw">↑↑↑</language>
-			<language type="ky">↑↑↑</language>
-			<language type="ky" alt="variant">↑↑↑</language>
-			<language type="la">↑↑↑</language>
-			<language type="lad">↑↑↑</language>
-			<language type="lag">↑↑↑</language>
-			<language type="lah" draft="contributed">↑↑↑</language>
-			<language type="lam" draft="contributed">↑↑↑</language>
-			<language type="lb">↑↑↑</language>
-			<language type="lez">↑↑↑</language>
-			<language type="lfn" draft="contributed">↑↑↑</language>
-			<language type="lg">↑↑↑</language>
-			<language type="li">↑↑↑</language>
-			<language type="lij" draft="contributed">↑↑↑</language>
-			<language type="liv" draft="contributed">↑↑↑</language>
-			<language type="lkt">↑↑↑</language>
-			<language type="lmo" draft="contributed">↑↑↑</language>
-			<language type="ln">↑↑↑</language>
-			<language type="lo">↑↑↑</language>
-			<language type="lol" draft="contributed">↑↑↑</language>
-			<language type="loz">↑↑↑</language>
-			<language type="lrc">↑↑↑</language>
-			<language type="lt">↑↑↑</language>
-			<language type="ltg" draft="contributed">↑↑↑</language>
-			<language type="lu">↑↑↑</language>
-			<language type="lua">↑↑↑</language>
-			<language type="lui" draft="contributed">↑↑↑</language>
-			<language type="lun">↑↑↑</language>
-			<language type="luo">↑↑↑</language>
-			<language type="lus">↑↑↑</language>
-			<language type="luy">↑↑↑</language>
-			<language type="lv">↑↑↑</language>
-			<language type="lzh" draft="contributed">↑↑↑</language>
-			<language type="lzz" draft="contributed">↑↑↑</language>
-			<language type="mad">↑↑↑</language>
-			<language type="maf">↑↑↑</language>
-			<language type="mag">↑↑↑</language>
-			<language type="mai">↑↑↑</language>
-			<language type="mak">↑↑↑</language>
-			<language type="man" draft="contributed">↑↑↑</language>
-			<language type="mas">↑↑↑</language>
-			<language type="mdf">↑↑↑</language>
-			<language type="mdr" draft="contributed">↑↑↑</language>
-			<language type="men">↑↑↑</language>
-			<language type="mer">↑↑↑</language>
 			<language type="mfe">Mauritian</language>
-			<language type="mg">↑↑↑</language>
-			<language type="mga" draft="contributed">↑↑↑</language>
-			<language type="mgh">↑↑↑</language>
-			<language type="mgo">↑↑↑</language>
-			<language type="mh">↑↑↑</language>
-			<language type="mi">↑↑↑</language>
-			<language type="mic">↑↑↑</language>
-			<language type="min">↑↑↑</language>
-			<language type="mk">↑↑↑</language>
-			<language type="ml">↑↑↑</language>
-			<language type="mn">↑↑↑</language>
-			<language type="mnc" draft="contributed">↑↑↑</language>
-			<language type="mni">↑↑↑</language>
-			<language type="moh">↑↑↑</language>
-			<language type="mos">↑↑↑</language>
-			<language type="mr">↑↑↑</language>
-			<language type="mrj" draft="contributed">↑↑↑</language>
-			<language type="ms">↑↑↑</language>
-			<language type="mt">↑↑↑</language>
-			<language type="mua">↑↑↑</language>
-			<language type="mul">↑↑↑</language>
-			<language type="mus">↑↑↑</language>
-			<language type="mwl">↑↑↑</language>
-			<language type="mwr" draft="contributed">↑↑↑</language>
-			<language type="mwv" draft="contributed">↑↑↑</language>
-			<language type="my">↑↑↑</language>
-			<language type="my" alt="variant">↑↑↑</language>
-			<language type="mye" draft="contributed">↑↑↑</language>
-			<language type="myv">↑↑↑</language>
-			<language type="mzn">↑↑↑</language>
-			<language type="na">↑↑↑</language>
-			<language type="nan" draft="contributed">↑↑↑</language>
-			<language type="nap">↑↑↑</language>
-			<language type="naq">↑↑↑</language>
-			<language type="nb">↑↑↑</language>
-			<language type="nd">↑↑↑</language>
-			<language type="nds">↑↑↑</language>
-			<language type="ne">↑↑↑</language>
-			<language type="new">↑↑↑</language>
-			<language type="ng">↑↑↑</language>
-			<language type="nia">↑↑↑</language>
-			<language type="niu">↑↑↑</language>
-			<language type="njo" draft="contributed">↑↑↑</language>
-			<language type="nl">↑↑↑</language>
-			<language type="nl_BE">Flemish</language>
-			<language type="nmg">↑↑↑</language>
-			<language type="nn">↑↑↑</language>
-			<language type="nnh">↑↑↑</language>
-			<language type="no">↑↑↑</language>
-			<language type="nog">↑↑↑</language>
-			<language type="non" draft="contributed">↑↑↑</language>
-			<language type="nov" draft="contributed">↑↑↑</language>
-			<language type="nqo">↑↑↑</language>
-			<language type="nr">↑↑↑</language>
-			<language type="nso">↑↑↑</language>
-			<language type="nus">↑↑↑</language>
-			<language type="nv">↑↑↑</language>
-			<language type="nwc" draft="contributed">↑↑↑</language>
-			<language type="ny">↑↑↑</language>
-			<language type="nym" draft="contributed">↑↑↑</language>
-			<language type="nyn">↑↑↑</language>
-			<language type="nyo" draft="contributed">↑↑↑</language>
-			<language type="nzi" draft="contributed">↑↑↑</language>
-			<language type="oc">↑↑↑</language>
-			<language type="oj" draft="contributed">↑↑↑</language>
-			<language type="om">↑↑↑</language>
-			<language type="or">↑↑↑</language>
-			<language type="os">↑↑↑</language>
-			<language type="osa" draft="contributed">↑↑↑</language>
-			<language type="ota" draft="contributed">↑↑↑</language>
-			<language type="pa">↑↑↑</language>
-			<language type="pag">↑↑↑</language>
-			<language type="pal" draft="contributed">↑↑↑</language>
-			<language type="pam">↑↑↑</language>
-			<language type="pap">↑↑↑</language>
-			<language type="pau">↑↑↑</language>
-			<language type="pcd" draft="contributed">↑↑↑</language>
-			<language type="pcm">↑↑↑</language>
-			<language type="pdc" draft="contributed">↑↑↑</language>
-			<language type="pdt" draft="contributed">↑↑↑</language>
-			<language type="peo" draft="contributed">↑↑↑</language>
-			<language type="pfl" draft="contributed">↑↑↑</language>
-			<language type="phn" draft="contributed">↑↑↑</language>
-			<language type="pi" draft="contributed">↑↑↑</language>
-			<language type="pl">↑↑↑</language>
-			<language type="pms" draft="contributed">↑↑↑</language>
-			<language type="pnt" draft="contributed">↑↑↑</language>
-			<language type="pon" draft="contributed">↑↑↑</language>
-			<language type="prg">↑↑↑</language>
-			<language type="pro" draft="contributed">↑↑↑</language>
-			<language type="ps">↑↑↑</language>
-			<language type="ps" alt="variant">↑↑↑</language>
-			<language type="pt">↑↑↑</language>
-			<language type="pt_BR">Brazilian Portuguese</language>
-			<language type="pt_PT">European Portuguese</language>
-			<language type="qu">↑↑↑</language>
-			<language type="quc">↑↑↑</language>
-			<language type="qug" draft="contributed">↑↑↑</language>
-			<language type="raj" draft="contributed">↑↑↑</language>
-			<language type="rap">↑↑↑</language>
-			<language type="rar">↑↑↑</language>
-			<language type="rgn" draft="contributed">↑↑↑</language>
-			<language type="rhg">↑↑↑</language>
-			<language type="rif" draft="contributed">↑↑↑</language>
-			<language type="rm">↑↑↑</language>
-			<language type="rn">↑↑↑</language>
-			<language type="ro">↑↑↑</language>
+			<language type="mus">Creek</language>
+			<language type="nds_NL">West Low German</language>
 			<language type="ro_MD">Moldovan</language>
-			<language type="rof">↑↑↑</language>
-			<language type="rom" draft="contributed">↑↑↑</language>
-			<language type="rtm" draft="contributed">↑↑↑</language>
-			<language type="ru">↑↑↑</language>
-			<language type="rue" draft="contributed">↑↑↑</language>
-			<language type="rug" draft="contributed">↑↑↑</language>
-			<language type="rup">↑↑↑</language>
-			<language type="rw">↑↑↑</language>
-			<language type="rwk">↑↑↑</language>
-			<language type="sa">↑↑↑</language>
-			<language type="sad">↑↑↑</language>
-			<language type="sah">↑↑↑</language>
-			<language type="sam" draft="contributed">↑↑↑</language>
-			<language type="saq">↑↑↑</language>
-			<language type="sas" draft="contributed">↑↑↑</language>
-			<language type="sat">↑↑↑</language>
-			<language type="saz" draft="contributed">↑↑↑</language>
-			<language type="sba">↑↑↑</language>
-			<language type="sbp">↑↑↑</language>
-			<language type="sc">↑↑↑</language>
-			<language type="scn">↑↑↑</language>
-			<language type="sco">↑↑↑</language>
-			<language type="sd">↑↑↑</language>
-			<language type="sdc" draft="contributed">↑↑↑</language>
-			<language type="sdh" draft="contributed">↑↑↑</language>
-			<language type="se">↑↑↑</language>
-			<language type="se" alt="menu">↑↑↑</language>
-			<language type="see" draft="contributed">↑↑↑</language>
-			<language type="seh">↑↑↑</language>
-			<language type="sei" draft="contributed">↑↑↑</language>
-			<language type="sel" draft="contributed">↑↑↑</language>
-			<language type="ses">↑↑↑</language>
-			<language type="sg">↑↑↑</language>
-			<language type="sga" draft="contributed">↑↑↑</language>
-			<language type="sgs" draft="contributed">↑↑↑</language>
-			<language type="sh" draft="contributed">↑↑↑</language>
-			<language type="shi">↑↑↑</language>
-			<language type="shn">↑↑↑</language>
-			<language type="shu" draft="contributed">↑↑↑</language>
-			<language type="si">↑↑↑</language>
-			<language type="sid" draft="contributed">↑↑↑</language>
-			<language type="sk">↑↑↑</language>
-			<language type="sl">↑↑↑</language>
-			<language type="sli" draft="contributed">↑↑↑</language>
-			<language type="sly" draft="contributed">↑↑↑</language>
-			<language type="sm">↑↑↑</language>
-			<language type="sma">↑↑↑</language>
-			<language type="smj">↑↑↑</language>
-			<language type="smn">↑↑↑</language>
-			<language type="smn" alt="menu">↑↑↑</language>
-			<language type="sms">↑↑↑</language>
-			<language type="sn">↑↑↑</language>
-			<language type="snk">↑↑↑</language>
-			<language type="so">↑↑↑</language>
-			<language type="sog" draft="contributed">↑↑↑</language>
-			<language type="sq">↑↑↑</language>
-			<language type="sr">↑↑↑</language>
-			<language type="sr_ME">Montenegrin</language>
-			<language type="srn">↑↑↑</language>
-			<language type="srr" draft="contributed">↑↑↑</language>
-			<language type="ss">↑↑↑</language>
-			<language type="ssy">↑↑↑</language>
-			<language type="st">↑↑↑</language>
-			<language type="stq" draft="contributed">↑↑↑</language>
-			<language type="su">↑↑↑</language>
-			<language type="suk">↑↑↑</language>
-			<language type="sus" draft="contributed">↑↑↑</language>
-			<language type="sux" draft="contributed">↑↑↑</language>
-			<language type="sv">↑↑↑</language>
-			<language type="sw">↑↑↑</language>
-			<language type="sw_CD">Congo Swahili</language>
-			<language type="swb">↑↑↑</language>
-			<language type="syc" draft="contributed">↑↑↑</language>
-			<language type="syr">↑↑↑</language>
-			<language type="szl" draft="contributed">↑↑↑</language>
-			<language type="ta">↑↑↑</language>
-			<language type="tcy" draft="contributed">↑↑↑</language>
-			<language type="te">↑↑↑</language>
-			<language type="tem">↑↑↑</language>
-			<language type="teo">↑↑↑</language>
-			<language type="ter" draft="contributed">↑↑↑</language>
-			<language type="tet">↑↑↑</language>
-			<language type="tg">↑↑↑</language>
-			<language type="th">↑↑↑</language>
-			<language type="ti">↑↑↑</language>
-			<language type="tig">↑↑↑</language>
-			<language type="tiv" draft="contributed">↑↑↑</language>
-			<language type="tk">↑↑↑</language>
-			<language type="tkl" draft="contributed">↑↑↑</language>
-			<language type="tkr" draft="contributed">↑↑↑</language>
-			<language type="tl" draft="contributed">↑↑↑</language>
-			<language type="tlh">↑↑↑</language>
-			<language type="tli" draft="contributed">↑↑↑</language>
-			<language type="tly" draft="contributed">↑↑↑</language>
-			<language type="tmh" draft="contributed">↑↑↑</language>
-			<language type="tn">↑↑↑</language>
-			<language type="to">↑↑↑</language>
-			<language type="tog" draft="contributed">↑↑↑</language>
-			<language type="tpi">↑↑↑</language>
-			<language type="tr">↑↑↑</language>
-			<language type="tru" draft="contributed">↑↑↑</language>
-			<language type="trv">↑↑↑</language>
-			<language type="ts">↑↑↑</language>
-			<language type="tsd" draft="contributed">↑↑↑</language>
-			<language type="tsi" draft="contributed">↑↑↑</language>
-			<language type="tt">↑↑↑</language>
-			<language type="ttt" draft="contributed">↑↑↑</language>
-			<language type="tum">↑↑↑</language>
+			<language type="sah">Yakut</language>
 			<language type="tvl">Tuvaluan</language>
-			<language type="tw" draft="contributed">↑↑↑</language>
-			<language type="twq">↑↑↑</language>
-			<language type="ty">↑↑↑</language>
-			<language type="tyv">↑↑↑</language>
-			<language type="tzm">↑↑↑</language>
-			<language type="udm">↑↑↑</language>
-			<language type="ug">↑↑↑</language>
-			<language type="ug" alt="variant">↑↑↑</language>
-			<language type="uga" draft="contributed">↑↑↑</language>
-			<language type="uk">↑↑↑</language>
-			<language type="umb">↑↑↑</language>
-			<language type="und">↑↑↑</language>
-			<language type="ur">↑↑↑</language>
-			<language type="uz">↑↑↑</language>
-			<language type="vai">↑↑↑</language>
-			<language type="ve">↑↑↑</language>
-			<language type="vec" draft="contributed">↑↑↑</language>
-			<language type="vep" draft="contributed">↑↑↑</language>
-			<language type="vi">↑↑↑</language>
-			<language type="vls" draft="contributed">↑↑↑</language>
-			<language type="vmf" draft="contributed">↑↑↑</language>
-			<language type="vo">↑↑↑</language>
-			<language type="vot" draft="contributed">↑↑↑</language>
-			<language type="vro" draft="contributed">↑↑↑</language>
-			<language type="vun">↑↑↑</language>
-			<language type="wa">↑↑↑</language>
-			<language type="wae">↑↑↑</language>
-			<language type="wal">↑↑↑</language>
-			<language type="war">↑↑↑</language>
-			<language type="was" draft="contributed">↑↑↑</language>
-			<language type="wbp" draft="contributed">↑↑↑</language>
-			<language type="wo">↑↑↑</language>
-			<language type="wuu" draft="contributed">↑↑↑</language>
-			<language type="xal">↑↑↑</language>
-			<language type="xh">↑↑↑</language>
-			<language type="xmf" draft="contributed">↑↑↑</language>
-			<language type="xog">↑↑↑</language>
-			<language type="yao" draft="contributed">↑↑↑</language>
-			<language type="yap" draft="contributed">↑↑↑</language>
-			<language type="yav">↑↑↑</language>
-			<language type="ybb">↑↑↑</language>
-			<language type="yi">↑↑↑</language>
-			<language type="yo">↑↑↑</language>
-			<language type="yrl" draft="contributed">↑↑↑</language>
-			<language type="yue">↑↑↑</language>
-			<language type="yue" alt="menu">↑↑↑</language>
-			<language type="za" draft="contributed">↑↑↑</language>
-			<language type="zap" draft="contributed">↑↑↑</language>
-			<language type="zbl" draft="contributed">↑↑↑</language>
-			<language type="zea" draft="contributed">↑↑↑</language>
-			<language type="zen" draft="contributed">↑↑↑</language>
-			<language type="zgh">↑↑↑</language>
-			<language type="zh">↑↑↑</language>
-			<language type="zh" alt="long">↑↑↑</language>
-			<language type="zh" alt="menu">↑↑↑</language>
-			<language type="zh_Hans">Simplified Chinese</language>
-			<language type="zh_Hans" alt="long">Simplified Mandarin Chinese</language>
-			<language type="zh_Hant">Traditional Chinese</language>
-			<language type="zh_Hant" alt="long">Traditional Mandarin Chinese</language>
-			<language type="zu">↑↑↑</language>
-			<language type="zun">↑↑↑</language>
-			<language type="zxx">↑↑↑</language>
-			<language type="zza">↑↑↑</language>
 		</languages>
-		<scripts>
-			<script type="Arab">↑↑↑</script>
-			<script type="Arab" alt="variant">↑↑↑</script>
-			<script type="Armn">↑↑↑</script>
-			<script type="Beng">↑↑↑</script>
-			<script type="Bopo">↑↑↑</script>
-			<script type="Brai">↑↑↑</script>
-			<script type="Cyrl">↑↑↑</script>
-			<script type="Deva">↑↑↑</script>
-			<script type="Ethi">↑↑↑</script>
-			<script type="Geor">↑↑↑</script>
-			<script type="Grek">↑↑↑</script>
-			<script type="Gujr">↑↑↑</script>
-			<script type="Guru">↑↑↑</script>
-			<script type="Hanb">↑↑↑</script>
-			<script type="Hang">↑↑↑</script>
-			<script type="Hani">↑↑↑</script>
-			<script type="Hans">↑↑↑</script>
-			<script type="Hans" alt="stand-alone">↑↑↑</script>
-			<script type="Hant">↑↑↑</script>
-			<script type="Hant" alt="stand-alone">↑↑↑</script>
-			<script type="Hebr">↑↑↑</script>
-			<script type="Hira">↑↑↑</script>
-			<script type="Hrkt">↑↑↑</script>
-			<script type="Jamo">↑↑↑</script>
-			<script type="Jpan">↑↑↑</script>
-			<script type="Kana">↑↑↑</script>
-			<script type="Khmr">↑↑↑</script>
-			<script type="Knda">↑↑↑</script>
-			<script type="Kore">↑↑↑</script>
-			<script type="Laoo">↑↑↑</script>
-			<script type="Latn">↑↑↑</script>
-			<script type="Mlym">↑↑↑</script>
-			<script type="Mong">↑↑↑</script>
-			<script type="Mymr">↑↑↑</script>
-			<script type="Orya">↑↑↑</script>
-			<script type="Sinh">↑↑↑</script>
-			<script type="Taml">↑↑↑</script>
-			<script type="Telu">↑↑↑</script>
-			<script type="Thaa">↑↑↑</script>
-			<script type="Thai">↑↑↑</script>
-			<script type="Tibt">↑↑↑</script>
-			<script type="Zmth">↑↑↑</script>
-			<script type="Zsye">↑↑↑</script>
-			<script type="Zsym">↑↑↑</script>
-			<script type="Zxxx">↑↑↑</script>
-			<script type="Zyyy">↑↑↑</script>
-			<script type="Zzzz">↑↑↑</script>
-		</scripts>
 		<territories>
-			<territory type="001">↑↑↑</territory>
-			<territory type="002">↑↑↑</territory>
-			<territory type="003">↑↑↑</territory>
-			<territory type="005">↑↑↑</territory>
-			<territory type="009">↑↑↑</territory>
-			<territory type="011">↑↑↑</territory>
-			<territory type="013">↑↑↑</territory>
-			<territory type="014">↑↑↑</territory>
-			<territory type="015">↑↑↑</territory>
-			<territory type="017">↑↑↑</territory>
-			<territory type="018">↑↑↑</territory>
-			<territory type="019">↑↑↑</territory>
-			<territory type="021">↑↑↑</territory>
-			<territory type="029">↑↑↑</territory>
-			<territory type="030">↑↑↑</territory>
-			<territory type="034">↑↑↑</territory>
-			<territory type="035">↑↑↑</territory>
-			<territory type="039">↑↑↑</territory>
-			<territory type="053">↑↑↑</territory>
-			<territory type="054">↑↑↑</territory>
-			<territory type="057">↑↑↑</territory>
-			<territory type="061">↑↑↑</territory>
-			<territory type="142">↑↑↑</territory>
-			<territory type="143">↑↑↑</territory>
-			<territory type="145">↑↑↑</territory>
-			<territory type="150">↑↑↑</territory>
-			<territory type="151">↑↑↑</territory>
-			<territory type="154">↑↑↑</territory>
-			<territory type="155">↑↑↑</territory>
-			<territory type="202">↑↑↑</territory>
-			<territory type="419">↑↑↑</territory>
-			<territory type="AC">↑↑↑</territory>
-			<territory type="AD">↑↑↑</territory>
-			<territory type="AE">↑↑↑</territory>
-			<territory type="AF">↑↑↑</territory>
 			<territory type="AG">Antigua and Barbuda</territory>
-			<territory type="AI">↑↑↑</territory>
-			<territory type="AL">↑↑↑</territory>
-			<territory type="AM">↑↑↑</territory>
-			<territory type="AO">↑↑↑</territory>
-			<territory type="AQ">↑↑↑</territory>
-			<territory type="AR">↑↑↑</territory>
-			<territory type="AS">↑↑↑</territory>
-			<territory type="AT">↑↑↑</territory>
-			<territory type="AU">↑↑↑</territory>
-			<territory type="AW">↑↑↑</territory>
-			<territory type="AX">↑↑↑</territory>
-			<territory type="AZ">↑↑↑</territory>
 			<territory type="BA">Bosnia and Herzegovina</territory>
-			<territory type="BA" alt="short">↑↑↑</territory>
-			<territory type="BB">↑↑↑</territory>
-			<territory type="BD">↑↑↑</territory>
-			<territory type="BE">↑↑↑</territory>
-			<territory type="BF">↑↑↑</territory>
-			<territory type="BG">↑↑↑</territory>
-			<territory type="BH">↑↑↑</territory>
-			<territory type="BI">↑↑↑</territory>
-			<territory type="BJ">↑↑↑</territory>
 			<territory type="BL">Saint-Barthélemy</territory>
-			<territory type="BM">↑↑↑</territory>
-			<territory type="BN">↑↑↑</territory>
-			<territory type="BO">↑↑↑</territory>
-			<territory type="BQ">↑↑↑</territory>
-			<territory type="BR">↑↑↑</territory>
-			<territory type="BS">↑↑↑</territory>
-			<territory type="BT">↑↑↑</territory>
-			<territory type="BV">↑↑↑</territory>
-			<territory type="BW">↑↑↑</territory>
-			<territory type="BY">↑↑↑</territory>
-			<territory type="BZ">↑↑↑</territory>
-			<territory type="CA">↑↑↑</territory>
-			<territory type="CC">↑↑↑</territory>
-			<territory type="CD">↑↑↑</territory>
-			<territory type="CD" alt="variant">↑↑↑</territory>
-			<territory type="CF">↑↑↑</territory>
-			<territory type="CG">↑↑↑</territory>
-			<territory type="CG" alt="variant">↑↑↑</territory>
-			<territory type="CH">↑↑↑</territory>
-			<territory type="CI">↑↑↑</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
-			<territory type="CK">↑↑↑</territory>
-			<territory type="CL">↑↑↑</territory>
-			<territory type="CM">↑↑↑</territory>
-			<territory type="CN">↑↑↑</territory>
-			<territory type="CO">↑↑↑</territory>
-			<territory type="CP">↑↑↑</territory>
-			<territory type="CR">↑↑↑</territory>
-			<territory type="CU">↑↑↑</territory>
-			<territory type="CV">↑↑↑</territory>
-			<territory type="CV" alt="variant">↑↑↑</territory>
-			<territory type="CW">↑↑↑</territory>
-			<territory type="CX">↑↑↑</territory>
-			<territory type="CY">↑↑↑</territory>
-			<territory type="CZ">↑↑↑</territory>
-			<territory type="CZ" alt="variant">↑↑↑</territory>
-			<territory type="DE">↑↑↑</territory>
-			<territory type="DG">↑↑↑</territory>
-			<territory type="DJ">↑↑↑</territory>
-			<territory type="DK">↑↑↑</territory>
-			<territory type="DM">↑↑↑</territory>
-			<territory type="DO">↑↑↑</territory>
-			<territory type="DZ">↑↑↑</territory>
 			<territory type="EA">Ceuta and Melilla</territory>
-			<territory type="EC">↑↑↑</territory>
-			<territory type="EE">↑↑↑</territory>
-			<territory type="EG">↑↑↑</territory>
-			<territory type="EH">↑↑↑</territory>
-			<territory type="ER">↑↑↑</territory>
-			<territory type="ES">↑↑↑</territory>
-			<territory type="ET">↑↑↑</territory>
-			<territory type="EU">↑↑↑</territory>
-			<territory type="EZ">↑↑↑</territory>
-			<territory type="FI">↑↑↑</territory>
-			<territory type="FJ">↑↑↑</territory>
-			<territory type="FK">↑↑↑</territory>
-			<territory type="FK" alt="variant">↑↑↑</territory>
-			<territory type="FM">↑↑↑</territory>
-			<territory type="FO">↑↑↑</territory>
-			<territory type="FR">↑↑↑</territory>
-			<territory type="GA">↑↑↑</territory>
-			<territory type="GB">↑↑↑</territory>
 			<territory type="GB" alt="short">U.K.</territory>
-			<territory type="GD">↑↑↑</territory>
-			<territory type="GE">↑↑↑</territory>
-			<territory type="GF">↑↑↑</territory>
-			<territory type="GG">↑↑↑</territory>
-			<territory type="GH">↑↑↑</territory>
-			<territory type="GI">↑↑↑</territory>
-			<territory type="GL">↑↑↑</territory>
-			<territory type="GM">↑↑↑</territory>
-			<territory type="GN">↑↑↑</territory>
-			<territory type="GP">↑↑↑</territory>
-			<territory type="GQ">↑↑↑</territory>
-			<territory type="GR">↑↑↑</territory>
 			<territory type="GS">South Georgia and South Sandwich Islands</territory>
-			<territory type="GT">↑↑↑</territory>
-			<territory type="GU">↑↑↑</territory>
-			<territory type="GW">↑↑↑</territory>
-			<territory type="GY">↑↑↑</territory>
-			<territory type="HK">↑↑↑</territory>
-			<territory type="HK" alt="short">↑↑↑</territory>
 			<territory type="HM">Heard and McDonald Islands</territory>
-			<territory type="HN">↑↑↑</territory>
-			<territory type="HR">↑↑↑</territory>
-			<territory type="HT">↑↑↑</territory>
-			<territory type="HU">↑↑↑</territory>
-			<territory type="IC">↑↑↑</territory>
-			<territory type="ID">↑↑↑</territory>
-			<territory type="IE">↑↑↑</territory>
-			<territory type="IL">↑↑↑</territory>
-			<territory type="IM">↑↑↑</territory>
-			<territory type="IN">↑↑↑</territory>
-			<territory type="IO">↑↑↑</territory>
-			<territory type="IQ">↑↑↑</territory>
-			<territory type="IR">↑↑↑</territory>
-			<territory type="IS">↑↑↑</territory>
-			<territory type="IT">↑↑↑</territory>
-			<territory type="JE">↑↑↑</territory>
-			<territory type="JM">↑↑↑</territory>
-			<territory type="JO">↑↑↑</territory>
-			<territory type="JP">↑↑↑</territory>
-			<territory type="KE">↑↑↑</territory>
-			<territory type="KG">↑↑↑</territory>
-			<territory type="KH">↑↑↑</territory>
-			<territory type="KI">↑↑↑</territory>
-			<territory type="KM">↑↑↑</territory>
 			<territory type="KN">Saint Kitts and Nevis</territory>
-			<territory type="KP">↑↑↑</territory>
-			<territory type="KR">↑↑↑</territory>
-			<territory type="KW">↑↑↑</territory>
-			<territory type="KY">↑↑↑</territory>
-			<territory type="KZ">↑↑↑</territory>
-			<territory type="LA">↑↑↑</territory>
-			<territory type="LB">↑↑↑</territory>
 			<territory type="LC">Saint Lucia</territory>
-			<territory type="LI">↑↑↑</territory>
-			<territory type="LK">↑↑↑</territory>
-			<territory type="LR">↑↑↑</territory>
-			<territory type="LS">↑↑↑</territory>
-			<territory type="LT">↑↑↑</territory>
-			<territory type="LU">↑↑↑</territory>
-			<territory type="LV">↑↑↑</territory>
-			<territory type="LY">↑↑↑</territory>
-			<territory type="MA">↑↑↑</territory>
-			<territory type="MC">↑↑↑</territory>
-			<territory type="MD">↑↑↑</territory>
-			<territory type="ME">↑↑↑</territory>
 			<territory type="MF">Saint Martin</territory>
-			<territory type="MG">↑↑↑</territory>
-			<territory type="MH">↑↑↑</territory>
-			<territory type="MK">↑↑↑</territory>
-			<territory type="ML">↑↑↑</territory>
-			<territory type="MM">↑↑↑</territory>
-			<territory type="MM" alt="short">↑↑↑</territory>
-			<territory type="MN">↑↑↑</territory>
-			<territory type="MO">↑↑↑</territory>
-			<territory type="MO" alt="short">↑↑↑</territory>
-			<territory type="MP">↑↑↑</territory>
-			<territory type="MQ">↑↑↑</territory>
-			<territory type="MR">↑↑↑</territory>
-			<territory type="MS">↑↑↑</territory>
-			<territory type="MT">↑↑↑</territory>
-			<territory type="MU">↑↑↑</territory>
-			<territory type="MV">↑↑↑</territory>
-			<territory type="MW">↑↑↑</territory>
-			<territory type="MX">↑↑↑</territory>
-			<territory type="MY">↑↑↑</territory>
-			<territory type="MZ">↑↑↑</territory>
-			<territory type="NA">↑↑↑</territory>
-			<territory type="NC">↑↑↑</territory>
-			<territory type="NE">↑↑↑</territory>
-			<territory type="NF">↑↑↑</territory>
-			<territory type="NG">↑↑↑</territory>
-			<territory type="NI">↑↑↑</territory>
-			<territory type="NL">↑↑↑</territory>
-			<territory type="NO">↑↑↑</territory>
-			<territory type="NP">↑↑↑</territory>
-			<territory type="NR">↑↑↑</territory>
-			<territory type="NU">↑↑↑</territory>
-			<territory type="NZ">↑↑↑</territory>
-			<territory type="OM">↑↑↑</territory>
-			<territory type="PA">↑↑↑</territory>
-			<territory type="PE">↑↑↑</territory>
-			<territory type="PF">↑↑↑</territory>
-			<territory type="PG">↑↑↑</territory>
-			<territory type="PH">↑↑↑</territory>
-			<territory type="PK">↑↑↑</territory>
-			<territory type="PL">↑↑↑</territory>
 			<territory type="PM">Saint-Pierre-et-Miquelon</territory>
-			<territory type="PN">↑↑↑</territory>
-			<territory type="PR">↑↑↑</territory>
-			<territory type="PS">↑↑↑</territory>
-			<territory type="PS" alt="short">↑↑↑</territory>
-			<territory type="PT">↑↑↑</territory>
-			<territory type="PW">↑↑↑</territory>
-			<territory type="PY">↑↑↑</territory>
-			<territory type="QA">↑↑↑</territory>
-			<territory type="QO">↑↑↑</territory>
-			<territory type="RE">↑↑↑</territory>
-			<territory type="RO">↑↑↑</territory>
-			<territory type="RS">↑↑↑</territory>
-			<territory type="RU">↑↑↑</territory>
-			<territory type="RW">↑↑↑</territory>
-			<territory type="SA">↑↑↑</territory>
-			<territory type="SB">↑↑↑</territory>
-			<territory type="SC">↑↑↑</territory>
-			<territory type="SD">↑↑↑</territory>
-			<territory type="SE">↑↑↑</territory>
-			<territory type="SG">↑↑↑</territory>
 			<territory type="SH">Saint Helena</territory>
-			<territory type="SI">↑↑↑</territory>
 			<territory type="SJ">Svalbard and Jan Mayen</territory>
-			<territory type="SK">↑↑↑</territory>
-			<territory type="SL">↑↑↑</territory>
-			<territory type="SM">↑↑↑</territory>
-			<territory type="SN">↑↑↑</territory>
-			<territory type="SO">↑↑↑</territory>
-			<territory type="SR">↑↑↑</territory>
-			<territory type="SS">↑↑↑</territory>
 			<territory type="ST">São Tomé and Príncipe</territory>
-			<territory type="SV">↑↑↑</territory>
-			<territory type="SX">↑↑↑</territory>
-			<territory type="SY">↑↑↑</territory>
-			<territory type="SZ">↑↑↑</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
-			<territory type="TA">↑↑↑</territory>
 			<territory type="TC">Turks and Caicos Islands</territory>
-			<territory type="TD">↑↑↑</territory>
-			<territory type="TF">↑↑↑</territory>
-			<territory type="TG">↑↑↑</territory>
-			<territory type="TH">↑↑↑</territory>
-			<territory type="TJ">↑↑↑</territory>
-			<territory type="TK">↑↑↑</territory>
-			<territory type="TL">↑↑↑</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
-			<territory type="TM">↑↑↑</territory>
-			<territory type="TN">↑↑↑</territory>
-			<territory type="TO">↑↑↑</territory>
-			<territory type="TR">↑↑↑</territory>
 			<territory type="TT">Trinidad and Tobago</territory>
-			<territory type="TV">↑↑↑</territory>
-			<territory type="TW">↑↑↑</territory>
-			<territory type="TZ">↑↑↑</territory>
-			<territory type="UA">↑↑↑</territory>
-			<territory type="UG">↑↑↑</territory>
-			<territory type="UM">U.S. Outlying Islands</territory>
-			<territory type="UN">↑↑↑</territory>
-			<territory type="UN" alt="short">↑↑↑</territory>
-			<territory type="US">↑↑↑</territory>
 			<territory type="US" alt="short">U.S.</territory>
-			<territory type="UY">↑↑↑</territory>
-			<territory type="UZ">↑↑↑</territory>
-			<territory type="VA">↑↑↑</territory>
 			<territory type="VC">Saint Vincent and the Grenadines</territory>
-			<territory type="VE">↑↑↑</territory>
-			<territory type="VG">↑↑↑</territory>
-			<territory type="VI">U.S. Virgin Islands</territory>
-			<territory type="VN">↑↑↑</territory>
-			<territory type="VU">↑↑↑</territory>
 			<territory type="WF">Wallis and Futuna</territory>
-			<territory type="WS">↑↑↑</territory>
-			<territory type="XA">↑↑↑</territory>
-			<territory type="XB">↑↑↑</territory>
-			<territory type="XK">↑↑↑</territory>
-			<territory type="YE">↑↑↑</territory>
-			<territory type="YT">↑↑↑</territory>
-			<territory type="ZA">↑↑↑</territory>
-			<territory type="ZM">↑↑↑</territory>
-			<territory type="ZW">↑↑↑</territory>
-			<territory type="ZZ">↑↑↑</territory>
 		</territories>
-		<subdivisions>
-			<subdivision type="gbeng">↑↑↑</subdivision>
-			<subdivision type="gbsct">↑↑↑</subdivision>
-			<subdivision type="gbwls">↑↑↑</subdivision>
-		</subdivisions>
 		<keys>
-			<key type="calendar">↑↑↑</key>
-			<key type="cf">↑↑↑</key>
-			<key type="colAlternate">↑↑↑</key>
-			<key type="colBackwards">↑↑↑</key>
-			<key type="colCaseFirst">↑↑↑</key>
-			<key type="colCaseLevel">↑↑↑</key>
-			<key type="collation">↑↑↑</key>
-			<key type="colNormalization">Normalized Sorting</key>
-			<key type="colNumeric">↑↑↑</key>
-			<key type="colReorder">↑↑↑</key>
-			<key type="colStrength">↑↑↑</key>
-			<key type="currency">↑↑↑</key>
-			<key type="d0">↑↑↑</key>
-			<key type="dx">↑↑↑</key>
-			<key type="em">↑↑↑</key>
-			<key type="fw">↑↑↑</key>
-			<key type="h0">↑↑↑</key>
-			<key type="hc">↑↑↑</key>
-			<key type="i0">↑↑↑</key>
-			<key type="k0">↑↑↑</key>
-			<key type="kv">↑↑↑</key>
-			<key type="lb">↑↑↑</key>
-			<key type="lw">↑↑↑</key>
-			<key type="m0">↑↑↑</key>
-			<key type="ms">↑↑↑</key>
-			<key type="numbers">↑↑↑</key>
-			<key type="rg">↑↑↑</key>
-			<key type="s0">↑↑↑</key>
-			<key type="sd">↑↑↑</key>
-			<key type="ss">↑↑↑</key>
-			<key type="t">↑↑↑</key>
-			<key type="t0">↑↑↑</key>
-			<key type="timezone">↑↑↑</key>
-			<key type="va">↑↑↑</key>
-			<key type="x">↑↑↑</key>
-			<key type="x0">↑↑↑</key>
+			<key type="colCaseLevel">Case-Sensitive Sorting</key>
 		</keys>
 		<types>
-			<type key="calendar" type="buddhist">↑↑↑</type>
-			<type key="calendar" type="chinese">↑↑↑</type>
 			<type key="calendar" type="dangi">Korean Calendar</type>
 			<type key="calendar" type="ethiopic">Ethiopian Calendar</type>
-			<type key="calendar" type="gregorian">↑↑↑</type>
-			<type key="calendar" type="hebrew">↑↑↑</type>
-			<type key="calendar" type="indian">↑↑↑</type>
-			<type key="calendar" type="islamic">↑↑↑</type>
-			<type key="calendar" type="islamic-civil">↑↑↑</type>
-			<type key="calendar" type="islamic-tbla">↑↑↑</type>
-			<type key="calendar" type="iso8601">↑↑↑</type>
-			<type key="calendar" type="japanese">↑↑↑</type>
-			<type key="calendar" type="persian">↑↑↑</type>
-			<type key="calendar" type="roc">↑↑↑</type>
-			<type key="cf" type="account">↑↑↑</type>
-			<type key="cf" type="standard">↑↑↑</type>
-			<type key="collation" type="ducet">↑↑↑</type>
-			<type key="collation" type="search">↑↑↑</type>
-			<type key="collation" type="standard">↑↑↑</type>
-			<type key="d0" type="ascii">↑↑↑</type>
+			<type key="colNormalization" type="no">Sort Without Normalisation</type>
+			<type key="colNormalization" type="yes">Sort Unicode Normalised</type>
 			<type key="d0" type="fwidth">To Full Width</type>
 			<type key="d0" type="hwidth">To Half Width</type>
 			<type key="d0" type="lower">To Lower Case</type>
 			<type key="d0" type="title">To Title Case</type>
 			<type key="d0" type="upper">To Upper Case</type>
-			<type key="em" type="default">↑↑↑</type>
-			<type key="em" type="emoji">↑↑↑</type>
-			<type key="em" type="text">↑↑↑</type>
-			<type key="fw" type="fri">↑↑↑</type>
-			<type key="fw" type="mon">↑↑↑</type>
-			<type key="fw" type="sat">↑↑↑</type>
-			<type key="fw" type="sun">↑↑↑</type>
-			<type key="fw" type="thu">↑↑↑</type>
-			<type key="fw" type="tue">↑↑↑</type>
-			<type key="fw" type="wed">↑↑↑</type>
-			<type key="hc" type="h11">↑↑↑</type>
-			<type key="hc" type="h12">↑↑↑</type>
-			<type key="hc" type="h23">↑↑↑</type>
-			<type key="hc" type="h24">↑↑↑</type>
-			<type key="kr" type="currency">↑↑↑</type>
-			<type key="kr" type="digit">↑↑↑</type>
-			<type key="kr" type="punct">↑↑↑</type>
-			<type key="kr" type="space">↑↑↑</type>
-			<type key="kr" type="symbol">↑↑↑</type>
-			<type key="lb" type="loose">↑↑↑</type>
-			<type key="lb" type="normal">↑↑↑</type>
-			<type key="lb" type="strict">↑↑↑</type>
-			<type key="lw" type="breakall">↑↑↑</type>
-			<type key="lw" type="keepall">↑↑↑</type>
-			<type key="lw" type="normal">↑↑↑</type>
-			<type key="m0" type="bgn">↑↑↑</type>
-			<type key="m0" type="prprname">↑↑↑</type>
-			<type key="m0" type="ungegn">↑↑↑</type>
-			<type key="ms" type="metric">↑↑↑</type>
-			<type key="ms" type="uksystem">↑↑↑</type>
+			<type key="hc" type="h11">12-Hour System (0–11)</type>
+			<type key="hc" type="h12">12-Hour System (1–12)</type>
+			<type key="hc" type="h23">24-Hour System (0–23)</type>
+			<type key="hc" type="h24">24-Hour System (1–24)</type>
 			<type key="ms" type="ussystem">U.S. Measurement System</type>
-			<type key="numbers" type="arab">↑↑↑</type>
-			<type key="numbers" type="arabext">↑↑↑</type>
-			<type key="numbers" type="armn">↑↑↑</type>
-			<type key="numbers" type="armnlow">↑↑↑</type>
-			<type key="numbers" type="beng">↑↑↑</type>
-			<type key="numbers" type="deva">↑↑↑</type>
-			<type key="numbers" type="ethi">↑↑↑</type>
-			<type key="numbers" type="fullwide">↑↑↑</type>
-			<type key="numbers" type="geor">↑↑↑</type>
-			<type key="numbers" type="grek">↑↑↑</type>
-			<type key="numbers" type="greklow">↑↑↑</type>
-			<type key="numbers" type="gujr">↑↑↑</type>
-			<type key="numbers" type="guru">↑↑↑</type>
-			<type key="numbers" type="hanidec">↑↑↑</type>
-			<type key="numbers" type="hans">↑↑↑</type>
-			<type key="numbers" type="hansfin">↑↑↑</type>
-			<type key="numbers" type="hant">↑↑↑</type>
-			<type key="numbers" type="hantfin">↑↑↑</type>
-			<type key="numbers" type="hebr">↑↑↑</type>
-			<type key="numbers" type="jpan">↑↑↑</type>
-			<type key="numbers" type="jpanfin">↑↑↑</type>
-			<type key="numbers" type="khmr">↑↑↑</type>
-			<type key="numbers" type="knda">↑↑↑</type>
-			<type key="numbers" type="laoo">↑↑↑</type>
-			<type key="numbers" type="latn">↑↑↑</type>
-			<type key="numbers" type="mlym">↑↑↑</type>
-			<type key="numbers" type="mymr">↑↑↑</type>
-			<type key="numbers" type="orya">↑↑↑</type>
-			<type key="numbers" type="roman">↑↑↑</type>
-			<type key="numbers" type="romanlow">↑↑↑</type>
-			<type key="numbers" type="taml">↑↑↑</type>
-			<type key="numbers" type="tamldec">↑↑↑</type>
-			<type key="numbers" type="telu">↑↑↑</type>
-			<type key="numbers" type="thai">↑↑↑</type>
-			<type key="numbers" type="tibt">↑↑↑</type>
-			<type key="ss" type="none">↑↑↑</type>
-			<type key="ss" type="standard">↑↑↑</type>
-			<type key="t0" type="und">↑↑↑</type>
 		</types>
 		<measurementSystemNames>
-			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">U.K.</measurementSystemName>
 			<measurementSystemName type="US">U.S.</measurementSystemName>
 		</measurementSystemNames>
-		<codePatterns>
-			<codePattern type="language">↑↑↑</codePattern>
-			<codePattern type="script">↑↑↑</codePattern>
-			<codePattern type="territory">↑↑↑</codePattern>
-		</codePatterns>
 	</localeDisplayNames>
-	<characters>
-		<exemplarCharacters>↑↑↑</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">↑↑↑</exemplarCharacters>
-		<exemplarCharacters type="index">↑↑↑</exemplarCharacters>
-		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
-		<exemplarCharacters type="punctuation">↑↑↑</exemplarCharacters>
-		<ellipsis type="final">↑↑↑</ellipsis>
-		<ellipsis type="initial">↑↑↑</ellipsis>
-		<ellipsis type="medial">↑↑↑</ellipsis>
-		<ellipsis type="word-final">↑↑↑</ellipsis>
-		<ellipsis type="word-initial">↑↑↑</ellipsis>
-		<ellipsis type="word-medial">↑↑↑</ellipsis>
-		<moreInformation>↑↑↑</moreInformation>
-		<parseLenients scope="date" level="lenient">
-			<parseLenient sample="-">↑↑↑</parseLenient>
-			<parseLenient sample=":">↑↑↑</parseLenient>
-		</parseLenients>
-		<parseLenients scope="general" level="lenient">
-			<parseLenient sample=".">↑↑↑</parseLenient>
-			<parseLenient sample="’">↑↑↑</parseLenient>
-			<parseLenient sample="%">↑↑↑</parseLenient>
-			<parseLenient sample="‰">↑↑↑</parseLenient>
-			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">↑↑↑</parseLenient>
-			<parseLenient sample="¥">↑↑↑</parseLenient>
-			<parseLenient sample="₩">↑↑↑</parseLenient>
-			<parseLenient sample="₹">↑↑↑</parseLenient>
-		</parseLenients>
-		<parseLenients scope="number" level="lenient">
-			<parseLenient sample="-">↑↑↑</parseLenient>
-			<parseLenient sample=",">↑↑↑</parseLenient>
-			<parseLenient sample="+">↑↑↑</parseLenient>
-		</parseLenients>
-		<parseLenients scope="number" level="stricter">
-			<parseLenient sample=",">↑↑↑</parseLenient>
-			<parseLenient sample=".">↑↑↑</parseLenient>
-		</parseLenients>
-	</characters>
-	<delimiters>
-		<quotationStart>↑↑↑</quotationStart>
-		<quotationEnd>↑↑↑</quotationEnd>
-		<alternateQuotationStart>↑↑↑</alternateQuotationStart>
-		<alternateQuotationEnd>↑↑↑</alternateQuotationEnd>
-	</delimiters>
 	<dates>
 		<calendars>
 			<calendar type="chinese">
-				<months>
-					<monthContext type="format">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
-				</months>
 				<dateFormats>
-					<dateFormatLength type="full">
-						<dateFormat>
-							<pattern>EEEE, MMMM d, r(U)</pattern>
-							<datetimeSkeleton>rMMMMEEEEd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="long">
-						<dateFormat>
-							<pattern>MMMM d, r(U)</pattern>
-							<datetimeSkeleton>rMMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="medium">
-						<dateFormat>
-							<pattern>MMM d, r</pattern>
-							<datetimeSkeleton>rMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
 							<pattern>r-MM-dd</pattern>
 							<pattern alt="variant">d/M/r</pattern>
-							<datetimeSkeleton>rMMdd</datetimeSkeleton>
-							<datetimeSkeleton alt="variant">rMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="Ed">d E</dateFormatItem>
-						<dateFormatItem id="GyMMMd">MMM d, r</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, r(U)</dateFormatItem>
+						<dateFormatItem id="GyMMMMd">d MMMM r(U)</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd">E, d MMMM r(U)</dateFormatItem>
+						<dateFormatItem id="M">LL</dateFormatItem>
 						<dateFormatItem id="Md">MM-dd</dateFormatItem>
 						<dateFormatItem id="Md" alt="variant">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E, MM-dd</dateFormatItem>
 						<dateFormatItem id="MEd" alt="variant">E, d/M</dateFormatItem>
-						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
-						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
-						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="UMd">U-MM-dd</dateFormatItem>
 						<dateFormatItem id="UMd" alt="variant">d/M/U</dateFormatItem>
-						<dateFormatItem id="UMMMd">MMM d, U</dateFormatItem>
-						<dateFormatItem id="yMd">r-MM-dd</dateFormatItem>
 						<dateFormatItem id="yMd" alt="variant">d/M/r</dateFormatItem>
 						<dateFormatItem id="yyyyM">r-MM</dateFormatItem>
-						<dateFormatItem id="yyyyM" alt="variant">M/r</dateFormatItem>
 						<dateFormatItem id="yyyyMd">r-MM-dd</dateFormatItem>
 						<dateFormatItem id="yyyyMd" alt="variant">d/M/r</dateFormatItem>
 						<dateFormatItem id="yyyyMEd">E, r-MM-dd</dateFormatItem>
 						<dateFormatItem id="yyyyMEd" alt="variant">E, d/M/r</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">MMM d, r</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">E, MMM d, r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">d MMMM r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">E, d MMMM r(U)</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Md">
@@ -1366,19 +113,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">E, MM-dd – E, MM-dd</greatestDifference>
 							<greatestDifference id="M" alt="variant">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
-						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">MMM d – d</greatestDifference>
-							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
-						</intervalFormatItem>
-						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
-							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
-						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">y-MM – y-MM</greatestDifference>
-							<greatestDifference id="M" alt="variant">M/y – M/y</greatestDifference>
 							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
-							<greatestDifference id="y" alt="variant">M/y – M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
@@ -1396,117 +133,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">E, y-MM-dd – E, y-MM-dd</greatestDifference>
 							<greatestDifference id="y" alt="variant">E, d/M/y – E, d/M/y</greatestDifference>
 						</intervalFormatItem>
-						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">MMM d – d, U</greatestDifference>
-							<greatestDifference id="M">MMM d – MMM d, U</greatestDifference>
-							<greatestDifference id="y">MMM d, U – MMM d, U</greatestDifference>
-						</intervalFormatItem>
-						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, MMM d – E, MMM d, U</greatestDifference>
-							<greatestDifference id="M">E, MMM d – E, MMM d, U</greatestDifference>
-							<greatestDifference id="y">E, MMM d, U – E, MMM d, U</greatestDifference>
-						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
 			<calendar type="generic">
 				<dateFormats>
-					<dateFormatLength type="full">
-						<dateFormat>
-							<pattern>EEEE, MMMM d, y G</pattern>
-							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="long">
-						<dateFormat>
-							<pattern>MMMM d, y G</pattern>
-							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="medium">
-						<dateFormat>
-							<pattern>MMM d, y G</pattern>
-							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>M/d/y GGGGG</pattern>
 							<pattern alt="variant">d/M/y GGGGG</pattern>
-							<datetimeSkeleton>GGGGGyMMdd</datetimeSkeleton>
-							<datetimeSkeleton alt="variant">GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
-					<dateTimeFormatLength type="full">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
-					<dateTimeFormatLength type="long">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
-					<dateTimeFormatLength type="medium">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
-					<dateTimeFormatLength type="short">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="Bh">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Bhm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Bhms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EBhm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EBhms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ehm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EHm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ehms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EHms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">M/d/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
-						<dateFormatItem id="h">↑↑↑</dateFormatItem>
-						<dateFormatItem id="H">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">L</dateFormatItem>
-						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="EBhm">E, h:mm B</dateFormatItem>
+						<dateFormatItem id="EBhms">E, h:mm:ss B</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Ehm">E, h:mm a</dateFormatItem>
+						<dateFormatItem id="EHm">E, HH:mm</dateFormatItem>
+						<dateFormatItem id="Ehms">E, h:mm:ss a</dateFormatItem>
+						<dateFormatItem id="EHms">E, HH:mm:ss</dateFormatItem>
 						<dateFormatItem id="Md" alt="variant">d/M</dateFormatItem>
-						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MEd" alt="variant">E, d/M</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
-						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
-						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
-						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyM" alt="variant">M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMd" alt="variant">d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMEd" alt="variant">E, d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatFallback>{0}–{1}</intervalFormatFallback>
@@ -1520,11 +170,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y G–y G</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
 							<greatestDifference id="G">M/y GGGGG–M/y GGGGG</greatestDifference>
@@ -1561,7 +211,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">E, MMM d, y–E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
 							<greatestDifference id="d">M/d–M/d</greatestDifference>
@@ -1587,13 +237,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">E, MMM d–E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">M/y–M/y GGGGG</greatestDifference>
-							<greatestDifference id="M" alt="variant">M/y – M/y GGGGG</greatestDifference>
 							<greatestDifference id="y">M/y–M/y GGGGG</greatestDifference>
-							<greatestDifference id="y" alt="variant">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">M/d/y–M/d/y GGGGG</greatestDifference>
@@ -1636,229 +284,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="9">Sept</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="9">Sept</month>
 						</monthWidth>
 					</monthContext>
 				</months>
-				<days>
-					<dayContext type="format">
-						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-					</dayContext>
-					<dayContext type="stand-alone">
-						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
-						</dayWidth>
-					</dayContext>
-				</days>
-				<quarters>
-					<quarterContext type="format">
-						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
-						</quarterWidth>
-						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
-						</quarterWidth>
-						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
-						</quarterWidth>
-					</quarterContext>
-					<quarterContext type="stand-alone">
-						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
-						</quarterWidth>
-						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
-						</quarterWidth>
-						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
-						</quarterWidth>
-					</quarterContext>
-				</quarters>
 				<dayPeriods>
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
 							<dayPeriod type="am">a.m.</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">p.m.</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">mid</dayPeriod>
 							<dayPeriod type="am">am</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">pm</dayPeriod>
 							<dayPeriod type="morning1">mor</dayPeriod>
 							<dayPeriod type="afternoon1">aft</dayPeriod>
@@ -1866,199 +309,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="night1">night</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
 							<dayPeriod type="am">a.m.</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">p.m.</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
 							<dayPeriod type="am">a.m.</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">p.m.</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">mid</dayPeriod>
 							<dayPeriod type="am">a.m.</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">pm</dayPeriod>
 							<dayPeriod type="morning1">mor</dayPeriod>
 							<dayPeriod type="afternoon1">aft</dayPeriod>
 							<dayPeriod type="evening1">eve</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
 							<dayPeriod type="am">a.m.</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">p.m.</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
-				<eras>
-					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
-					</eraNames>
-					<eraAbbr>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
-					</eraAbbr>
-				</eras>
 				<dateFormats>
-					<dateFormatLength type="full">
-						<dateFormat>
-							<pattern>EEEE, MMMM d, y</pattern>
-							<datetimeSkeleton>yMMMMEEEEd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="long">
-						<dateFormat>
-							<pattern>MMMM d, y</pattern>
-							<datetimeSkeleton>yMMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="medium">
-						<dateFormat>
-							<pattern>MMM d, y</pattern>
-							<datetimeSkeleton>yMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
 							<pattern>y-MM-dd</pattern>
 							<pattern alt="variant">d/M/yy</pattern>
-							<datetimeSkeleton>yMMdd</datetimeSkeleton>
-							<datetimeSkeleton alt="variant">yyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
-				<timeFormats>
-					<timeFormatLength type="full">
-						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
-						</timeFormat>
-					</timeFormatLength>
-					<timeFormatLength type="long">
-						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
-						</timeFormat>
-					</timeFormatLength>
-					<timeFormatLength type="medium">
-						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
-						</timeFormat>
-					</timeFormatLength>
-					<timeFormatLength type="short">
-						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
-						</timeFormat>
-					</timeFormatLength>
-				</timeFormats>
 				<dateTimeFormats>
-					<dateTimeFormatLength type="full">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
-					<dateTimeFormatLength type="long">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
-					<dateTimeFormatLength type="medium">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
-					<dateTimeFormatLength type="short">
-						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
-						</dateTimeFormat>
-					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="Bh">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Bhm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Bhms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EBhm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EBhms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ehm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EHm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ehms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="EHms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">M/d/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
-						<dateFormatItem id="h">↑↑↑</dateFormatItem>
-						<dateFormatItem id="H">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hmsv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hmsv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hmv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hmv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
+						<dateFormatItem id="EBhm">E, h:mm B</dateFormatItem>
+						<dateFormatItem id="EBhms">E, h:mm:ss B</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Md">MM-dd</dateFormatItem>
 						<dateFormatItem id="Md" alt="variant">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E, MM-dd</dateFormatItem>
 						<dateFormatItem id="MEd" alt="variant">E, d/M</dateFormatItem>
 						<dateFormatItem id="MMdd">MM-dd</dateFormatItem>
 						<dateFormatItem id="MMdd" alt="variant">dd/MM</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
-						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
-						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="other">↑↑↑</dateFormatItem>
-						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM" alt="variant">M/y</dateFormatItem>
+						<dateFormatItem id="yM">MM/y</dateFormatItem>
 						<dateFormatItem id="yMd">y-MM-dd</dateFormatItem>
 						<dateFormatItem id="yMd" alt="variant">d/M/y</dateFormatItem>
 						<dateFormatItem id="yMEd">E, y-MM-dd</dateFormatItem>
 						<dateFormatItem id="yMEd" alt="variant">E, d/M/y</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">MMM d, y</dateFormatItem>
-						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yw" count="one">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yw" count="other">↑↑↑</dateFormatItem>
 					</availableFormats>
-					<appendItems>
-						<appendItem request="Timezone">↑↑↑</appendItem>
-					</appendItems>
 					<intervalFormats>
 						<intervalFormatFallback>{0}–{1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
@@ -2071,7 +369,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y G–y G</greatestDifference>
@@ -2113,10 +411,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a–h a</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
 							<greatestDifference id="a">h:mm a–h:mm a</greatestDifference>
@@ -2124,8 +422,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
 							<greatestDifference id="a">h:mm a–h:mm a v</greatestDifference>
@@ -2133,18 +431,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a">h a–h a v</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
 							<greatestDifference id="d">M/d–M/d</greatestDifference>
@@ -2170,13 +468,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">E, MMM d–E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">M/y–M/y</greatestDifference>
-							<greatestDifference id="M" alt="variant">M/y – M/y</greatestDifference>
 							<greatestDifference id="y">M/y–M/y</greatestDifference>
-							<greatestDifference id="y" alt="variant">M/y – M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">M/d/y–M/d/y</greatestDifference>
@@ -2215,780 +511,288 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
-			<calendar type="indian">
-				<months>
-					<monthContext type="format">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
-				</months>
-				<eras>
-					<eraAbbr>
-						<era type="0">↑↑↑</era>
-					</eraAbbr>
-				</eras>
-			</calendar>
 			<calendar type="islamic">
-				<months>
-					<monthContext type="format">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
-				</months>
-				<eras>
-					<eraAbbr>
-						<era type="0">↑↑↑</era>
-					</eraAbbr>
-				</eras>
-				<dateFormats>
-					<dateFormatLength type="full">
-						<dateFormat>
-							<pattern>EEEE, MMMM d, y G</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="long">
-						<dateFormat>
-							<pattern>MMMM d, y G</pattern>
-							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="medium">
-						<dateFormat>
-							<pattern>MMM d, y G</pattern>
-							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-					<dateFormatLength type="short">
-						<dateFormat>
-							<pattern>M/d/y GGGGG</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
-						</dateFormat>
-					</dateFormatLength>
-				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">M/d/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
-						<dateFormatItem id="M">L</dateFormatItem>
-						<dateFormatItem id="Md">M/d</dateFormatItem>
-						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
-						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
-						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
 		</calendars>
 		<fields>
-			<field type="era">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="era-short">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="year">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>yr</displayName>
+				<relative type="-1">last yr</relative>
+				<relative type="0">this yr</relative>
+				<relative type="1">next yr</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} yr</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} yrs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} yr ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} yrs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last yr</relative>
+				<relative type="0">this yr</relative>
+				<relative type="1">next yr</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} yr</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} yrs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} yr ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} yrs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="quarter">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="quarter-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>qtr</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} qtr</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} qtrs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} qtr ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} qtrs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>qtr</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} qtr</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} qtrs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} qtr ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} qtrs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="month">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>mo</displayName>
+				<relative type="-1">last mo</relative>
+				<relative type="0">this mo</relative>
+				<relative type="1">next mo</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} mo</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} mos</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mo ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} mos ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>mo</displayName>
+				<relative type="-1">last mo</relative>
+				<relative type="0">this mo</relative>
+				<relative type="1">next mo</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} mo</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} mos</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mo ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} mos ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="week">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
-			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>wk</displayName>
+				<relative type="-1">last wk</relative>
+				<relative type="0">this wk</relative>
+				<relative type="1">next wk</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} wk</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} wks</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} wk ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} wks ago</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>wk</displayName>
+				<relative type="-1">last wk</relative>
+				<relative type="0">this wk</relative>
+				<relative type="1">next wk</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} wk</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} wks</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} wk ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} wks ago</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
-			</field>
-			<field type="weekOfMonth">
-				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>wk of mo</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="day">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
-			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
-			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
-			<field type="dayOfYear">
-				<displayName>↑↑↑</displayName>
+				<displayName>wk of mo</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>day of yr</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="weekday">
-				<displayName>↑↑↑</displayName>
+				<displayName>day of yr</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>day of wk</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="weekdayOfMonth">
-				<displayName>↑↑↑</displayName>
+				<displayName>day of wk</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>wkday of mo</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="sun">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
+				<displayName>wkday of mo</displayName>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Sun</relative>
+				<relative type="0">this Sun</relative>
+				<relative type="1">next Sun</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Sun</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Sun’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Sun ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Sun’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Su’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Su’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="mon">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Mon</relative>
+				<relative type="0">this Mon</relative>
+				<relative type="1">next Mon</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Mon</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Mon’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Mon ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Mon’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} M’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} M’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="tue">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="tue-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Tue</relative>
+				<relative type="0">this Tue</relative>
+				<relative type="1">next Tue</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Tue</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Tue’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Tue ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Tue’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Tu’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Tu’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="wed">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="wed-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Wed</relative>
+				<relative type="0">this Wed</relative>
+				<relative type="1">next Wed</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Wed</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Wed’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Wed ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Wed’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} W’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} W’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="thu">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="thu-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Thu</relative>
+				<relative type="0">this Thu</relative>
+				<relative type="1">next Thu</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Thu</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Thu’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Thu ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Thu’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Th’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Th’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="fri">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="fri-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Fri</relative>
+				<relative type="0">this Fri</relative>
+				<relative type="1">next Fri</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Fri</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Fri’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Fri ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Fri’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} F’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} F’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="sat">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="sat-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Sat</relative>
+				<relative type="0">this Sat</relative>
+				<relative type="1">next Sat</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} Sat</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Sat’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Sat ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Sat’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} Sa’s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Sa’s ago</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3001,1836 +805,260 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="dayperiod-narrow">
 				<displayName>a.m./p.m.</displayName>
 			</field>
-			<field type="hour">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>hr</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} hr</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} hrs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} hr ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} hrs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} hr</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} hrs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} hr ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} hrs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="minute">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>min</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} min</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} mins</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} min ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} mins ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>min</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} min</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} mins</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} min ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} mins ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="second">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
-				</relativeTime>
-			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>sec</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} sec</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} secs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} sec ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} secs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} sec</relativeTimePattern>
 					<relativeTimePattern count="other">in {0} secs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} sec ago</relativeTimePattern>
 					<relativeTimePattern count="other">{0} secs ago</relativeTimePattern>
 				</relativeTime>
 			</field>
-			<field type="zone">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
-			</field>
-			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
-			</field>
 		</fields>
 		<timeZoneNames>
-			<hourFormat>↑↑↑</hourFormat>
-			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>GMT</gmtZeroFormat>
-			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0} Daylight Saving Time</regionFormat>
-			<regionFormat type="standard">↑↑↑</regionFormat>
-			<fallbackFormat>↑↑↑</fallbackFormat>
-			<zone type="Etc/UTC">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</zone>
-			<zone type="Etc/Unknown">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Andorra">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Dubai">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Kabul">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Antigua">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Anguilla">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Tirane">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Yerevan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Luanda">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Rothera">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Palmer">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Troll">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Syowa">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Mawson">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Davis">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Vostok">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Casey">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/DumontDUrville">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/McMurdo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/Rio_Gallegos">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Mendoza">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/San_Juan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/Ushuaia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/La_Rioja">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/San_Luis">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Catamarca">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/Salta">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Jujuy">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Argentina/Tucuman">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Cordoba">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Buenos_Aires">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Pago_Pago">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Vienna">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Perth">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Eucla">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Darwin">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Adelaide">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Broken_Hill">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Melbourne">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Currie">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Hobart">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Lindeman">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Sydney">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Brisbane">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Antarctica/Macquarie">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Australia/Lord_Howe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Aruba">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Mariehamn">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Baku">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Sarajevo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Barbados">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Dhaka">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Brussels">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Ouagadougou">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Sofia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Bahrain">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Bujumbura">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Porto-Novo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="America/St_Barthelemy">
 				<exemplarCity>Saint-Barthélemy</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Bermuda">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Brunei">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/La_Paz">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Kralendijk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Eirunepe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Rio_Branco">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Porto_Velho">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Boa_Vista">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Manaus">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Cuiaba">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Santarem">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Campo_Grande">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Belem">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Araguaina">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Sao_Paulo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Bahia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Fortaleza">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Maceio">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Recife">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Noronha">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Nassau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Thimphu">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Gaborone">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Minsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Belize">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Dawson">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Whitehorse">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Inuvik">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Vancouver">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Fort_Nelson">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Dawson_Creek">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Creston">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Yellowknife">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Edmonton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Swift_Current">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Cambridge_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Regina">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Winnipeg">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Resolute">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Rainy_River">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Rankin_Inlet">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Coral_Harbour">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Thunder_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Nipigon">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Toronto">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Iqaluit">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Pangnirtung">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Moncton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Halifax">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Goose_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Glace_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Blanc-Sablon">
-				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/St_Johns">
 				<exemplarCity>Saint John’s</exemplarCity>
 			</zone>
-			<zone type="Indian/Cocos">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Kinshasa">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Lubumbashi">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Bangui">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Brazzaville">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Zurich">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Abidjan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Rarotonga">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Easter">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Punta_Arenas">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Santiago">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Douala">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Urumqi">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Shanghai">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Bogota">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Costa_Rica">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Havana">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Cape_Verde">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Curacao">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Christmas">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Nicosia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Famagusta">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Prague">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Busingen">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Berlin">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Djibouti">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Copenhagen">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Dominica">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Santo_Domingo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Algiers">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Galapagos">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Guayaquil">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Tallinn">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Cairo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/El_Aaiun">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Asmera">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Canary">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Ceuta">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Madrid">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Addis_Ababa">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Helsinki">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Fiji">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Stanley">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Truk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Ponape">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kosrae">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Faeroe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Paris">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Libreville">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/London">
-				<long>
-					<daylight>↑↑↑</daylight>
-				</long>
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Grenada">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Tbilisi">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Cayenne">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Guernsey">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Accra">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Gibraltar">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Thule">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Godthab">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Scoresbysund">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Danmarkshavn">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Banjul">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Conakry">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Guadeloupe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Malabo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Athens">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/South_Georgia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Guatemala">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Guam">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Bissau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Guyana">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Hong_Kong">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Tegucigalpa">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Zagreb">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Port-au-Prince">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Budapest">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Jakarta">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Pontianak">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Makassar">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Jayapura">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Dublin">
-				<long>
-					<daylight>↑↑↑</daylight>
-				</long>
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Jerusalem">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Isle_of_Man">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Calcutta">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Chagos">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Baghdad">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Tehran">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Reykjavik">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Rome">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Jersey">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Jamaica">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Amman">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Tokyo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Nairobi">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Bishkek">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Phnom_Penh">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Enderbury">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kiritimati">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Tarawa">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Comoro">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="America/St_Kitts">
 				<exemplarCity>Saint Kitts</exemplarCity>
 			</zone>
-			<zone type="Asia/Pyongyang">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Seoul">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Kuwait">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Cayman">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Asia/Aqtau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Oral">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Atyrau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Aqtobe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Qostanay">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Qyzylorda">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Almaty">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Vientiane">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Beirut">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>Aktau</exemplarCity>
 			</zone>
 			<zone type="America/St_Lucia">
 				<exemplarCity>Saint Lucia</exemplarCity>
 			</zone>
-			<zone type="Europe/Vaduz">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Colombo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Monrovia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Maseru">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Vilnius">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Luxembourg">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Riga">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Tripoli">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Casablanca">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Monaco">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Chisinau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Podgorica">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Marigot">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Antananarivo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kwajalein">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Majuro">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Skopje">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Bamako">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Asia/Rangoon">
 				<exemplarCity>Rangoon</exemplarCity>
-			</zone>
-			<zone type="Asia/Hovd">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Ulaanbaatar">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Choibalsan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Macau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Saipan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Martinique">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Nouakchott">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Montserrat">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Malta">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Mauritius">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Maldives">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Blantyre">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Tijuana">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Hermosillo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Mazatlan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Chihuahua">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Bahia_Banderas">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Ojinaga">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Monterrey">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Mexico_City">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Matamoros">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Merida">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Cancun">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Kuala_Lumpur">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Kuching">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Maputo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Windhoek">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Noumea">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Niamey">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Norfolk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Lagos">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Managua">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Amsterdam">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Oslo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Katmandu">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Nauru">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Niue">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Chatham">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Auckland">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Muscat">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Panama">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Lima">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Tahiti">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Marquesas">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Gambier">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Port_Moresby">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Bougainville">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Manila">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Karachi">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Warsaw">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Miquelon">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Pitcairn">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Puerto_Rico">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Gaza">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Hebron">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Azores">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Atlantic/Madeira">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Lisbon">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Palau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Asuncion">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Qatar">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Reunion">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Bucharest">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Belgrade">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Kaliningrad">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Moscow">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Volgograd">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Saratov">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Astrakhan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Ulyanovsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Kirov">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Samara">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Yekaterinburg">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Omsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Novosibirsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Barnaul">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Tomsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Novokuznetsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Krasnoyarsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Irkutsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Chita">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Yakutsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Vladivostok">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Khandyga">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Sakhalin">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Ust-Nera">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Magadan">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Srednekolymsk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Kamchatka">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Anadyr">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Kigali">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Riyadh">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Guadalcanal">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Mahe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Khartoum">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Stockholm">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Singapore">
-				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Atlantic/St_Helena">
 				<exemplarCity>Saint Helena</exemplarCity>
 			</zone>
-			<zone type="Europe/Ljubljana">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Arctic/Longyearbyen">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Bratislava">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Freetown">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/San_Marino">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Dakar">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Mogadishu">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Paramaribo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Juba">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Sao_Tome">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/El_Salvador">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Lower_Princes">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Damascus">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Mbabane">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Grand_Turk">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Ndjamena">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Kerguelen">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Lome">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Bangkok">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Dushanbe">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Fakaofo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Dili">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Ashgabat">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Tunis">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Tongatapu">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Istanbul">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Port_of_Spain">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Funafuti">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Taipei">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Dar_es_Salaam">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Uzhgorod">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Kiev">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Simferopol">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Zaporozhye">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Kampala">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Midway">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Wake">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Adak">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Nome">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Honolulu">
-				<short>
-					<generic>HST</generic>
-					<standard>HST</standard>
-					<daylight>HDT</daylight>
-				</short>
-			</zone>
-			<zone type="Pacific/Johnston">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Anchorage">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Yakutat">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Sitka">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Juneau">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Metlakatla">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Los_Angeles">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Boise">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Phoenix">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Denver">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/North_Dakota/Beulah">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/North_Dakota/New_Salem">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/North_Dakota/Center">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Chicago">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Menominee">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Vincennes">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Petersburg">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Tell_City">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Knox">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Winamac">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Marengo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indianapolis">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Louisville">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Indiana/Vevay">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Kentucky/Monticello">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Detroit">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/New_York">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Montevideo">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Samarkand">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Tashkent">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Europe/Vatican">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="America/St_Vincent">
 				<exemplarCity>Saint Vincent</exemplarCity>
-			</zone>
-			<zone type="America/Caracas">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="America/Tortola">
-				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/St_Thomas">
 				<exemplarCity>Saint Thomas</exemplarCity>
 			</zone>
-			<zone type="Asia/Saigon">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Efate">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Wallis">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Apia">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Asia/Aden">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Indian/Mayotte">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Johannesburg">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Lusaka">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Africa/Harare">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<metazone type="Afghanistan">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">AFT</standard>
+					<standard>AFT</standard>
 				</short>
-			</metazone>
-			<metazone type="Africa_Central">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Africa_Eastern">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Africa_Southern">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Africa_Western">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Alaska">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Alaska Daylight Saving Time</daylight>
-				</long>
-				<short>
-					<generic>AKT</generic>
-					<standard>AKST</standard>
-					<daylight>AKDT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Amazon">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Central Daylight Saving Time</daylight>
 				</long>
-				<short>
-					<generic>CT</generic>
-					<standard>CST</standard>
-					<daylight>CDT</daylight>
-				</short>
 			</metazone>
 			<metazone type="America_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Eastern Daylight Saving Time</daylight>
 				</long>
-				<short>
-					<generic>ET</generic>
-					<standard>EST</standard>
-					<daylight>EDT</daylight>
-				</short>
 			</metazone>
 			<metazone type="America_Mountain">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Mountain Daylight Saving Time</daylight>
 				</long>
-				<short>
-					<generic>MT</generic>
-					<standard>MST</standard>
-					<daylight>MDT</daylight>
-				</short>
 			</metazone>
 			<metazone type="America_Pacific">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Pacific Daylight Saving Time</daylight>
 				</long>
-				<short>
-					<generic>PT</generic>
-					<standard>PST</standard>
-					<daylight>PDT</daylight>
-				</short>
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Apia Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Arabian Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">ART</generic>
+					<generic>ART</generic>
 				</short>
-			</metazone>
-			<metazone type="Argentina_Western">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Armenia">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Atlantic">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Atlantic Daylight Saving Time</daylight>
 				</long>
-				<short>
-					<generic>AT</generic>
-					<standard>AST</standard>
-					<daylight>ADT</daylight>
-				</short>
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Australian Central Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_CentralWestern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Australian Central Western Daylight Saving Time</daylight>
 				</long>
 				<short>
-					<generic draft="contributed">ACWT</generic>
-					<standard draft="contributed">ACWST</standard>
-					<daylight draft="contributed">ACWDT</daylight>
+					<generic>ACWT</generic>
+					<standard>ACWST</standard>
+					<daylight>ACWDT</daylight>
 				</short>
 			</metazone>
 			<metazone type="Australia_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Australian Eastern Daylight Saving Time</daylight>
 				</long>
 				<short>
-					<generic draft="contributed">AET</generic>
-					<standard draft="contributed">AEST</standard>
-					<daylight draft="contributed">AEDT</daylight>
+					<generic>AET</generic>
+					<standard>AEST</standard>
+					<daylight>AEDT</daylight>
 				</short>
 			</metazone>
 			<metazone type="Australia_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Australian Western Daylight Saving Time</daylight>
 				</long>
 				<short>
-					<standard draft="contributed">AWST</standard>
-					<daylight draft="contributed">AWDT</daylight>
+					<standard>AWST</standard>
+					<daylight>AWDT</daylight>
 				</short>
 			</metazone>
-			<metazone type="Azerbaijan">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Azores">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
 			<metazone type="Bangladesh">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<standard draft="contributed">BST</standard>
+					<standard>BST</standard>
 				</short>
 			</metazone>
 			<metazone type="Bhutan">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">BTT</standard>
+					<standard>BTT</standard>
 				</short>
 			</metazone>
-			<metazone type="Bolivia">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Brasilia">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">BRT</generic>
-					<daylight draft="contributed">BRST</daylight>
+					<generic>BRT</generic>
+					<daylight>BRST</daylight>
 				</short>
 			</metazone>
 			<metazone type="Brunei">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">BNT</standard>
+					<standard>BNT</standard>
 				</short>
-			</metazone>
-			<metazone type="Cape_Verde">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Chamorro">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 			</metazone>
 			<metazone type="Chatham">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Chatham Daylight Saving Time</daylight>
 				</long>
 				<short>
-					<standard draft="contributed">CHAST</standard>
-					<daylight draft="contributed">CHADT</daylight>
+					<standard>CHAST</standard>
+					<daylight>CHADT</daylight>
 				</short>
-			</metazone>
-			<metazone type="Chile">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="China">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>China Daylight Saving Time</daylight>
 				</long>
 			</metazone>
-			<metazone type="Choibalsan">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
 			<metazone type="Christmas">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">CXT</standard>
+					<standard>CXT</standard>
 				</short>
 			</metazone>
 			<metazone type="Cocos">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">CCT</standard>
+					<standard>CCT</standard>
 				</short>
 			</metazone>
 			<metazone type="Colombia">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<daylight draft="contributed">COST</daylight>
+					<daylight>COST</daylight>
 				</short>
-			</metazone>
-			<metazone type="Cook">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Cuba">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Cuba Daylight Saving Time</daylight>
 				</long>
 			</metazone>
-			<metazone type="Davis">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="DumontDUrville">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="East_Timor">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">TLT</standard>
+					<standard>TLT</standard>
 				</short>
 			</metazone>
 			<metazone type="Easter">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<standard draft="contributed">EAST</standard>
-					<daylight draft="contributed">EASST</daylight>
+					<standard>EAST</standard>
+					<daylight>EASST</daylight>
 				</short>
 			</metazone>
 			<metazone type="Ecuador">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">ECT</standard>
+					<standard>ECT</standard>
 				</short>
-			</metazone>
-			<metazone type="Europe_Central">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Europe_Eastern">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Europe_Further_Eastern">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Europe_Western">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Falkland">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">FKT</generic>
-					<daylight draft="contributed">FKST</daylight>
+					<generic>FKT</generic>
+					<daylight>FKST</daylight>
 				</short>
-			</metazone>
-			<metazone type="Fiji">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="French_Guiana">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 			</metazone>
 			<metazone type="French_Southern">
 				<long>
@@ -4838,328 +1066,111 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</long>
 			</metazone>
 			<metazone type="Galapagos">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">GALT</standard>
+					<standard>GALT</standard>
 				</short>
-			</metazone>
-			<metazone type="Gambier">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Georgia">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Gilbert_Islands">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="GMT">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 			</metazone>
 			<metazone type="Greenland_Eastern">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">EGT</generic>
+					<generic>EGT</generic>
 				</short>
 			</metazone>
-			<metazone type="Greenland_Western">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Gulf">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Guyana">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">GYT</standard>
+					<standard>GYT</standard>
 				</short>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Hawaii-Aleutian Daylight Saving Time</daylight>
-				</long>
-				<short>
-					<generic>HAT</generic>
-					<standard>HAST</standard>
-					<daylight>HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hong_Kong">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hovd">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="India">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">IST</standard>
+					<standard>IST</standard>
 				</short>
 			</metazone>
-			<metazone type="Indian_Ocean">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Indochina">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">ICT</standard>
+					<standard>ICT</standard>
 				</short>
 			</metazone>
 			<metazone type="Indonesia_Central">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">WITA</standard>
+					<standard>WITA</standard>
 				</short>
 			</metazone>
 			<metazone type="Indonesia_Eastern">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">WIT</standard>
+					<standard>WIT</standard>
 				</short>
 			</metazone>
 			<metazone type="Indonesia_Western">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">WIB</standard>
+					<standard>WIB</standard>
 				</short>
 			</metazone>
 			<metazone type="Iran">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Iran Daylight Saving Time</daylight>
 				</long>
 				<short>
-					<standard draft="contributed">IRST</standard>
-					<daylight draft="contributed">IRDT</daylight>
+					<standard>IRST</standard>
+					<daylight>IRDT</daylight>
 				</short>
-			</metazone>
-			<metazone type="Irkutsk">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Israel">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Israel Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Japan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Japan Daylight Saving Time</daylight>
-				</long>
-			</metazone>
-			<metazone type="Kazakhstan_Eastern">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Kazakhstan_Western">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Korea">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Korean Daylight Saving Time</daylight>
-				</long>
-			</metazone>
-			<metazone type="Kosrae">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Krasnoyarsk">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Kyrgystan">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Line_Islands">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Lord_Howe">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Lord Howe Daylight Saving Time</daylight>
 				</long>
 			</metazone>
-			<metazone type="Macquarie">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Magadan">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
 			<metazone type="Malaysia">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">MYT</standard>
+					<standard>MYT</standard>
 				</short>
 			</metazone>
 			<metazone type="Maldives">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">MVT</standard>
+					<standard>MVT</standard>
 				</short>
-			</metazone>
-			<metazone type="Marquesas">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Marshall_Islands">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Mauritius">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Mawson">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 			</metazone>
 			<metazone type="Mexico_Northwest">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Northwest Mexico Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Pacific">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Mexican Pacific Daylight Saving Time</daylight>
 				</long>
 			</metazone>
-			<metazone type="Mongolia">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Moscow">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Myanmar">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Nauru">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Nepal">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">NPT</standard>
+					<standard>NPT</standard>
 				</short>
-			</metazone>
-			<metazone type="New_Caledonia">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="New_Zealand">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>New Zealand Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Newfoundland">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Newfoundland Daylight Saving Time</daylight>
 				</long>
 				<short>
@@ -5168,94 +1179,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>NDT</daylight>
 				</short>
 			</metazone>
-			<metazone type="Niue">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Norfolk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Norfolk Island Daylight Saving Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Noronha">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">FNT</generic>
+					<generic>FNT</generic>
 				</short>
-			</metazone>
-			<metazone type="Novosibirsk">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Omsk">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Pakistan">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<standard draft="contributed">PKT</standard>
+					<standard>PKT</standard>
 				</short>
 			</metazone>
-			<metazone type="Palau">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Papua_New_Guinea">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Paraguay">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">PYT</generic>
-					<daylight draft="contributed">PYST</daylight>
+					<generic>PYT</generic>
+					<daylight>PYST</daylight>
 				</short>
 			</metazone>
 			<metazone type="Peru">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<generic draft="contributed">PET</generic>
+					<generic>PET</generic>
 				</short>
-			</metazone>
-			<metazone type="Philippines">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Phoenix_Islands">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 			</metazone>
 			<metazone type="Pierre_Miquelon">
 				<long>
@@ -5264,2646 +1212,441 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>Saint-Pierre-et-Miquelon Daylight Saving Time</daylight>
 				</long>
 				<short>
-					<generic draft="contributed">PMT</generic>
-					<standard draft="contributed">PMST</standard>
-					<daylight draft="contributed">PMDT</daylight>
+					<generic>PMT</generic>
+					<standard>PMST</standard>
+					<daylight>PMDT</daylight>
 				</short>
-			</metazone>
-			<metazone type="Pitcairn">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Ponape">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Pyongyang">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Reunion">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Rothera">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Sakhalin">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Samoa">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Samoa Daylight Saving Time</daylight>
-				</long>
-			</metazone>
-			<metazone type="Seychelles">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Singapore">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Solomon">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="South_Georgia">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Suriname">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Syowa">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Tahiti">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Taipei">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
 					<daylight>Taipei Daylight Saving Time</daylight>
 				</long>
 			</metazone>
-			<metazone type="Tajikistan">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Tokelau">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Tonga">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Truk">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Turkmenistan">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Tuvalu">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 			<metazone type="Uruguay">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 				<short>
-					<standard draft="contributed">UYT</standard>
-					<daylight draft="contributed">UYST</daylight>
+					<standard>UYT</standard>
+					<daylight>UYST</daylight>
 				</short>
-			</metazone>
-			<metazone type="Uzbekistan">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Vanuatu">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
 			</metazone>
 			<metazone type="Venezuela">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 				<short>
-					<standard draft="contributed">VET</standard>
+					<standard>VET</standard>
 				</short>
-			</metazone>
-			<metazone type="Vladivostok">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Volgograd">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Vostok">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
-			<metazone type="Wake">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
 			</metazone>
 			<metazone type="Wallis">
 				<long>
 					<standard>Wallis and Futuna Time</standard>
 				</long>
 			</metazone>
-			<metazone type="Yakutsk">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Yekaterinburg">
-				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Yukon">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-			</metazone>
 		</timeZoneNames>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
-		<otherNumberingSystems>
-			<native>↑↑↑</native>
-		</otherNumberingSystems>
-		<minimumGroupingDigits>↑↑↑</minimumGroupingDigits>
-		<symbols numberSystem="latn">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<decimalFormats numberSystem="latn">
-			<decimalFormatLength>
-				<decimalFormat>
-					<pattern>↑↑↑</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-			<decimalFormatLength type="long">
-				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-			<decimalFormatLength type="short">
-				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-		</decimalFormats>
-		<scientificFormats numberSystem="latn">
-			<scientificFormatLength>
-				<scientificFormat>
-					<pattern>↑↑↑</pattern>
-				</scientificFormat>
-			</scientificFormatLength>
-		</scientificFormats>
-		<percentFormats numberSystem="latn">
-			<percentFormatLength>
-				<percentFormat>
-					<pattern>↑↑↑</pattern>
-				</percentFormat>
-			</percentFormatLength>
-		</percentFormats>
-		<currencyFormats numberSystem="latn">
-			<currencyFormatLength>
-				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-				</currencyFormat>
-				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-				</currencyFormat>
-			</currencyFormatLength>
-			<currencyFormatLength type="short">
-				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-				</currencyFormat>
-			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
-		</currencyFormats>
 		<currencies>
 			<currency type="AED">
-				<displayName>↑↑↑</displayName>
 				<displayName count="one">U.A.E. dirham</displayName>
 				<displayName count="other">U.A.E. dirhams</displayName>
-				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AFN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-			</currency>
-			<currency type="ALL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="AMD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-			</currency>
-			<currency type="ANG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="AOA">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="ARS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="AUD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="AWG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="AZN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-			</currency>
-			<currency type="BAM">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BBD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BDT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BGN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="BHD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="BIF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName count="one">Afghan afghani</displayName>
+				<displayName count="other">Afghan afghanis</displayName>
 			</currency>
 			<currency type="BMD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<displayName>Bermudian Dollar</displayName>
+				<displayName count="one">Bermudian dollar</displayName>
+				<displayName count="other">Bermudian dollars</displayName>
 			</currency>
-			<currency type="BND">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BOB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BRL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BSD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="BTN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="BWP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+			<currency type="BYB">
+				<displayName>Belarusian New Rouble (1994–1999)</displayName>
+				<displayName count="one">Belarusian new rouble (1994–1999)</displayName>
+				<displayName count="other">Belarusian new roubles (1994–1999)</displayName>
 			</currency>
 			<currency type="BYN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<displayName>Belarusian Rouble</displayName>
+				<displayName count="one">Belarusian rouble</displayName>
+				<displayName count="other">Belarusian roubles</displayName>
 			</currency>
-			<currency type="BZD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+			<currency type="BYR">
+				<displayName>Belarusian Rouble (2000–2016)</displayName>
+				<displayName count="one">Belarusian rouble (2000–2016)</displayName>
+				<displayName count="other">Belarusian roubles (2000–2016)</displayName>
 			</currency>
 			<currency type="CAD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
 				<symbol>$</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="CDF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="CHF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="CLP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="CNH">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="CNY">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="COP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="CRC">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="CUC">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="CUP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="CVE">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="CZK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="DJF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="DKK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="DOP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="DZD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="EGP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="ERN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ETB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="EUR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="FJD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="FKP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="GBP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="GEL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="GHS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-			</currency>
-			<currency type="GIP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="GMD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="GNF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="GTQ">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="GYD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="HKD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="HNL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="HRK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="HTG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="HUF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="IDR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="ILS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="INR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="IQD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="IRR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="ISK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="JMD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="JOD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName count="other">Ethiopian birr</displayName>
 			</currency>
 			<currency type="JPY">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="KES">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="KGS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="KHR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="KMF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="KPW">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="KRW">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="KWD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="KYD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="KZT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="LAK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="LBP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="LKR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="LRD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol>JP¥</symbol>
 			</currency>
 			<currency type="LSL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName count="other">Lesotho maloti</displayName>
 			</currency>
-			<currency type="LYD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MAD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MDL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+			<currency type="LVR">
+				<displayName>Latvian Rouble</displayName>
+				<displayName count="one">Latvian rouble</displayName>
+				<displayName count="other">Latvian roubles</displayName>
 			</currency>
 			<currency type="MGA">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="MKD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MMK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="MNT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="MOP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MRO">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MRU">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MUR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<displayName count="other">Malagasy ariary</displayName>
 			</currency>
 			<currency type="MVR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MWK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="MXN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="MYR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="MZN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="NAD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="NGN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="NIO">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="NOK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="NPR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="NZD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="OMR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="PAB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="PEN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="PGK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName count="other">Maldivian rufiyaa</displayName>
 			</currency>
 			<currency type="PHP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="PKR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="PLN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="PYG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="QAR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="RON">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="RSD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName>Philippine Peso</displayName>
+				<displayName count="one">Philippine peso</displayName>
+				<displayName count="other">Philippine pesos</displayName>
 			</currency>
 			<currency type="RUB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<displayName>Russian Rouble</displayName>
+				<displayName count="one">Russian rouble</displayName>
+				<displayName count="other">Russian roubles</displayName>
 			</currency>
-			<currency type="RWF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="SAR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="SBD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="SCR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="SDG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="SEK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="SGD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+			<currency type="RUR">
+				<displayName>Russian Rouble (1991–1998)</displayName>
+				<displayName count="one">Russian rouble (1991–1998)</displayName>
+				<displayName count="other">Russian roubles (1991–1998)</displayName>
 			</currency>
 			<currency type="SHP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="SLL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="SOS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="SRD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="SSP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="STD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName>St Helena Pound</displayName>
+				<displayName count="one">St Helena pound</displayName>
+				<displayName count="other">St Helena pounds</displayName>
 			</currency>
 			<currency type="STN">
 				<displayName>São Tomé and Príncipe Dobra</displayName>
 				<displayName count="one">São Tomé and Príncipe dobra</displayName>
 				<displayName count="other">São Tomé and Príncipe dobras</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
-			<currency type="SYP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="SZL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="THB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="TJS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="TMT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="TND">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="TOP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="TRY">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">↑↑↑</symbol>
+			<currency type="TJR">
+				<displayName>Tajikistani Rouble</displayName>
+				<displayName count="one">Tajikistani rouble</displayName>
+				<displayName count="other">Tajikistani roubles</displayName>
 			</currency>
 			<currency type="TTD">
 				<displayName>Trinidad and Tobago Dollar</displayName>
 				<displayName count="one">Trinidad and Tobago dollar</displayName>
 				<displayName count="other">Trinidad and Tobago dollars</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="TWD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="TZS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="UAH">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="UGX">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="USD">
 				<displayName>U.S. Dollar</displayName>
 				<displayName count="one">U.S. dollar</displayName>
 				<displayName count="other">U.S. dollars</displayName>
 				<symbol>US$</symbol>
-				<symbol alt="narrow">$</symbol>
-			</currency>
-			<currency type="UYU">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="UZS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="VEF">
-				<displayName>Venezuelan Bolívar (2008–2018)</displayName>
-				<displayName count="one">Venezuelan bolívar (2008–2018)</displayName>
-				<displayName count="other">Venezuelan bolívars (2008–2018)</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="VES">
-				<displayName>Venezuelan Bolívar</displayName>
-				<displayName count="one">Venezuelan bolívar</displayName>
-				<displayName count="other">Venezuelan bolívars</displayName>
-				<symbol draft="contributed">VES</symbol>
-			</currency>
-			<currency type="VND">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="VUV">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="WST">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="XAF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="XCD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="XOF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="XPF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="XXX">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-			</currency>
-			<currency type="YER">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-			</currency>
-			<currency type="ZAR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
-			</currency>
-			<currency type="ZMW">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<displayName count="other">Vanuatu vatu</displayName>
 			</currency>
 		</currencies>
-		<miscPatterns numberSystem="latn">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
-		</miscPatterns>
-		<minimalPairs>
-			<pluralMinimalPairs count="one">↑↑↑</pluralMinimalPairs>
-			<pluralMinimalPairs count="other">↑↑↑</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="few">↑↑↑</ordinalMinimalPairs>
-			<ordinalMinimalPairs ordinal="one">↑↑↑</ordinalMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
-			<ordinalMinimalPairs ordinal="two">↑↑↑</ordinalMinimalPairs>
-		</minimalPairs>
 	</numbers>
 	<units>
 		<unitLength type="long">
-			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>deca{0}</unitPrefixPattern>
 			</compoundUnit>
-			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
-			</compoundUnit>
-			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
-			</compoundUnit>
-			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
-			</compoundUnit>
-			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
-			</compoundUnit>
-			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metres per second squared</displayName>
+				<unitPattern count="one">{0} metre per second squared</unitPattern>
+				<unitPattern count="other">{0} metres per second squared</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>square kilometres</displayName>
+				<unitPattern count="one">{0} square kilometre</unitPattern>
+				<unitPattern count="other">{0} square kilometres</unitPattern>
+				<perUnitPattern>{0} per square kilometre</perUnitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>square metres</displayName>
+				<unitPattern count="one">{0} square metre</unitPattern>
+				<unitPattern count="other">{0} square metres</unitPattern>
+				<perUnitPattern>{0} per square metre</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-karat">
-				<displayName>karats</displayName>
-				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="other">{0} karats</unitPattern>
+				<displayName>square centimetres</displayName>
+				<unitPattern count="one">{0} square centimetre</unitPattern>
+				<unitPattern count="other">{0} square centimetres</unitPattern>
+				<perUnitPattern>{0} per square centimetre</perUnitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milligrams per decilitre</displayName>
+				<unitPattern count="one">{0} milligram per decilitre</unitPattern>
+				<unitPattern count="other">{0} milligrams per decilitre</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimoles per litre</displayName>
+				<unitPattern count="one">{0} millimole per litre</unitPattern>
+				<unitPattern count="other">{0} millimoles per litre</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>per cent</displayName>
+				<unitPattern count="one">{0} per cent</unitPattern>
+				<unitPattern count="other">{0} per cent</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>per mille</displayName>
+				<unitPattern count="one">{0} per mille</unitPattern>
+				<unitPattern count="other">{0} per mille</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>per myriad</displayName>
 				<unitPattern count="one">{0} per myriad</unitPattern>
 				<unitPattern count="other">{0} per myriad</unitPattern>
 			</unit>
-			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litres per kilometre</displayName>
+				<unitPattern count="one">{0} litre per kilometre</unitPattern>
+				<unitPattern count="other">{0} litres per kilometre</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litres per 100 kilometres</displayName>
+				<unitPattern count="one">{0} litre per 100 kilometres</unitPattern>
+				<unitPattern count="other">{0} litres per 100 kilometres</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles per US gallon</displayName>
+				<unitPattern count="one">{0} mile per US gallon</unitPattern>
+				<unitPattern count="other">{0} miles per US gallon</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles per gallon</displayName>
+				<unitPattern count="one">{0} mile per gallon</unitPattern>
+				<unitPattern count="other">{0} miles per gallon</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kilowatt-hour</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilowatt-hour per 100 kilometres</displayName>
+				<unitPattern count="one">{0} kilowatt-hour per 100 kilometres</unitPattern>
+				<unitPattern count="other">{0} kilowatt-hours per 100 kilometres</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>pixels per centimetre</displayName>
 				<unitPattern count="one">{0} pixel per centimetre</unitPattern>
 				<unitPattern count="other">{0} pixels per centimetre</unitPattern>
 			</unit>
-			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dots per centimetre</displayName>
 				<unitPattern count="one">{0} dot per centimetre</unitPattern>
 				<unitPattern count="other">{0} dots per centimetre</unitPattern>
 			</unit>
-			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} dot</unitPattern>
 				<unitPattern count="other">{0} dots</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} earth radii</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kilometres</displayName>
+				<unitPattern count="one">{0} kilometre</unitPattern>
+				<unitPattern count="other">{0} kilometres</unitPattern>
+				<perUnitPattern>{0} per kilometre</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>metres</displayName>
+				<unitPattern count="one">{0} metre</unitPattern>
+				<unitPattern count="other">{0} metres</unitPattern>
+				<perUnitPattern>{0} per metre</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>decimetre</displayName>
+				<unitPattern count="one">{0} decimetre</unitPattern>
+				<unitPattern count="other">{0} decimetres</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>centimetres</displayName>
+				<unitPattern count="one">{0} centimetre</unitPattern>
+				<unitPattern count="other">{0} centimetres</unitPattern>
+				<perUnitPattern>{0} per centimetre</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimetres</displayName>
+				<unitPattern count="one">{0} millimetre</unitPattern>
+				<unitPattern count="other">{0} millimetres</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>micrometre</displayName>
+				<unitPattern count="one">{0} micrometre</unitPattern>
+				<unitPattern count="other">{0} micrometres</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanometres</displayName>
+				<unitPattern count="one">{0} nanometre</unitPattern>
+				<unitPattern count="other">{0} nanometres</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>picometres</displayName>
+				<unitPattern count="one">{0} picometre</unitPattern>
+				<unitPattern count="other">{0} picometres</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Scandinavian mile</displayName>
+				<unitPattern count="one">{0} Scandinavian mile</unitPattern>
+				<unitPattern count="other">{0} Scandinavian miles</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>candelas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} candelas</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>lumens</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} lumens</unitPattern>
 			</unit>
 			<unit type="mass-metric-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tonnes</displayName>
+				<unitPattern count="one">{0} tonne</unitPattern>
+				<unitPattern count="other">{0} tonnes</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stone</displayName>
+				<unitPattern count="other">{0} stone</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimetres of mercury</displayName>
+				<unitPattern count="one">{0} millimetre of mercury</unitPattern>
+				<unitPattern count="other">{0} millimetres of mercury</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilometres per hour</displayName>
+				<unitPattern count="one">{0} kilometre per hour</unitPattern>
+				<unitPattern count="other">{0} kilometres per hour</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metres per second</displayName>
+				<unitPattern count="one">{0} metre per second</unitPattern>
+				<unitPattern count="other">{0} metres per second</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>degree</displayName>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kelvin</displayName>
+				<unitPattern count="other">{0} kelvin</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>newton metres</displayName>
+				<unitPattern count="one">{0} newton metre</unitPattern>
+				<unitPattern count="other">{0} newton metres</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cubic kilometres</displayName>
+				<unitPattern count="one">{0} cubic kilometre</unitPattern>
+				<unitPattern count="other">{0} cubic kilometres</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cubic metres</displayName>
+				<unitPattern count="one">{0} cubic metre</unitPattern>
+				<unitPattern count="other">{0} cubic metres</unitPattern>
+				<perUnitPattern>{0} per cubic metre</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cubic centimetres</displayName>
+				<unitPattern count="one">{0} cubic centimetre</unitPattern>
+				<unitPattern count="other">{0} cubic centimetres</unitPattern>
+				<perUnitPattern>{0} per cubic centimetre</perUnitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megalitres</displayName>
+				<unitPattern count="one">{0} megalitre</unitPattern>
+				<unitPattern count="other">{0} megalitres</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectolitres</displayName>
+				<unitPattern count="one">{0} hectolitre</unitPattern>
+				<unitPattern count="other">{0} hectolitres</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>litres</displayName>
+				<unitPattern count="one">{0} litre</unitPattern>
+				<unitPattern count="other">{0} litres</unitPattern>
+				<perUnitPattern>{0} per litre</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>decilitres</displayName>
+				<unitPattern count="one">{0} decilitre</unitPattern>
+				<unitPattern count="other">{0} decilitres</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>centilitres</displayName>
+				<unitPattern count="one">{0} centilitre</unitPattern>
+				<unitPattern count="other">{0} centilitres</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millilitres</displayName>
+				<unitPattern count="one">{0} millilitre</unitPattern>
+				<unitPattern count="other">{0} millilitres</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>US gallons</displayName>
+				<unitPattern count="one">{0} US gallon</unitPattern>
+				<unitPattern count="other">{0} US gallons</unitPattern>
+				<perUnitPattern>{0} per US gallon</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gallons</displayName>
+				<unitPattern count="one">{0} gallon</unitPattern>
+				<unitPattern count="other">{0} gallons</unitPattern>
+				<perUnitPattern>{0} per gallon</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US quarts</displayName>
+				<unitPattern count="one">{0} US quart</unitPattern>
+				<unitPattern count="other">{0} US quarts</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US fluid ounces</displayName>
+				<unitPattern count="one">{0} US fluid ounce</unitPattern>
+				<unitPattern count="other">{0} US fluid ounces</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>fluid ounces</displayName>
 				<unitPattern count="one">{0} fluid ounce</unitPattern>
 				<unitPattern count="other">{0} fluid ounces</unitPattern>
 			</unit>
-			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US dessertspoon</displayName>
+				<unitPattern count="one">{0} US dessertspoon</unitPattern>
+				<unitPattern count="other">{0} US dessertspoons</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-drop">
-				<displayName>drops</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dessertspoon</displayName>
+				<unitPattern count="one">{0} dessertspoon</unitPattern>
+				<unitPattern count="other">{0} dessertspoons</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fluid drams</displayName>
 				<unitPattern count="one">{0} fluid dram</unitPattern>
 				<unitPattern count="other">{0} fluid drams</unitPattern>
 			</unit>
-			<unit type="volume-jigger">
-				<displayName>jiggers</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-pinch">
-				<displayName>pinches</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>quart</displayName>
+				<unitPattern count="one">{0} quart</unitPattern>
+				<unitPattern count="other">{0} quarts</unitPattern>
 			</unit>
-			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
-			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
-			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
-			</compoundUnit>
-			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
-			</compoundUnit>
-			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
-			</compoundUnit>
-			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
-			</compoundUnit>
-			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metres/sec²</displayName>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} revs</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>metres²</displayName>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/sq mi</perUnitPattern>
-			</unit>
-			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>sq yards</displayName>
 				<unitPattern count="one">{0} sq yd</unitPattern>
 				<unitPattern count="other">{0} sq yd</unitPattern>
-			</unit>
-			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>sq inches</displayName>
@@ -7911,656 +1654,128 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} sq in</unitPattern>
 				<perUnitPattern>{0}/sq in</perUnitPattern>
 			</unit>
-			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-karat">
-				<displayName>karats</displayName>
-				<unitPattern count="one">{0} kt</unitPattern>
-				<unitPattern count="other">{0} kt</unitPattern>
-			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>milligrams/decilitre</displayName>
-				<unitPattern count="one">{0} mg/dL</unitPattern>
-				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>millimoles/litre</displayName>
-				<unitPattern count="one">{0} mmol/L</unitPattern>
-				<unitPattern count="other">{0} mmol/L</unitPattern>
-			</unit>
-			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>per cent</displayName>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>per mille</displayName>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>per myriad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>moles</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">{0} L/km</unitPattern>
+				<displayName>litres/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>litres/100 km</displayName>
-				<unitPattern count="one">{0} L/100 km</unitPattern>
-				<unitPattern count="other">{0} L/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles/US gal</displayName>
+				<unitPattern count="one">{0} mpg US</unitPattern>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles/gal</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>bytes</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} bytes</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>bits</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} bits</unitPattern>
 			</unit>
-			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/yr</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} mo</unitPattern>
 				<unitPattern count="other">{0} mos</unitPattern>
 				<perUnitPattern>{0}/mo</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/wk</perUnitPattern>
 			</unit>
-			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} hrs</unitPattern>
 				<perUnitPattern>{0}/hr</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} mins</unitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} secs</unitPattern>
 				<perUnitPattern>{0}/sec</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} millisec</unitPattern>
 				<unitPattern count="other">{0} millisecs</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} μsec</unitPattern>
 				<unitPattern count="other">{0} μsecs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} nanosec</unitPattern>
 				<unitPattern count="other">{0} nanosecs</unitPattern>
 			</unit>
-			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kilojoules</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kW-hours</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>electronvolts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
 				<unitPattern count="one">{0} kWh/100 km</unitPattern>
 				<unitPattern count="other">{0} kWh/100 km</unitPattern>
 			</unit>
-			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dot</unitPattern>
 				<unitPattern count="other">{0} dots</unitPattern>
 			</unit>
-			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metres</displayName>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-metric-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-stone">
-				<displayName>stones</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μmetres</displayName>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ct</unitPattern>
+				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>grains</displayName>
-				<unitPattern count="one">{0} grain</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} grains</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
-			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="pressure-bar">
 				<displayName>bars</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metres/sec</displayName>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>deg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>deg C</displayName>
@@ -8571,21 +1786,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>deg F</displayName>
 				<unitPattern count="one">{0} °F</unitPattern>
 				<unitPattern count="other">{0} °F</unitPattern>
-			</unit>
-			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>cu kilometres</displayName>
@@ -8624,108 +1824,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} cu in</unitPattern>
 				<unitPattern count="other">{0} cu in</unitPattern>
 			</unit>
-			<unit type="volume-megaliter">
-				<displayName>ML</displayName>
-				<unitPattern count="one">{0} ML</unitPattern>
-				<unitPattern count="other">{0} ML</unitPattern>
-			</unit>
-			<unit type="volume-hectoliter">
-				<displayName>hL</displayName>
-				<unitPattern count="one">{0} hL</unitPattern>
-				<unitPattern count="other">{0} hL</unitPattern>
-			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} L</unitPattern>
-				<unitPattern count="other">{0} L</unitPattern>
-				<perUnitPattern>{0}/L</perUnitPattern>
-			</unit>
-			<unit type="volume-deciliter">
-				<displayName>dL</displayName>
-				<unitPattern count="one">{0} dL</unitPattern>
-				<unitPattern count="other">{0} dL</unitPattern>
-			</unit>
-			<unit type="volume-centiliter">
-				<displayName>cL</displayName>
-				<unitPattern count="one">{0} cL</unitPattern>
-				<unitPattern count="other">{0} cL</unitPattern>
-			</unit>
-			<unit type="volume-milliliter">
-				<displayName>mL</displayName>
-				<unitPattern count="one">{0} mL</unitPattern>
-				<unitPattern count="other">{0} mL</unitPattern>
-			</unit>
-			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litres</displayName>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>US gal</displayName>
+				<unitPattern count="one">{0} US gal</unitPattern>
+				<unitPattern count="other">{0} US gal</unitPattern>
+				<perUnitPattern>{0}/US gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US qts</displayName>
+				<unitPattern count="one">{0} US qt</unitPattern>
+				<unitPattern count="other">{0} US qt</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US fl oz</displayName>
+				<unitPattern count="one">{0} US fl oz</unitPattern>
+				<unitPattern count="other">{0} US fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0} fl oz</unitPattern>
 				<unitPattern count="other">{0} fl oz</unitPattern>
-			</unit>
-			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>US dssp</displayName>
@@ -8739,8 +1866,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-drop">
 				<displayName>drops</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} drops</unitPattern>
+				<unitPattern count="other">{0} drops</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl drams</displayName>
@@ -8749,1003 +1876,113 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>jiggers</displayName>
-				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">{0} jiggers</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>pinches</displayName>
-				<unitPattern count="one">{0} pinch</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} pinches</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
-			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
-			</coordinateUnit>
 		</unitLength>
 		<unitLength type="narrow">
-			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
-			</compoundUnit>
-			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
-			</compoundUnit>
-			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
-			</compoundUnit>
-			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
-			</compoundUnit>
-			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
-			</compoundUnit>
-			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0}revs</unitPattern>
 			</unit>
-			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/in²</perUnitPattern>
-			</unit>
-			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metres²</displayName>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>mg/dL</displayName>
-				<unitPattern count="one">{0}mg/dL</unitPattern>
-				<unitPattern count="other">{0}mg/dL</unitPattern>
-			</unit>
-			<unit type="concentr-millimole-per-liter">
-				<displayName>mmol/L</displayName>
-				<unitPattern count="one">{0}mmol/L</unitPattern>
-				<unitPattern count="other">{0}mmol/L</unitPattern>
-			</unit>
-			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="consumption-liter-per-kilometer">
-				<displayName>L/km</displayName>
-				<unitPattern count="one">{0}L/km</unitPattern>
-				<unitPattern count="other">{0}L/km</unitPattern>
-			</unit>
-			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>L/100km</displayName>
-				<unitPattern count="one">{0}L/100km</unitPattern>
-				<unitPattern count="other">{0}L/100km</unitPattern>
+				<displayName>carat</displayName>
+				<unitPattern count="one">{0}ct</unitPattern>
+				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg US</displayName>
+				<unitPattern count="one">{0}mpgUS</unitPattern>
+				<unitPattern count="other">{0}mpgUS</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0}mpg</unitPattern>
+				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0}bits</unitPattern>
 			</unit>
-			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/y</perUnitPattern>
-			</unit>
-			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/m</perUnitPattern>
-			</unit>
-			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/w</perUnitPattern>
-			</unit>
-			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/d</perUnitPattern>
-			</unit>
-			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/h</perUnitPattern>
-			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0}min</unitPattern>
 				<unitPattern count="other">{0}min</unitPattern>
-				<perUnitPattern>{0}/min</perUnitPattern>
-			</unit>
-			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0}/s</perUnitPattern>
-			</unit>
-			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>A</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>Ω</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>V</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metre</displayName>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lx</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-metric-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}lb</unitPattern>
+				<unitPattern count="other">{0}lb</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ct</displayName>
 				<unitPattern count="one">{0}ct</unitPattern>
 				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
-			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="power-watt">
 				<displayName>W</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mph</displayName>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
-			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-megaliter">
-				<displayName>ML</displayName>
-				<unitPattern count="one">{0}ML</unitPattern>
-				<unitPattern count="other">{0}ML</unitPattern>
-			</unit>
-			<unit type="volume-hectoliter">
-				<displayName>hL</displayName>
-				<unitPattern count="one">{0}hL</unitPattern>
-				<unitPattern count="other">{0}hL</unitPattern>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0}L</unitPattern>
-				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>{0}/L</perUnitPattern>
-			</unit>
-			<unit type="volume-deciliter">
-				<displayName>dL</displayName>
-				<unitPattern count="one">{0}dL</unitPattern>
-				<unitPattern count="other">{0}dL</unitPattern>
-			</unit>
-			<unit type="volume-centiliter">
-				<displayName>cL</displayName>
-				<unitPattern count="one">{0}cL</unitPattern>
-				<unitPattern count="other">{0}cL</unitPattern>
-			</unit>
-			<unit type="volume-milliliter">
-				<displayName>mL</displayName>
-				<unitPattern count="one">{0}mL</unitPattern>
-				<unitPattern count="other">{0}mL</unitPattern>
+				<displayName>litre</displayName>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>mpt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>US gal</displayName>
 				<unitPattern count="one">{0}USgal</unitPattern>
 				<unitPattern count="other">{0}USgal</unitPattern>
 				<perUnitPattern>{0}/USgal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0}gal</unitPattern>
+				<unitPattern count="other">{0}gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>US qt</displayName>
 				<unitPattern count="one">{0}USqt</unitPattern>
 				<unitPattern count="other">{0}USqt</unitPattern>
 			</unit>
-			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="volume-cup">
 				<displayName>cups</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>US fl oz</displayName>
@@ -9757,21 +1994,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0}fl oz</unitPattern>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
-			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>US dsp</displayName>
 				<unitPattern count="one">{0}USdsp</unitPattern>
@@ -9782,11 +2004,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0}dsp</unitPattern>
 				<unitPattern count="other">{0}dsp</unitPattern>
 			</unit>
-			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="volume-dram">
 				<displayName>fl dr</displayName>
 				<unitPattern count="one">{0}fl dr</unitPattern>
@@ -9794,268 +2011,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>jiggers</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0}jiggers</unitPattern>
-			</unit>
-			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>qt</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
-			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
-			</coordinateUnit>
 		</unitLength>
-		<durationUnit type="hm">
-			<durationUnitPattern>↑↑↑</durationUnitPattern>
-		</durationUnit>
-		<durationUnit type="hms">
-			<durationUnitPattern>↑↑↑</durationUnitPattern>
-		</durationUnit>
-		<durationUnit type="ms">
-			<durationUnitPattern>↑↑↑</durationUnitPattern>
-		</durationUnit>
 	</units>
 	<listPatterns>
 		<listPattern>
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} and {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
 			<listPatternPart type="end">{0} or {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
 			<listPatternPart type="end">{0} or {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
-		</listPattern>
-		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} and {1}</listPatternPart>
 			<listPatternPart type="2">{0} and {1}</listPatternPart>
 		</listPattern>
-		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
-		</listPattern>
-		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
-		</listPattern>
-		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
-		</listPattern>
 	</listPatterns>
-	<posix>
-		<messages>
-			<yesstr>↑↑↑</yesstr>
-			<nostr>↑↑↑</nostr>
-		</messages>
-	</posix>
 	<characterLabels>
-		<characterLabelPattern type="all">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="category-list">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="compatibility">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="enclosed">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="extended">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="historic">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="miscellaneous">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="other">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="scripts">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="one">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="other">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="subscript">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="superscript">↑↑↑</characterLabelPattern>
-		<characterLabel type="activities">↑↑↑</characterLabel>
-		<characterLabel type="african_scripts">↑↑↑</characterLabel>
-		<characterLabel type="american_scripts">↑↑↑</characterLabel>
-		<characterLabel type="animal">↑↑↑</characterLabel>
-		<characterLabel type="animals_nature">↑↑↑</characterLabel>
-		<characterLabel type="arrows">↑↑↑</characterLabel>
-		<characterLabel type="body">↑↑↑</characterLabel>
-		<characterLabel type="box_drawing">↑↑↑</characterLabel>
-		<characterLabel type="braille">↑↑↑</characterLabel>
-		<characterLabel type="building">↑↑↑</characterLabel>
-		<characterLabel type="bullets_stars">↑↑↑</characterLabel>
-		<characterLabel type="consonantal_jamo">↑↑↑</characterLabel>
-		<characterLabel type="currency_symbols">↑↑↑</characterLabel>
-		<characterLabel type="dash_connector">↑↑↑</characterLabel>
-		<characterLabel type="digits">↑↑↑</characterLabel>
-		<characterLabel type="dingbats">↑↑↑</characterLabel>
-		<characterLabel type="divination_symbols">↑↑↑</characterLabel>
+		<characterLabelPattern type="all">{0} – all</characterLabelPattern>
+		<characterLabelPattern type="compatibility">{0} – compatibility</characterLabelPattern>
+		<characterLabelPattern type="enclosed">{0} – enclosed</characterLabelPattern>
+		<characterLabelPattern type="extended">{0} – extended</characterLabelPattern>
+		<characterLabelPattern type="historic">{0} – historic</characterLabelPattern>
+		<characterLabelPattern type="miscellaneous">{0} – miscellaneous</characterLabelPattern>
+		<characterLabelPattern type="other">{0} – other</characterLabelPattern>
+		<characterLabelPattern type="scripts">scripts – {0}</characterLabelPattern>
 		<characterLabel type="downwards_arrows">downward arrow</characterLabel>
 		<characterLabel type="downwards_upwards_arrows">downward upward arrow</characterLabel>
-		<characterLabel type="east_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="emoji">↑↑↑</characterLabel>
-		<characterLabel type="european_scripts">↑↑↑</characterLabel>
-		<characterLabel type="female">↑↑↑</characterLabel>
-		<characterLabel type="flag">↑↑↑</characterLabel>
-		<characterLabel type="flags">↑↑↑</characterLabel>
-		<characterLabel type="food_drink">↑↑↑</characterLabel>
-		<characterLabel type="format">↑↑↑</characterLabel>
-		<characterLabel type="format_whitespace">↑↑↑</characterLabel>
-		<characterLabel type="full_width_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="geometric_shapes">↑↑↑</characterLabel>
-		<characterLabel type="half_width_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="han_characters">↑↑↑</characterLabel>
-		<characterLabel type="han_radicals">↑↑↑</characterLabel>
-		<characterLabel type="hanja">↑↑↑</characterLabel>
-		<characterLabel type="hanzi_simplified">↑↑↑</characterLabel>
-		<characterLabel type="hanzi_traditional">↑↑↑</characterLabel>
-		<characterLabel type="heart">↑↑↑</characterLabel>
-		<characterLabel type="historic_scripts">↑↑↑</characterLabel>
-		<characterLabel type="ideographic_desc_characters">↑↑↑</characterLabel>
-		<characterLabel type="japanese_kana">↑↑↑</characterLabel>
-		<characterLabel type="kanbun">↑↑↑</characterLabel>
-		<characterLabel type="kanji">↑↑↑</characterLabel>
-		<characterLabel type="keycap">↑↑↑</characterLabel>
 		<characterLabel type="leftwards_arrows">leftward arrow</characterLabel>
 		<characterLabel type="leftwards_rightwards_arrows">leftward rightward arrow</characterLabel>
 		<characterLabel type="letterlike_symbols">letter-like symbol</characterLabel>
 		<characterLabel type="limited_use">limited use</characterLabel>
-		<characterLabel type="male">↑↑↑</characterLabel>
-		<characterLabel type="math_symbols">math symbol</characterLabel>
-		<characterLabel type="middle_eastern_scripts">↑↑↑</characterLabel>
-		<characterLabel type="miscellaneous">↑↑↑</characterLabel>
-		<characterLabel type="modern_scripts">↑↑↑</characterLabel>
-		<characterLabel type="modifier">↑↑↑</characterLabel>
-		<characterLabel type="musical_symbols">↑↑↑</characterLabel>
-		<characterLabel type="nature">↑↑↑</characterLabel>
 		<characterLabel type="nonspacing">non-spacing</characterLabel>
-		<characterLabel type="numbers">↑↑↑</characterLabel>
-		<characterLabel type="objects">↑↑↑</characterLabel>
-		<characterLabel type="other">↑↑↑</characterLabel>
-		<characterLabel type="paired">↑↑↑</characterLabel>
-		<characterLabel type="person">↑↑↑</characterLabel>
-		<characterLabel type="phonetic_alphabet">↑↑↑</characterLabel>
-		<characterLabel type="pictographs">↑↑↑</characterLabel>
-		<characterLabel type="place">↑↑↑</characterLabel>
-		<characterLabel type="plant">↑↑↑</characterLabel>
-		<characterLabel type="punctuation">↑↑↑</characterLabel>
 		<characterLabel type="rightwards_arrows">rightward arrow</characterLabel>
-		<characterLabel type="sign_standard_symbols">↑↑↑</characterLabel>
-		<characterLabel type="small_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="smiley">↑↑↑</characterLabel>
-		<characterLabel type="smileys_people">↑↑↑</characterLabel>
-		<characterLabel type="south_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="southeast_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="spacing">↑↑↑</characterLabel>
-		<characterLabel type="sport">↑↑↑</characterLabel>
-		<characterLabel type="symbols">↑↑↑</characterLabel>
-		<characterLabel type="technical_symbols">↑↑↑</characterLabel>
-		<characterLabel type="tone_marks">↑↑↑</characterLabel>
-		<characterLabel type="travel">↑↑↑</characterLabel>
-		<characterLabel type="travel_places">↑↑↑</characterLabel>
 		<characterLabel type="upwards_arrows">upward arrows</characterLabel>
-		<characterLabel type="variant_forms">↑↑↑</characterLabel>
-		<characterLabel type="vocalic_jamo">↑↑↑</characterLabel>
-		<characterLabel type="weather">↑↑↑</characterLabel>
-		<characterLabel type="western_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="whitespace">↑↑↑</characterLabel>
 	</characterLabels>
 	<typographicNames>
-		<axisName type="ital">↑↑↑</axisName>
-		<axisName type="opsz">↑↑↑</axisName>
-		<axisName type="slnt">↑↑↑</axisName>
-		<axisName type="wdth">↑↑↑</axisName>
-		<axisName type="wght">↑↑↑</axisName>
-		<styleName type="ital" subtype="1">↑↑↑</styleName>
-		<styleName type="opsz" subtype="8">↑↑↑</styleName>
-		<styleName type="opsz" subtype="12">↑↑↑</styleName>
-		<styleName type="opsz" subtype="18">↑↑↑</styleName>
-		<styleName type="opsz" subtype="72">↑↑↑</styleName>
-		<styleName type="opsz" subtype="144">↑↑↑</styleName>
-		<styleName type="slnt" subtype="-12">↑↑↑</styleName>
-		<styleName type="slnt" subtype="0">↑↑↑</styleName>
-		<styleName type="slnt" subtype="12">↑↑↑</styleName>
 		<styleName type="slnt" subtype="24">extraslanted</styleName>
-		<styleName type="wdth" subtype="50">↑↑↑</styleName>
-		<styleName type="wdth" subtype="50" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="50" alt="narrow">↑↑↑</styleName>
 		<styleName type="wdth" subtype="62.5">extracondensed</styleName>
 		<styleName type="wdth" subtype="62.5" alt="compressed">extracompressed</styleName>
 		<styleName type="wdth" subtype="62.5" alt="narrow">extranarrow</styleName>
-		<styleName type="wdth" subtype="75">↑↑↑</styleName>
-		<styleName type="wdth" subtype="75" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="75" alt="narrow">↑↑↑</styleName>
-		<styleName type="wdth" subtype="87.5">↑↑↑</styleName>
-		<styleName type="wdth" subtype="87.5" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="87.5" alt="narrow">↑↑↑</styleName>
-		<styleName type="wdth" subtype="100">↑↑↑</styleName>
-		<styleName type="wdth" subtype="112.5">↑↑↑</styleName>
-		<styleName type="wdth" subtype="112.5" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="112.5" alt="wide">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125" alt="wide">↑↑↑</styleName>
 		<styleName type="wdth" subtype="150">extraexpanded</styleName>
 		<styleName type="wdth" subtype="150" alt="extended">extraextended</styleName>
 		<styleName type="wdth" subtype="150" alt="wide">extrawide</styleName>
-		<styleName type="wdth" subtype="200">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200" alt="wide">↑↑↑</styleName>
-		<styleName type="wght" subtype="100">↑↑↑</styleName>
 		<styleName type="wght" subtype="200">extralight</styleName>
-		<styleName type="wght" subtype="200" alt="ultra">↑↑↑</styleName>
-		<styleName type="wght" subtype="300">↑↑↑</styleName>
-		<styleName type="wght" subtype="350">↑↑↑</styleName>
-		<styleName type="wght" subtype="380">↑↑↑</styleName>
-		<styleName type="wght" subtype="400">↑↑↑</styleName>
-		<styleName type="wght" subtype="500">↑↑↑</styleName>
-		<styleName type="wght" subtype="600">↑↑↑</styleName>
-		<styleName type="wght" subtype="600" alt="demi">↑↑↑</styleName>
-		<styleName type="wght" subtype="700">↑↑↑</styleName>
 		<styleName type="wght" subtype="800">extrabold</styleName>
-		<styleName type="wght" subtype="900">↑↑↑</styleName>
-		<styleName type="wght" subtype="900" alt="heavy">↑↑↑</styleName>
 		<styleName type="wght" subtype="950">extrablack</styleName>
-		<styleName type="wght" subtype="950" alt="ultrablack">↑↑↑</styleName>
-		<styleName type="wght" subtype="950" alt="ultraheavy">↑↑↑</styleName>
-		<featureName type="afrc">↑↑↑</featureName>
-		<featureName type="cpsp">↑↑↑</featureName>
-		<featureName type="dlig">↑↑↑</featureName>
-		<featureName type="frac">↑↑↑</featureName>
-		<featureName type="lnum">↑↑↑</featureName>
-		<featureName type="onum">↑↑↑</featureName>
-		<featureName type="ordn">↑↑↑</featureName>
-		<featureName type="pnum">↑↑↑</featureName>
-		<featureName type="smcp">↑↑↑</featureName>
-		<featureName type="tnum">↑↑↑</featureName>
-		<featureName type="zero">↑↑↑</featureName>
 	</typographicNames>
 </ldml>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,286 +1,1400 @@
-locale=en_001; action=delete; path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EBhm"]
-locale=en_001; action=delete; path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EBhms"]
-locale=en_001; action=delete; path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-jigger"]/unitPattern[@count="one"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="🏓"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="🔧"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="🚰"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="↜"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="↝"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="↤"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="↥"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="↦"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="↧"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="⇄"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="⇋"]
-locale=en_001; action=delete; path=//ldml/annotations/annotation[@cp="⇌"]
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="PM"]; new_value=St Pierre & Miquelon
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="BL"]; new_value=St Barthélemy
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="KN"]; new_value=St Kitts & Nevis
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="LC"]; new_value=St Lucia
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="MF"]; new_value=St Martin
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="VC"]; new_value=St Vincent & the Grenadines
-locale=en_001; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="SH"]; new_value=St Helena
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="9"]; new_value=Sept
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"]; new_value=Sept
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="full"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm:ss zzzz
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="long"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm:ss z
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="medium"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm:ss
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="short"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]; new_value=d/M/y GGGGG
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMEd"]/greatestDifference[@id="d"]; new_value=E d MMM – E d MMM
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="d"]; new_value=E, d MMM – E, d MMM y
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]; new_value=E dd/MM
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMEd"]; new_value=E d MMM
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"]; new_value=dd/MM–dd/MM
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"]; new_value=dd/MM–dd/MM
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMEd"]/greatestDifference[@id="d"]; new_value=E d MMM – E d MMM
-locale=en_001; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="d"]; new_value=E, d MMM – E, d MMM y G
-locale=en_001; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="Europe/London"]/short/daylight; new_value=BST
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-imperial"]/displayName; new_value=fluid ounces
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="one"]; new_value={0} fluid ounce
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="other"]; new_value={0} fluid ounces
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce-imperial"]/displayName; new_value=fl oz
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="one"]; new_value={0} fl oz
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="other"]; new_value={0} fl oz
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce-imperial"]/displayName; new_value=fl oz
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="one"]; new_value={0}fl oz
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="other"]; new_value={0}fl oz
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon"]/displayName; new_value=US dsp
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="one"]; new_value={0}US dsp
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="other"]; new_value={0}US dsp
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon-imperial"]/displayName; new_value=dsp
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="one"]; new_value={0}dsp
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="other"]; new_value={0}dsp
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-jigger"]/unitPattern[@count="other"]; new_value={0}jiggers
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart-imperial"]/displayName; new_value=qt
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="one"]; new_value={0}qt
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="other"]; new_value={0}qt
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-karat"]/displayName; new_value=carats
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="concentr-karat"]/displayName; new_value=carat
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="concentr-karat"]/unitPattern[@count="one"]; new_value={0}ct
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="concentr-karat"]/unitPattern[@count="other"]; new_value={0}ct
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/displayName; new_value=kilowatt-hour per 100 kilometres
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/unitPattern[@count="one"]; new_value={0} kilowatt-hour per 100 kilometres
-locale=en_001; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/unitPattern[@count="other"]; new_value={0} kilowatt-hours per 100 kilometres
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="😷"]; new_value=cold | doctor | ill | mask | medicine | poorly | sick
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="😵‍💫"]; new_value=dizzy | face with spiral eyes | hypnotised | spiral | trouble | whoa
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🫤"]; new_value=disappointed | meh | sceptical | unsure
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="😤"]; new_value=angry | face | face with steam from nose | frustration | triumph | won
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🙌"]; new_value=celebration | gesture | hand | hooray | woo hoo | yay
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🙏"]; new_value=ask | hand | high 5 | high five | please | pray | thanks
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="👬"]; new_value=couple | Gemini | holding hands | man | men holding hands | twins | zodiac
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧇"]; new_value=breakfast | iron | unclear | vague | waffle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥩"]; new_value=chop | cut of meat | lamb chop | pork chop | steak
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍥"]; new_value=cake | fish | fish cake with swirl | narutomaki | pastry | swirl
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍶"]; new_value=bar | beverage | bottle | cup | drink | sake | saké
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗻"][@type="tts"]; new_value=Mount Fuji
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗻"]; new_value=Fuji | Mount Fuji | mountain
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏛"]; new_value=classical | classical building | column
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕌"]; new_value=Islam | mosque | Muslim | religion
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛕"][@type="tts"]; new_value=Hindu temple
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛕"]; new_value=Hindu | temple
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕋"][@type="tts"]; new_value=Kaaba
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕋"]; new_value=Islam | Kaaba | Muslim | religion
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚙"]; new_value=4x4 | off-road vehicle | sport utility | sport utility vehicle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛞"]; new_value=circle | turn | tyre
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🩱"]; new_value=bathing suit | one-piece swimsuit | swimming costume
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥿"]; new_value=ballet flat | flat shoe | pump | slip-on | slipper
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="📯"][@type="tts"]; new_value=post horn
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="💷"]; new_value=banknote | bill | currency | money | note | pound | sterling
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="📫"]; new_value=closed postbox with raised flag | letterbox | mail | mailbox | post | post box | postbox
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="📪"]; new_value=closed postbox with lowered flag | letterbox | lowered | mail | mailbox | post box | postbox
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="📬"]; new_value=mail | mailbox | open postbox with raised flag | post | post box | postbox
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="📭"]; new_value=lowered | mail | mailbox | open postbox with lowered flag | post | post box | postbox
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔒"]; new_value=closed | locked | padlock
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔓"]; new_value=lock | open | padlock | unlock | unlocked
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🦯"]; new_value=accessibility | blind | guide cane
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🩹"]; new_value=injury | plaster | sticking plaster
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🪒"]; new_value=cut-throat | razor | sharp | shave
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🪪"]; new_value=credentials | driving | ID | licence | security
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚾"]; new_value=closet | lavatory | restroom | toilet | water | wc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔄"]; new_value=anticlockwise | anticlockwise arrows button | arrow | counterclockwise | counterclockwise arrows button | withershins
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="✡"][@type="tts"]; new_value=Star of David
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="✡"]; new_value=David | Jewish | Judaism | religion | star | Star of David
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="✝"][@type="tts"]; new_value=Latin cross
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="✝"]; new_value=Christian | cross | Latin cross | religion
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="☦"][@type="tts"]; new_value=Orthodox cross
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="☦"]; new_value=Christian | cross | Orthodox cross | religion
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="☪"]; new_value=Islam | Muslim | religion | star and crescent
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="✖"]; new_value=× | cancel | heavy multiplication sign | multiplication | sign | x
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="➖"]; new_value=- | − | heavy minus sign | math | maths | sign
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🟰"]; new_value=equality | math | maths
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="|"]; new_value=bar | line | pipe | sheffer stroke | vertical bar | vertical line
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⁉"]; new_value=! | !? | ? | interrobang | mark | punctuation | question
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="،"][@type="tts"]; new_value=Arabic comma
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="،"]; new_value=Arabic | comma
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="؛"][@type="tts"]; new_value=Arabic semicolon
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="؛"]; new_value=Arabic | Arabic semicolon | semi-colon
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="؟"][@type="tts"]; new_value=Arabic question mark
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="؟"]; new_value=Arabic | Arabic question mark | question | question mark
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="‘"]; new_value=apostrophe | curly quote | left apostrophe | quote | single quote | smart quote
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="’"]; new_value=apostrophe | curly quote | quote | right apostrophe | single quote | smart quote
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="“"]; new_value=curly quotes | double quote | left quotation mark | quotation | quote | smart quotation
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="”"]; new_value=curly quotes | double quote | quotation | quote | right quotation mark | smart quotation
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp=")"]; new_value=bracket | close parenthesis | parens | parenthesis | round bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="["]; new_value=bracket | crotchet | left square bracket | open square bracket | square bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="]"]; new_value=bracket | close square bracket | crotchet | right square bracket | square bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="{"]; new_value=brace | bracket | curly brace | curly bracket | gullwing | left curly bracket | open curly bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="}"]; new_value=brace | bracket | close curly bracket | curly brace | curly bracket | gullwing | right curly bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="〔"]; new_value=bracket | left tortoise shell bracket | open tortoise shell bracket | shell bracket | tortoise shell bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="〕"]; new_value=bracket | close tortoise shell bracket | right tortoise shell bracket | shell bracket | tortoise shell bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="〈"]; new_value=angle bracket | bracket | chevron | diamond brackets | left angle bracket | pointy bracket | tuple
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="〉"]; new_value=angle bracket | bracket | chevron | diamond brackets | pointy bracket | right angle bracket | tuple
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="《"]; new_value=bracket | double angle bracket | left double angle bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="》"]; new_value=bracket | double angle bracket | right double angle bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="「"]; new_value=bracket | corner bracket | left corner bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="」"]; new_value=bracket | corner bracket | right corner bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="『"]; new_value=bracket | hollow corner bracket | left hollow corner bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="』"]; new_value=bracket | hollow corner bracket | right hollow corner bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="〖"]; new_value=bracket | hollow lens bracket | hollow lenticular bracket | left hollow lenticular bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="〗"]; new_value=bracket | hollow lens bracket | hollow lenticular bracket | right hollow lenticular bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="【"]; new_value=bracket | left black lenticular bracket | lens bracket | lenticular bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="】"]; new_value=bracket | lens bracket | lenticular bracket | right black lenticular bracket
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₹"][@type="tts"]; new_value=Indian rupee
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₹"]; new_value=currency | Indian rupee | rupee
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="®"]; new_value=r | registered | trademark
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="↹"]; new_value=leftwards arrow to bar over rightwards arrow to bar
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∂"]; new_value=differential | partial derivative | partial differential
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∃"]; new_value=existential | mathematics | quantifier | there exists
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∅"]; new_value=empty set | mathematics | null set | null sign | set operator
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∉"][@type="tts"]; new_value=not an element of
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∉"]; new_value=element | not an element | set
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∎"][@type="tts"]; new_value=end of proof
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∑"]; new_value=mathematics | n-ary summation | sigma | summation
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∓"]; new_value=minus-or-plus | minus-plus
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∝"][@type="tts"]; new_value=is proportional
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∣"]; new_value=divides | divisor | vertical bar
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∥"][@type="tts"]; new_value=parallel to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="∮"]; new_value=complex analysis | contour integral
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≃"][@type="tts"]; new_value=asymptotically equal to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≅"][@type="tts"]; new_value=approximately equal to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≌"][@type="tts"]; new_value=all equal to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≣"][@type="tts"]; new_value=strictly equivalent to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≳"][@type="tts"]; new_value=greater-than or equivalent to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≳"]; new_value=equivalent | greater-than | inequality | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≺"]; new_value=mathematics | ordered set | precedes | set operator
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="≻"]; new_value=follows | mathematics | ordered set | set operator | succeeds
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊁"]; new_value=does not succeed | mathematics | ordered set | set operator
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊃"][@type="tts"]; new_value=superset of
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊃"]; new_value=mathematics | proper superset | set operator
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊆"][@type="tts"]; new_value=subset of or equal to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊆"]; new_value=equal | mathematics | subset
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊇"][@type="tts"]; new_value=superset of or equal to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊇"]; new_value=equal | mathematics | superset
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊕"]; new_value=circled plus | direct sum | exclusive or | logic | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊖"]; new_value=circled minus | erosion | mathematics | symmetric difference
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊗"]; new_value=circled times | Kronecker | product | tensor
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊙"]; new_value=circled dot operator | mathematics | vector | XNOR
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊛"]; new_value=circled asterisk operator
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊞"]; new_value=addition-like | free additive convolution | mathematics | squared plus
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊮"]; new_value=does not force | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊰"]; new_value=mathematics | ordered set | precedes under relation | set operator
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊱"]; new_value=mathematics | ordered set | set operator | succeeds under relation
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋭"][@type="tts"]; new_value=does not contain as normal subgroup or equal
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊶"][@type="tts"]; new_value=original of
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋰"][@type="tts"]; new_value=upwards right diagonal ellipsis
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋰"]; new_value=ellipsis | mathematics | upwards diagonal ellipsis
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋱"][@type="tts"]; new_value=downwards right diagonal ellipsis
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋱"]; new_value=downwards right diagonal ellipsis | ellipsis | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="■"]; new_value=black square | filled square
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="□"]; new_value=hollow square | white square
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▢"]; new_value=hollow square with rounded corners | white square with rounded corners
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▣"]; new_value=hollow square containing filled square | white square containing black small square
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▦"][@type="tts"]; new_value=square with orthogonal crosshatch fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▦"]; new_value=square with orthogonal crosshatch fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▧"][@type="tts"]; new_value=square with upper left to lower right fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▧"]; new_value=square with upper left to lower right fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▨"][@type="tts"]; new_value=square with upper right to lower left fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▨"]; new_value=square with upper right to lower left fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▩"][@type="tts"]; new_value=square with diagonal crosshatch fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▩"]; new_value=square with diagonal crosshatch fill
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▬"]; new_value=black rectangle | filled rectangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▭"]; new_value=hollow rectangle | white rectangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▮"]; new_value=black vertical rectangle | filled vertical rectangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▰"]; new_value=black parallelogram | filled parallelogram
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="△"]; new_value=hollow up-pointing triangle | white up-pointing triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▴"]; new_value=black up-pointing small triangle | filled up-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▵"]; new_value=hollow up-pointing small triangle | white up-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▷"]; new_value=hollow right-pointing triangle | white right-pointing triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▸"]; new_value=black right-pointing triangle | filled right-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▹"]; new_value=hollow right-pointing small triangle | white right-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="►"]; new_value=black right-pointing pointer | filled right-pointing pointer
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▻"]; new_value=hollow right-pointing pointer | white right-pointing pointer
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▽"]; new_value=hollow down-pointing triangle | white down-pointing triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▾"]; new_value=black down-pointing small triangle | filled down-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▿"]; new_value=hollow down-pointing small triangle | white down-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◁"]; new_value=hollow left-pointing triangle | white left-pointing triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◂"]; new_value=black left-pointing small triangle | filled left-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◃"]; new_value=hollow left-pointing small triangle | white left-pointing small triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◄"]; new_value=black left-pointing pointer | filled left-pointing pointer
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◅"]; new_value=hollow left-pointing pointer | white left-pointing pointer
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◆"]; new_value=black diamond | filled diamond
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◇"]; new_value=hollow diamond | white diamond
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◈"]; new_value=hollow diamond containing filled diamond | white diamond containing black small diamond
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◉"]; new_value=circled dot | concentric circles filled | fisheye | hollow circle containing filled circle | white circle containing black small circle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◔"][@type="tts"]; new_value=circle with upper-right quadrant filled
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◔"]; new_value=circle with upper-right quadrant filled
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◕"][@type="tts"]; new_value=circle with all but upper-left quadrant filled
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◕"]; new_value=circle with all but upper-left quadrant filled
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◖"]; new_value=left half black circle | left half filled circle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◗"]; new_value=right half black circle | right half filled circle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◙"]; new_value=black square containing hollow circle | inverse hollow circle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◜"][@type="tts"]; new_value=upper-left quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◜"]; new_value=upper-left quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◝"][@type="tts"]; new_value=upper-right quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◝"]; new_value=upper-right quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◞"][@type="tts"]; new_value=lower-right quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◞"]; new_value=lower-right quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◟"][@type="tts"]; new_value=lower-left quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◟"]; new_value=lower-left quadrant circular arc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◢"][@type="tts"]; new_value=filled lower-right triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◢"]; new_value=black lower-right triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◣"][@type="tts"]; new_value=filled lower-left triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◣"]; new_value=black lower-left triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◤"][@type="tts"]; new_value=filled upper-left triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◤"]; new_value=black upper-left triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◥"][@type="tts"]; new_value=filled upper-right triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◥"]; new_value=black upper-right triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◳"][@type="tts"]; new_value=hollow square with upper-right quadrant
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◳"]; new_value=white square with upper-right quadrant
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◷"][@type="tts"]; new_value=hollow circle with upper-right quadrant
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◷"]; new_value=white circle with upper-right quadrant
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◿"][@type="tts"]; new_value=lower-right triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◿"]; new_value=lower-right triangle | white
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨧"][@type="tts"]; new_value=plus sign with subscript two
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨧"]; new_value=plus sign with subscript two
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨯"][@type="tts"]; new_value=vector or cross product
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨯"]; new_value=vector or cross product
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨼"]; new_value=interior product | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩣"][@type="tts"]; new_value=logical or with double underbar
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩣"]; new_value=logical or with double underbar | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩽"][@type="tts"]; new_value=less-than or slanted equal to
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩽"]; new_value=inequality | less-than or slanted equal to | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪍"][@type="tts"]; new_value=less-than above similar or equal
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪍"]; new_value=less-than above similar or equal
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪚"][@type="tts"]; new_value=double-line equal to or greater-than
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪚"]; new_value=double-line equal to or greater-than | inequality | mathematics
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₢"]; new_value=Brazil | BRB | cruzeiro | currency
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₣"][@type="tts"]; new_value=French franc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₣"]; new_value=currency | franc | France | French franc
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₤"]; new_value=currency | Italy | lira
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₰"][@type="tts"]; new_value=German penny
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₰"]; new_value=currency | German penny | pfennig
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₳"]; new_value=ARA | Argentina | austral | currency
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="₶"]; new_value=currency | France | livre tournois
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▼"]; new_value=arrow | black down-pointing triangle | down | triangle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="▲"]; new_value=arrow | black up-pointing triangle | triangle | up
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="●"]; new_value=black circle | circle | filled circle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="○"]; new_value=circle | hollow circle | ring | white circle
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="◯"]; new_value=circle | large hollow circle | large white circle | ring
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚩"]; new_value=post | red flag | triangular flag
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏳"]; new_value=surrender | waving | white flag
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏻"]; new_value=light skin tone | skin tone
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏼"]; new_value=medium-light skin tone | skin tone
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏽"]; new_value=medium skin tone | skin tone
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏾"]; new_value=medium-dark skin tone | skin tone
-locale=en_001; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏿"]; new_value=dark skin tone | skin tone
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="bn"]; new_value=Bengali
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="en_US"][@alt="short"]; new_value=U.S. English
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="nds_NL"]; new_value=West Low German
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="mfe"]; new_value=Mauritian
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="mus"]; new_value=Creek
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="ro_MD"]; new_value=Moldovan
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="sah"]; new_value=Yakut
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/languages/language[@type="tvl"]; new_value=Tuvaluan
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="PM"]; new_value=Saint-Pierre-et-Miquelon
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="US"][@alt="short"]; new_value=U.S.
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="AG"]; new_value=Antigua and Barbuda
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="BL"]; new_value=Saint-Barthélemy
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="KN"]; new_value=Saint Kitts and Nevis
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="LC"]; new_value=Saint Lucia
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="MF"]; new_value=Saint Martin
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="TC"]; new_value=Turks and Caicos Islands
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="TT"]; new_value=Trinidad and Tobago
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="VC"]; new_value=Saint Vincent and the Grenadines
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="GS"]; new_value=South Georgia and South Sandwich Islands
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="EA"]; new_value=Ceuta and Melilla
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="SH"]; new_value=Saint Helena
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="ST"]; new_value=São Tomé and Príncipe
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="GB"][@alt="short"]; new_value=U.K.
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="SJ"]; new_value=Svalbard and Jan Mayen
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="BA"]; new_value=Bosnia and Herzegovina
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="HM"]; new_value=Heard and McDonald Islands
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/territories/territory[@type="WF"]; new_value=Wallis and Futuna
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="dangi"]; new_value=Korean Calendar
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="ethiopic"]; new_value=Ethiopian Calendar
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/keys/key[@type="colCaseLevel"]; new_value=Case-Sensitive Sorting
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="colNormalization"][@type="no"]; new_value=Sort Without Normalisation
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="colNormalization"][@type="yes"]; new_value=Sort Unicode Normalised
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="d0"][@type="fwidth"]; new_value=To Full Width
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="d0"][@type="hwidth"]; new_value=To Half Width
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="d0"][@type="lower"]; new_value=To Lower Case
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="d0"][@type="title"]; new_value=To Title Case
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="d0"][@type="upper"]; new_value=To Upper Case
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="hc"][@type="h11"]; new_value=12-Hour System (0–11)
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="hc"][@type="h12"]; new_value=12-Hour System (1–12)
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="hc"][@type="h23"]; new_value=24-Hour System (0–23)
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="hc"][@type="h24"]; new_value=24-Hour System (1–24)
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/types/type[@key="ms"][@type="ussystem"]; new_value=U.S. Measurement System
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/displayName; new_value=yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-short"]/displayName; new_value=qtr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-narrow"]/displayName; new_value=qtr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/displayName; new_value=mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/displayName; new_value=mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/displayName; new_value=wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/displayName; new_value=wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="weekOfMonth-short"]/displayName; new_value=wk of mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="weekOfMonth-narrow"]/displayName; new_value=wk of mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="dayOfYear-short"]/displayName; new_value=day of yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="dayOfYear-narrow"]/displayName; new_value=day of yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="weekday-short"]/displayName; new_value=day of wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="weekday-narrow"]/displayName; new_value=day of wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="weekdayOfMonth-short"]/displayName; new_value=wkday of mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="weekdayOfMonth-narrow"]/displayName; new_value=wkday of mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="dayperiod"]/displayName; new_value=a.m./p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="dayperiod-short"]/displayName; new_value=a.m./p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="dayperiod-narrow"]/displayName; new_value=a.m./p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-short"]/displayName; new_value=hr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-short"]/displayName; new_value=min
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-narrow"]/displayName; new_value=min
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-short"]/displayName; new_value=sec
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relative[@type="-1"]; new_value=last yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relative[@type="0"]; new_value=this yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relative[@type="1"]; new_value=next yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} yrs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} yr ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} yrs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relative[@type="-1"]; new_value=last yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relative[@type="0"]; new_value=this yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relative[@type="1"]; new_value=next yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} yr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} yrs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} yr ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} yrs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} qtr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} qtrs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} qtr ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} qtrs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} qtr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} qtrs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} qtr ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="quarter-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} qtrs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relative[@type="-1"]; new_value=last mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relative[@type="0"]; new_value=this mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relative[@type="1"]; new_value=next mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} mos
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} mo ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} mos ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relative[@type="-1"]; new_value=last mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relative[@type="0"]; new_value=this mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relative[@type="1"]; new_value=next mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} mo
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} mos
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} mo ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} mos ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relative[@type="-1"]; new_value=last wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relative[@type="0"]; new_value=this wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relative[@type="1"]; new_value=next wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} wks
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} wk ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} wks ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relative[@type="-1"]; new_value=last wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relative[@type="0"]; new_value=this wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relative[@type="1"]; new_value=next wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} wk
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} wks
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} wk ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} wks ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} hr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} hrs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} hr ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} hrs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} hr
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} hrs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} hr ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="hour-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} hrs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} min
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} mins
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} min ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} mins ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} min
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} mins
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} min ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="minute-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} mins ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} sec
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} secs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} sec ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} secs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} sec
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} secs
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} sec ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="second-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} secs ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relative[@type="-1"]; new_value=last Sun
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relative[@type="0"]; new_value=this Sun
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relative[@type="1"]; new_value=next Sun
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Sun
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Sun’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Sun ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Sun’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Su’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sun-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Su’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relative[@type="-1"]; new_value=last Mon
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relative[@type="0"]; new_value=this Mon
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relative[@type="1"]; new_value=next Mon
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Mon
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Mon’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Mon ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Mon’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} M’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="mon-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} M’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relative[@type="-1"]; new_value=last Tue
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relative[@type="0"]; new_value=this Tue
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relative[@type="1"]; new_value=next Tue
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Tue
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Tue’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Tue ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Tue’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Tu’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="tue-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Tu’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relative[@type="-1"]; new_value=last Wed
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relative[@type="0"]; new_value=this Wed
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relative[@type="1"]; new_value=next Wed
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Wed
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Wed’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Wed ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Wed’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} W’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="wed-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} W’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relative[@type="-1"]; new_value=last Thu
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relative[@type="0"]; new_value=this Thu
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relative[@type="1"]; new_value=next Thu
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Thu
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Thu’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Thu ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Thu’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Th’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="thu-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Th’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relative[@type="-1"]; new_value=last Fri
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relative[@type="0"]; new_value=this Fri
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relative[@type="1"]; new_value=next Fri
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Fri
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Fri’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Fri ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Fri’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} F’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="fri-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} F’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relative[@type="-1"]; new_value=last Sat
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relative[@type="0"]; new_value=this Sat
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relative[@type="1"]; new_value=next Sat
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="one"]; new_value=in {0} Sat
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Sat’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="one"]; new_value={0} Sat ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-short"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Sat’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-narrow"]/relativeTime[@type="future"]/relativeTimePattern[@count="other"]; new_value=in {0} Sa’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/fields/field[@type="sat-narrow"]/relativeTime[@type="past"]/relativeTimePattern[@count="other"]; new_value={0} Sa’s ago
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="9"]; new_value=Sept
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"]; new_value=Sept
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="am"]; new_value=a.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="pm"]; new_value=p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="am"]; new_value=a.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="pm"]; new_value=p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="abbreviated"]/dayPeriod[@type="am"]; new_value=a.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="abbreviated"]/dayPeriod[@type="pm"]; new_value=p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="abbreviated"]/dayPeriod[@type="am"]; new_value=a.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="abbreviated"]/dayPeriod[@type="pm"]; new_value=p.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="am"]; new_value=am
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="pm"]; new_value=pm
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="midnight"]; new_value=mid
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="morning1"]; new_value=mor
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="afternoon1"]; new_value=aft
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="evening1"]; new_value=eve
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="night1"]; new_value=night
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="am"]; new_value=a.m.
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="pm"]; new_value=pm
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="midnight"]; new_value=mid
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="morning1"]; new_value=mor
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="afternoon1"]; new_value=aft
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="evening1"]; new_value=eve
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]; new_value=y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"][@alt="variant"]; new_value=d/M/yy
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="full"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm:ss zzzz
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="long"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm:ss z
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="medium"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm:ss
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/timeFormats/timeFormatLength[@type="short"]/timeFormat[@type="standard"]/pattern[@type="standard"]; new_value=HH:mm
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ed"]; new_value=E d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]; new_value=MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"][@alt="variant"]; new_value=d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]; new_value=E, MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"][@alt="variant"]; new_value=E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMdd"]; new_value=MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMdd"][@alt="variant"]; new_value=dd/MM
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yM"]; new_value=MM/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMd"]; new_value=y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMd"][@alt="variant"]; new_value=d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMEd"]; new_value=E, y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMEd"][@alt="variant"]; new_value=E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EBhm"]; new_value=E, h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EBhms"]; new_value=E, h:mm:ss B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bh"]/greatestDifference[@id="B"]; new_value=h B–h B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bh"]/greatestDifference[@id="h"]; new_value=h–h B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bhm"]/greatestDifference[@id="B"]; new_value=h:mm B–h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bhm"]/greatestDifference[@id="h"]; new_value=h:mm–h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bhm"]/greatestDifference[@id="m"]; new_value=h:mm–h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="d"]/greatestDifference[@id="d"]; new_value=d–d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Gy"]/greatestDifference[@id="G"]; new_value=y G–y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Gy"]/greatestDifference[@id="y"]; new_value=y–y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyM"]/greatestDifference[@id="G"]; new_value=M/y GGGGG–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyM"]/greatestDifference[@id="M"]; new_value=M/y–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyM"]/greatestDifference[@id="y"]; new_value=M/y–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="d"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="G"]; new_value=M/d/y GGGGG–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="M"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="y"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="d"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="G"]; new_value=E, M/d/y GGGGG–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="M"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="y"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMM"]/greatestDifference[@id="G"]; new_value=MMM y G–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMM"]/greatestDifference[@id="M"]; new_value=MMM–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMM"]/greatestDifference[@id="y"]; new_value=MMM y–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="d"]; new_value=MMM d–d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="G"]; new_value=MMM d, y G–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="M"]; new_value=MMM d–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="y"]; new_value=MMM d, y–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="d"]; new_value=E, MMM d–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="G"]; new_value=E, MMM d, y G–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="M"]; new_value=E, MMM d–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="y"]; new_value=E, MMM d, y–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="M"]/greatestDifference[@id="M"]; new_value=M–M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"]; new_value=M/d–M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"][@alt="variant"]; new_value=d/M – d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"]; new_value=M/d–M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"][@alt="variant"]; new_value=d/M – d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="d"]; new_value=E, M/d–E, M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=E, d/M – E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="M"]; new_value=E, M/d–E, M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=E, d/M – E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMM"]/greatestDifference[@id="M"]; new_value=MMM–MMM
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMd"]/greatestDifference[@id="d"]; new_value=MMM d–d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMd"]/greatestDifference[@id="M"]; new_value=MMM d–MMM d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMEd"]/greatestDifference[@id="d"]; new_value=E, MMM d–E, MMM d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMEd"]/greatestDifference[@id="M"]; new_value=E, MMM d–E, MMM d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="y"]/greatestDifference[@id="y"]; new_value=y–y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yM"]/greatestDifference[@id="M"]; new_value=M/y–M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yM"]/greatestDifference[@id="y"]; new_value=M/y–M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="d"]; new_value=M/d/y–M/d/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=d/M/y – d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="M"]; new_value=M/d/y–M/d/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=d/M/y – d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"]; new_value=M/d/y–M/d/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"][@alt="variant"]; new_value=d/M/y – d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="d"]; new_value=E, M/d/y–E, M/d/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="M"]; new_value=E, M/d/y–E, M/d/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="y"]; new_value=E, M/d/y–E, M/d/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="y"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMM"]/greatestDifference[@id="M"]; new_value=MMM–MMM y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMM"]/greatestDifference[@id="y"]; new_value=MMM y–MMM y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMd"]/greatestDifference[@id="d"]; new_value=MMM d–d, y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMd"]/greatestDifference[@id="M"]; new_value=MMM d–MMM d, y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMd"]/greatestDifference[@id="y"]; new_value=MMM d, y–MMM d, y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="d"]; new_value=E, MMM d–E, MMM d, y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="M"]; new_value=E, MMM d–E, MMM d, y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="y"]; new_value=E, MMM d, y–E, MMM d, y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMM"]/greatestDifference[@id="M"]; new_value=MMMM–MMMM y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMM"]/greatestDifference[@id="y"]; new_value=MMMM y–MMMM y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="h"]/greatestDifference[@id="a"]; new_value=h a–h a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="h"]/greatestDifference[@id="h"]; new_value=h–h a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hm"]/greatestDifference[@id="a"]; new_value=h:mm a–h:mm a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hm"]/greatestDifference[@id="h"]; new_value=h:mm–h:mm a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hm"]/greatestDifference[@id="m"]; new_value=h:mm–h:mm a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hmv"]/greatestDifference[@id="a"]; new_value=h:mm a–h:mm a v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hmv"]/greatestDifference[@id="h"]; new_value=h:mm–h:mm a v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hmv"]/greatestDifference[@id="m"]; new_value=h:mm–h:mm a v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hv"]/greatestDifference[@id="a"]; new_value=h a–h a v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="hv"]/greatestDifference[@id="h"]; new_value=h–h a v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="H"]/greatestDifference[@id="H"]; new_value=HH–HH
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Hm"]/greatestDifference[@id="H"]; new_value=HH:mm–HH:mm
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Hm"]/greatestDifference[@id="m"]; new_value=HH:mm–HH:mm
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Hmv"]/greatestDifference[@id="H"]; new_value=HH:mm–HH:mm v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Hmv"]/greatestDifference[@id="m"]; new_value=HH:mm–HH:mm v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Hv"]/greatestDifference[@id="H"]; new_value=HH–HH v
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatFallback; new_value={0}–{1}
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"][@alt="variant"]; new_value=d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ed"]; new_value=E d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"][@alt="variant"]; new_value=d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"][@alt="variant"]; new_value=E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"][@alt="variant"]; new_value=d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"][@alt="variant"]; new_value=E, d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EBhm"]; new_value=E, h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EBhms"]; new_value=E, h:mm:ss B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ehm"]; new_value=E, h:mm a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ehms"]; new_value=E, h:mm:ss a
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EHm"]; new_value=E, HH:mm
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="EHms"]; new_value=E, HH:mm:ss
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bh"]/greatestDifference[@id="B"]; new_value=h B–h B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bh"]/greatestDifference[@id="h"]; new_value=h–h B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bhm"]/greatestDifference[@id="B"]; new_value=h:mm B–h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bhm"]/greatestDifference[@id="h"]; new_value=h:mm–h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Bhm"]/greatestDifference[@id="m"]; new_value=h:mm–h:mm B
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="d"]/greatestDifference[@id="d"]; new_value=d–d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Gy"]/greatestDifference[@id="G"]; new_value=y G–y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Gy"]/greatestDifference[@id="y"]; new_value=y–y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyM"]/greatestDifference[@id="G"]; new_value=M/y GGGGG–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyM"]/greatestDifference[@id="M"]; new_value=M/y–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyM"]/greatestDifference[@id="y"]; new_value=M/y–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="d"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="G"]; new_value=M/d/y GGGGG–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="M"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMd"]/greatestDifference[@id="y"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="d"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="G"]; new_value=E, M/d/y GGGGG–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="M"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMEd"]/greatestDifference[@id="y"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMM"]/greatestDifference[@id="G"]; new_value=MMM y G–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMM"]/greatestDifference[@id="M"]; new_value=MMM–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMM"]/greatestDifference[@id="y"]; new_value=MMM y–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="d"]; new_value=MMM d–d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="G"]; new_value=MMM d, y G–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="M"]; new_value=MMM d–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMd"]/greatestDifference[@id="y"]; new_value=MMM d, y–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="d"]; new_value=E, MMM d–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="G"]; new_value=E, MMM d, y G–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="M"]; new_value=E, MMM d–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="GyMMMEd"]/greatestDifference[@id="y"]; new_value=E, MMM d, y–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="M"]/greatestDifference[@id="M"]; new_value=M–M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"]; new_value=M/d–M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"][@alt="variant"]; new_value=d/M – d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"]; new_value=M/d–M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"][@alt="variant"]; new_value=d/M – d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="d"]; new_value=E, M/d–E, M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=E, d/M – E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="M"]; new_value=E, M/d–E, M/d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=E, d/M – E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMM"]/greatestDifference[@id="M"]; new_value=MMM–MMM
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMd"]/greatestDifference[@id="d"]; new_value=MMM d–d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMd"]/greatestDifference[@id="M"]; new_value=MMM d–MMM d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMEd"]/greatestDifference[@id="d"]; new_value=E, MMM d–E, MMM d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MMMEd"]/greatestDifference[@id="M"]; new_value=E, MMM d–E, MMM d
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="y"]/greatestDifference[@id="y"]; new_value=y–y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yM"]/greatestDifference[@id="M"]; new_value=M/y–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yM"]/greatestDifference[@id="y"]; new_value=M/y–M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="d"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=d/M/y – d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="M"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=d/M/y – d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"]; new_value=M/d/y–M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"][@alt="variant"]; new_value=d/M/y – d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="d"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="M"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="y"]; new_value=E, M/d/y–E, M/d/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="y"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y GGGGG
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMM"]/greatestDifference[@id="M"]; new_value=MMM–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMM"]/greatestDifference[@id="y"]; new_value=MMM y–MMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMd"]/greatestDifference[@id="d"]; new_value=MMM d–d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMd"]/greatestDifference[@id="M"]; new_value=MMM d–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMd"]/greatestDifference[@id="y"]; new_value=MMM d, y–MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="d"]; new_value=E, MMM d–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="M"]; new_value=E, MMM d–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMEd"]/greatestDifference[@id="y"]; new_value=E, MMM d, y–E, MMM d, y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMM"]/greatestDifference[@id="M"]; new_value=MMMM–MMMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMMMM"]/greatestDifference[@id="y"]; new_value=MMMM y–MMMM y G
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/intervalFormats/intervalFormatFallback; new_value={0}–{1}
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]; new_value=r-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"][@alt="variant"]; new_value=d/M/r
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMEd"]; new_value=E, MMM d, r(U)
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMMd"]; new_value=d MMMM r(U)
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMMEd"]; new_value=E, d MMMM r(U)
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="M"]; new_value=LL
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]; new_value=MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"][@alt="variant"]; new_value=d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]; new_value=E, MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"][@alt="variant"]; new_value=E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="UMd"]; new_value=U-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="UMd"][@alt="variant"]; new_value=d/M/U
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMd"][@alt="variant"]; new_value=d/M/r
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]; new_value=r-MM
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]; new_value=r-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"][@alt="variant"]; new_value=d/M/r
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]; new_value=E, r-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"][@alt="variant"]; new_value=E, d/M/r
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMEd"]; new_value=E, MMM d, r(U)
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMMd"]; new_value=d MMMM r(U)
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMMEd"]; new_value=E, d MMMM r(U)
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"]; new_value=MM-dd – MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="d"][@alt="variant"]; new_value=d/M – d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"]; new_value=MM-dd – MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="Md"]/greatestDifference[@id="M"][@alt="variant"]; new_value=d/M – d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="d"]; new_value=E, MM-dd – E, MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=E, d/M – E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="M"]; new_value=E, MM-dd – E, MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="MEd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=E, d/M – E, d/M
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yM"]/greatestDifference[@id="M"]; new_value=y-MM – y-MM
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yM"]/greatestDifference[@id="y"]; new_value=y-MM – y-MM
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="d"]; new_value=y-MM-dd – y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=d/M/y – d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="M"]; new_value=y-MM-dd – y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=d/M/y – d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"]; new_value=y-MM-dd – y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"][@alt="variant"]; new_value=d/M/y – d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="d"]; new_value=E, y-MM-dd – E, y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="d"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="M"]; new_value=E, y-MM-dd – E, y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="M"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="y"]; new_value=E, y-MM-dd – E, y-MM-dd
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMEd"]/greatestDifference[@id="y"][@alt="variant"]; new_value=E, d/M/y – E, d/M/y
+locale=en_CA; action=addNew; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ed"]; new_value=E d
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/regionFormat[@type="daylight"]; new_value={0} Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Alaska"]/long/daylight; new_value=Alaska Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="America_Central"]/long/daylight; new_value=Central Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="America_Eastern"]/long/daylight; new_value=Eastern Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="America_Mountain"]/long/daylight; new_value=Mountain Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="America_Pacific"]/long/daylight; new_value=Pacific Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Atlantic"]/long/daylight; new_value=Atlantic Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Cuba"]/long/daylight; new_value=Cuba Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Greenland_Eastern"]/short/generic; new_value=EGT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Hawaii_Aleutian"]/long/daylight; new_value=Hawaii-Aleutian Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Mexico_Northwest"]/long/daylight; new_value=Northwest Mexico Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Mexico_Pacific"]/long/daylight; new_value=Mexican Pacific Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Newfoundland"]/short/generic; new_value=NT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Newfoundland"]/short/standard; new_value=NST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Newfoundland"]/long/daylight; new_value=Newfoundland Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Newfoundland"]/short/daylight; new_value=NDT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pierre_Miquelon"]/long/generic; new_value=Saint-Pierre-et-Miquelon Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pierre_Miquelon"]/short/generic; new_value=PMT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pierre_Miquelon"]/long/standard; new_value=Saint-Pierre-et-Miquelon Standard Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pierre_Miquelon"]/short/standard; new_value=PMST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pierre_Miquelon"]/long/daylight; new_value=Saint-Pierre-et-Miquelon Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pierre_Miquelon"]/short/daylight; new_value=PMDT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="America/St_Barthelemy"]/exemplarCity; new_value=Saint-Barthélemy
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="America/St_Johns"]/exemplarCity; new_value=Saint John’s
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="America/St_Kitts"]/exemplarCity; new_value=Saint Kitts
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="America/St_Lucia"]/exemplarCity; new_value=Saint Lucia
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="America/St_Thomas"]/exemplarCity; new_value=Saint Thomas
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="America/St_Vincent"]/exemplarCity; new_value=Saint Vincent
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Argentina"]/short/generic; new_value=ART
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Brasilia"]/short/generic; new_value=BRT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Brasilia"]/short/daylight; new_value=BRST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Colombia"]/short/daylight; new_value=COST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Easter"]/short/standard; new_value=EAST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Easter"]/short/daylight; new_value=EASST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Ecuador"]/short/standard; new_value=ECT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Falkland"]/short/generic; new_value=FKT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Falkland"]/short/daylight; new_value=FKST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Galapagos"]/short/standard; new_value=GALT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Guyana"]/short/standard; new_value=GYT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Noronha"]/short/generic; new_value=FNT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Paraguay"]/short/generic; new_value=PYT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Paraguay"]/short/daylight; new_value=PYST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Peru"]/short/generic; new_value=PET
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Uruguay"]/short/standard; new_value=UYT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Uruguay"]/short/daylight; new_value=UYST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Venezuela"]/short/standard; new_value=VET
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="French_Southern"]/long/standard; new_value=French Southern and Antarctic Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="Atlantic/St_Helena"]/exemplarCity; new_value=Saint Helena
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Arabian"]/long/daylight; new_value=Arabian Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Israel"]/long/daylight; new_value=Israel Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="Asia/Aqtau"]/exemplarCity; new_value=Aktau
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="China"]/long/daylight; new_value=China Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Japan"]/long/daylight; new_value=Japan Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Korea"]/long/daylight; new_value=Korean Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Taipei"]/long/daylight; new_value=Taipei Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Afghanistan"]/short/standard; new_value=AFT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Bangladesh"]/short/standard; new_value=BST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Bhutan"]/short/standard; new_value=BTT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="India"]/short/standard; new_value=IST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Iran"]/short/standard; new_value=IRST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Iran"]/long/daylight; new_value=Iran Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Iran"]/short/daylight; new_value=IRDT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Maldives"]/short/standard; new_value=MVT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Nepal"]/short/standard; new_value=NPT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Pakistan"]/short/standard; new_value=PKT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Brunei"]/short/standard; new_value=BNT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="East_Timor"]/short/standard; new_value=TLT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Indochina"]/short/standard; new_value=ICT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Indonesia_Central"]/short/standard; new_value=WITA
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Indonesia_Eastern"]/short/standard; new_value=WIT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Indonesia_Western"]/short/standard; new_value=WIB
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Malaysia"]/short/standard; new_value=MYT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/zone[@type="Asia/Rangoon"]/exemplarCity; new_value=Rangoon
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Central"]/long/daylight; new_value=Australian Central Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_CentralWestern"]/short/generic; new_value=ACWT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_CentralWestern"]/short/standard; new_value=ACWST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_CentralWestern"]/long/daylight; new_value=Australian Central Western Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_CentralWestern"]/short/daylight; new_value=ACWDT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Eastern"]/short/generic; new_value=AET
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Eastern"]/short/standard; new_value=AEST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Eastern"]/long/daylight; new_value=Australian Eastern Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Eastern"]/short/daylight; new_value=AEDT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Western"]/short/standard; new_value=AWST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Western"]/long/daylight; new_value=Australian Western Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Australia_Western"]/short/daylight; new_value=AWDT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Chatham"]/short/standard; new_value=CHAST
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Chatham"]/long/daylight; new_value=Chatham Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Chatham"]/short/daylight; new_value=CHADT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Christmas"]/short/standard; new_value=CXT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Cocos"]/short/standard; new_value=CCT
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Lord_Howe"]/long/daylight; new_value=Lord Howe Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="New_Zealand"]/long/daylight; new_value=New Zealand Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Norfolk"]/long/daylight; new_value=Norfolk Island Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Apia"]/long/daylight; new_value=Apia Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Samoa"]/long/daylight; new_value=Samoa Daylight Saving Time
+locale=en_CA; action=addNew; new_path=//ldml/dates/timeZoneNames/metazone[@type="Wallis"]/long/standard; new_value=Wallis and Futuna Time
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BMD"]/displayName[@count="one"]; new_value=Bermudian dollar
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BMD"]/displayName[@count="other"]; new_value=Bermudian dollars
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BMD"]/displayName; new_value=Bermudian Dollar
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="CAD"]/symbol; new_value=$
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="USD"]/displayName[@count="one"]; new_value=U.S. dollar
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="USD"]/displayName[@count="other"]; new_value=U.S. dollars
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="USD"]/displayName; new_value=U.S. Dollar
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="USD"]/symbol; new_value=US$
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="TTD"]/displayName[@count="one"]; new_value=Trinidad and Tobago dollar
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="TTD"]/displayName[@count="other"]; new_value=Trinidad and Tobago dollars
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="TTD"]/displayName; new_value=Trinidad and Tobago Dollar
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="LVR"]/displayName[@count="one"]; new_value=Latvian rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="LVR"]/displayName[@count="other"]; new_value=Latvian roubles
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="LVR"]/displayName; new_value=Latvian Rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYN"]/displayName[@count="one"]; new_value=Belarusian rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYN"]/displayName[@count="other"]; new_value=Belarusian roubles
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYN"]/displayName; new_value=Belarusian Rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYB"]/displayName[@count="one"]; new_value=Belarusian new rouble (1994–1999)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYB"]/displayName[@count="other"]; new_value=Belarusian new roubles (1994–1999)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYB"]/displayName; new_value=Belarusian New Rouble (1994–1999)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYR"]/displayName[@count="one"]; new_value=Belarusian rouble (2000–2016)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYR"]/displayName[@count="other"]; new_value=Belarusian roubles (2000–2016)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="BYR"]/displayName; new_value=Belarusian Rouble (2000–2016)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="RUB"]/displayName[@count="one"]; new_value=Russian rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="RUB"]/displayName[@count="other"]; new_value=Russian roubles
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="RUB"]/displayName; new_value=Russian Rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="RUR"]/displayName[@count="one"]; new_value=Russian rouble (1991–1998)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="RUR"]/displayName[@count="other"]; new_value=Russian roubles (1991–1998)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="RUR"]/displayName; new_value=Russian Rouble (1991–1998)
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="SHP"]/displayName[@count="one"]; new_value=St Helena pound
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="SHP"]/displayName[@count="other"]; new_value=St Helena pounds
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="SHP"]/displayName; new_value=St Helena Pound
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="STN"]/displayName[@count="one"]; new_value=São Tomé and Príncipe dobra
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="STN"]/displayName[@count="other"]; new_value=São Tomé and Príncipe dobras
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="STN"]/displayName; new_value=São Tomé and Príncipe Dobra
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="ETB"]/displayName[@count="other"]; new_value=Ethiopian birr
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="MGA"]/displayName[@count="other"]; new_value=Malagasy ariary
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="LSL"]/displayName[@count="other"]; new_value=Lesotho maloti
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="AED"]/displayName[@count="one"]; new_value=U.A.E. dirham
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="AED"]/displayName[@count="other"]; new_value=U.A.E. dirhams
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="TJR"]/displayName[@count="one"]; new_value=Tajikistani rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="TJR"]/displayName[@count="other"]; new_value=Tajikistani roubles
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="TJR"]/displayName; new_value=Tajikistani Rouble
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="JPY"]/symbol; new_value=JP¥
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="AFN"]/displayName[@count="one"]; new_value=Afghan afghani
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="AFN"]/displayName[@count="other"]; new_value=Afghan afghanis
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="MVR"]/displayName[@count="other"]; new_value=Maldivian rufiyaa
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="PHP"]/displayName[@count="one"]; new_value=Philippine peso
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="PHP"]/displayName[@count="other"]; new_value=Philippine pesos
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="PHP"]/displayName; new_value=Philippine Peso
+locale=en_CA; action=addNew; new_path=//ldml/numbers/currencies/currency[@type="VUV"]/displayName[@count="other"]; new_value=Vanuatu vatu
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/measurementSystemNames/measurementSystemName[@type="UK"]; new_value=U.K.
+locale=en_CA; action=addNew; new_path=//ldml/localeDisplayNames/measurementSystemNames/measurementSystemName[@type="US"]; new_value=U.S.
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/perUnitPattern; new_value={0}/yr
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-month"]/perUnitPattern; new_value={0}/mo
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-month"]/unitPattern[@count="one"]; new_value={0} mo
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-month"]/unitPattern[@count="other"]; new_value={0} mos
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-week"]/perUnitPattern; new_value={0}/wk
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-hour"]/perUnitPattern; new_value={0}/hr
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-hour"]/unitPattern[@count="other"]; new_value={0} hrs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-minute"]/unitPattern[@count="other"]; new_value={0} mins
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-minute"]/unitPattern[@count="one"]; new_value={0}min
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-minute"]/unitPattern[@count="other"]; new_value={0}min
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-second"]/perUnitPattern; new_value={0}/sec
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-second"]/unitPattern[@count="other"]; new_value={0} secs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-millisecond"]/unitPattern[@count="one"]; new_value={0} millisec
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-millisecond"]/unitPattern[@count="other"]; new_value={0} millisecs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-microsecond"]/unitPattern[@count="one"]; new_value={0} μsec
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-microsecond"]/unitPattern[@count="other"]; new_value={0} μsecs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-nanosecond"]/unitPattern[@count="one"]; new_value={0} nanosec
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-nanosecond"]/unitPattern[@count="other"]; new_value={0} nanosecs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot"]/unitPattern[@count="one"]; new_value={0} dot
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot"]/unitPattern[@count="other"]; new_value={0} dots
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="graphics-dot"]/unitPattern[@count="one"]; new_value={0} dot
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="graphics-dot"]/unitPattern[@count="other"]; new_value={0} dots
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot-per-centimeter"]/displayName; new_value=dots per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot-per-centimeter"]/unitPattern[@count="one"]; new_value={0} dot per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot-per-centimeter"]/unitPattern[@count="other"]; new_value={0} dots per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-pixel-per-centimeter"]/displayName; new_value=pixels per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-pixel-per-centimeter"]/unitPattern[@count="one"]; new_value={0} pixel per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-pixel-per-centimeter"]/unitPattern[@count="other"]; new_value={0} pixels per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-earth-radius"]/unitPattern[@count="other"]; new_value={0} earth radii
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-kilometer"]/displayName; new_value=kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-kilometer"]/perUnitPattern; new_value={0} per kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-kilometer"]/unitPattern[@count="one"]; new_value={0} kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-kilometer"]/unitPattern[@count="other"]; new_value={0} kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/displayName; new_value=metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/perUnitPattern; new_value={0} per metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"]; new_value={0} metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="other"]; new_value={0} metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-meter"]/displayName; new_value=metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="length-meter"]/displayName; new_value=metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-decimeter"]/displayName; new_value=decimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-decimeter"]/unitPattern[@count="one"]; new_value={0} decimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-decimeter"]/unitPattern[@count="other"]; new_value={0} decimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-centimeter"]/displayName; new_value=centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-centimeter"]/perUnitPattern; new_value={0} per centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-centimeter"]/unitPattern[@count="one"]; new_value={0} centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-centimeter"]/unitPattern[@count="other"]; new_value={0} centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-millimeter"]/displayName; new_value=millimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-millimeter"]/unitPattern[@count="one"]; new_value={0} millimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-millimeter"]/unitPattern[@count="other"]; new_value={0} millimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-micrometer"]/displayName; new_value=micrometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-micrometer"]/unitPattern[@count="one"]; new_value={0} micrometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-micrometer"]/unitPattern[@count="other"]; new_value={0} micrometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-micrometer"]/displayName; new_value=μmetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nanometer"]/displayName; new_value=nanometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nanometer"]/unitPattern[@count="one"]; new_value={0} nanometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nanometer"]/unitPattern[@count="other"]; new_value={0} nanometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-picometer"]/displayName; new_value=picometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-picometer"]/unitPattern[@count="one"]; new_value={0} picometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-picometer"]/unitPattern[@count="other"]; new_value={0} picometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/displayName; new_value=Scandinavian mile
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"]; new_value={0} Scandinavian mile
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="other"]; new_value={0} Scandinavian miles
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-kilometer"]/displayName; new_value=square kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-kilometer"]/perUnitPattern; new_value={0} per square kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-kilometer"]/unitPattern[@count="one"]; new_value={0} square kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-kilometer"]/unitPattern[@count="other"]; new_value={0} square kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-meter"]/displayName; new_value=square metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-meter"]/perUnitPattern; new_value={0} per square metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-meter"]/unitPattern[@count="one"]; new_value={0} square metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-meter"]/unitPattern[@count="other"]; new_value={0} square metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-meter"]/displayName; new_value=metres²
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="area-square-meter"]/displayName; new_value=metres²
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-centimeter"]/displayName; new_value=square centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-centimeter"]/perUnitPattern; new_value={0} per square centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-centimeter"]/unitPattern[@count="one"]; new_value={0} square centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-centimeter"]/unitPattern[@count="other"]; new_value={0} square centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-mile"]/perUnitPattern; new_value={0}/sq mi
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-yard"]/displayName; new_value=sq yards
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-yard"]/unitPattern[@count="one"]; new_value={0} sq yd
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-yard"]/unitPattern[@count="other"]; new_value={0} sq yd
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-inch"]/displayName; new_value=sq inches
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-inch"]/perUnitPattern; new_value={0}/sq in
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-inch"]/unitPattern[@count="one"]; new_value={0} sq in
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="area-square-inch"]/unitPattern[@count="other"]; new_value={0} sq in
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-kilometer"]/displayName; new_value=cubic kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="one"]; new_value={0} cubic kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="other"]; new_value={0} cubic kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-kilometer"]/displayName; new_value=cu kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="one"]; new_value={0} cu km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="other"]; new_value={0} cu km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/displayName; new_value=cubic metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/perUnitPattern; new_value={0} per cubic metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="one"]; new_value={0} cubic metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="other"]; new_value={0} cubic metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-meter"]/displayName; new_value=cu metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-meter"]/perUnitPattern; new_value={0}/cu m
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="one"]; new_value={0}/cu m
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="other"]; new_value={0}/cu m
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-centimeter"]/displayName; new_value=cubic centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-centimeter"]/perUnitPattern; new_value={0} per cubic centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-centimeter"]/unitPattern[@count="one"]; new_value={0} cubic centimetre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-centimeter"]/unitPattern[@count="other"]; new_value={0} cubic centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-centimeter"]/displayName; new_value=cu centimetres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-centimeter"]/perUnitPattern; new_value={0}/cu cm
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-centimeter"]/unitPattern[@count="one"]; new_value={0}/cu cm
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-centimeter"]/unitPattern[@count="other"]; new_value={0}/cu cm
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-mile"]/displayName; new_value=cu miles
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-mile"]/unitPattern[@count="one"]; new_value={0} cu mi
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-mile"]/unitPattern[@count="other"]; new_value={0} cu mi
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-yard"]/displayName; new_value=cu yards
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-yard"]/unitPattern[@count="one"]; new_value={0} cu yd
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-yard"]/unitPattern[@count="other"]; new_value={0} cu yd
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-foot"]/displayName; new_value=cu feet
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-foot"]/unitPattern[@count="one"]; new_value={0} cu ft
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-foot"]/unitPattern[@count="other"]; new_value={0} cu ft
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-inch"]/displayName; new_value=cu inches
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-inch"]/unitPattern[@count="one"]; new_value={0} cu in
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-inch"]/unitPattern[@count="other"]; new_value={0} cu in
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-megaliter"]/displayName; new_value=megalitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-megaliter"]/unitPattern[@count="one"]; new_value={0} megalitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-megaliter"]/unitPattern[@count="other"]; new_value={0} megalitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-hectoliter"]/displayName; new_value=hectolitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-hectoliter"]/unitPattern[@count="one"]; new_value={0} hectolitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-hectoliter"]/unitPattern[@count="other"]; new_value={0} hectolitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/displayName; new_value=litres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/perUnitPattern; new_value={0} per litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"]; new_value={0} litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="other"]; new_value={0} litres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-liter"]/displayName; new_value=litres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-liter"]/displayName; new_value=litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-deciliter"]/displayName; new_value=decilitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-deciliter"]/unitPattern[@count="one"]; new_value={0} decilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-deciliter"]/unitPattern[@count="other"]; new_value={0} decilitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-centiliter"]/displayName; new_value=centilitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-centiliter"]/unitPattern[@count="one"]; new_value={0} centilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-centiliter"]/unitPattern[@count="other"]; new_value={0} centilitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-milliliter"]/displayName; new_value=millilitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-milliliter"]/unitPattern[@count="one"]; new_value={0} millilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-milliliter"]/unitPattern[@count="other"]; new_value={0} millilitres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-pint-metric"]/displayName; new_value=mpt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon"]/displayName; new_value=US gallons
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon"]/perUnitPattern; new_value={0} per US gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon"]/unitPattern[@count="one"]; new_value={0} US gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon"]/unitPattern[@count="other"]; new_value={0} US gallons
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon"]/displayName; new_value=US gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon"]/perUnitPattern; new_value={0}/US gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon"]/unitPattern[@count="one"]; new_value={0} US gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon"]/unitPattern[@count="other"]; new_value={0} US gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon"]/displayName; new_value=US gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon"]/perUnitPattern; new_value={0}/USgal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon"]/unitPattern[@count="one"]; new_value={0}USgal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon"]/unitPattern[@count="other"]; new_value={0}USgal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon-imperial"]/displayName; new_value=gallons
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon-imperial"]/perUnitPattern; new_value={0} per gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="one"]; new_value={0} gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="other"]; new_value={0} gallons
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon-imperial"]/displayName; new_value=gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon-imperial"]/perUnitPattern; new_value={0}/gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="one"]; new_value={0} gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="other"]; new_value={0} gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon-imperial"]/displayName; new_value=gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon-imperial"]/perUnitPattern; new_value={0}/gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="one"]; new_value={0}gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="other"]; new_value={0}gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart"]/displayName; new_value=US quarts
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart"]/unitPattern[@count="one"]; new_value={0} US quart
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart"]/unitPattern[@count="other"]; new_value={0} US quarts
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-quart"]/displayName; new_value=US qts
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-quart"]/unitPattern[@count="one"]; new_value={0} US qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-quart"]/unitPattern[@count="other"]; new_value={0} US qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart"]/displayName; new_value=US qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart"]/unitPattern[@count="one"]; new_value={0}USqt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart"]/unitPattern[@count="other"]; new_value={0}USqt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-cup"]/displayName; new_value=cups
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce"]/displayName; new_value=US fluid ounces
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="one"]; new_value={0} US fluid ounce
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="other"]; new_value={0} US fluid ounces
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce"]/displayName; new_value=US fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="one"]; new_value={0} US fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="other"]; new_value={0} US fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce"]/displayName; new_value=US fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="one"]; new_value={0}US fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="other"]; new_value={0}US fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-imperial"]/displayName; new_value=fluid ounces
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="one"]; new_value={0} fluid ounce
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="other"]; new_value={0} fluid ounces
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce-imperial"]/displayName; new_value=fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="one"]; new_value={0} fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="other"]; new_value={0} fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce-imperial"]/displayName; new_value=fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="one"]; new_value={0}fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-fluid-ounce-imperial"]/unitPattern[@count="other"]; new_value={0}fl oz
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dessert-spoon"]/displayName; new_value=US dessertspoon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="one"]; new_value={0} US dessertspoon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="other"]; new_value={0} US dessertspoons
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dessert-spoon"]/displayName; new_value=US dssp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="one"]; new_value={0} US dssp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="other"]; new_value={0} US dssp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon"]/displayName; new_value=US dsp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="one"]; new_value={0}USdsp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon"]/unitPattern[@count="other"]; new_value={0}USdsp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dessert-spoon-imperial"]/displayName; new_value=dessertspoon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="one"]; new_value={0} dessertspoon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="other"]; new_value={0} dessertspoons
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dessert-spoon-imperial"]/displayName; new_value=dssp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="one"]; new_value={0} dssp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="other"]; new_value={0} dssp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon-imperial"]/displayName; new_value=dsp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="one"]; new_value={0}dsp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dessert-spoon-imperial"]/unitPattern[@count="other"]; new_value={0}dsp
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-drop"]/displayName; new_value=drops
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-drop"]/unitPattern[@count="one"]; new_value={0} drops
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-drop"]/unitPattern[@count="other"]; new_value={0} drops
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dram"]/displayName; new_value=fluid drams
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dram"]/unitPattern[@count="one"]; new_value={0} fluid dram
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dram"]/unitPattern[@count="other"]; new_value={0} fluid drams
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dram"]/displayName; new_value=fl drams
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dram"]/unitPattern[@count="one"]; new_value={0} fl dram
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-dram"]/unitPattern[@count="other"]; new_value={0} fl drams
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dram"]/displayName; new_value=fl dr
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dram"]/unitPattern[@count="one"]; new_value={0}fl dr
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-dram"]/unitPattern[@count="other"]; new_value={0}fl dr
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-jigger"]/displayName; new_value=jiggers
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-jigger"]/unitPattern[@count="other"]; new_value={0} jiggers
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-jigger"]/displayName; new_value=jiggers
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-jigger"]/unitPattern[@count="other"]; new_value={0}jiggers
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-pinch"]/displayName; new_value=pinches
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-pinch"]/unitPattern[@count="other"]; new_value={0} pinches
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart-imperial"]/displayName; new_value=quart
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="one"]; new_value={0} quart
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="other"]; new_value={0} quarts
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-quart-imperial"]/displayName; new_value=qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="one"]; new_value={0} qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="other"]; new_value={0} qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart-imperial"]/displayName; new_value=qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="one"]; new_value={0}qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="other"]; new_value={0}qt
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-meter-per-square-second"]/displayName; new_value=metres per second squared
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-meter-per-square-second"]/unitPattern[@count="one"]; new_value={0} metre per second squared
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-meter-per-square-second"]/unitPattern[@count="other"]; new_value={0} metres per second squared
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="acceleration-meter-per-square-second"]/displayName; new_value=metres/sec²
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-kilometer-per-hour"]/displayName; new_value=kilometres per hour
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-kilometer-per-hour"]/unitPattern[@count="one"]; new_value={0} kilometre per hour
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-kilometer-per-hour"]/unitPattern[@count="other"]; new_value={0} kilometres per hour
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-kilometer-per-hour"]/displayName; new_value=km/h
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-meter-per-second"]/displayName; new_value=metres per second
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-meter-per-second"]/unitPattern[@count="one"]; new_value={0} metre per second
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-meter-per-second"]/unitPattern[@count="other"]; new_value={0} metres per second
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-meter-per-second"]/displayName; new_value=metres/sec
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-mile-per-hour"]/displayName; new_value=mph
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/displayName; new_value=tonnes
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/unitPattern[@count="one"]; new_value={0} tonne
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/unitPattern[@count="other"]; new_value={0} tonnes
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-stone"]/displayName; new_value=stone
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-stone"]/unitPattern[@count="other"]; new_value={0} stone
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-pound"]/unitPattern[@count="one"]; new_value={0}lb
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-pound"]/unitPattern[@count="other"]; new_value={0}lb
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-carat"]/unitPattern[@count="one"]; new_value={0} ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-carat"]/unitPattern[@count="other"]; new_value={0} ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-carat"]/displayName; new_value=ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-carat"]/unitPattern[@count="one"]; new_value={0}ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-carat"]/unitPattern[@count="other"]; new_value={0}ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-grain"]/displayName; new_value=grains
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-grain"]/unitPattern[@count="other"]; new_value={0} grains
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="energy-kilojoule"]/displayName; new_value=kilojoules
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilowatt-hour"]/unitPattern[@count="one"]; new_value={0} kilowatt-hour
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="energy-kilowatt-hour"]/displayName; new_value=kW-hours
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="energy-electronvolt"]/displayName; new_value=electronvolts
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="power-watt"]/displayName; new_value=W
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="electric-ampere"]/displayName; new_value=A
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="electric-ohm"]/displayName; new_value=Ω
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="electric-volt"]/displayName; new_value=V
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-millimeter-ofhg"]/displayName; new_value=millimetres of mercury
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-millimeter-ofhg"]/unitPattern[@count="one"]; new_value={0} millimetre of mercury
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-millimeter-ofhg"]/unitPattern[@count="other"]; new_value={0} millimetres of mercury
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="pressure-millimeter-ofhg"]/displayName; new_value=mm Hg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="pressure-millimeter-ofhg"]/unitPattern[@count="one"]; new_value={0} mm Hg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="pressure-millimeter-ofhg"]/unitPattern[@count="other"]; new_value={0} mm Hg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="pressure-bar"]/displayName; new_value=bars
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-generic"]/displayName; new_value=degree
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-generic"]/displayName; new_value=deg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-celsius"]/displayName; new_value=deg C
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"]; new_value={0} °C
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-celsius"]/unitPattern[@count="other"]; new_value={0} °C
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"]; new_value={0}°
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="temperature-celsius"]/unitPattern[@count="other"]; new_value={0}°
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-fahrenheit"]/displayName; new_value=deg F
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-fahrenheit"]/unitPattern[@count="one"]; new_value={0} °F
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="temperature-fahrenheit"]/unitPattern[@count="other"]; new_value={0} °F
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="temperature-fahrenheit"]/unitPattern[@count="one"]; new_value={0}°F
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="temperature-fahrenheit"]/unitPattern[@count="other"]; new_value={0}°F
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/displayName; new_value=kelvin
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="other"]; new_value={0} kelvin
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="digital-byte"]/displayName; new_value=bytes
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="digital-byte"]/unitPattern[@count="other"]; new_value={0} bytes
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="digital-bit"]/displayName; new_value=bits
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="digital-bit"]/unitPattern[@count="other"]; new_value={0} bits
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="digital-bit"]/unitPattern[@count="other"]; new_value={0}bits
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="angle-revolution"]/unitPattern[@count="other"]; new_value={0} revs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="angle-revolution"]/unitPattern[@count="other"]; new_value={0}revs
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="concentr-karat"]/displayName; new_value=carat
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="concentr-karat"]/unitPattern[@count="one"]; new_value={0}ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="concentr-karat"]/unitPattern[@count="other"]; new_value={0}ct
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-milligram-ofglucose-per-deciliter"]/displayName; new_value=milligrams per decilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-milligram-ofglucose-per-deciliter"]/unitPattern[@count="one"]; new_value={0} milligram per decilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-milligram-ofglucose-per-deciliter"]/unitPattern[@count="other"]; new_value={0} milligrams per decilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-milligram-ofglucose-per-deciliter"]/displayName; new_value=milligrams/decilitre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-millimole-per-liter"]/displayName; new_value=millimoles per litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-millimole-per-liter"]/unitPattern[@count="one"]; new_value={0} millimole per litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-millimole-per-liter"]/unitPattern[@count="other"]; new_value={0} millimoles per litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-millimole-per-liter"]/displayName; new_value=millimoles/litre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/displayName; new_value=per cent
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/unitPattern[@count="one"]; new_value={0} per cent
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/unitPattern[@count="other"]; new_value={0} per cent
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-percent"]/displayName; new_value=per cent
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/displayName; new_value=per mille
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/unitPattern[@count="one"]; new_value={0} per mille
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/unitPattern[@count="other"]; new_value={0} per mille
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-permille"]/displayName; new_value=per mille
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permyriad"]/displayName; new_value=per myriad
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permyriad"]/unitPattern[@count="one"]; new_value={0} per myriad
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permyriad"]/unitPattern[@count="other"]; new_value={0} per myriad
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-permyriad"]/displayName; new_value=per myriad
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-mole"]/displayName; new_value=moles
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-liter-per-kilometer"]/displayName; new_value=litres per kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-liter-per-kilometer"]/unitPattern[@count="one"]; new_value={0} litre per kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-liter-per-kilometer"]/unitPattern[@count="other"]; new_value={0} litres per kilometre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-liter-per-kilometer"]/displayName; new_value=litres/km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-liter-per-kilometer"]/unitPattern[@count="one"]; new_value={0} l/km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-liter-per-100-kilometer"]/displayName; new_value=litres per 100 kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-liter-per-100-kilometer"]/unitPattern[@count="one"]; new_value={0} litre per 100 kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-liter-per-100-kilometer"]/unitPattern[@count="other"]; new_value={0} litres per 100 kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-liter-per-100-kilometer"]/displayName; new_value=litres/100 km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-mile-per-gallon"]/displayName; new_value=miles per US gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-mile-per-gallon"]/unitPattern[@count="one"]; new_value={0} mile per US gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-mile-per-gallon"]/unitPattern[@count="other"]; new_value={0} miles per US gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-mile-per-gallon"]/displayName; new_value=miles/US gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-mile-per-gallon"]/unitPattern[@count="one"]; new_value={0} mpg US
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-mile-per-gallon"]/unitPattern[@count="other"]; new_value={0} mpg US
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="consumption-mile-per-gallon"]/displayName; new_value=mpg US
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="consumption-mile-per-gallon"]/unitPattern[@count="one"]; new_value={0}mpgUS
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="consumption-mile-per-gallon"]/unitPattern[@count="other"]; new_value={0}mpgUS
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-mile-per-gallon-imperial"]/displayName; new_value=miles per gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-mile-per-gallon-imperial"]/unitPattern[@count="one"]; new_value={0} mile per gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="consumption-mile-per-gallon-imperial"]/unitPattern[@count="other"]; new_value={0} miles per gallon
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-mile-per-gallon-imperial"]/displayName; new_value=miles/gal
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-mile-per-gallon-imperial"]/unitPattern[@count="one"]; new_value={0} mpg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="consumption-mile-per-gallon-imperial"]/unitPattern[@count="other"]; new_value={0} mpg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="consumption-mile-per-gallon-imperial"]/displayName; new_value=mpg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="consumption-mile-per-gallon-imperial"]/unitPattern[@count="one"]; new_value={0}mpg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="consumption-mile-per-gallon-imperial"]/unitPattern[@count="other"]; new_value={0}mpg
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/displayName; new_value=kilowatt-hour per 100 kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/unitPattern[@count="one"]; new_value={0} kilowatt-hour per 100 kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/unitPattern[@count="other"]; new_value={0} kilowatt-hours per 100 kilometres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/displayName; new_value=kWh/100 km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/unitPattern[@count="one"]; new_value={0} kWh/100 km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="force-kilowatt-hour-per-100-kilometer"]/unitPattern[@count="other"]; new_value={0} kWh/100 km
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="light-lux"]/displayName; new_value=lx
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-candela"]/displayName; new_value=candelas
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-candela"]/unitPattern[@count="other"]; new_value={0} candelas
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/displayName; new_value=lumens
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="other"]; new_value={0} lumens
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="torque-newton-meter"]/displayName; new_value=newton metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="torque-newton-meter"]/unitPattern[@count="one"]; new_value={0} newton metre
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="torque-newton-meter"]/unitPattern[@count="other"]; new_value={0} newton metres
+locale=en_CA; action=addNew; new_path=//ldml/units/unitLength[@type="long"]/compoundUnit[@type="10p1"]/unitPrefixPattern; new_value=deca{0}
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="all"]; new_value={0} – all
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="compatibility"]; new_value={0} – compatibility
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="enclosed"]; new_value={0} – enclosed
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="extended"]; new_value={0} – extended
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="historic"]; new_value={0} – historic
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="miscellaneous"]; new_value={0} – miscellaneous
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="other"]; new_value={0} – other
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabelPattern[@type="scripts"]; new_value=scripts – {0}
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="downwards_arrows"]; new_value=downward arrow
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="downwards_upwards_arrows"]; new_value=downward upward arrow
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="leftwards_arrows"]; new_value=leftward arrow
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="leftwards_rightwards_arrows"]; new_value=leftward rightward arrow
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="letterlike_symbols"]; new_value=letter-like symbol
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="limited_use"]; new_value=limited use
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="nonspacing"]; new_value=non-spacing
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="rightwards_arrows"]; new_value=rightward arrow
+locale=en_CA; action=addNew; new_path=//ldml/characterLabels/characterLabel[@type="upwards_arrows"]; new_value=upward arrows
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🙃"]; new_value=face | upside down | upside-down face
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😍"][@type="tts"]; new_value=smiling face with heart eyes
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😍"]; new_value=eye | face | love | smile | smiling face with heart eyes | smiling face with heart-eyes
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😋"]; new_value=delicious | face | face savouring food | savoring | savouring | smile | yum
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤭"]; new_value=face with hand over mouth | oops | whoops
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😷"]; new_value=cold | doctor | face | face with medical mask | ill | mask | sick
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤕"]; new_value=bandage | face | face with head bandage | hurt | injury
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤧"]; new_value=bless you | face | gesundheit | sneeze | sneezing face
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😵‍💫"]; new_value=dizzy | face with spiral eyes | hypnotised | spiral | trouble | whoa
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🫤"]; new_value=disappointed | meh | sceptical | unsure
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😤"]; new_value=angry | face | face with steam from nose | frustration | triumph | won
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😻"][@type="tts"]; new_value=smiling cat face with heart eyes
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="😻"]; new_value=cat | eye | face | heart | love | smile | smiling cat face with heart-eyes
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗨"]; new_value=dialogue | left speech bubble | speech
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🫱"][@type="tts"]; new_value=rightward hand
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🫱"]; new_value=hand | right | rightward | rightwards
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🫲"][@type="tts"]; new_value=leftward hand
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🫲"]; new_value=hand | left | leftward | leftwards
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👌"]; new_value=hand | OK | perfect
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤞"]; new_value=cross | crossed fingers | finger | good luck | hand | luck
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤟"]; new_value=hand | ILY | love you gesture | love-you gesture
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤘"]; new_value=finger | hand | horns | rock on | sign of the horns
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤙"]; new_value=call | call me hand | call-me hand | hand
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤛"]; new_value=fist | left-facing fist | leftward
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤜"]; new_value=fist | right-facing fist | rightward
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🙏"]; new_value=ask | folded hands | hand | high five | please | pray | thanks
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🦻"]; new_value=accessibility | ear with hearing aid | hard of hearing | hearing impaired
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👧"]; new_value=girl | young
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧏"]; new_value=accessibility | deaf | deaf person | ear | hear | hearing impaired
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧑‍⚕"]; new_value=care | doctor | health | health worker | healthcare | nurse | therapist
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👨‍⚕"]; new_value=doctor | health care | man | man health worker | nurse | therapist
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👩‍⚕"]; new_value=doctor | health care | nurse | therapist | woman | woman health worker
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧑‍🚒"]; new_value=engine | fire | firefighter | firetruck | truck
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👨‍🚒"]; new_value=fire truck | firefighter | fireman | man
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👩‍🚒"]; new_value=engine | fire | firefighter | firetruck | firewoman | truck | woman
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎅"]; new_value=celebration | Christmas | Claus | Father | Santa
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤶"]; new_value=celebration | Christmas | Claus | Mother | Mrs.
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧑‍🎄"][@type="tts"]; new_value=Mx. Claus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧑‍🎄"]; new_value=Claus, Christmas | Mx. Claus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="💇"]; new_value=barber | beauty | haircut | parlour | person getting haircut
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏋"]; new_value=lifter | person lifting weights | weight | weightlifter
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤹"]; new_value=balance | juggle | multi-task | multitask | person juggling | skill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤹‍♂"]; new_value=juggling | man | multi-task | multitask
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤹‍♀"]; new_value=juggling | multi-task | multitask | woman
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👭"]; new_value=couple | hand | holding hands | two women holding hands | women
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👬"]; new_value=couple | Gemini | holding hands | men | twins | two men holding hands | zodiac
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🐫"]; new_value=Bactrian | camel | hump | two-hump camel
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🐞"][@type="tts"]; new_value=ladybug
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌾"]; new_value=ear | grain | rice | sheaf | sheaf of rice
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌰"]; new_value=chestnut | nut | plant
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥐"]; new_value=bread | crescent roll | croissant | food | French
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥖"]; new_value=baguette | bread | food | French
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧇"]; new_value=breakfast | iron | unclear | vague | waffle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥩"]; new_value=chop | cut of meat | lamb chop | pork chop | steak
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍟"][@type="tts"]; new_value=French fries
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍟"]; new_value=French | fries
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌮"]; new_value=Mexican | taco
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌯"]; new_value=burrito | Mexican | wrap
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧆"]; new_value=chick pea | chickpea | falafel | meatball
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍥"]; new_value=cake | fish | fish cake with swirl | narutomaki | pastry | swirl
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍦"]; new_value=cream | dessert | ice | soft | sweet
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍬"]; new_value=candy | dessert | sweet | sweets
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍶"]; new_value=bar | beverage | bottle | cup | drink | sake | saké
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🍴"]; new_value=cooking | cutlery | fork | fork and knife | knife | knife and fork
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗻"][@type="tts"]; new_value=mount Fuji
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗻"]; new_value=Fuji | mount Fuji | mountain
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏛"]; new_value=classical | classical building | column
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏪"]; new_value=convenience | dépanneur | store
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗼"][@type="tts"]; new_value=Tokyo Tower
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗼"]; new_value=Tokyo | Tower
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🗽"]; new_value=Liberty | Statue | Statue of Liberty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕌"]; new_value=Islam | mosque | Muslim | religion
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛕"][@type="tts"]; new_value=Hindu temple
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛕"]; new_value=Hindu | temple
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕍"]; new_value=Jew | Jewish | religion | shul | synagogue | temple
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⛩"][@type="tts"]; new_value=Shinto shrine
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⛩"]; new_value=religion | Shinto | shrine
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕋"][@type="tts"]; new_value=Kaaba
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕋"]; new_value=Islam | kaaba | Kaaba | Muslim | religion
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎡"][@type="tts"]; new_value=Ferris wheel
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎡"]; new_value=amusement park | Ferris | theme park | wheel
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚃"]; new_value=car | electric | railway | train | tram | trolley bus | trolleybus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚄"]; new_value=high-speed train | railway | Shinkansen | speed | train
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚅"]; new_value=bullet | railway | Shinkansen | speed | train
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚇"][@type="tts"]; new_value=subway
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚊"]; new_value=car | streetcar | tram | tramcar | trolley | trolley bus | trolleybus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚋"][@type="tts"]; new_value=streetcar
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚋"]; new_value=car | streetcar | tram | tramcar | trolley | trolley bus | trolleybus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚎"][@type="tts"]; new_value=trolley bus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚎"]; new_value=bus | streetcar | tram | trolley | trolleybus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚒"][@type="tts"]; new_value=fire truck
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚙"]; new_value=recreational | sport utility | sport utility vehicle | SUV
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚛"][@type="tts"]; new_value=semi
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛺"]; new_value=auto rickshaw | tuk tuk | tuk-tuk | tuktuk
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚏"]; new_value=bus | busstop | stop
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛣"][@type="tts"]; new_value=highway
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⛽"][@type="tts"]; new_value=gas pump
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛞"]; new_value=circle | turn | tyre
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛥"][@type="tts"]; new_value=motorboat
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕧"][@type="tts"]; new_value=twelve thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕧"]; new_value=12 | 12:30 | clock | half past twelve | thirty | twelve | twelve-thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕜"][@type="tts"]; new_value=one thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕜"]; new_value=1 | 1:30 | clock | half past one | one | one-thirty | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕝"][@type="tts"]; new_value=two thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕝"]; new_value=2 | 2:30 | clock | half past two | thirty | two | two-thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕞"][@type="tts"]; new_value=three thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕞"]; new_value=3 | 3:30 | clock | half past three | thirty | three | three-thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕟"][@type="tts"]; new_value=four thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕟"]; new_value=4 | 4:30 | clock | four | four-thirty | half past four | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕠"][@type="tts"]; new_value=five thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕠"]; new_value=5 | 5:30 | clock | five | five-thirty | half past five | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕡"][@type="tts"]; new_value=six thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕡"]; new_value=6 | 6:30 | clock | half past six | six | six-thirty | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕢"][@type="tts"]; new_value=seven thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕢"]; new_value=7 | 7:30 | clock | half past seven | seven | seven-thirty | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕣"][@type="tts"]; new_value=eight thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕣"]; new_value=8 | 8:30 | clock | eight | eight-thirty | half past eight | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕤"][@type="tts"]; new_value=nine thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕤"]; new_value=9 | 9:30 | clock | half past nine | nine | nine-thirty | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕥"][@type="tts"]; new_value=ten thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕥"]; new_value=10 | 10:30 | clock | half past ten | ten | ten-thirty | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕦"][@type="tts"]; new_value=eleven thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🕦"]; new_value=11 | 11:30 | clock | eleven | eleven-thirty | half past eleven | thirty
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌝"][@type="tts"]; new_value=full-moon face
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌝"]; new_value=bright | face | full | full-moon face | moon
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌌"][@type="tts"]; new_value=Milky Way
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🌌"]; new_value=Milky | space | Way
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎃"]; new_value=celebration | Halloween | jack | jack-o-lantern | jack-o’-lantern | lantern
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎋"][@type="tts"]; new_value=Tanabata tree
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎋"]; new_value=banner | celebration | Japanese | Tanabata tree | tree
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎑"][@type="tts"]; new_value=moon-viewing ceremony
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🎑"]; new_value=celebration | ceremony | moon | moon viewing ceremony | moon-viewing ceremony
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏈"][@type="tts"]; new_value=football
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏉"][@type="tts"]; new_value=rugby
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥏"]; new_value=flying disc | Frisbee | ultimate
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏏"]; new_value=ball | bat | cricket | cricket match | game
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏒"][@type="tts"]; new_value=hockey
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🤿"]; new_value=diving | diving mask | scuba | snorkelling
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥌"][@type="tts"]; new_value=curling rock
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥌"]; new_value=curling rock | curling stone | game | rock
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧿"]; new_value=bead | charm | evil eye | nazar | nazar amulet | talisman
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🀄"][@type="tts"]; new_value=Mahjong red dragon
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🀄"]; new_value=game | Mahjong | Mahjong red dragon | red
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="👕"]; new_value=clothing | shirt | t-shirt | T-shirt | tee-shirt | tshirt
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🩱"]; new_value=bathing suit | one-piece swimsuit | swimming costume
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🩴"][@type="tts"]; new_value=flip-flop
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🩴"]; new_value=beach sandal | flip-flop | sandal | thong | zōri
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🥿"]; new_value=ballet flat | flat shoe | pump | slip-on | slipper
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🧢"][@type="tts"]; new_value=baseball cap
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="💎"][@type="tts"]; new_value=gemstone
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="💎"]; new_value=diamond | gem | gem stone | gemstone | jewel
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📯"][@type="tts"]; new_value=post horn
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="💾"]; new_value=computer | disk | diskette | floppy
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="💷"]; new_value=banknote | bill | currency | money | note | pound | sterling
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✉"]; new_value=e-mail | email | envelope | letter
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📫"]; new_value=closed | closed postbox with raised flag | mail | mailbox | post | post box | postbox
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📪"]; new_value=closed | closed postbox with lowered flag | mail | mailbox | post | post box | postbox
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📬"]; new_value=mail | mailbox | open | open postbox with raised flag | post | post box | postbox
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📭"]; new_value=mail | mailbox | open | open postbox with lowered flag | post | post box | postbox
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📮"][@type="tts"]; new_value=mailbox
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📮"]; new_value=mail | mailbox | post | post box | postbox
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📐"]; new_value=ruler | set | set square | triangle | triangular ruler
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔒"]; new_value=closed | locked | padlock
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔓"]; new_value=lock | open | padlock | unlock | unlocked
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🦯"]; new_value=accessibility | blind | guide cane
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🩹"]; new_value=injury | plaster | sticking plaster
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛋"]; new_value=couch | couch and lamp | hotel | lamp | sofa | sofa and lamp
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚽"]; new_value=lavatory | toilet
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🪤"][@type="tts"]; new_value=mousetrap
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🪤"]; new_value=bait | mouse | mousetrap | snare | trap
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🪒"]; new_value=cut-throat | razor | sharp | shave
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🛒"]; new_value=basket | cart | shopping | trolley
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🪪"]; new_value=credentials | ID | licence | security
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚮"]; new_value=garbage | litter | litter bin | litter in bin sign | trash
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚹"]; new_value=bathroom | lavatory | men’s | men’s room | restroom | washroom | wc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚺"][@type="tts"]; new_value=ladies’ room
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚺"]; new_value=bathroom | lavatory | restroom | washroom | wc | women’s | women’s room
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚻"][@type="tts"]; new_value=washroom
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚻"]; new_value=bathroom | lavatory | restroom | washroom | WC
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚾"]; new_value=closet | lavatory | restroom | toilet | water | wc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✡"][@type="tts"]; new_value=Star of David
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✡"]; new_value=David | Jewish | Judaism | religion | star | Star of David
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="☯"]; new_value=religion | Tao | Taoist | yang | yin
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✝"][@type="tts"]; new_value=Latin cross
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✝"]; new_value=Christian | cross | Latin cross | religion
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="☦"][@type="tts"]; new_value=Orthodox cross
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="☦"]; new_value=Christian | cross | Orthodox cross | religion
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="☪"]; new_value=Islam | Muslim | religion | star and crescent
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="♏"]; new_value=Scorpio | scorpion | Scorpius | zodiac
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔼"][@type="tts"]; new_value=upward button
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔼"]; new_value=arrow | button | red | upward button | upwards button
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔽"][@type="tts"]; new_value=downward button
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔽"]; new_value=arrow | button | down | downward button | downwards button | red
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="📳"]; new_value=cell | mobile | mode | phone | telephone | vibrate | vibration
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✖"]; new_value=× | cancel | heavy multiplication sign | multiplication | sign | x
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🟰"]; new_value=equality | math | maths
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≈"]; new_value=about | almost equal | approximate | approximation | around
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp=">"][@type="tts"]; new_value=greater than
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp=">"]; new_value=close tag | greater than | greater-than sign | tag
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="<"][@type="tts"]; new_value=less than
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≤"][@type="tts"]; new_value=less than or equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≤"]; new_value=equal | equals | inequality | less than or equal to | less-than
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≥"][@type="tts"]; new_value=greater than or equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≥"]; new_value=equal | equals | greater than or equal to | greater-than | inequality
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="|"]; new_value=bar | line | pipe | sheffer stroke | vertical bar | vertical line
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⁉"]; new_value=! | !? | ? | interrobang | mark | punctuation | question
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="،"][@type="tts"]; new_value=Arabic comma
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="،"]; new_value=Arabic | comma
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="؛"][@type="tts"]; new_value=Arabic semicolon
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="؛"]; new_value=Arabic | Arabic semicolon | semi-colon
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="؟"][@type="tts"]; new_value=Arabic question mark
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="؟"]; new_value=Arabic | Arabic question mark | question | question mark
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="%"]; new_value=per cent | per-cent | percent | percentage
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="@"][@type="tts"]; new_value=at sign
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="@"]; new_value=ampersat | arobase | arroba | at mark | at-sign | commercial at | email | strudel
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="‘"]; new_value=apostrophe | curly quote | left apostrophe | quote | single quote | smart quote
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="’"]; new_value=apostrophe | curly quote | quote | right apostrophe | single quote | smart quote
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="“"]; new_value=curly quotes | double quote | left quotation mark | quotation | quote | smart quotation
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="”"]; new_value=curly quotes | double quote | quotation | quote | right quotation mark | smart quotation
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp=")"]; new_value=bracket | close parenthesis | parens | parenthesis | round bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="["]; new_value=bracket | crotchet | left square bracket | open square bracket | square bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="]"]; new_value=bracket | close square bracket | crotchet | right square bracket | square bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="{"]; new_value=brace | bracket | curly brace | curly bracket | gullwing | left curly bracket | open curly bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="}"]; new_value=brace | bracket | close curly bracket | curly brace | curly bracket | gullwing | right curly bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="〔"]; new_value=bracket | left tortoise shell bracket | open tortoise shell bracket | shell bracket | tortoise shell bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="〕"]; new_value=bracket | close tortoise shell bracket | right tortoise shell bracket | shell bracket | tortoise shell bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="〈"]; new_value=angle bracket | bracket | chevron | diamond brackets | left angle bracket | pointy bracket | tuple
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="〉"]; new_value=angle bracket | bracket | chevron | diamond brackets | pointy bracket | right angle bracket | tuple
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="《"]; new_value=bracket | double angle bracket | left double angle bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="》"]; new_value=bracket | double angle bracket | right double angle bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="「"]; new_value=bracket | corner bracket | left corner bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="」"]; new_value=bracket | corner bracket | right corner bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="『"]; new_value=bracket | hollow corner bracket | left hollow corner bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="』"]; new_value=bracket | hollow corner bracket | right hollow corner bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="〖"]; new_value=bracket | hollow lens bracket | hollow lenticular bracket | left hollow lenticular bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="〗"]; new_value=bracket | hollow lens bracket | hollow lenticular bracket | right hollow lenticular bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="【"]; new_value=bracket | left black lenticular bracket | lens bracket | lenticular bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="】"]; new_value=bracket | lens bracket | lenticular bracket | right black lenticular bracket
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₹"][@type="tts"]; new_value=Indian rupee
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₹"]; new_value=currency | Indian rupee | rupee
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="$"]; new_value=CAD | cash | dollar | dollars | money | peso | USD
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="¢"]; new_value=cent | cents
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₱"]; new_value=peso | pesos
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="✅"]; new_value=✓ | button | check | mark | tick
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="☑"]; new_value=✓ | box | check | check box with check | tick | tick box with tick
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="®"]; new_value=r | registered | trademark
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="↹"]; new_value=leftwards arrow to bar over rightwards arrow to bar
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∂"]; new_value=differential | partial derivative | partial differential
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∃"]; new_value=existential | mathematics | quantifier | there exists
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∅"]; new_value=empty set | mathematics | null set | null sign | set operator
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∉"][@type="tts"]; new_value=not an element of
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∉"]; new_value=element | not an element | set
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∎"][@type="tts"]; new_value=end of proof
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∑"]; new_value=mathematics | n-ary summation | sigma | summation
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∓"]; new_value=minus-or-plus | minus-plus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∝"][@type="tts"]; new_value=is proportional
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∣"]; new_value=divides | divisor | vertical bar
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∥"][@type="tts"]; new_value=parallel to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="∮"]; new_value=complex analysis | contour integral
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≃"][@type="tts"]; new_value=asymptotically equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≅"][@type="tts"]; new_value=approximately equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≌"][@type="tts"]; new_value=all equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≣"][@type="tts"]; new_value=strictly equivalent to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≳"][@type="tts"]; new_value=greater-than or equivalent to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≳"]; new_value=equivalent | greater-than | inequality | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≺"]; new_value=mathematics | ordered set | precedes | set operator
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="≻"]; new_value=follows | mathematics | ordered set | set operator | succeeds
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊁"]; new_value=does not succeed | mathematics | ordered set | set operator
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊃"][@type="tts"]; new_value=superset of
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊃"]; new_value=mathematics | proper superset | set operator
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊆"][@type="tts"]; new_value=subset of or equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊆"]; new_value=equal | mathematics | subset
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊇"][@type="tts"]; new_value=superset of or equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊇"]; new_value=equal | mathematics | superset
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊕"]; new_value=circled plus | direct sum | exclusive or | logic | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊖"]; new_value=circled minus | erosion | mathematics | symmetric difference
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊗"]; new_value=circled times | Kronecker | product | tensor
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊙"]; new_value=circled dot operator | mathematics | vector | XNOR
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊛"]; new_value=circled asterisk operator
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊞"]; new_value=addition-like | free additive convolution | mathematics | squared plus
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊮"]; new_value=does not force | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊰"]; new_value=mathematics | ordered set | precedes under relation | set operator
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊱"]; new_value=mathematics | ordered set | set operator | succeeds under relation
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋭"][@type="tts"]; new_value=does not contain as normal subgroup or equal
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⊶"][@type="tts"]; new_value=original of
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋰"][@type="tts"]; new_value=upwards right diagonal ellipsis
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋰"]; new_value=ellipsis | mathematics | upwards diagonal ellipsis
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋱"][@type="tts"]; new_value=downwards right diagonal ellipsis
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⋱"]; new_value=downwards right diagonal ellipsis | ellipsis | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="■"]; new_value=black square | filled square
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="□"]; new_value=hollow square | white square
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▢"]; new_value=hollow square with rounded corners | white square with rounded corners
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▣"]; new_value=hollow square containing filled square | white square containing black small square
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▦"][@type="tts"]; new_value=square with orthogonal crosshatch fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▦"]; new_value=square with orthogonal crosshatch fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▧"][@type="tts"]; new_value=square with upper left to lower right fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▧"]; new_value=square with upper left to lower right fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▨"][@type="tts"]; new_value=square with upper right to lower left fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▨"]; new_value=square with upper right to lower left fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▩"][@type="tts"]; new_value=square with diagonal crosshatch fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▩"]; new_value=square with diagonal crosshatch fill
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▬"]; new_value=black rectangle | filled rectangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▭"]; new_value=hollow rectangle | white rectangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▮"]; new_value=black vertical rectangle | filled vertical rectangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▰"]; new_value=black parallelogram | filled parallelogram
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="△"]; new_value=hollow up-pointing triangle | white up-pointing triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▴"]; new_value=black up-pointing small triangle | filled up-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▵"]; new_value=hollow up-pointing small triangle | white up-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▷"]; new_value=hollow right-pointing triangle | white right-pointing triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▸"]; new_value=black right-pointing triangle | filled right-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▹"]; new_value=hollow right-pointing small triangle | white right-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="►"]; new_value=black right-pointing pointer | filled right-pointing pointer
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▻"]; new_value=hollow right-pointing pointer | white right-pointing pointer
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▽"]; new_value=hollow down-pointing triangle | white down-pointing triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▾"]; new_value=black down-pointing small triangle | filled down-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▿"]; new_value=hollow down-pointing small triangle | white down-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◁"]; new_value=hollow left-pointing triangle | white left-pointing triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◂"]; new_value=black left-pointing small triangle | filled left-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◃"]; new_value=hollow left-pointing small triangle | white left-pointing small triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◄"]; new_value=black left-pointing pointer | filled left-pointing pointer
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◅"]; new_value=hollow left-pointing pointer | white left-pointing pointer
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◆"]; new_value=black diamond | filled diamond
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◇"]; new_value=hollow diamond | white diamond
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◈"]; new_value=hollow diamond containing filled diamond | white diamond containing black small diamond
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◉"]; new_value=circled dot | concentric circles filled | fisheye | hollow circle containing filled circle | white circle containing black small circle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◔"][@type="tts"]; new_value=circle with upper-right quadrant filled
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◔"]; new_value=circle with upper-right quadrant filled
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◕"][@type="tts"]; new_value=circle with all but upper-left quadrant filled
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◕"]; new_value=circle with all but upper-left quadrant filled
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◖"]; new_value=left half black circle | left half filled circle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◗"]; new_value=right half black circle | right half filled circle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◙"]; new_value=black square containing hollow circle | inverse hollow circle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◜"][@type="tts"]; new_value=upper-left quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◜"]; new_value=upper-left quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◝"][@type="tts"]; new_value=upper-right quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◝"]; new_value=upper-right quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◞"][@type="tts"]; new_value=lower-right quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◞"]; new_value=lower-right quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◟"][@type="tts"]; new_value=lower-left quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◟"]; new_value=lower-left quadrant circular arc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◢"][@type="tts"]; new_value=filled lower-right triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◢"]; new_value=black lower-right triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◣"][@type="tts"]; new_value=filled lower-left triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◣"]; new_value=black lower-left triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◤"][@type="tts"]; new_value=filled upper-left triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◤"]; new_value=black upper-left triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◥"][@type="tts"]; new_value=filled upper-right triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◥"]; new_value=black upper-right triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◳"][@type="tts"]; new_value=hollow square with upper-right quadrant
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◳"]; new_value=white square with upper-right quadrant
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◷"][@type="tts"]; new_value=hollow circle with upper-right quadrant
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◷"]; new_value=white circle with upper-right quadrant
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◿"][@type="tts"]; new_value=lower-right triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◿"]; new_value=lower-right triangle | white
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨧"][@type="tts"]; new_value=plus sign with subscript two
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨧"]; new_value=plus sign with subscript two
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨯"][@type="tts"]; new_value=vector or cross product
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨯"]; new_value=vector or cross product
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⨼"]; new_value=interior product | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩣"][@type="tts"]; new_value=logical or with double underbar
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩣"]; new_value=logical or with double underbar | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩽"][@type="tts"]; new_value=less-than or slanted equal to
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⩽"]; new_value=inequality | less-than or slanted equal to | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪍"][@type="tts"]; new_value=less-than above similar or equal
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪍"]; new_value=less-than above similar or equal
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪚"][@type="tts"]; new_value=double-line equal to or greater-than
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="⪚"]; new_value=double-line equal to or greater-than | inequality | mathematics
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₢"]; new_value=Brazil | BRB | cruzeiro | currency
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₣"][@type="tts"]; new_value=French franc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₣"]; new_value=currency | franc | France | French franc
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₤"]; new_value=currency | Italy | lira
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₰"][@type="tts"]; new_value=German penny
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₰"]; new_value=currency | German penny | pfennig
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₳"]; new_value=ARA | Argentina | austral | currency
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="₶"]; new_value=currency | France | livre tournois
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔠"][@type="tts"]; new_value=input Latin uppercase
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔠"]; new_value=ABCD | input | Latin | letters | uppercase
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔡"][@type="tts"]; new_value=input Latin lowercase
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔡"]; new_value=abcd | input | Latin | letters | lowercase
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔤"][@type="tts"]; new_value=input Latin letters
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🔤"]; new_value=abc | alphabet | input | Latin | letters
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▼"]; new_value=arrow | black down-pointing triangle | down | triangle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="▲"]; new_value=arrow | black up-pointing triangle | triangle | up
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="●"]; new_value=black circle | circle | filled circle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="○"]; new_value=circle | hollow circle | ring | white circle
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="◯"]; new_value=circle | large hollow circle | large white circle | ring
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏁"][@type="tts"]; new_value=checkered flag
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏁"]; new_value=checkered | checkered flag | chequered | chequered flag | racing
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🚩"]; new_value=post | red flag | triangular flag
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏳"]; new_value=surrender | waving | white flag
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏻"]; new_value=light skin tone | skin tone
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏼"]; new_value=medium-light skin tone | skin tone
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏽"]; new_value=medium skin tone | skin tone
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏾"]; new_value=medium-dark skin tone | skin tone
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🏿"]; new_value=dark skin tone | skin tone
+locale=en_CA; action=addNew; new_path=//ldml/annotations/annotation[@cp="🦳"]; new_value=gray | grey | hair | old | white
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="slnt"][@subtype="24"]; new_value=extraslanted
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wdth"][@subtype="62.5"]; new_value=extracondensed
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wdth"][@subtype="62.5"][@alt="compressed"]; new_value=extracompressed
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wdth"][@subtype="62.5"][@alt="narrow"]; new_value=extranarrow
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wdth"][@subtype="150"]; new_value=extraexpanded
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wdth"][@subtype="150"][@alt="extended"]; new_value=extraextended
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wdth"][@subtype="150"][@alt="wide"]; new_value=extrawide
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wght"][@subtype="200"]; new_value=extralight
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wght"][@subtype="800"]; new_value=extrabold
+locale=en_CA; action=addNew; new_path=//ldml/typographicNames/styleName[@type="wght"][@subtype="950"]; new_value=extrablack
+locale=en_CA; action=addNew; new_path=//ldml/listPatterns/listPattern/listPatternPart[@type="end"]; new_value={0} and {1}
+locale=en_CA; action=addNew; new_path=//ldml/listPatterns/listPattern[@type="standard-short"]/listPatternPart[@type="2"]; new_value={0} and {1}
+locale=en_CA; action=addNew; new_path=//ldml/listPatterns/listPattern[@type="standard-short"]/listPatternPart[@type="end"]; new_value={0} and {1}
+locale=en_CA; action=addNew; new_path=//ldml/listPatterns/listPattern[@type="or"]/listPatternPart[@type="end"]; new_value={0} or {1}
+locale=en_CA; action=addNew; new_path=//ldml/listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="end"]; new_value={0} or {1}
+locale=en_CA; action=addNew; new_path=//ldml/listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="end"]; new_value={0} or {1}


### PR DESCRIPTION
That is, with the new inheritance, the resolved file is the same as the resolved file with the old inheritance.

That is, the revised file has items that were in the old en_001 + en_CA but not in en.

That means people won't see a difference in the results that they saw in the ST. Note that in the process, the up arrows are removed. That won't make any effective difference: for the release they are removed anyway, and during the next cycle people's votes for inheritance should be restored (since those will be the winning values).

CLDR-14635

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
