### PR TITLE
CLDR-14642 cldr-json: skip en-US-u-va-posix

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Timer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Timer.java
@@ -4,6 +4,7 @@ import java.util.Locale;
 
 import com.ibm.icu.impl.duration.DurationFormatter;
 import com.ibm.icu.text.DecimalFormat;
+import com.ibm.icu.text.DurationFormat;
 import com.ibm.icu.text.MeasureFormat;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.RelativeDateTimeFormatter;
@@ -58,8 +59,13 @@ public final class Timer {
      * @return the duration as a measureformat string
      */
     public String toMeasureString() {
+        double seconds = getSeconds();
+        double minutes = Math.floorDiv((int) seconds, 60);
+        seconds = seconds - (minutes * 60.0);
+
         return MeasureFormat.getInstance(ULocale.ENGLISH, FormatWidth.SHORT)
-            .formatMeasures(new Measure(getNanoseconds(), MeasureUnit.NANOSECOND));
+            .formatMeasures(new Measure(seconds, MeasureUnit.SECOND),
+                new Measure(minutes, MeasureUnit.MINUTE));
     }
 
     public String toString(Timer other) {


### PR DESCRIPTION
- skip locales with subtags (currently: en-US-u-va-posix)
This behavior is controlled by the -T option
- add a hasLocales() property to RunType, which could simplify
many if clauses
- fix Timer use to show min/sec instead of nanoseconds

CLDR-14642

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
