### PR TITLE
CLDR-15113 json: move datetimeSkeleton to a parallel location

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -34,9 +34,9 @@
 < (.*/ellipsis)\[@type="([^"]*)"\](.*)$
 > $1/$2$3
 
-# move datetimeSkeleton to a separate path
-< (.*/calendars)/calendar\[@type="([^"]*)"\](.*)Length\[@type="([^"]*)"\]/(date|time|dateTime)Format\[@type="([^"]*)"\]/datetimeSkeleton(.*)
-> $1/$2/$5Formats/$4-datetimeSkeleton$7
+# move datetimeSkeleton to a parallel path
+< (.*/calendars)/calendar\[@type="([^"]*)"\](.*)Length\[@type="([^"]*)"\]/(date|time|dateTime)Format\[@type="([^"]*)"\]/(datetimeSkeleton)(.*)
+> $1/$2/$5Skeletons/$4$8
 
 # Remove unnecessary dateFormat/pattern
 < (.*/calendars)/calendar\[@type="([^"]*)"\](.*)Length\[@type="([^"]*)"\]/(date|time|dateTime)Format\[@type="([^"]*)"\]/pattern\[@type="([^"]*)"\](.*)


### PR DESCRIPTION
CLDR-15113

- [X] This PR completes the ticket. (yet again!)

Change from the previous stopgap format in #1552 to:

```json
"dateFormats": {
  "full": "EEEE, MMMM d, y",
  "long": "MMMM d, y",
  "medium": "MMM d, y",
  "short": "M/d/yy"
},
"datetimeSkeleton": {
  "full": "ahmmsszzzz",
  "long": "ahmmssz",
  "medium": "ahmmss",
  "short": "ahmm"
},
```

@macchiati this is _slightly different_ than your proposal in https://github.com/unicode-org/cldr/pull/1552#issuecomment-948033291 - I made the object name `datetimeSkeleton` to match the actual element name in CLDR, and the structure would allow a `timeSkeleton` etc if such was needed. 
