### PR TITLE
CLDR-15056 Coverage Progress Bars: improve event handling

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrCoverage.js
+++ b/tools/cldr-apps/js/src/esm/cldrCoverage.js
@@ -136,7 +136,6 @@ function updateCoverage(theDiv) {
 export {
   covName,
   covValue,
-  effectiveCoverage,
   effectiveName,
   getSurveyOrgCov,
   getSurveyUserCov,

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -1093,6 +1093,7 @@ function flipToEmptyOther() {
 
 function coverageUpdate() {
   cldrCoverage.updateCoverage(flipper.get(pages.data));
+  handleCoverageChanged(cldrCoverage.effectiveName());
 }
 
 function setLoading(loading) {

--- a/tools/cldr-apps/js/src/views/ProgressMeters.vue
+++ b/tools/cldr-apps/js/src/views/ProgressMeters.vue
@@ -28,7 +28,6 @@
 
 <script>
 import * as cldrLoad from "../esm/cldrLoad.js";
-import * as cldrProgress from "../esm/cldrProgress.js";
 import * as cldrStatus from "../esm/cldrStatus.js";
 
 export default {

--- a/tools/cldr-apps/js/test/mockup.html
+++ b/tools/cldr-apps/js/test/mockup.html
@@ -188,9 +188,7 @@
           <li>Survey Tool 40 Data Submission</li>
           <li><a class="gear" href="#gear">⚙</a></li>
           <li>
-            <a
-              href="https://cldr.unicode.org/translation/"
-              target="_blank"
+            <a href="https://cldr.unicode.org/translation/" target="_blank"
               >Instructions</a
             >
           </li>


### PR DESCRIPTION
-Update voter completion after vote/abstain, updateStatsOneVote just as for section completion

-Call cldrLoad.handleCoverageChanged from cldrLoad.coverageUpdate, do not wait for menu choice

-Remove unneeded timeout for cldrProgress.insertWidget

-Remove some unused imports and exports

-Comments

CLDR-15056

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
