### PR TITLE
CLDR-15113 json: fix repeat keys in dateTime

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -34,6 +34,10 @@
 < (.*/ellipsis)\[@type="([^"]*)"\](.*)$
 > $1/$2$3
 
+# move datetimeSkeleton to a separate path
+< (.*/calendars)/calendar\[@type="([^"]*)"\](.*)Length\[@type="([^"]*)"\]/(date|time|dateTime)Format\[@type="([^"]*)"\]/datetimeSkeleton(.*)
+> $1/$2/$5Formats/$4-datetimeSkeleton$7
+
 # Remove unnecessary dateFormat/pattern
 < (.*/calendars)/calendar\[@type="([^"]*)"\](.*)Length\[@type="([^"]*)"\]/(date|time|dateTime)Format\[@type="([^"]*)"\]/pattern\[@type="([^"]*)"\](.*)
 > $1/$2/$5Formats/$4$8


### PR DESCRIPTION
- move 'datetimeSkeleton' elements to for eample 'full-datetimeSkeleton'
- does NOT address all dup keys, see CLDR-14717 ( and #1551)

CLDR-15113

- [X] This PR completes the ticket.

Updated format. The "-datetimeSkeleton" part MAY change later.

```json
            "dateFormats": {
              "full": "EEEE, MMMM d, y G",
              "full-datetimeSkeleton": "GyMMMMEEEEd",
              "long": "MMMM d, y G",
              "long-datetimeSkeleton": "GyMMMMd",
              "medium": "MMM d, y G",
              "medium-datetimeSkeleton": "GyMMMd",
              "short": "M/d/y GGGGG",
              "short-datetimeSkeleton": "GGGGGyMd"
```

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
