### PR TITLE
CLDR-14971 update spec mods for intervalFmts repeat fields clarification

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -6,7 +6,7 @@
 <table><tbody>
 <tr><td>Version</td><td>40</td></tr>
 <tr><td>Editors</td><td>Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a></td></tr>
-<tr><td>Date</td><td>2021-05-17</td></tr>
+<tr><td>Date</td><td>2021-10-05</td></tr>
 <tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-64/tr35.html">https://www.unicode.org/reports/tr35/tr35-64/tr35.html</a></td></tr>
 <tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-63/tr35.html">https://www.unicode.org/reports/tr35/tr35-63/tr35.html</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>
@@ -3717,6 +3717,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 * Locale Identifiers
   * Extended the minimum support size for locale and language identifiers to 255 (CLDR-13729)[https://unicode-org.atlassian.net/browse/CLDR-13729]
 	* Provided an explanation for the use of alphabetical order of variants (CLDR-13729)[https://unicode-org.atlassian.net/browse/CLDR-13729]
+* Dates
+  * In [Element intervalFormats](tr35-dates.md#intervalFormats), clarified that when determining the repeating field of an interval pattern, standalone and format fields are considered equivalent. (CLDR-14971)[https://unicode-org.atlassian.net/browse/CLDR-14971] 
 * Units
   * Allowed for generative number prefixes, such as gallons-per-100-miles (CLDR-14751)[https://unicode-org.atlassian.net/browse/CLDR-14751]
   * Added support for formatting currencies in units, such as curr-eur-per-square-meter (CLDR-14676)[https://unicode-org.atlassian.net/browse/CLDR-14676]


### PR DESCRIPTION
CLDR-14971

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This just updates the spec mods section to reflect the body changes made in https://github.com/unicode-org/cldr/pull/1428 (clarifying that when determining the repeating field of an interval pattern, standalone and format fields are considered equivalent).