### PR TITLE
CLDR-13729 doc: BCP47 Truncation: typo

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -451,7 +451,7 @@ _Examples:_
 
 ##### Truncation
 
-BCP47 allows requires that implementations allow for language tags of at least 35 characters, in [Section 4.1.1](https://tools.ietf.org/search/bcp47#section-4.4.1).
+BCP47 requires that implementations allow for language tags of at least 35 characters, in [Section 4.1.1](https://tools.ietf.org/search/bcp47#section-4.4.1).
 To allow for use of extensions, CLDR extends that minimum to 255 for Unicode locale identifiers.
 Theoretically, a language tag could be far longer, due to the possibility of a large number of variants and extensions.
 In practice, the typical size of a locale or language identifier will be much smaller, so implementations can optimize for smaller sizes, as long as there is an escape mechanism allowing for up to 255.


### PR DESCRIPTION
CLDR-13729

- [X] This PR completes the ticket.

Typo from https://github.com/unicode-org/cldr/pull/1514/files#r732118623 (I see there are other PRs going into maint-40 still, so we could reopen the ticket if need be?)