### PR TITLE
CLDR-15056 Coverage Progress Bars, front end beginnings

### DIFF
--- a/tools/cldr-apps/js/src/cldrVueRouter.js
+++ b/tools/cldr-apps/js/src/cldrVueRouter.js
@@ -56,6 +56,17 @@ function showPanel(type, el, opts) {
  * Handle a coverage level change.
  * @param {String} newLevel new coverage level
  * @returns true if handled
+ *
+ * Note: this mechanism is limited to the "most recent" Vue component (lastRoot).
+ * It may work for some "special page" components that are shown only one at a
+ * time. As it stands, it isn't suitable for general components such as widgets.
+ *
+ * Compare cldrLoad.handleCoverageChanged, which is somewhat more general; how does it
+ * compare to this function (cldrVueRouter.handleCoverageChanged), and do we need both?
+ *
+ * Note: cldrBundle.handleCoverageChanged is the same as cldrVueRouter.handleCoverageChanged
+ *
+ * Compare cldrGenericVue.handleCoverageChanged which calls cldrBundle.handleCoverageChanged
  */
 function handleCoverageChanged(newLevel) {
   if (!lastRoot || !lastRoot.handleCoverageChanged) {

--- a/tools/cldr-apps/js/src/esm/cldrAjax.js
+++ b/tools/cldr-apps/js/src/esm/cldrAjax.js
@@ -5,9 +5,25 @@ import * as cldrStatus from "./cldrStatus.js";
 
 const ST_AJAX_DEBUG = true;
 
+/**
+ * Call the standard js fetch function, possibly with additional handling suitable
+ * for Survey Tool such as setting session headers and debugging
+ *
+ * Session headers are automatically added unless init.headers is already set
+ *
+ * @param {String} resource the url or other resource, or Request object
+ * @param {Object} init an object containing any custom settings for the request
+ * @returns a Promise that resolves to a Response object
+ */
 function doFetch(resource, init) {
   if (ST_AJAX_DEBUG) {
     console.log("cldrAjax.doFetch: " + resource);
+  }
+  if (!init) {
+    init = {};
+  }
+  if (!init.headers) {
+    init.headers = cldrStatus.sessionHeaders();
   }
   return fetch(resource, init);
 }

--- a/tools/cldr-apps/js/src/esm/cldrGenericVue.js
+++ b/tools/cldr-apps/js/src/esm/cldrGenericVue.js
@@ -20,7 +20,7 @@ function load(specialPage) {
  * @returns true if the change was handled
  */
 function handleCoverageChanged(newLevel) {
-  return cldrBundle.handleCoverageChanged(newLevel);
+  return cldrBundle.handleCoverageChanged(newLevel); // = cldrVueRouter.handleCoverageChanged
 }
 
 function loadHandler(json, specialPage) {

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -533,29 +533,36 @@ function reloadV() {
 } // end reloadV
 
 /**
- * The coverage level changed. Pass this off to the Vue component or the Special page.
+ * The coverage level changed. Pass this off to the Vue component(s) or the Special page(s).
  * @param {String} newLevel
  * @returns true if the change was handled.
+ *
+ * This works for some "special pages" (of which it is assumed no more than one can exist
+ * simultaneously). It also works for certain components that are not "special pages",
+ * but rather "widgets" such as DashboardWidget.vue.
+ *
+ * TODO: does any caller really need to know "if the change was handled"? If so,
+ * explain, and revise updateWidgetsWithCoverage to return that boolean; otherwise
+ * simplify all "handleCoverageChanged" functions -- no need for boolean return
  */
 function handleCoverageChanged(newLevel) {
   const currentSpecial = cldrStatus.getCurrentSpecial();
+  let anyChangeWasHandled = false;
   if (currentSpecial) {
     const special = getSpecial(currentSpecial);
     if (
       special.handleCoverageChanged &&
       special.handleCoverageChanged(newLevel)
     ) {
-      return true;
-    }
-    if (isReport(currentSpecial)) {
+      anyChangeWasHandled = true;
+    } else if (isReport(currentSpecial)) {
       // Cause the page to reload.
       reloadV();
-      return true;
+      anyChangeWasHandled = true;
     }
-  } else {
-    cldrGui.updateDashboardCoverage(newLevel);
   }
-  return false;
+  cldrGui.updateWidgetsWithCoverage(newLevel);
+  return anyChangeWasHandled;
 }
 
 function ignoreReloadRequest() {

--- a/tools/cldr-apps/js/src/esm/cldrRetry.js
+++ b/tools/cldr-apps/js/src/esm/cldrRetry.js
@@ -45,7 +45,7 @@ function handleDisconnect(why, json, word, what) {
 
   // window.location.href = "#retry"; // load() will be called
   // Instead of looping via #retry, simply remount 'retry' directly
-  cldrGenericVue.load('retry_inplace');
+  cldrGenericVue.load("retry_inplace");
 }
 
 // called as special.load

--- a/tools/cldr-apps/js/src/esm/cldrVote.js
+++ b/tools/cldr-apps/js/src/esm/cldrVote.js
@@ -121,7 +121,7 @@ function handleWiredClick(tr, theRow, vHash, box, button) {
     "Vote for " + tr.rowHash + " v='" + vHash + "', value='" + value + "'"
   );
   var ourContent = {
-    what: "submit", /* cf. WHAT_SUBMIT in SurveyAjax.java */
+    what: "submit" /* cf. WHAT_SUBMIT in SurveyAjax.java */,
     xpath: tr.xpathId,
     _: cldrStatus.getCurrentLocale(),
     fhash: tr.rowHash,

--- a/tools/cldr-apps/js/src/getCldrOpts.js
+++ b/tools/cldr-apps/js/src/getCldrOpts.js
@@ -1,4 +1,3 @@
-import { useCssModule } from "@vue/runtime-dom";
 import * as cldrEvent from "./esm/cldrEvent.js";
 import * as cldrLoad from "./esm/cldrLoad.js";
 import * as cldrStatus from "./esm/cldrStatus.js";
@@ -7,11 +6,12 @@ import * as cldrSurvey from "./esm/cldrSurvey.js";
 function getCldrOpts() {
   const locale = cldrStatus.getCurrentLocale();
   const locmap = cldrLoad.getTheLocaleMap();
-  let localeInfo = null;
   let localeDir = null;
   if (locale) {
-    localeInfo = locmap.getLocaleInfo(locale);
-    localeDir = localeInfo.dir;
+    const localeInfo = locmap.getLocaleInfo(locale);
+    if (localeInfo) {
+      localeDir = localeInfo.dir;
+    }
   }
   return {
     // modules
@@ -23,7 +23,6 @@ function getCldrOpts() {
     // additional variables
     locale,
     locmap,
-    localeInfo,
     localeDir,
     sessionId: cldrStatus.getSessionId(),
   };

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -210,6 +210,10 @@ export default {
     },
 
     fetchData() {
+      if (!cldrStatus.getSurveyUser()) {
+        this.fetchErr = "Please log in to see the Dashboard.";
+        return;
+      }
       this.locale = cldrStatus.getCurrentLocale();
       this.level = cldrCoverage.effectiveName(this.locale);
       if (!this.locale || !this.level) {
@@ -218,8 +222,13 @@ export default {
       }
       this.localeName = cldrLoad.getLocaleName(this.locale);
       this.loadingMessage = `Loading ${this.localeName} dashboard at ${this.level} level`;
+      this.reallyFetch();
+    },
+
+    reallyFetch() {
+      const url = `api/summary/dashboard/${this.locale}/${this.level}`;
       cldrAjax
-        .doFetch(this.getUrl())
+        .doFetch(url)
         .then((response) => {
           if (!response.ok) {
             throw Error(response.statusText);
@@ -235,13 +244,6 @@ export default {
           console.error("Error loading Dashboard data: " + err);
           this.fetchErr = err;
         });
-    },
-
-    getUrl() {
-      const api = `summary/dashboard/${this.locale}/${this.level}`;
-      const p = new URLSearchParams();
-      p.append("session", cldrStatus.getSessionId());
-      return cldrAjax.makeApiUrl(api, p);
     },
 
     /**

--- a/tools/cldr-apps/js/src/views/VettingParticipation2.vue
+++ b/tools/cldr-apps/js/src/views/VettingParticipation2.vue
@@ -15,10 +15,10 @@
 
 <script>
 import { ref } from "vue";
+import * as cldrAjax from "../esm/cldrAjax.js";
 import * as cldrStatus from "../esm/cldrStatus.js";
 import * as localesTxtGenerator from "../esm/localesTxtGenerator.mjs";
-import * as cldrAjax from "../esm/cldrAjax.js";
-const fetch = cldrAjax.doFetch; // shadow global fetch
+
 export default {
   setup() {
     return {
@@ -32,9 +32,7 @@ export default {
     async fetchData() {
       try {
         this.loading = true;
-        const raw = await fetch(`api/voting/participation`, {
-          headers: cldrStatus.sessionHeaders(),
-        });
+        const raw = await cldrAjax.doFetch("api/voting/participation");
         this.participationData = await raw.json();
         this.localeTxt = localesTxtGenerator
           .generateLocalesTxt(this.participationData)

--- a/tools/cldr-apps/js/src/views/VotingCompletion.vue
+++ b/tools/cldr-apps/js/src/views/VotingCompletion.vue
@@ -1,0 +1,110 @@
+<template>
+  <span id="CompletionSection" v-if="!hide">
+    <span v-if="fetchErr" class="st-sad">{{ fetchErr }}</span>
+    <span v-if="total < 0 && !fetchErr"><a-spin></a-spin> </span>
+    <span
+      :title="
+        'Voting Completion (locale: ' +
+        localeName +
+        '; coverage: ' +
+        level +
+        ')'
+      "
+      >Votes: {{ votes }} / Total: {{ total }}</span
+    >
+  </span>
+</template>
+
+<script>
+import * as cldrAjax from "../esm/cldrAjax.js";
+import * as cldrCoverage from "../esm/cldrCoverage.js";
+import * as cldrLoad from "../esm/cldrLoad.js";
+import * as cldrStatus from "../esm/cldrStatus.js";
+
+export default {
+  props: [],
+  data() {
+    return {
+      hide: true,
+      total: -1,
+      votes: -1,
+      fetchErr: null,
+      locale: null,
+      localeName: null,
+      level: null,
+    };
+  },
+
+  created() {
+    this.fetchData();
+  },
+
+  methods: {
+    handleCoverageChanged(level) {
+      console.log("Completion changing level: " + level);
+      this.fetchData();
+      return true;
+    },
+
+    fetchData() {
+      if (!cldrStatus.getSurveyUser()) {
+        this.hide = true;
+        return;
+      }
+      this.hide = false;
+      const locale = cldrStatus.getCurrentLocale();
+      if (!locale) {
+        this.fetchErr = "(no locale)";
+        return;
+      }
+      const level = cldrCoverage.effectiveName(locale);
+      if (!level) {
+        this.fetchErr = "(no level)";
+        return;
+      }
+      this.locale = locale;
+      this.level = level;
+      this.localeName = cldrLoad.getLocaleName(this.locale);
+      this.reallyFetch();
+    },
+
+    reallyFetch() {
+      const url = `api/completion/voting/${this.locale}/${this.level}`;
+      cldrAjax
+        .doFetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            throw Error(response.statusText);
+          }
+          return response;
+        })
+        .then((data) => data.json())
+        .then((data) => {
+          this.votes = data.votes;
+          this.total = data.total;
+        })
+        .catch((err) => {
+          console.error("Error loading Completion data: " + err);
+          this.fetchErr = err;
+        });
+    },
+  },
+
+  computed: {
+    console: () => console,
+  },
+};
+</script>
+
+<style scoped>
+#CompletionSection {
+  border: 1px solid purple;
+  font-size: small;
+}
+
+.st-sad {
+  font-style: italic;
+  border: 1px dashed red;
+  color: darkred;
+}
+</style>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -97,13 +98,9 @@ public class Summary {
         }
     )
     public Response getDashboard(
-        @QueryParam("session") @Schema(required = true, description = "Session ID")
-        String session,
-        @PathParam("locale") @Schema(required = true, description = "Locale ID")
-        String locale,
-        @PathParam("level") @Schema(required = true, description = "Coverage Level")
-        String level
-    ) {
+        @PathParam("locale") @Schema(required = true, description = "Locale ID") String locale,
+        @PathParam("level") @Schema(required = true, description = "Coverage Level") String level,
+        @HeaderParam(Auth.SESSION_HEADER) String session) {
         CLDRLocale loc = CLDRLocale.getInstance(locale);
         CookieSession cs = Auth.getSession(session);
         if (cs == null) {


### PR DESCRIPTION
-New widget component VotingCompletion.vue, which gets data from api

-Extend cldrGui to insert new widget, generalizing from dashboard

-New widget depends on boolean GUI_HAS_COMPLETION_WIDGET, false until ready for production

-Enhance cldrAjax.doFetch to add session headers automatically; simplify some of its callers

-Revise Summary.java so Dashboard uses Auth.SESSION_HEADER

-Improve Dashboard message, if not logged in: Please log in...

-Remove unused import useCssModule

-Remove unneeded localeInfo, which gave TypeError; use local variable instead

-Format js

-Comments, including questions about handleCoverageChanged

CLDR-15056

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
