### PR TITLE
CLDR-15126 Bogus xpath warning when press Previous or Next button

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -869,6 +869,7 @@ function chgPage(shift) {
   }
   cldrStatus.setCurrentSection(menus[parentIndex].id);
   cldrStatus.setCurrentPage(menus[parentIndex].pagesFiltered[index].id);
+  cldrStatus.setCurrentId(null);
 
   cldrLoad.reloadV();
 


### PR DESCRIPTION
-In cldrSurvey.chgPage set id to null to prevent warning when that id is not found on new page

CLDR-15126

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
