### PR TITLE
CLDR-14642 json: bcp47 filenames and values

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -599,13 +599,14 @@ class LdmlConvertRules {
 
     static final Set<String> BOOLEAN_OMIT_FALSE = ImmutableSet.of(
         // attribute names within bcp47 that are booleans, but omitted if false.
-        "deprecated"
-    );
+        "deprecated");
 
     // These attributes are booleans, and should be omitted if false
     public static final boolean attrIsBooleanOmitFalse(final String fullPath, final String nodeName, final String parent, final String key) {
         return (fullPath != null &&
-            (fullPath.startsWith("//supplementalData/metaZones/metazoneIds") &&
-            BOOLEAN_OMIT_FALSE.contains(key)));
+            (fullPath.startsWith("//supplementalData/metaZones/metazoneIds") ||
+             fullPath.startsWith("//ldmlBCP47/keyword/key"))
+              &&
+            BOOLEAN_OMIT_FALSE.contains(key));
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -262,6 +262,15 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
     }
 
     /**
+     * Return BCP47 languageTag, using special rules for root
+     * @param locale
+     * @return
+     */
+    public static String toLanguageTag(final String locale) {
+        return getInstance(locale).toLanguageTag();
+    }
+
+    /**
      * Construct a CLDRLocale from a string with the full locale ID.
      * Internal, called by the factory function.
      *

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Timer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Timer.java
@@ -1,7 +1,15 @@
 package org.unicode.cldr.util;
 
+import java.util.Locale;
+
+import com.ibm.icu.impl.duration.DurationFormatter;
 import com.ibm.icu.text.DecimalFormat;
+import com.ibm.icu.text.MeasureFormat;
 import com.ibm.icu.text.NumberFormat;
+import com.ibm.icu.text.RelativeDateTimeFormatter;
+import com.ibm.icu.text.MeasureFormat.FormatWidth;
+import com.ibm.icu.util.Measure;
+import com.ibm.icu.util.MeasureUnit;
 import com.ibm.icu.util.ULocale;
 
 public final class Timer {
@@ -44,6 +52,14 @@ public final class Timer {
     @Override
     public String toString() {
         return nf.format(getDuration() / NANOS_PER_SECOND) + "s";
+    }
+
+    /**
+     * @return the duration as a measureformat string
+     */
+    public String toMeasureString() {
+        return MeasureFormat.getInstance(ULocale.ENGLISH, FormatWidth.SHORT)
+            .formatMeasures(new Measure(getNanoseconds(), MeasureUnit.NANOSECOND));
     }
 
     public String toString(Timer other) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_bcp47.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_bcp47.txt
@@ -1,1 +1,1 @@
-section=bcp47 ; path=//cldr/keyword/key/.* ; package=bcp47
+section=bcp47 ; path=//ldmlBCP47/keyword/[tu]/.* ; package=bcp47

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -26,6 +26,7 @@
 ## (Note: CLDR version is added in code)
 
 # Transform underscore to hyphen-minus in language keys
+# Does not produce valid bcp47, see Ldml2JsonConverter.fixXpathBcp47()
 < (.*/language\[@type="[a-z]{2,3})_([^"]*"\](\[@alt="short"])?)
 > $1-$2
 


### PR DESCRIPTION
- add a "-t all" that converts all types in one operation
- use a modern Timer for progress
- update progress messages
- modify some paths to use valid bcp47 values
- produce bcp47 locale ids for files, such as und, ca-ES-valencia, en-US-u-va-posix
- add a new tool option --bcp47=false which produces the old behavior (for compatibility)
- correct JSON_config_bcp47.txt (update to CLDR-14571)

CLDR-14642

- [X] This PR completes the ticket.