### PR TITLE
CLDR-14877 Coverage Progress Bars

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -169,7 +169,13 @@ abstract public class CheckCLDR {
             ) {
 
             PathHeader.SurveyToolStatus status = ph.getSurveyToolStatus();
-            // always forbid deprecated items - don't show.
+            /*
+             * Always forbid DEPRECATED items - don't show.
+             *
+             * Currently, bulk submission and TC voting are allowed even for SurveyToolStatus.HIDE,
+             * but not for SurveyToolStatus.DEPRECATED. If we ever want to treat HIDE and DEPRECATED
+             * the same here, then it would be simpler to call ph.shouldHide which is true for both.
+             */
             if (status == SurveyToolStatus.DEPRECATED) {
                 return StatusAction.FORBID_READONLY;
             }
@@ -178,12 +184,6 @@ abstract public class CheckCLDR {
                 return StatusAction.ALLOW_TICKET_ONLY;
             }
 
-            /*
-             * TODO: is it intentional that bulk submission and TC voting are allowed even for SurveyToolStatus.HIDE?
-             * If not, fix it by calling PathHeader.shouldHide() above instead of referencing SurveyToolStatus.DEPRECATED
-             * above and SurveyToolStatus.HIDE below. Otherwise add a comment here confirming that these are allowed for
-             * SurveyToolStatus.HIDE. Reference: https://unicode-org.atlassian.net/browse/CLDR-14877
-             */
 
             // always forbid bulk import except in data submission.
             if (inputMethod == InputMethod.BULK && this != Phase.SUBMISSION) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -637,7 +637,7 @@ public class GenerateSidewaysView {
                 if (path.indexOf("/identity") >= 0) continue;
                 if (path.indexOf("/references") >= 0) continue;
                 PathHeader ph = fixPath(path, postFix);
-                if (ph.shouldHide()) {
+                if (ph == null || ph.shouldHide()) {
                     continue;
                 }
                 String fullPath = cldrFile.getFullXPath(path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -777,12 +777,7 @@ public class TestCheckCLDR extends TestFmwk {
                             ph,
                             dummyUserInfo);
 
-                        /*
-                         * TODO: if there is a reason to distinguish between SurveyToolStatus.HIDE and
-                         * SurveyToolStatus.DEPRECATED here, explain it with a comment; otherwise, call
-                         * ph.shouldHide() instead. Reference: https://unicode-org.atlassian.net/browse/CLDR-14877
-                         */
-                        if (surveyToolStatus == SurveyToolStatus.HIDE) {
+                        if (ph.shouldHide()) {
                             assertEquals("HIDE ==> FORBID_READONLY", StatusAction.FORBID_READONLY, action);
                         } else if (CheckCLDR.LIMITED_SUBMISSION) {
                             if (status == CheckStatus.Type.Error) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -357,20 +357,15 @@ public class TestPathHeader extends TestFmwkPlus {
                     continue;
                 }
 
-                PathHeader p = pathHeaderFactory.fromPath(path);
-                final SurveyToolStatus status = p.getSurveyToolStatus();
-                /*
-                 * TODO: is it intentional that SurveyToolStatus.DEPRECATED is distinguished from
-                 * SurveyToolStatus.HIDE here? If so, add a comment to make the intention clear; otherwise,
-                 * call PathHeader.shouldHide(). Reference: https://unicode-org.atlassian.net/browse/CLDR-14877
-                 */
-                if (status == SurveyToolStatus.DEPRECATED) {
+                PathHeader ph = pathHeaderFactory.fromPath(path);
+                if (ph == null || ph.shouldHide()) {
                     continue;
                 }
+                final SurveyToolStatus status = ph.getSurveyToolStatus();
                 sorted.put(
-                    p,
-                    locale + "\t" + status + "\t" + p + "\t"
-                        + p.getOriginalPath());
+                    ph,
+                    locale + "\t" + status + "\t" + ph + "\t"
+                        + ph.getOriginalPath());
             }
             Set<String> codes = new LinkedHashSet<>();
             PathHeader old = null;
@@ -673,7 +668,6 @@ public class TestPathHeader extends TestFmwkPlus {
             SurveyToolStatus.class);
         Set<String> nuked = new HashSet<>();
         Set<String> deprecatedStar = new HashSet<>();
-        Set<String> differentStar = new HashSet<>();
 
         for (String path : nativeFile.fullIterable()) {
 
@@ -686,30 +680,10 @@ public class TestPathHeader extends TestFmwkPlus {
                     + ": " + p);
             }
 
-            /*
-             * TODO: if the goal here is to treat SurveyToolStatus.DEPRECATED and SurveyToolStatus.HIDE
-             * the same for the purpose of this test, then call PathHeader.shouldHide(). Otherwise, add a
-             * comment to explain this mysterious code. Reference: https://unicode-org.atlassian.net/browse/CLDR-14877
-             */
-            final SurveyToolStatus tempSTS = surveyToolStatus == SurveyToolStatus.DEPRECATED ? SurveyToolStatus.HIDE
-                : surveyToolStatus;
             String starred = starrer.set(path);
             List<String> attr = starrer.getAttributes();
             if (surveyToolStatus != SurveyToolStatus.READ_WRITE) {
                 nuked.add(starred);
-            }
-
-            // check against old
-            SurveyToolStatus oldStatus = SurveyToolStatus.READ_WRITE;
-
-            if (tempSTS != oldStatus
-                && oldStatus != SurveyToolStatus.READ_WRITE
-                && !path.endsWith(APPEND_TIMEZONE_END)) {
-                if (!differentStar.contains(starred)) {
-                    errln("Different from old:\t" + oldStatus + "\tnew:\t"
-                        + surveyToolStatus + "\t" + path);
-                    differentStar.add(starred);
-                }
             }
 
             // check against deprecated


### PR DESCRIPTION
-Remove superfluous path exclusion checks for altProposed, /references

-Refactor and format DataSection.ensureComplete to clarify it only applies to timeZoneNames paths

-Use ph.shouldHide instead of SurveyToolStatus.DEPRECATED/HIDE where the distinction is unneeded

-Simplify code that had impossible conditions in TestPathHeader

-Fix deprecation warnings for SurveyLog, setCldrFileToCheck

-Comments, clean-up

CLDR-14877

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
