### PR TITLE
CLDR-14607 deprecated gaza should NOT alias to Asia/Gaza but SHOULD have a preferred mapping to gazastrp

### DIFF
--- a/common/bcp47/timezone.xml
+++ b/common/bcp47/timezone.xml
@@ -176,7 +176,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="fotho" description="Faroe Islands" alias="Atlantic/Faeroe Atlantic/Faroe"/>
             <type name="frpar" description="Paris, France" alias="Europe/Paris"/>
             <type name="galbv" description="Libreville, Gabon" alias="Africa/Libreville"/>
-            <type name="gaza" description="Gaza Strip, Palestinian Territories" deprecated="true" alias="Asia/Gaza gazastrp"/>
+            <type name="gaza" description="Gaza Strip, Palestinian Territories" deprecated="true" preferred="gazastrp"/>
             <type name="gazastrp" description="Gaza Strip, Palestinian Territories" alias="Asia/Gaza"/>
             <type name="gblon" description="London, United Kingdom" alias="Europe/London Europe/Belfast GB GB-Eire"/>
             <type name="gdgnd" description="Grenada" alias="America/Grenada"/>


### PR DESCRIPTION
CLDR-14607

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

We had
```
    <type name="gaza" description="Gaza Strip, Palestinian Territories" deprecated="true" alias="Asia/Gaza gazastrp"/>
    <type name="gazastrp" description="Gaza Strip, Palestinian Territories" alias="Asia/Gaza"/>
```
but the first entry had two problems: the deprecated "gaza" short ID should not have the alias mapping to Asia/Gaza (that conflicts with the correct mapping from Asia/Gaza to gazastrp), and its reference to "gazastrp" should be via a preferred attribute, not an alias.
