### PR TITLE
CLDR-15009 Fixed Unicode keyword type name definition  for colReorder

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1335,6 +1335,11 @@ annotations.
 			<type key="colNormalization" type="yes">Sort Unicode Normalized</type>
 			<type key="colNumeric" type="no">Sort Digits Individually</type>
 			<type key="colNumeric" type="yes">Sort Digits Numerically</type>
+			<type key="colReorder" type="currency">Currency</type>
+			<type key="colReorder" type="digit">Digits</type>
+			<type key="colReorder" type="punct">Punctuation</type>
+			<type key="colReorder" type="space">Whitespace</type>
+			<type key="colReorder" type="symbol">Symbol</type>
 			<type key="colStrength" type="identical">Sort All</type>
 			<type key="colStrength" type="primary">Sort Base Letters Only</type>
 			<type key="colStrength" type="quaternary">Sort Accents/Case/Width/Kana</type>
@@ -1410,11 +1415,6 @@ annotations.
 			<type key="k0" type="var">Keyboard Variant</type>
 			<type key="k0" type="viqr">Vietnamese VIQR Keyboard</type>
 			<type key="k0" type="windows">Windows Keyboard</type>
-			<type key="kr" type="currency">Currency</type>
-			<type key="kr" type="digit">Digits</type>
-			<type key="kr" type="punct">Punctuation</type>
-			<type key="kr" type="space">Whitespace</type>
-			<type key="kr" type="symbol">Symbol</type>
 			<type key="kv" type="currency">Ignore Symbols affects spaces, punctuation, all symbols</type>
 			<type key="kv" type="punct">Ignore Symbols affects spaces and punctuation only</type>
 			<type key="kv" type="space">Ignore Symbols affects spaces only</type>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -1302,6 +1302,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="collation" type="phonebook">↑↑↑</type>
 			<type key="collation" type="search">↑↑↑</type>
 			<type key="collation" type="standard">↑↑↑</type>
+			<type key="colReorder" type="currency">↑↑↑</type>
+			<type key="colReorder" type="digit">↑↑↑</type>
+			<type key="colReorder" type="punct">↑↑↑</type>
+			<type key="colReorder" type="space">↑↑↑</type>
+			<type key="colReorder" type="symbol">↑↑↑</type>
 			<type key="d0" type="ascii">↑↑↑</type>
 			<type key="d0" type="fwidth">↑↑↑</type>
 			<type key="d0" type="hwidth">↑↑↑</type>
@@ -1322,11 +1327,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="hc" type="h12">↑↑↑</type>
 			<type key="hc" type="h23">↑↑↑</type>
 			<type key="hc" type="h24">↑↑↑</type>
-			<type key="kr" type="currency">↑↑↑</type>
-			<type key="kr" type="digit">↑↑↑</type>
-			<type key="kr" type="punct">↑↑↑</type>
-			<type key="kr" type="space">↑↑↑</type>
-			<type key="kr" type="symbol">↑↑↑</type>
 			<type key="lb" type="loose">↑↑↑</type>
 			<type key="lb" type="normal">↑↑↑</type>
 			<type key="lb" type="strict">↑↑↑</type>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -1082,6 +1082,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="colNormalization" type="yes">↑↑↑</type>
 			<type key="colNumeric" type="no">↑↑↑</type>
 			<type key="colNumeric" type="yes">↑↑↑</type>
+			<type key="colReorder" type="currency">↑↑↑</type>
+			<type key="colReorder" type="digit">↑↑↑</type>
+			<type key="colReorder" type="punct">↑↑↑</type>
+			<type key="colReorder" type="space">↑↑↑</type>
+			<type key="colReorder" type="symbol">↑↑↑</type>
 			<type key="colStrength" type="identical">↑↑↑</type>
 			<type key="colStrength" type="primary">↑↑↑</type>
 			<type key="colStrength" type="quaternary">↑↑↑</type>
@@ -1155,11 +1160,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="k0" type="var">↑↑↑</type>
 			<type key="k0" type="viqr">↑↑↑</type>
 			<type key="k0" type="windows">↑↑↑</type>
-			<type key="kr" type="currency">↑↑↑</type>
-			<type key="kr" type="digit">↑↑↑</type>
-			<type key="kr" type="punct">↑↑↑</type>
-			<type key="kr" type="space">↑↑↑</type>
-			<type key="kr" type="symbol">↑↑↑</type>
 			<type key="kv" type="currency">↑↑↑</type>
 			<type key="kv" type="punct">↑↑↑</type>
 			<type key="kv" type="space">↑↑↑</type>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -1076,6 +1076,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="collation" type="ducet">↑↑↑</type>
 			<type key="collation" type="search">↑↑↑</type>
 			<type key="collation" type="standard">↑↑↑</type>
+			<type key="colReorder" type="currency">↑↑↑</type>
+			<type key="colReorder" type="digit">↑↑↑</type>
+			<type key="colReorder" type="punct">↑↑↑</type>
+			<type key="colReorder" type="space">↑↑↑</type>
+			<type key="colReorder" type="symbol">↑↑↑</type>
 			<type key="d0" type="ascii">↑↑↑</type>
 			<type key="d0" type="fwidth">↑↑↑</type>
 			<type key="d0" type="hwidth">↑↑↑</type>
@@ -1096,11 +1101,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="hc" type="h12">↑↑↑</type>
 			<type key="hc" type="h23">↑↑↑</type>
 			<type key="hc" type="h24">↑↑↑</type>
-			<type key="kr" type="currency">↑↑↑</type>
-			<type key="kr" type="digit">↑↑↑</type>
-			<type key="kr" type="punct">↑↑↑</type>
-			<type key="kr" type="space">↑↑↑</type>
-			<type key="kr" type="symbol">↑↑↑</type>
 			<type key="lb" type="loose">↑↑↑</type>
 			<type key="lb" type="normal">↑↑↑</type>
 			<type key="lb" type="strict">↑↑↑</type>


### PR DESCRIPTION
When colReorder type names were introduced in CLDR 30, `<type key="xxx">`  used new BCP47 key "kr", instead of "colReorder". By the definition, when old key is available, type display name definition should refer the old key, not BCP47 version. Fixed these definitions in en and some sublocales. There are no translations available in other locales.

CLDR-15009

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
