### PR TITLE
CLDR-14748 GitHub annotations updates

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -1,12 +1,10 @@
 # Manually run: commit checker
-
 name: commit-checker
 
-# Triggered on push to master,
-# or PR against master.
 on:
   workflow_dispatch:
     inputs:
+      # NB: the version numbers don't need to be updated here, they are only examples.
       end-ref:
         description: CLDR Commit (e.g. master or maint/maint-38)
         required: true
@@ -23,7 +21,7 @@ on:
       tool-ref:
         description: Commit Checker ICU branch/tag
         required: true
-        default: 'master'
+        default: 'main'
 jobs:
   build:
     name: Run Checker
@@ -35,7 +33,7 @@ jobs:
           ref: ${{ github.event.inputs.end-ref }}
           lfs: false # not needed here
           path: cldr
-          fetch-depth: 0 # expensive, but needed for checker
+          fetch-depth: 0 # expensive, but we need history for the checker
       - name: clone ICU for tools
         uses: actions/checkout@v2
         with:
@@ -43,28 +41,35 @@ jobs:
           ref: ${{ github.event.inputs.tool-ref }}
           lfs: false # not needed here
           path: icu
-      #- name: Prepare Check
       - name: Run Check and Publish
         run: |
+          echo "::group::Setup Checker"
           END_HASH=$(cd ${GITHUB_WORKSPACE}/cldr ; git rev-parse --short HEAD )
           REPORT="CLDR-Report-"$(date +"%Y-%m-%d")-v38-${END_HASH}
           echo $REPORT
           cd icu/tools/commit-checker
           command -v pipenv >/dev/null 2>/dev/null || sudo pip3 install pipenv
           pipenv install
+          echo "::endgroup::"
+          echo "::group::Run Checker"
           pipenv run python3 check.py \
           --nocopyright \
           --jira-query "project=CLDR AND fixVersion=${FV}" \
           --repo-root ${GITHUB_WORKSPACE}/cldr \
           --github-url https://github.com/unicode-org/cldr \
           --rev-range "release-${LV}..${END_REF}" > ${GITHUB_WORKSPACE}/${REPORT}.md
+          echo "::endgroup::"
+          echo "::group::Format .html"
           cd ${GITHUB_WORKSPACE}
           wc -l ${REPORT}.md
           npx -p markdown-to-html markdown --flavor gfm --title ${REPORT} ${REPORT}.md -c unicode-org/cldr README.md --stylesheet github-markdown.css > ${REPORT}.html
+          echo "::endgroup::"
+          echo "::group::Publish Report"
           echo "${RSA_KEY_CCC}" > ${HOME}/.key && chmod go= ${HOME}/.key
           echo "${CCC_KNOWNHOSTS}" > ${HOME}/.knownhosts && chmod go= ${HOME}/.knownhosts
           ln ${REPORT}.md CLDR_REPORT.md # use a fixed name for the publish step
           scp -o UserKnownHostsFile=${HOME}/.knownhosts -i ${HOME}/.key -P ${CCC_PORT} ${REPORT}.md ${REPORT}.html ${CCC_USER}@${CCC_HOST}:public_html/
+          echo "::endgroup::"
           echo "Now go to https://cldr-smoke.unicode.org/cldrcc/${REPORT}.html"
         env:
           END_REF: ${{ github.event.inputs.end-ref }}


### PR DESCRIPTION
CLDR-14748

improvements to actions using github annotations.

Commit Checker:
- use ::group:: commands
- also fix ICU‘s branch to “main”
- bumped version numbers (not important)

TestFmwk
- emit Error: and Warning: doubly so it's searchable
- actual source locations for warnings and errors

ConsoleCheck

- actual source locations for warnings and errors


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
