### PR TITLE
CLDR-14976 de: compact decimals, revert formats for 1000..100000 to use 0, not Tsd.

### DIFF
--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -5875,12 +5875,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>
-					<pattern type="1000" count="one">0 Tsd'.'</pattern>
-					<pattern type="1000" count="other">0 Tsd'.'</pattern>
-					<pattern type="10000" count="one">00 Tsd'.'</pattern>
-					<pattern type="10000" count="other">00 Tsd'.'</pattern>
-					<pattern type="100000" count="one">000 Tsd'.'</pattern>
-					<pattern type="100000" count="other">000 Tsd'.'</pattern>
+					<pattern type="1000" count="one">0</pattern>
+					<pattern type="1000" count="other">0</pattern>
+					<pattern type="10000" count="one">0</pattern>
+					<pattern type="10000" count="other">0</pattern>
+					<pattern type="100000" count="one">0</pattern>
+					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">0 Mio'.'</pattern>
 					<pattern type="1000000" count="other">0 Mio'.'</pattern>
 					<pattern type="10000000" count="one">00 Mio'.'</pattern>
@@ -5927,12 +5927,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">0 Tsd'.' ¤</pattern>
-					<pattern type="1000" count="other">0 Tsd'.' ¤</pattern>
-					<pattern type="10000" count="one">00 Tsd'.' ¤</pattern>
-					<pattern type="10000" count="other">00 Tsd'.' ¤</pattern>
-					<pattern type="100000" count="one">000 Tsd'.' ¤</pattern>
-					<pattern type="100000" count="other">000 Tsd'.' ¤</pattern>
+					<pattern type="1000" count="one">0</pattern>
+					<pattern type="1000" count="other">0</pattern>
+					<pattern type="10000" count="one">0</pattern>
+					<pattern type="10000" count="other">0</pattern>
+					<pattern type="100000" count="one">0</pattern>
+					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">0 Mio'.' ¤</pattern>
 					<pattern type="1000000" count="other">0 Mio'.' ¤</pattern>
 					<pattern type="10000000" count="one">00 Mio'.' ¤</pattern>


### PR DESCRIPTION
CLDR-14976

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Once again, for German compact decimals, revert formats for 1000..100000 to use just 0 (as in https://github.com/unicode-org/cldr/pull/151 and 2 or 3 others), not formats with Tsd.