### PR TITLE
CLDR-14976 spec: finish updating version from 64 to 65

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -14,7 +14,7 @@
 <tr><td>Latest Proposed Update</td><td><a href="https://unicode-org.github.io/cldr/ldml/tr35.html">https://unicode-org.github.io/cldr/ldml/tr35.html</a></td></tr>
 <tr><td>Namespace</td><td><a href="https://unicode.org/cldr/">https://unicode.org/cldr/</a></td></tr>
 <tr><td>DTDs</td><td><a href="http://www.unicode.org/cldr/dtd/40/">http://www.unicode.org/cldr/dtd/40/</a></td></tr>
-<tr><td>Revision</td><td><a href="#Modifications">64</a></td></tr>
+<tr><td>Revision</td><td><a href="#Modifications">65</a></td></tr>
 </tbody></table>
 
 ### _Summary_
@@ -3718,7 +3718,7 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
-**Revision 64**
+**Revision 65**
 * Locale Identifiers
   * In [BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion), extended the minimum support size for locale and language identifiers to 255 [CLDR-13729](https://unicode-org.atlassian.net/browse/CLDR-13729)
 	* In [Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers), provided an explanation for the use of alphabetical order of variants [CLDR-13729](https://unicode-org.atlassian.net/browse/CLDR-13729)


### PR DESCRIPTION
CLDR-14976

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

The spec version had been partially updated from 64 to 65 (in the path for current version), but not in the Modifications section reference in the header, or in the Mods section itself. (Was updated manually in the posted version)