### PR TITLE
CLDR-15024 get correct coverage information

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1274,7 +1274,7 @@ public class VettingViewer<T> {
 
         String value = sourceFile.getStringValue(path);
         Status status = new Status();
-        String sourceLocale = sourceFile.getSourceLocaleID(path, status); // does not skip inheritance marker
+        String sourceLocale = sourceFile.getSourceLocaleIdExtended(path, status, false); // does not skip inheritance marker
 
         boolean isAliased = !path.equals(status.pathWhereFound); // this was path.equals, which would be incorrect!
         if (DEBUG) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -1398,7 +1398,7 @@ public class TestUtilities extends TestFmwkPlus {
     public void TestMissingGrammar() {
         // https://cldr-smoke.unicode.org/cldr-apps/v#/hu/Length/a4915bf505ffb49
         final String path = "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"one\"][@case=\"accusative\"]";
-        checkGrammarCoverage("hr", path,    MissingStatus.ABSENT, DEBUG, 0, 0, 1, 1, 0);
+        checkGrammarCoverage("hr", path,    MissingStatus.PRESENT, DEBUG, 1, 0, 0, 0, 0); // this isn't a very good test, since we have to adjust each time. Should create fake cldr data instead
         checkGrammarCoverage("kw", path, MissingStatus.ABSENT, false, 0, 0, 1, 1, 0);
         checkGrammarCoverage("en_NZ", path, MissingStatus.ALIASED, DEBUG, 1, 0, 0, 0, 0);
     }
@@ -1415,7 +1415,7 @@ public class TestUtilities extends TestFmwkPlus {
         final MissingStatus expected = statusExpected;
         final MissingStatus status = VettingViewer.getMissingStatus(cldrFile, path, true /* latin */);
         if (status != expected) {
-            errln("Got getMissingStatus = " + status.toString() + "; expected " + expected.toString());
+            errln(locale + " got getMissingStatus = " + status.toString() + "; expected " + expected.toString());
         }
         Iterable<String> pathsToTest = Collections.singleton(path);
         Counter<org.unicode.cldr.util.Level> foundCounter = new Counter<>();
@@ -1425,11 +1425,11 @@ public class TestUtilities extends TestFmwkPlus {
         Set<String> unconfirmedPaths = new TreeSet<>();
         VettingViewer.getStatus(pathsToTest, cldrFile, PathHeader.getFactory(),
             foundCounter, unconfirmedCounter, missingCounter, missingPaths, unconfirmedPaths);
-        assertEquals(locale + " foundCounter", sizes[0], foundCounter.getTotal());
-        assertEquals(locale + " unconfirmedCounter", sizes[1], unconfirmedCounter.getTotal());
-        assertEquals(locale + " missingCounter", sizes[2], missingCounter.getTotal());
-        assertEquals(locale + " missingPaths", sizes[3], missingPaths.size());
-        assertEquals(locale + " unconfirmedPaths", sizes[4], unconfirmedPaths.size());
+        assertEquals(locale + " foundCounter (0)", sizes[0], foundCounter.getTotal());
+        assertEquals(locale + " unconfirmedCounter (1)", sizes[1], unconfirmedCounter.getTotal());
+        assertEquals(locale + " missingCounter (2)", sizes[2], missingCounter.getTotal());
+        assertEquals(locale + " missingPaths (3)", sizes[3], missingPaths.size());
+        assertEquals(locale + " unconfirmedPaths (4)", sizes[4], unconfirmedPaths.size());
         showStatusResults(locale, foundCounter, unconfirmedCounter, missingCounter, missingPaths, unconfirmedPaths);
         if (debug) {
             foundCounter.clear();


### PR DESCRIPTION
CLDR-15024

Note that the old comment says specifically "does not skip inheritance marker", but made a function call that **did** skip the inheritance marker.

Note that we would still have to change our process for generating charts, as in the ticket.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
