### PR TITLE
CLDR-13731 Report in ConsoleCheck if alt without non-alt

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -869,6 +869,7 @@ function chgPage(shift) {
   }
   cldrStatus.setCurrentSection(menus[parentIndex].id);
   cldrStatus.setCurrentPage(menus[parentIndex].pagesFiltered[index].id);
+  cldrStatus.setCurrentId(null);
 
   cldrLoad.reloadV();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAlt.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAlt.java
@@ -35,31 +35,6 @@ public class CheckAlt extends CheckCLDR {
         if (otherValue != null) {
             return this;
         }
-        // String localeID = getCldrFileToCheck().getSourceLocaleID(path, null);
-        // if (!localeID.equals(getCldrFileToCheck().getLocaleID())) {
-        // return this; // must be same file
-        // }
-        // if (!status.pathWhereFound.equals(path)) return this; // must be unaliased
-
-        // if (fullPath.contains("x999")) {
-        // result.add(new CheckStatus().setCause(this).setType(CheckStatus.warningType)
-        // .setMessage("There was a conflict introduced as a result of fixing default contents: please pick among the values or add a corrected value.",
-        // new Object[]{}));
-        // }
-
-        // String strippedPath = removeProposed(path);
-        // if (strippedPath.equals(path)) return this; // happened to match "proposed" but wasn't in 'alt';
-        //
-        // localeID = getCldrFileToCheck().getSourceLocaleID(strippedPath, null);
-        // // if localeID is null, or if it is CODE_FALLBACK_ID or root, we have a potential problem.
-        // if (localeID == null || localeID.equals(XMLSource.CODE_FALLBACK_ID)) { // || localeID.equals("root")
-        // String message = strippedPath;
-        // boolean checkOnSubmit = true;
-
-        // if (seenSoFar.contains(strippedPath)) {
-        // message += "MULTIPLE! ";
-        // checkOnSubmit = false;
-        // }
         result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.warningType)
             .setSubtype(Subtype.noUnproposedVariant)
             .setCheckOnSubmit(false)
@@ -68,29 +43,6 @@ public class CheckAlt extends CheckCLDR {
 
         return this;
     }
