### PR TITLE
CLDR-15104 docs: use gh-pages branch and tr-archiver

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,56 @@
+name: Publish to gh-pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: false
+      - name: Cache local npm repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-nodetr-${{ hashFiles('tools/scripts/tr-archive/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nodetr-
+            nodetr-
+      - name: Ruby cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/vendor
+          key: ${{ runner.os }}-gems-${{ hashFiles('docs/**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Build Jekyll part of the site
+        run: |
+          gem install bundler github-pages kramdown-parser-gfm  # should pull in jekyll, etc.
+          jekyll build -s docs -d _site
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Run TR archiver
+        run: 'cd tools/scripts/tr-archive/ && bash make-tr-archive.sh'
+      - name: Rearrange stuff
+        run: 'cp -vr tools/scripts/tr-archive/dist/* ./_site/ldml/ && cp tools/scripts/tr-archive/reports-v2.css ./_site/'
+      - name: Deploy to GitHub Pages
+        uses: Cecilapp/GitHub-Pages-deploy@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # email: username@domain.tld
+          build_dir: _site               # optional
+          branch: gh-pages                # optional
+          # cname: domain.tld              # optional
+          # jekyll: no                     # optional
+          commit_message: CLDR-00000 Automated Build of Pages # optional
+
+# zero change

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ tools/cldr-code/dependency-reduced-pom.xml
 .apt_generated_tests
 exception.log
 
+# Site generation stuff
+/_site

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+_site
+.sass-cache
+.jekyll-metadata
+.jekyll-cache

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 name: CLDR LDML
 
-markdown: GFM
+markdown: kramdown
+input: GFM
 
 # Google Analytics
 ga_tracking: UA-7672775-1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+---
+
+---
+
+# CLDR Docs
+
+CLDR main page: [https://unicode.org/cldr](https://unicode.org/cldr)
+
+## TR35
+
+- [Unicode Technical Standard #35 UNICODE LOCALE DATA MARKUP LANGUAGE (LDML)](ldml/tr35.html)
+
+## RFC
+
+- draft-davis-t-langtag-ext: [html](rfc/draft-davis-t-langtag-ext.html) [txt](rfc/draft-davis-t-langtag-ext.txt)
+
+- draft-davis-u-langtag-ext-00: [html](rfc/draft-davis-u-langtag-ext-00.html) [txt](rfc/draft-davis-u-langtag-ext-00.txt)
+
+##### Copyright
+
+Copyright &copy; 1991-2019 Unicode, Inc.
+All rights reserved.
+[Terms of use](http://www.unicode.org/copyright.html)

--- a/tools/scripts/tr-archive/make-tr-archive.sh
+++ b/tools/scripts/tr-archive/make-tr-archive.sh
@@ -12,5 +12,5 @@ then
     wget -c 'https://www.unicode.org/reports/logo60s2.gif'
 fi
 mkdir -p dist
-cp -vR ../../../docs/ldml/ ./dist/
+cp -vR ../../../docs/ldml/* ./dist/
 node archive.js && zip -r tr35.zip dist/*.html dist/images


### PR DESCRIPTION
- build into the 'gh-pages' branch instead of using Github Pages default build
- use the tr-archiver for the spec

CLDR-15104

- [ ] This PR completes the ticket.

Sample site: https://srl295.github.io/cldr/ (Just URLs under this location!)
Compare https://unicode-org.github.io/cldr/