### PR TITLE
CLDR-14717 json: fix repeat keys

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -20,7 +20,7 @@ section=calendarData ; path=//cldr/supplemental/calendarData/.* ; package=core
 section=calendarPreferenceData ; path=//cldr/supplemental/calendarPreferenceData/.* ; package=core
 section=unitPreferenceData ; path=//cldr/supplemental/unitPreferenceData/.* ; package=core
 section=grammaticalFeatures ; path=//cldr/supplemental/(grammaticalData)/.* ; package=core
-section=grammaticalGenderFeatures ; path=//cldr/supplemental/(grammaticalGenderData).* ; package=core
+#section=grammaticalGenderFeatures ; path=//cldr/supplemental/(grammaticalGenderData).* ; package=core
 section=weekData ; path=//cldr/supplemental/weekData/.* ; package=core
 section=timeData ; path=//cldr/supplemental/timeData/.* ; package=core
 section=measurementData ; path=//cldr/supplemental/measurementData/.* ; package=core

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -143,8 +143,8 @@
 > $1/$2/$4/default$5
 
 # Grammar : put grammaticalGender into a separate section
-< (.*)/(grammaticalData)/(.*)/(grammaticalGender)(.*)$
-> $1/grammaticalGenderData/$3/$4$5
+#< (.*)/(grammaticalData)/(.*)/(grammaticalGender)(.*)$
+#> $1/grammaticalGenderData/$3/$4$5
 
 # BCP47 (No extension, assume 'u')
 < (.*)/(keyword)/(key)\[@name="([^"]*)"\](.*)$


### PR DESCRIPTION
Rewrite output section completely to avoid dups

- use JsonObject instead of JsonWriter, using pseudo-jsonpath
- exclude `<language type="root"/>` explicitly from bcp47-strict output
- remove grammaticalGenderFeatures.json
  it's now folded (back) into grammaticalFeatures.json (where it belongs)

CLDR-14717

- [ ] This PR completes the ticket.