### PR TITLE
CLDR-14635 Update languageInfo to make en_CA and en_PH closer to en_US

### DIFF
--- a/common/supplemental/languageInfo.xml
+++ b/common/supplemental/languageInfo.xml
@@ -10,7 +10,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<languageMatching>
 		<languageMatches type="written_new">
 			<paradigmLocales locales="en en_GB es es_419 pt_BR pt_PT"/>
-			<matchVariable id="$enUS" value="AS+GU+MH+MP+PR+UM+US+VI"/>
+			<matchVariable id="$enUS" value="AS+CA+GU+MH+MP+PH+PR+UM+US+VI"/>
 			<matchVariable id="$cnsar" value="HK+MO"/>
 			<matchVariable id="$americas" value="019"/>
 			<matchVariable id="$maghreb" value="MA+DZ+TN+LY+MR+EH"/>


### PR DESCRIPTION
CLDR-14635 Philippines English ...
(and CLDR-14544 Canadian English should fallback to en instead of en-GB)

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

The two tickets above are about making en_CA and en_PH closer to en[_US] than to en_001/en_GB (both for formats and for vocabulary/orthography). The original PRs for those tickets changed the supplemental parentLocales for en_CA/en_PH but dit not change the Language Matcher data; this PR fixes that to also update the Language Matcher data.

Amazingly, this did not require any CLDR unit test updates (though we have a ticket to add tests specifically for this: https://unicode-org.atlassian.net/browse/CLDR-15082)