### PR TITLE
CLDR-15081 sr[_Latn], revert grego format month names to nominative as in v39

### DIFF
--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -1538,18 +1538,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">д</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">јануара</month>
-							<month type="2">фебруара</month>
-							<month type="3">марта</month>
-							<month type="4">априла</month>
-							<month type="5">маја</month>
-							<month type="6">јуна</month>
-							<month type="7">јула</month>
-							<month type="8">августа</month>
-							<month type="9">септембра</month>
-							<month type="10">октобра</month>
-							<month type="11">новембра</month>
-							<month type="12">децембра</month>
+							<month type="1">јануар</month>
+							<month type="2">фебруар</month>
+							<month type="3">март</month>
+							<month type="4">април</month>
+							<month type="5">мај</month>
+							<month type="6">јун</month>
+							<month type="7">јул</month>
+							<month type="8">август</month>
+							<month type="9">септембар</month>
+							<month type="10">октобар</month>
+							<month type="11">новембар</month>
+							<month type="12">децембар</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -1467,18 +1467,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">d</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">januara</month>
-							<month type="2">februara</month>
-							<month type="3">marta</month>
-							<month type="4">aprila</month>
-							<month type="5">maja</month>
-							<month type="6">juna</month>
-							<month type="7">jula</month>
-							<month type="8">avgusta</month>
-							<month type="9">septembra</month>
-							<month type="10">oktobra</month>
-							<month type="11">novembra</month>
-							<month type="12">decembra</month>
+							<month type="1">januar</month>
+							<month type="2">februar</month>
+							<month type="3">mart</month>
+							<month type="4">april</month>
+							<month type="5">maj</month>
+							<month type="6">jun</month>
+							<month type="7">jul</month>
+							<month type="8">avgust</month>
+							<month type="9">septembar</month>
+							<month type="10">oktobar</month>
+							<month type="11">novembar</month>
+							<month type="12">decembar</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">


### PR DESCRIPTION
CLDR-15081

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

For sr and sr_Latn, revert the Gregorian-calendar format-style wide month names to nominative form, as in CLDR v39.