### PR TITLE
CLDR-14976 update ICU4J libs to get post-70rc fixes; update doc dates

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -6,7 +6,7 @@
 <table><tbody>
 <tr><td>Version</td><td>40</td></tr>
 <tr><td>Editors</td><td>Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a></td></tr>
-<tr><td>Date</td><td>2021-10-18</td></tr>
+<tr><td>Date</td><td>2021-10-19</td></tr>
 <tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-64/tr35.html">https://www.unicode.org/reports/tr35/tr35-64/tr35.html</a></td></tr>
 <tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-63/tr35.html">https://www.unicode.org/reports/tr35/tr35-63/tr35.html</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>

--- a/readme.html
+++ b/readme.html
@@ -12,7 +12,7 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 40</h3>
-    <p>Last updated: 2021-Oct-14</p>
+    <p>Last updated: 2021-Oct-19</p>
 
     <!--<p><b>Note:</b> CLDR 40 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 40, intended for those wishing to do pre-release testing.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>70.1-SNAPSHOT-cldr-2021-09-29</icu4j.version>
+		<icu4j.version>70.1-cldr-2021-10-19</icu4j.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-14976

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Update ICU4J libs in CLDR to get post-70rc bug fixes in ICU. Also update document dates in CLDR.