### PR TITLE
CLDR-14571 json: improve format of metazone short alias

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -1168,7 +1168,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST metazoneId longId CDATA #IMPLIED >
     <!--@MATCH:metazone-->
     <!--@VALUE-->
-    <!ATTLIST metazoneId deprecated (true | false) "false" >
+<!ATTLIST metazoneId deprecated (true | false) "false" >
     <!--@VALUE-->
 <!ATTLIST metazoneId preferred NMTOKEN #IMPLIED >
     <!--@MATCH:metazone-->

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1251,7 +1251,6 @@ public class Ldml2JsonConverter {
                     out.name(attrAsKey).value(v);
                 } // else, omit
             } else {
-                System.err.println(node.getUntransformedPath()+ "@BOOOOL@"+ node.getName() +":"+ node.getParent() +":"+ key+"="+rawAttrValue);
                 out.name(attrAsKey).value(value);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -597,7 +597,7 @@ class LdmlConvertRules {
             || (parent!=null && CHILD_VALUE_IS_SPACESEP_ARRAY.contains(parent));
     }
 
-    static final Set<String> BCP47_BOOLEAN_OMIT_FALSE = ImmutableSet.of(
+    static final Set<String> BOOLEAN_OMIT_FALSE = ImmutableSet.of(
         // attribute names within bcp47 that are booleans, but omitted if false.
         "deprecated"
     );
@@ -605,7 +605,7 @@ class LdmlConvertRules {
     // These attributes are booleans, and should be omitted if false
     public static final boolean attrIsBooleanOmitFalse(final String fullPath, final String nodeName, final String parent, final String key) {
         return (fullPath != null &&
-            (fullPath.startsWith("//ldmlBCP47/keyword/key") &&
-            BCP47_BOOLEAN_OMIT_FALSE.contains(key)));
+            (fullPath.startsWith("//supplementalData/metaZones/metazoneIds") &&
+            BOOLEAN_OMIT_FALSE.contains(key)));
     }
 }


### PR DESCRIPTION
CLDR-14571
- omit _deprecated:false (the default)
- use _deprecated: true (a boolean instead of string)
- remove debugging string

Also:
- CLDR-14607: whitespace fix in DTD

- [ ] This PR completes the ticket.

fyi @nordzilla 

Examples:

This under JSON package **cldr-core** supplemental/metaZones.json
```json
"supplemental": {
   "metaZones": {
      "metazoneIds": {
        "acre": {
          "_longId": "Acre",
          "_since": "40"
        },
        "afce": {
          "_longId": "Africa_Central",
          "_since": "40"
        },
        "afea": {
          "_longId": "Africa_Eastern",
          "_since": "40"
        }
    }
}
```

And a contrived example on incorrect data, just to show that other fields work:

```json
        "chil": {
          "_deprecated": true,
          "_longId": "Chile",
          "_preferred": "EST3CDT",
          "_since": "22"
        },
```

Note that `_deprecated`  is omitted unless `true` in which case it is a boolean.