### PR TITLE
CLDR-15056 Coverage Progress Bars: improve event handling

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -1093,6 +1093,7 @@ function flipToEmptyOther() {
 
 function coverageUpdate() {
   cldrCoverage.updateCoverage(flipper.get(pages.data));
+  handleCoverageChanged(cldrCoverage.effectiveName());
 }
 
 function setLoading(loading) {

--- a/tools/cldr-apps/js/src/esm/cldrProgress.js
+++ b/tools/cldr-apps/js/src/esm/cldrProgress.js
@@ -18,6 +18,9 @@ const USE_NEW_PROGRESS_WIDGET = false;
 let progressWrapper = null;
 
 let sectionProgressStats = null;
+let voterProgressStats = null;
+
+let sectionProgressRows = null;
 
 /**
  * Create the ProgressMeters component
@@ -27,9 +30,7 @@ let sectionProgressStats = null;
 function insertWidget(spanId) {
   if (USE_NEW_PROGRESS_WIDGET) {
     hideLegacyCompletionWidget();
-    setTimeout(function () {
-      reallyInsertWidget(spanId);
-    }, 3000 /* three seconds -- temporary work-around for delays in initializing locale and coverage level */);
+    reallyInsertWidget(spanId);
   }
 }
 
@@ -59,8 +60,16 @@ function reallyInsertWidget(spanId) {
  */
 function updateWidgetsWithCoverage(newLevel) {
   if (progressWrapper) {
-    console.log("cldrProgress changing level: " + newLevel);
-    fetchVoterData(); // for voterBar
+    if (sectionProgressRows) {
+      // For sectionBar, we have saved a pointer to the rows; we need to recalculate
+      // the votes and total based on the coverage level of each row
+      sectionProgressStats = getSectionCompletionFromRows(sectionProgressRows);
+      refresh();
+    }
+    // For voterBar
+    fetchVoterData();
+
+    // localeBar does NOT depend on the user's chosen coverage level
   }
 }
 
@@ -75,9 +84,16 @@ function refresh() {
       updateLegacyCompletionWidget(sectionProgressStats);
     }
   }
+  if (voterProgressStats && USE_NEW_PROGRESS_WIDGET) {
+    progressWrapper?.updateVoterVotesAndTotal(
+      voterProgressStats.votes,
+      voterProgressStats.total
+    );
+  }
 }
 
 function updateSectionCompletion(rows) {
+  sectionProgressRows = rows;
   sectionProgressStats = getSectionCompletionFromRows(rows);
   refresh();
 }
@@ -85,7 +101,11 @@ function updateSectionCompletion(rows) {
 function getSectionCompletionFromRows(rows) {
   let votes = 0;
   let total = 0;
+  const cov = cldrCoverage.effectiveCoverage(); // an integer
   for (let row of Object.values(rows)) {
+    if (parseInt(row.coverageValue) > cov) {
+      continue;
+    }
     ++total;
     if (row.hasVoted) {
       ++votes;
@@ -98,17 +118,24 @@ function getSectionCompletionFromRows(rows) {
 }
 
 function updateSectionCompletionOneVote(hasVoted) {
-  if (sectionProgressStats) {
+  if (sectionProgressStats || voterProgressStats) {
+    updateStatsOneVote(sectionProgressStats, hasVoted);
+    updateStatsOneVote(voterProgressStats, hasVoted);
+    refresh();
+  }
+}
+
+function updateStatsOneVote(stats, hasVoted) {
+  if (stats) {
     if (hasVoted) {
-      if (sectionProgressStats.votes < sectionProgressStats.total) {
-        sectionProgressStats.votes++;
+      if (stats.votes < stats.total) {
+        stats.votes++;
       }
     } else {
-      if (sectionProgressStats.votes > 0) {
-        sectionProgressStats.votes--;
+      if (stats.votes > 0) {
+        stats.votes--;
       }
     }
-    refresh();
   }
 }
 
@@ -147,6 +174,10 @@ function reallyFetchVoterData(locale, level) {
     .then((data) => data.json())
     .then((json) => {
       progressWrapper.setHidden(false);
+      voterProgressStats = {
+        votes: json.votes,
+        total: json.total,
+      };
       progressWrapper.updateVoterVotesAndTotal(json.votes, json.total);
     })
     .catch((err) => {
@@ -179,7 +210,6 @@ function updateLegacyCompletionWidget(sectionVotesTotal) {
 }
 
 export {
-  fetchVoterData,
   insertWidget,
   refresh,
   updateSectionCompletion,

--- a/tools/cldr-apps/js/src/views/ProgressMeters.vue
+++ b/tools/cldr-apps/js/src/views/ProgressMeters.vue
@@ -28,7 +28,6 @@
 
 <script>
 import * as cldrLoad from "../esm/cldrLoad.js";
-import * as cldrProgress from "../esm/cldrProgress.js";
 import * as cldrStatus from "../esm/cldrStatus.js";
 
 export default {


### PR DESCRIPTION
-Bug fix: filter for coverage when count rows in section

-Update voter completion after vote/abstain, updateStatsOneVote just as for section completion

-Call cldrLoad.handleCoverageChanged from cldrLoad.coverageUpdate, do not wait for menu choice

-Remove unneeded timeout for cldrProgress.insertWidget

-Remove some unused imports and exports

-Comments

CLDR-15056

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
