### PR TITLE
CLDR-15076 Add tz 2021b new zone ID Pacific/Kanton as an alias of kip…

### DIFF
--- a/common/bcp47/timezone.xml
+++ b/common/bcp47/timezone.xml
@@ -229,7 +229,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="kgfru" description="Bishkek, Kyrgyzstan" alias="Asia/Bishkek"/>
             <type name="khpnh" description="Phnom Penh, Cambodia" alias="Asia/Phnom_Penh"/>
             <type name="kicxi" description="Kiritimati, Kiribati" alias="Pacific/Kiritimati"/>
-            <type name="kipho" description="Enderbury Island, Kiribati" alias="Pacific/Enderbury"/>
+            <type name="kipho" description="Enderbury Island, Kiribati" alias="Pacific/Enderbury Pacific/Kanton"/>
             <type name="kitrw" description="Tarawa, Kiribati" alias="Pacific/Tarawa"/>
             <type name="kmyva" description="Comoros" alias="Indian/Comoro"/>
             <type name="knbas" description="Saint Kitts" alias="America/St_Kitts"/>


### PR DESCRIPTION
…ho (Pacific/Enderbury)

CLDR-15076

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
