### PR TITLE
CLDR-15003 v40 BRS§A18

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -340,6 +340,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Buhid; ?; ? } => { Buhid; Latin; Philippines }-->
 		<likelySubtag from="bkv" to="bkv_Latn_ZZ"/>
 		<!--{ Bekwarra; ?; ? } => { Bekwarra; Latin; Unknown Region }-->
+		<likelySubtag from="blg" to="blg_Latn_MY"/>
+		<!--{ Balau; ?; ? } => { Balau; Latin; Malaysia }-->
 		<likelySubtag from="blt" to="blt_Tavt_VN"/>
 		<!--{ Tai Dam; ?; ? } => { Tai Dam; Tai Viet; Vietnam }-->
 		<likelySubtag from="bm" to="bm_Latn_ML"/>
@@ -3651,7 +3653,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Rjng" to="rej_Rjng_ID"/>
 		<!--{ ?; Rejang; ? } => { Rejang; Rejang; Indonesia }-->
 		<likelySubtag from="und_Rohg" to="rhg_Rohg_MM"/>
-		<!--{ ?; Hanifi Rohingya; ? } => { Rohingya; Hanifi Rohingya; Myanmar (Burma) }-->
+		<!--{ ?; Hanifi; ? } => { Rohingya; Hanifi; Myanmar (Burma) }-->
 		<likelySubtag from="und_Runr" to="non_Runr_SE"/>
 		<!--{ ?; Runic; ? } => { Old Norse; Runic; Sweden }-->
 		<likelySubtag from="und_Samr" to="smp_Samr_IL"/>


### PR DESCRIPTION
CLDR-15003

- [ ] This PR completes the ticket.

~Note: Draft because it actually depends on #1467  #1473~

I did _not_ make the following changes: (links go to PRs that introduced the original change).
GenerateMaximalLocales attempted the following, but I edited the results.
- Did not dropping default contents: `hnj_Hmnp_US` (#1267) 
- Did not change DC for ossetic from `os_GE` to `os_RU` (#676)
- Did not remove likely subtags for `rhg_Arab_MM` (#1254) and `hnj_Hmnp_US` ( #1267)
- Did not remove `<likelySubtag from="und_Cpmn_CY" to="und_Cpmn_CY"/>` (#1424 )

Still not clear what the right process is here.   Filed CLDR-15010 to track.
