### PR TITLE
CLDR-14976 update ICU4J libs to release-70-rc (use different but equivalent tag)

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>70.0.1-SNAPSHOT-cldr-2021-09-15</icu4j.version>
+		<icu4j.version>70.1-SNAPSHOT-cldr-2021-09-29</icu4j.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-14976

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Update IC4J libs in CLDR to ICU release-70-rc. Since for some reason that release-70-rc tag was not available in https://github.com/unicode-org/icu/packages/411079/versions (github action failure?), created a separate but equivalent ICU tag "cldr/2021-09-29" and used that instead.