-
-    // private String removeProposed(String path) {
-    // parts.set(path);
-    // for (int i = 0; i < parts.size(); ++i) {
-    // Map attributes = parts.getAttributes(i);
-    // for (Iterator it = attributes.keySet().iterator(); it.hasNext();) {
-    // String attribute = (String) it.next();
-    // if (!attribute.equals("alt")) continue;
-    // String attributeValue = (String) attributes.get(attribute);
-    // int pos = attributeValue.indexOf("proposed");
-    // if (pos < 0) continue;
-    // if (pos > 0 && attributeValue.charAt(pos-1) == '-') --pos; // backup for "...-proposed"
-    // if (pos == 0) {
-    // attributes.remove(attribute);
-    // continue;
-    // }
-    // attributeValue = attributeValue.substring(0,pos); // strip it off
-    // attributes.put(attribute, attributeValue);
-    // }
-    // }
-    // String strippedPath = parts.toString();
-    // return strippedPath;
-    // }
 
     @Override
     public CheckCLDR setCldrFileToCheck(CLDRFile cldrFileToCheck, Options options,
@@ -108,27 +60,4 @@ public class CheckAlt extends CheckCLDR {
         seenSoFar.clear();
         return this;
     }
-    // Matcher myLocalePlus = PatternCache.get(cldrFileToCheck.getLocaleID() + "_[^_]*").matcher("");
-    // Set children = cldrFileToCheck.getAvailableLocales();
-    // List iChildren = new ArrayList();
-    // for (Iterator it = children.iterator(); it.hasNext();) {
-    // String locale = (String)it.next();
-    // if (!myLocalePlus.reset(locale).matches()) continue;
-    // CLDRFile child = cldrFileToCheck.make(locale, true);
-    // if (child == null) {
-    // CheckStatus item = new CheckStatus().setCause(this).setType(CheckStatus.errorType)
-    // .setMessage("Null file from: {0}", new Object[]{locale});
-    // possibleErrors.add(item);
-    // } else {
-    // iChildren.add(child);
-    // }
-    // }
-    // if (iChildren.size() == 0) immediateChildren = null;
-    // else {
-    // immediateChildren = new CLDRFile[iChildren.size()];
-    // immediateChildren = (CLDRFile[]) iChildren.toArray(immediateChildren);
-    // }
-    // return this;
-    // }
-
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAltOnly.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAltOnly.java
@@ -1,0 +1,71 @@
+package org.unicode.cldr.test;
+
+import java.util.List;
+
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.XPathParts;
+
+/**
+ * Check whether a path with alt is present but the corresponding path without alt is missing
+ */
+public class CheckAltOnly extends FactoryCheckCLDR {
+
+    private final static String message = "A path with alt is present but the corresponding path without alt is missing";
+
+    public CheckAltOnly(Factory factory) {
+        super(factory);
+    }
+
+    @Override
+    public CheckCLDR handleCheck(String path, String fullPath, String value,
+        Options options, List<CheckStatus> result) {
+
+        if (path == null || fullPath == null || path.indexOf("[@alt=") <= 0) {
+            return this;
+        }
+        final CLDRFile file = getCldrFileToCheck();
+        final String localeId = file.getLocaleID();
+        if ("root".equals(localeId)) {
+            return this;
+        }
+        if (!file.isHere(path)) {
+            return this;
+        }
+        final String nonAltPath = XPathParts.getPathWithoutAlt(path);
+        if (file.isHere(nonAltPath)) {
+            return this;
+        }
+        if (isPresentInParent(nonAltPath, localeId)) {
+            return this;
+        }
+        if (file.getConstructedValue(nonAltPath) != null) {
+            return this;
+        }
+        final CheckStatus item = new CheckStatus()
+            .setCause(this)
+            .setMainType(CheckStatus.errorType)
+            .setSubtype(Subtype.missingNonAltPath)
+            .setMessage(message);
+        result.add(item);
+        return this;
+    }
+
+    /**
+     * Is the given path present in a parent non-root locale?
+     *
+     * @param nonAltPath
+     * @param childLocaleId
+     * @return true if present in parent, else false
+     */
+    private Boolean isPresentInParent(String nonAltPath, String childLocaleId) {
+        final String parentLocaleId = LocaleIDParser.getParent(childLocaleId);
+        if (parentLocaleId == null || "root".equals(parentLocaleId)) {
+            return false;
+        }
+        final CLDRFile parentCldrFile = getFactory().make(parentLocaleId, true);
+        return parentCldrFile.isHere(nonAltPath);
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -589,6 +589,7 @@ abstract public class CheckCLDR {
             .add(new CheckMetazones())
             .add(new CheckLogicalGroupings(factory))
             .add(new CheckAlt())
+            .add(new CheckAltOnly(factory))
             .add(new CheckCurrencies())
             .add(new CheckCasing())
             .add(new CheckConsistentCasing(factory)) // this doesn't work; many spurious errors that user can't correct
@@ -728,7 +729,8 @@ abstract public class CheckCLDR {
             invalidPlaceHolder, asciiQuotesNotAllowed, badMinimumGroupingDigits, inconsistentPeriods,
             inheritanceMarkerNotAllowed, invalidDurationUnitPattern, invalidDelimiter, illegalCharactersInPattern,
             badParseLenient, tooManyValues, invalidSymbol, invalidGenderCode,
-            mismatchedUnitComponent, longPowerWithSubscripts, gapsInPlaceholderNumbers, duplicatePlaceholders, largerDifferences
+            mismatchedUnitComponent, longPowerWithSubscripts, gapsInPlaceholderNumbers, duplicatePlaceholders, largerDifferences,
+            missingNonAltPath
             ;
 
             @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -89,16 +89,13 @@ import com.ibm.icu.util.ULocale;
 description = "Run CheckCLDR against CLDR data")
 public class ConsoleCheckCLDR {
     private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
-    private static final PathHeader.Factory PATH_HEADER_FACTORY = PathHeader.getFactory();
     public static boolean showStackTrace = false;
     public static boolean errorsOnly = false;
     static boolean SHOW_LOCALE = true;
     static boolean SHOW_EXAMPLES = false;
-    // static PrettyPath prettyPathMaker = new PrettyPath();
     private static boolean CLDR_GITHUB_ANNOTATIONS = (Boolean.parseBoolean(System.getProperty("CLDR_GITHUB_ANNOTATIONS", "false")));
 
-    private static final int HELP1 = 0,
-        HELP2 = 1,
+    private static final int
         COVERAGE = 2,
         EXAMPLES = 3,
         FILE_FILTER = 4,
@@ -117,9 +114,7 @@ public class ConsoleCheckCLDR {
         VOTE_RESOLVE = 17,
         ID_VIEW = 18,
         SUBTYPE_FILTER = 19,
-        SOURCE_ALL = 20,
         BAILEY = 21
-        // VOTE_RESOLVE2 = 21
         ;
 
     static final String SOURCE_DIRS = CLDRPaths.MAIN_DIRECTORY + "," + CLDRPaths.ANNOTATIONS_DIRECTORY + "," + CLDRPaths.SEED_DIRECTORY;
@@ -205,8 +200,6 @@ public class ConsoleCheckCLDR {
         UOption.create("source_all", 'S', UOption.OPTIONAL_ARG).setDefault("common,seed,exemplars"),
         UOption.create("bailey", 'b', UOption.NO_ARG),
         UOption.create("exemplarError", 'E', UOption.NO_ARG)
-        // UOption.create("vote resolution2", 'w', UOption.OPTIONAL_ARG).setDefault(Utility.BASE_DIRECTORY +
-        // "incoming/vetted/main/votes/"),
     };
 
     private static final Comparator<String> baseFirstCollator = new Comparator<String>() {
@@ -224,37 +217,13 @@ public class ConsoleCheckCLDR {
     };
     private static final boolean PATH_IN_COUNT = false;
 
-    /*
-     * TODO: unused? Should be used?
-     */
-    private static String[] HelpMessage = {
-        "-h \t This message",
-        "-s \t Source directory, default = " + SOURCE_DIRS,
-        "-S common,seed\t Use common AND seed directories. ( Set CLDR_DIR, don't use this with -s. )\n",
-        "-fxxx \t Pick the locales (files) to check: xxx is a regular expression, eg -f fr, or -f fr.*, or -f (fr|en-.*)",
-        "-pxxx \t Pick the paths to check, eg -p(.*languages.*)",
-        "-cxxx \t Set the coverage: eg -c comprehensive or -c modern or -c moderate or -c basic",
-        "-txxx \t Filter the Checks: xxx is a regular expression, eg -t.*number.*. To check all BUT a given test, use the style -t ((?!.*CheckZones).*)",
-        "-oxxx \t Organization: ibm, google, ....; filters locales and uses Locales.txt for coverage tests",
-        "-x \t Turn on examples (actually a summary of the demo).",
-        "-d \t Turn on special date format checks",
-        "-a \t Show all paths",
-        "-e \t Show errors only (with -ef, only final processing errors)",
-        "-n \t No aliases",
-        "-u \t User, eg -uu148",
-        "-y \t error/warning subtype filter, eg unexpectedOrderOfEraYear",
-        "-b \t check bailey values (" + CldrUtility.INHERITANCE_MARKER + ")",
-    };
-
     static Counter<ErrorType> subtotalCount = new Counter<>(true); // new ErrorCount();
     static Counter<ErrorType> totalCount = new Counter<>(true);
 
     /**
-     * This will be the test framework way of using these tests. It is preliminary for now.
-     * The Survey Tool will call setDisplayInformation, and getCheckAll.
-     * For each cldrfile, it will set the cldrFile.
-     * Then on each path in the file it will call check.
-     * Right now it doesn't work with resolved files, so just use unresolved ones.
+     * This will be the test framework way of using these tests.
+     *
+     * It doesn't work with resolved files, so just use unresolved ones.
      *
      * @param args
      * @throws IOException
@@ -262,14 +231,7 @@ public class ConsoleCheckCLDR {
     public static void main(String[] args) throws IOException {
         MyOptions.parse(args, true);
         ElapsedTimer totalTimer = new ElapsedTimer();
-        //CldrUtility.showOptions(args);
         UOption.parseArgs(args, options);
-//        if (options[HELP1].doesOccur || options[HELP2].doesOccur) {
-//            for (int i = 0; i < HelpMessage.length; ++i) {
-//                System.out.println(HelpMessage[i]);
-//            }
-//            return;
-//        }
         String factoryFilter = options[FILE_FILTER].value;
         if (factoryFilter.equals("key")) {
             factoryFilter = "(en|ru|nl|fr|de|it|pl|es|tr|th|ja|zh|ko|ar|bg|sr|uk|ca|hr|cs|da|fil|fi|hu|id|lv|lt|no|pt|ro|sk|sl|sv|vi|el|he|fa|hi|am|af|et|is|ms|sw|zu|bn|mr|ta|eu|gl|ur|gu|kn|ml|te|zh_Hant|pt_PT|en_GB)";
@@ -292,9 +254,6 @@ public class ConsoleCheckCLDR {
         }
 
         errorsOnly = options[ERRORS_ONLY].doesOccur;
-        // if ("f".equals(options[ERRORS_ONLY].value)) {
-        // CheckCLDR.finalErrorType = CheckStatus.warningType;
-        // }
 
         SHOW_EXAMPLES = options[EXAMPLES].doesOccur;
         boolean showAll = options[SHOWALL].doesOccur;
@@ -326,11 +285,8 @@ public class ConsoleCheckCLDR {
             }
         }
         final CLDRConfig cldrConf = CLDR_CONFIG;
-        // set the envronment to UNITTEST as suggested
         cldrConf.setEnvironment(Environment.UNITTEST);
-        // get the Phase from CLDRConfig object
         final Phase phase;
-        //   Phase phase = Phase.BUILD;
         if (options[PHASE].doesOccur) {
             String phaseVal = options[PHASE].value;
             try {
@@ -386,13 +342,6 @@ public class ConsoleCheckCLDR {
             coverageLevel = Level.MODERN; // reset
             ErrorFile.generated_html_directory = options[GENERATE_HTML].value;
             ErrorFile.generated_html_count = FileUtilities.openUTF8Writer(ErrorFile.generated_html_directory, "count.txt");
-            // try {
-            // ErrorFile.voteFactory = CLDRFile.Factory.make(sourceDirectory + "../../proposed/main/", ".*");
-            // } catch (RuntimeException e) {
-            // ErrorFile.voteFactory = null;
-            // }
-            // PrintWriter cssFile = FileUtilities.openUTF8Writer(generated_html_directory, "index.css");
-            // Utility;
         }
 
         idView = options[ID_VIEW].doesOccur;
@@ -405,11 +354,6 @@ public class ConsoleCheckCLDR {
             voteResolver = new VoteResolver<>();
         }
 
-        // check stuff
-        // Comparator cc = StandardCodes.make().getTZIDComparator();
-        // System.out.println(cc.compare("Antarctica/Rothera", "America/Cordoba"));
-        // System.out.println(cc.compare("Antarctica/Rothera", "America/Indianapolis"));
-
         String user = options[USER].value;
 
         System.out.println("Source directories:\n");
@@ -417,23 +361,6 @@ public class ConsoleCheckCLDR {
             System.out.println("    " + f.getPath() + "\t("
                 + PathUtilities.getNormalizedPathString(f) + ")");
         }
-//        System.out.println("factoryFilter: " + factoryFilter);
-//        System.out.println("test filter: " + checkFilter);
-//        System.out.println("organization: " + organization);
-//        System.out.println("show examples: " + SHOW_EXAMPLES);
-//        System.out.println("phase: " + phase);
-//        System.out.println("path filter: " + pathFilterString);
-//        System.out.println("coverage level: " + coverageLevel);
-//        System.out.println("checking dates: " + checkFlexibleDates);
-//        System.out.println("only check-on-submit: " + checkOnSubmit);
-//        System.out.println("show all: " + showAll);
-//        System.out.println("errors only?: " + errorsOnly);
-//        System.out.println("generate error counts: " + ErrorFile.generated_html_directory);
-//        // System.out.println("vote directory: " + (ErrorFile.voteFactory == null ? null :
-//        // ErrorFile.voteFactory.getSourceDirectory()));
-//        System.out.println("resolve votes: " + resolveVotesDirectory);
-//        System.out.println("id view: " + idView);
-//        System.out.println("subtype filter: " + subtypeFilter);
 
         // set up the test
         Factory cldrFactory = SimpleFactory.make(sourceDirectories, factoryFilter)
@@ -457,8 +384,7 @@ public class ConsoleCheckCLDR {
 
         List<CheckStatus> result = new ArrayList<>();
         Set<PathHeader> paths = new TreeSet<>(); // CLDRFile.ldmlComparator);
-        Map m = new TreeMap();
-        // double testNumber = 0;
+        Map<String, String> m = new TreeMap<>();
         Map<String, String> options = new HashMap<>();
         FlexibleDateFromCLDR fset = new FlexibleDateFromCLDR();
         Set<String> englishPaths = null;
@@ -510,14 +436,10 @@ public class ConsoleCheckCLDR {
                 options.put(Options.Option.CheckCoverage_skip.getKey(), "true");
             }
 
-            // if (coverageLevel != null) options.put("CoverageLevel.requiredLevel", coverageLevel.toString());
             if (organization != null) options.put(Options.Option.CoverageLevel_localeType.getKey(), organization.toString());
             options.put(Options.Option.phase.getKey(), phase.toString());
-            //options.put(Options.Option.SHOW_TIMES.getKey(), "true");
 
             if (SHOW_LOCALE) System.out.println();
-
-            // options.put("CheckCoverage.requiredLevel","comprehensive");
 
             CLDRFile file;
             CLDRFile englishFile = english;
@@ -533,7 +455,6 @@ public class ConsoleCheckCLDR {
                 if (parentID != null) {
                     parent = cldrFactory.make(parentID, true);
                 }
-                //englishFile = cldrFactory.make("en", true);
             } catch (RuntimeException e) {
                 fatalErrors.add(localeID);
                 System.out.println("FATAL ERROR: " + localeID);
@@ -549,7 +470,6 @@ public class ConsoleCheckCLDR {
                     lastBaseLanguage = baseLanguage;
                     ErrorFile.openErrorFile(localeID, baseLanguage);
                 }
-
             }
 
             if (user != null) {
@@ -558,7 +478,7 @@ public class ConsoleCheckCLDR {
                     parent = new CLDRFile.TestUser(parent, user, isLanguageLocale);
                 }
             }
-            checkCldr.setCldrFileToCheck(file, options, result);
+            checkCldr.setCldrFileToCheck(file, new Options(options), result);
 
             subtotalCount.clear();
 
@@ -597,8 +517,6 @@ public class ConsoleCheckCLDR {
                 }
                 paths.add(pathHeaderFactory.fromPath(path));
             }
-            // addPrettyPaths(file, pathFilter, prettyPathMaker, noaliases, false, paths);
-            // addPrettyPaths(file, file.getExtraPaths(), pathFilter, prettyPathMaker, noaliases, false, paths);
 
             // also add the English paths
             // initialize the first time in.
@@ -610,7 +528,6 @@ public class ConsoleCheckCLDR {
                     true, englishPaths);
                 englishPaths = Collections.unmodifiableSet(englishPaths); // for robustness
             }
-            // paths.addAll(englishPaths);
 
             UnicodeSet missingExemplars = new UnicodeSet();
             UnicodeSet missingCurrencyExemplars = new UnicodeSet();
@@ -623,7 +540,6 @@ public class ConsoleCheckCLDR {
             ExampleGenerator exampleGenerator = SHOW_EXAMPLES ? new ExampleGenerator(file, englishFile,
                 CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY) : null;
 
-            // Status pathStatus = new Status();
             int pathCount = 0;
             Status otherPath = new Status();
 
@@ -631,12 +547,6 @@ public class ConsoleCheckCLDR {
                 pathCount++;
                 String path = pathHeader.getOriginalPath();
                 String prettyPath = pathHeader.toString().replace('\t', '|').replace(' ', '_');
-                // String prettyPath = it2.next();
-                // String path = prettyPathMaker.getOriginal(prettyPath);
-                // if (path == null) {
-                // prettyPathMaker.getOriginal(prettyPath);
-                // }
-
                 if (!showAll && !file.isWinningPath(path)) {
                     continue;
                 }
@@ -650,9 +560,8 @@ public class ConsoleCheckCLDR {
                         continue;
                     }
                 }
-
-                if (path.contains("@alt")) {
-                    if (path.contains("proposed")) continue;
+                if (path.contains("@alt") && path.contains("proposed")) {
+                    continue;
                 }
                 String value = file.getStringValue(path);
                 if (baileyTest) {
@@ -661,20 +570,13 @@ public class ConsoleCheckCLDR {
                 String fullPath = file.getFullXPath(path);
 
                 String example = "";
-
                 if (SHOW_EXAMPLES) {
                     example = ExampleGenerator.simplify(exampleGenerator.getExampleHtml(path, value));
                     showExamples(checkCldr, prettyPath, localeID, path, value, fullPath, example);
                 }
-
                 if (checkFlexibleDates) {
                     fset.checkFlexibles(path, value, fullPath);
                 }
-
-                if (path.contains("duration-century")) {
-                    int debug = 0;
-                }
-
                 int limit = 1;
                 for (int jj = 0; jj < limit; ++jj) {
                     if (jj == 0) {
@@ -717,14 +619,11 @@ public class ConsoleCheckCLDR {
                             if (!status.isCheckOnSubmit() || !statusType.equals(CheckStatus.errorType)) continue;
                         }
 
-                        // System.out.print("Locale:\t" + getLocaleAndName(localeID) + "\t");
                         if (statusType.equals(CheckStatus.demoType)) {
                             SimpleDemo d = status.getDemo();
                             if (d != null && d instanceof FormatDemo) {
                                 FormatDemo fd = (FormatDemo) d;
                                 m.clear();
-                                // m.put("pattern", fd.getPattern());
-                                // m.put("input", fd.getRandomInput());
                                 if (d.processPost(m)) System.out.println("\tDemo:\t" + fd.getPlainText(m));
                             }
                             continue;
@@ -741,9 +640,6 @@ public class ConsoleCheckCLDR {
                         showValue(file, prettyPath, localeID, example, path, value, fullPath, statusString,
                             status.getSubtype());
                         showedOne = true;
-
-                        // survey tool will use: if (status.hasHTMLMessage())
-                        // System.out.println(status.getHTMLMessage());
                     }
                     if (!showedOne && phase != Phase.FINAL_TESTING) {
                         if (!showedOne && showAll) {
@@ -751,7 +647,6 @@ public class ConsoleCheckCLDR {
                             showedOne = true;
                         }
                     }
-
                 }
             }
 
@@ -835,7 +730,6 @@ public class ConsoleCheckCLDR {
         }
         long errorCount = totalCount.getCount(ErrorType.error) + fatalErrors.size();
         if (errorCount != 0) {
-            //            System.exit((int) errorCount); // cast is safe; we'll never have that many errors
             System.out.println();
             System.out.println("<< FAILURE - Error count is " + errorCount + " . >>");
             System.exit(-1);
@@ -849,7 +743,7 @@ public class ConsoleCheckCLDR {
             }
         }
         checkCldr.handleFinish();
-    }
+    } // end of main()
 
     static class LocaleVotingData {
         private int disputedCount = 0;
@@ -1015,32 +909,6 @@ public class ConsoleCheckCLDR {
         }
     }
 
-    /*
-     * static class ErrorCount implements Comparable<ErrorCount> {
-     * private Counter<ErrorType> counter = new Counter<ErrorType>();
-     *
-     * public int compareTo(ErrorCount o) {
-     * // we don't really need a good comparison - aren't going to be sorting
-     * return total() < o.total() ? -1 : total() > o.total() ? 1 : 0;
-     * }
-     * public long total() {
-     * return counter.getTotal();
-     * }
-     * public void clear() {
-     * counter.clear();
-     * }
-     * public Set<ErrorType> keySet() {
-     * return counter.getKeysetSortedByKey();
-     * }
-     * public long getCount(ErrorType input) {
-     * return counter.getCount(input);
-     * }
-     * public void increment(ErrorType errorType) {
-     * counter.add(errorType, 1);
-     * }
-     * }
-     */
-
     static class ErrorFile {
 
         private static final boolean SHOW_VOTING_INFO = false;
@@ -1098,19 +966,13 @@ public class ConsoleCheckCLDR {
                 String section = item.get1();
                 ErrorType shortStatus = item.get2();
                 Subtype subtype = item.get3();
-                // final String prettyPath = path == null ? "general" : prettyPathMaker.getPrettyPath(path, true);
-                // final String outputForm = path == null ? "general" : prettyPathMaker.getOutputForm(prettyPath);
                 errorFileTable.addRow()
                 .addCell(shortStatus)
                 .addCell(subtype)
                 .addCell(localeID)
                 .addCell(ConsoleCheckCLDR.getLocaleName(localeID))
-                // .addCell(prettyPath) // menuPath == null ? "" : "<a href='" + link + "'>" + menuPath + "</a>"
                 .addCell(section) // menuPath == null ? "" : "<a href='" + link + "'>" + menuPath + "</a>"
                 .addCell(errorFileCounter.getCount(item))
-                // .addCell(ConsoleCheckCLDR.safeForHtml(path == null ? null :
-                // ConsoleCheckCLDR.getEnglishPathValue(path)))
-                // .addCell(ConsoleCheckCLDR.safeForHtml(value))
                 .finishRow();
             }
 
@@ -1121,7 +983,6 @@ public class ConsoleCheckCLDR {
                     .addColumn("Organization")
                     .addColumn("Missing")
                     .addColumn("Conflicted")
-                    // .addColumn("Good")
                     ;
                 for (String localeID : locales) {
                     // now the voting info
@@ -1139,7 +1000,6 @@ public class ConsoleCheckCLDR {
                             .addCell(org)
                             .addCell(localeVotingData.missingOrganizationCounter.getCount(org))
                             .addCell(localeVotingData.conflictedOrganizations.getCount(org))
-                            // .addCell(localeVotingData.goodOrganizationCounter.getCount(org))
                             .finishRow();
                         }
                     }
@@ -1372,8 +1232,6 @@ public class ConsoleCheckCLDR {
         }
 
         private static void writeErrorCountsText() {
-            // if (ErrorFile.htmlErrorsPerLocale.total() != 0) {
-
             // do the plain text file
             ErrorFile.generated_html_count.print(ConsoleCheckCLDR.lastHtmlLocaleID + ";\tcounts");
             for (ConsoleCheckCLDR.ErrorType type : ConsoleCheckCLDR.ErrorType.showInSummary) {
@@ -1386,32 +1244,15 @@ public class ConsoleCheckCLDR {
             ErrorFile.errorFileIndexData.put(ConsoleCheckCLDR.lastHtmlLocaleID,
                 new Pair<>(ConsoleCheckCLDR.lastHtmlLocaleID, ErrorFile.htmlErrorsPerLocale));
             ErrorFile.htmlErrorsPerLocale = new Counter<>();
-            // }
-        }
-
-        /*
-         * static Counter<Organization> missingOrganizationCounter = new Counter<Organization>(true);
-         * static Counter<Organization> goodOrganizationCounter = new Counter<Organization>(true);
-         * static Counter<Organization> conflictedOrganizations = new Counter<Organization>(true);
-         * static Counter<VoteResolver.Status> winningStatusCounter = new Counter<VoteResolver.Status>(true);
-         */
+         }
 
         static Counter<ErrorType> htmlErrorsPerLocale = new Counter<>(); // ConsoleCheckCLDR.ErrorCount();
         static PrintWriter generated_html_count = null;
         private static TreeMap<String, Pair<String, Counter<ErrorType>>> errorFileIndexData = new TreeMap<>();
 
-        // private static ConsoleCheckCLDR.ErrorCount htmlErrorsPerBaseLanguage = new ConsoleCheckCLDR.ErrorCount();
         static PrintWriter errorFileWriter = null;
         private static final String ERROR_CHART_HEADER = org.unicode.cldr.test.HelpMessages
             .getChartMessages("error_locale_header");
-        // "Please review and correct them. " +
-        // "Note that errors in <i>sublocales</i> are often fixed by fixing the main locale.</p>" +
-        // Utility.LINE_SEPARATOR +
-        // "<p><i>This list is only generated daily, and so may not reflect fixes you have made until tomorrow. " +
-        // "(There were production problems in integrating it fully into the Survey tool. " +
-        // "However, it should let you see the problems and make sure that they get taken care of.)</i></p>" +
-        // "<p>Coverage depends on your organizations goals: the highest tier languages should include up through all Modern values.</p>"
-        // + Utility.LINE_SEPARATOR;
         static String generated_html_directory = null;
         public static Counter<Row.R4<String, ErrorType, Subtype, String>> sectionToProblemsToLocaleToCount = new Counter<>();
     }
@@ -1439,7 +1280,6 @@ public class ConsoleCheckCLDR {
 
     private static void addPrettyPaths(CLDRFile file, Collection<String> paths, Matcher pathFilter,
         PathHeader.Factory pathHeaderFactory, boolean noaliases, boolean filterDraft, Collection<String> target) {
-        // Status pathStatus = new Status();
         for (String path : paths) {
             if (pathFilter != null && !pathFilter.reset(path).matches()) continue;
             addPrettyPath(file, pathHeaderFactory, noaliases, filterDraft, target, path);
@@ -1451,10 +1291,6 @@ public class ConsoleCheckCLDR {
         if (noaliases && XMLSource.Alias.isAliasPath(path)) { // this is just for console testing, the survey tool
             // shouldn't do it.
             return;
-            // file.getSourceLocaleID(path, pathStatus);
-            // if (!path.equals(pathStatus.pathWhereFound)) {
-            // continue;
-            // }
         }
         if (filterDraft) {
             String newPath = CLDRFile.getNondraftNonaltXPath(path);
@@ -1465,22 +1301,15 @@ public class ConsoleCheckCLDR {
                 }
             }
         }
-        String prettyPath = pathHeaderFactory.fromPath(path).toString(); // prettyPathMaker.getPrettyPath(path, true);
-        // // get sortable version
+        String prettyPath = pathHeaderFactory.fromPath(path).toString();
         target.add(prettyPath);
     }
 
-    public static synchronized void setDisplayInformation(CLDRFile inputDisplayInformation,
-        ExampleGenerator inputExampleGenerator) {
-        CheckCLDR.setDisplayInformation(inputDisplayInformation);
+    private static synchronized void setExampleGenerator(ExampleGenerator inputExampleGenerator) {
         englishExampleGenerator = inputExampleGenerator;
     }
 
-    public static synchronized void setExampleGenerator(ExampleGenerator inputExampleGenerator) {
-        englishExampleGenerator = inputExampleGenerator;
-    }
-
-    public static synchronized ExampleGenerator getExampleGenerator() {
+    private static synchronized ExampleGenerator getExampleGenerator() {
         return englishExampleGenerator;
     }
 
@@ -1529,7 +1358,7 @@ public class ConsoleCheckCLDR {
                 englishExample = ExampleGenerator.simplify(getExampleGenerator().getExampleHtml(path, englishPathValue));
             }
             englishExample = englishExample == null ? "" : englishExample;
-            String cleanPrettyPath = path == null ? null : prettyPath; // prettyPathMaker.getOutputForm(prettyPath);
+            String cleanPrettyPath = path == null ? null : prettyPath;
             Status status = new Status();
             String sourceLocaleID = path == null ? null : cldrFile.getSourceLocaleID(path, status);
             String fillinValue = path == null ? null : cldrFile.getFillInValue(path);
@@ -1577,7 +1406,6 @@ public class ConsoleCheckCLDR {
             }
             if (!localeID.equals(lastHtmlLocaleID)) {
                 ErrorFile.writeErrorCountsText();
-                // startGeneratedTable(generated_html, generated_html_table);
                 lastHtmlLocaleID = localeID;
             }
             addError(shortStatus);
@@ -1624,7 +1452,6 @@ public class ConsoleCheckCLDR {
             newLocale = true;
             LocaleIDParser localeIDParser = new LocaleIDParser();
             showEnglish = !localeIDParser.set(localeID).getLanguageScript().equals("en");
-            // localeID.equals(CheckCLDR.displayInformation.getLocaleID());
             lastPath = null;
             lastSplitPath = null;
         }
@@ -1637,11 +1464,6 @@ public class ConsoleCheckCLDR {
             this.splitChar = splitChar;
             return this;
         }
-    }
-
-    private static void showValue(String path, String value, boolean showEnglish, String localeID) {
-        System.out.println("\tValue:\t" + value + (showEnglish ? "\t" + getEnglishPathValue(path) : "") + "\tLocale:\t"
-            + localeID);
     }
 
     private static String getEnglishPathValue(String path) {
@@ -1659,7 +1481,7 @@ public class ConsoleCheckCLDR {
      * @param locale
      * @return
      */
-    public static String getLocaleAndName(String locale) {
+    private static String getLocaleAndName(String locale) {
         String localizedName = CheckCLDR.getDisplayInformation().getName(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return locale + " [" + localizedName + "]";
@@ -1673,7 +1495,7 @@ public class ConsoleCheckCLDR {
      *            TODO
      * @return
      */
-    public static String getNameAndLocale(String locale, boolean linkToXml) {
+    private static String getNameAndLocale(String locale, boolean linkToXml) {
         String localizedName = CheckCLDR.getDisplayInformation().getName(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         if (linkToXml) {
@@ -1682,13 +1504,13 @@ public class ConsoleCheckCLDR {
         return localizedName + " [" + locale + "]";
     }
 
-    public static String getLocaleName(String locale) {
+    private static String getLocaleName(String locale) {
         String localizedName = CheckCLDR.getDisplayInformation().getName(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return localizedName;
     }
 
-    public static String getLinkedLocale(String locale) {
+    private static String getLinkedLocale(String locale) {
         return "<a href='http://unicode.org/cldr/apps/survey?_=" + locale + "'>" + locale + "</a>";
     }
 
@@ -1696,7 +1518,7 @@ public class ConsoleCheckCLDR {
     /**
      * Approximate xml path
      */
-    public static String guessFilePath(Pair<String, String> locPath) {
+    private static String guessFilePath(Pair<String, String> locPath) {
         final File base = new File(CLDRPaths.BASE_DIRECTORY);
         final String loc = locPath.getFirst();
         final String path = locPath.getSecond();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
@@ -201,6 +201,7 @@ public class TestAll extends TestGroup {
             "org.unicode.cldr.unittest.TestCLDRUtils",
             "org.unicode.cldr.unittest.TestCanonicalIds",
             "org.unicode.cldr.unittest.TestCasingInfo",
+            "org.unicode.cldr.unittest.TestCheckAltOnly",
             "org.unicode.cldr.unittest.TestCheckCLDR",
             "org.unicode.cldr.unittest.TestComparisonBuilder",
             "org.unicode.cldr.unittest.TestCoverageLevel",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckAltOnly.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckAltOnly.java
@@ -1,0 +1,171 @@
+package org.unicode.cldr.unittest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.unicode.cldr.test.CheckAltOnly;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus;
+import org.unicode.cldr.test.CheckCLDR.Options;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.SimpleXMLSource;
+import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.util.XPathParts;
+
+import com.google.common.collect.ImmutableList;
+import com.ibm.icu.dev.test.TestFmwk;
+
+/**
+ * Unit tests for CheckAltOnly.java
+ */
+public class TestCheckAltOnly extends TestFmwk {
+    public static void main(String[] args) {
+        new TestCheckAltOnly().run(args);
+    }
+
+    /**
+     * Test with a data item for which CheckAltOnly was originally created:
+     *
+     * wo.xml:
+     *   <territory type="HK" alt="short">Ooŋ Koŋ</territory>
+     *
+     * That should trigger an error if the corresponding path without alt isn't present.
+     */
+    public void testAltWithoutNonAlt() {
+        final String testLocale = "wo";
+        final String altPath = "//ldml/localeDisplayNames/territories/territory[@type=\"HK\"][@alt=\"short\"]";
+        final String value = "Ooŋ Koŋ";
+
+        final XMLSource source = new SimpleXMLSource(testLocale);
+
+        source.putValueAtPath(altPath, value);
+
+        final CLDRFile cldrFile = new CLDRFile(source);
+        final TestFactory factory = new TestFactory();
+        factory.addFile(cldrFile);
+
+        final CheckAltOnly ch = new CheckAltOnly(factory);
+        ch.setEnglishFile(CLDRConfig.getInstance().getEnglish());
+
+        final CLDRFile resolved = factory.make(testLocale, true);
+        /*
+         * Expect an error for altPath
+         */
+        checkFile(ch, cldrFile, resolved, altPath);
+    }
+
+    private enum TestSubLocaleMode {
+        PARENT_PRESENT,
+        PARENT_ABSENT,
+    }
+
+    private enum TestPathType {
+        CONSTRUCTED,
+        NOT_CONSTRUCTED,
+    }
+
+    /**
+     * Test CheckAltOnly for situations involving sub-locales
+     *
+     * yo_BJ.xml:
+     *   <language type="en_US" alt="short">Èdè Gɛ̀ɛ́sì (US)</language>
+     *
+     * yo.xml:
+     *   <language type="en_US">↑↑↑</language>
+     *   <language type="en_US" alt="short">Èdè Gẹ̀ẹ́sì (US)</language>
+     *
+     * There are two important factors:
+     * (1) whether there is a constructed value for the non-alt path, in which case, no error
+     * (2) whether the non-alt path is present in the parent locale, in which case, no error
+     *
+     * In the actual data this is based on, there was a constructed value for the languages/language
+     * path. We also test for a different path (...territories/territory...), without a constructed value.
+     *
+     * As in the actual data, the values (Gɛ̀ɛ́sì vs Gẹ̀ẹ́sì) are slightly different, and the value in
+     * the parent is "↑↑↑" (CldrUtility.INHERITANCE_MARKER), but those facts are probably not important
+     * for this test.
+     */
+    public void testSubLocale() {
+        final String altPathConstructed = "//ldml/localeDisplayNames/languages/language[@type=\"en_US\"][@alt=\"short\"]";
+        final String altPathNotConstructed = "//ldml/localeDisplayNames/territories/territory[@type=\"CI\"][@alt=\"variant\"]";
+
+        reallyTestSubLocale(TestSubLocaleMode.PARENT_PRESENT, altPathConstructed, TestPathType.CONSTRUCTED);
+        reallyTestSubLocale(TestSubLocaleMode.PARENT_ABSENT, altPathConstructed, TestPathType.CONSTRUCTED);
+        reallyTestSubLocale(TestSubLocaleMode.PARENT_PRESENT, altPathNotConstructed, TestPathType.NOT_CONSTRUCTED);
+        reallyTestSubLocale(TestSubLocaleMode.PARENT_ABSENT, altPathNotConstructed, TestPathType.NOT_CONSTRUCTED);
+    }
+
+    private void reallyTestSubLocale(TestSubLocaleMode mode, String altPath, TestPathType pathType) {
+        final String subLocale = "yo_BJ";
+        final String parLocale = "yo";
+        final String nonAltPath = XPathParts.getPathWithoutAlt(altPath);
+        final String valueSubAlt = "Èdè Gɛ̀ɛ́sì";
+        final String valueParAlt = "Èdè Gẹ̀ẹ́sì";
+        final String valueParNonAlt = CldrUtility.INHERITANCE_MARKER;
+
+        final XMLSource parSource = new SimpleXMLSource(parLocale);
+        final XMLSource subSource = new SimpleXMLSource(subLocale);
+
+        subSource.putValueAtPath(altPath, valueSubAlt);
+
+        if (TestSubLocaleMode.PARENT_PRESENT.equals(mode)) {
+            parSource.putValueAtPath(altPath, valueParAlt);
+            parSource.putValueAtPath(nonAltPath, valueParNonAlt);
+        }
+
+        final CLDRFile parCldrFile = new CLDRFile(parSource);
+        final CLDRFile subCldrFile = new CLDRFile(subSource);
+        final TestFactory factory = new TestFactory();
+        factory.addFile(parCldrFile);
+        factory.addFile(subCldrFile);
+
+        final CheckAltOnly ch = new CheckAltOnly(factory);
+        ch.setEnglishFile(CLDRConfig.getInstance().getEnglish());
+
+        final CLDRFile resolved = factory.make(subLocale, true);
+        if (TestSubLocaleMode.PARENT_PRESENT.equals(mode) || TestPathType.CONSTRUCTED.equals(pathType)) {
+            /*
+             * Expect no errors
+             */
+            checkFile(ch, subCldrFile, resolved);
+        } else {
+            /*
+             * Expect error for altPath
+             */
+            checkFile(ch, subCldrFile, resolved, altPath);
+        }
+    }
+
+    private void checkFile(CheckAltOnly ch, CLDRFile cldrFile, CLDRFile cldrFileResolved, String... expectedErrors) {
+        List<CheckStatus> possibleErrors = new ArrayList<>();
+        Options options = new Options();
+        ch.setCldrFileToCheck(cldrFile, options, possibleErrors);
+        Map<String,List<CheckStatus>> found = new HashMap<>();
+        for (String path : cldrFileResolved) {
+            String value = cldrFileResolved.getStringValue(path);
+            ch.check(path, path, value, options, possibleErrors);
+            if (!possibleErrors.isEmpty()) {
+                found.put(path, ImmutableList.copyOf(possibleErrors));
+                possibleErrors.clear();
+            }
+        }
+        Set<String> expected = new TreeSet<>(Arrays.asList(expectedErrors));
+        for (Entry<String, List<CheckStatus>> entry : found.entrySet()) {
+            String path = entry.getKey();
+            if (expected.contains(path)) {
+                expected.remove(path);
+            } else {
+                errln(cldrFile.getLocaleID() + " unexpected error: " + path + " : " + entry.getValue());
+            }
+        }
+        assertEquals(cldrFile.getLocaleID() + " expected to be errors: ", Collections.emptySet(), expected);
+    }
+}


### PR DESCRIPTION
-New CheckAltOnly.java to check if only the alt path is present but the non-alt path is absent

-New CheckCLDR.CheckStatus.Subtype.missingNonAltPath

-New TestCheckAltOnly.java (unit test for CheckAltOnly.java)

-Skip CheckAltOnly (no error) for the root locale

-Skip CheckAltOnly (no error) if the non-alt path has a constructed value

-Fix some warnings

-Remove some dead/commented-out code

-Change some public to private

-Comments

CLDR-13731

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
