### PR TITLE
CLDR-14751 unit number prefixes

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3733,6 +3733,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 * **Part 3: [Numbers](tr35-numbers.md#Contents) (number & currency formatting)**
   * **Section 4 [Currencies](tr35-numbers.md#Currencies):**
     * Added notes on considerations for currency display names.
+* Units
+  * Allow for generative number prefixes, such as gallons-per-100-miles (CLDR-14751)[https://unicode-org.atlassian.net/browse/CLDR-14751]
 
 * Units
   * Add support for formatting currencies in units, such as curr-eur-per-square-meter


### PR DESCRIPTION
CLDR-14751

* Note that this doesn't remove the old Modifications; that is in a separate ticket
* Also, the syntax is different than originally proposed: see ticket

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
