### PR TITLE
CLDR-14945 Abstain should not cause disappearance of inherited item

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
@@ -2080,6 +2080,12 @@ public class DataSection implements JSONString {
              * at http://localhost:8080/cldr-apps/v#/fr_CA/CAsia/
              *
              * getStringValue calls getFallbackPath which calls getRawExtraPaths which contains xpath
+             *
+             * However, we could get ourValue == null due to various bugs when in reality the path is NOT "extra",
+             * so this code is fragile and problematic. Possibly rename from isExtraPath to hasNullValue; possibly
+             * don't use extraXpaths at all; possibly change the code further below that depends on this
+             * boolean value...
+             * Reference: https://unicode-org.atlassian.net/browse/CLDR-14945
              */
             if (DEBUG) {
                 System.err.println("warning: populateFromThisXpath " + this + ": " + locale + ":" + xpath + " = NULL! wasExtraPath="
@@ -2103,6 +2109,10 @@ public class DataSection implements JSONString {
         CLDRFile.Status sourceLocaleStatus = new CLDRFile.Status();
         String sourceLocale = ourSrc.getSourceLocaleID(xpath, sourceLocaleStatus);
 
+        /**
+         * Dubious! The value could be inherited from another path in the same locale.
+         * "ourValueIsInherited" doesn't appear to mean what the name seems to imply.
+         */
         boolean ourValueIsInherited = !(sourceLocale.equals(locale.toString()));
 
         /*


### PR DESCRIPTION
-In voteForValue, call setValueFromResolver with resolveMorePaths true so vote resolution is not bypassed

-In setValueFromResolver, fix handling of Status.missing: no premature return, must update delegate

-Change setValueFromResolver from public to private since only called locally

-Change TestSTFactory.TestSparseVote to expect inheritance, not null

-Rename some variables in TestSTFactory.TestSparseVote

-Comments

CLDR-14945

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
