### PR TITLE
CLDR-15166 Fix date and time localization

### DIFF
--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -809,7 +809,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</keys>
 		<types>
 			<type key="calendar" type="buddhist">බොදු දින දසුන</type>
-			<type key="calendar" type="chinese">චීන දින දසුන </type>
+			<type key="calendar" type="chinese">චීන දින දසුන</type>
 			<type key="calendar" type="dangi">ඩැන්ගී දින දසුන</type>
 			<type key="calendar" type="ethiopic">ඉතියෝපියානු දින දසුන</type>
 			<type key="calendar" type="gregorian">ග්‍රෙගරියානු දින දසුන</type>
@@ -2329,7 +2329,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>මිනි.</displayName>
+				<displayName>විනා.</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">විනාඩි {0}කින්</relativeTimePattern>
 					<relativeTimePattern count="other">විනාඩි {0}කින්</relativeTimePattern>
@@ -2340,7 +2340,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>මිනි.</displayName>
+				<displayName>විනා.</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">විනාඩි {0}කින්</relativeTimePattern>
 					<relativeTimePattern count="other">විනාඩි {0}කින්</relativeTimePattern>
@@ -6195,7 +6195,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">අංශක {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>චාපමිනිත්තු</displayName>
+				<displayName>චාපවිනාඩි</displayName>
 				<unitPattern count="one">චාපවිනාඩි {0}</unitPattern>
 				<unitPattern count="other">චාපවිනාඩි {0}</unitPattern>
 			</unit>
@@ -6393,43 +6393,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>වසර</displayName>
 				<unitPattern count="one">වසර {0}</unitPattern>
 				<unitPattern count="other">වසර {0}</unitPattern>
-				<perUnitPattern>වසරට {0}</perUnitPattern>
+				<perUnitPattern>වසර {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>මාස</displayName>
 				<unitPattern count="one">මාස {0}</unitPattern>
 				<unitPattern count="other">මාස {0}</unitPattern>
-				<perUnitPattern>මාසයට {0}</perUnitPattern>
+				<perUnitPattern>මාස {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>සති</displayName>
 				<unitPattern count="one">සති {0}</unitPattern>
 				<unitPattern count="other">සති {0}</unitPattern>
-				<perUnitPattern>සතියට {0}</perUnitPattern>
+				<perUnitPattern>සති {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>දින</displayName>
 				<unitPattern count="one">දින {0}</unitPattern>
 				<unitPattern count="other">දින {0}</unitPattern>
-				<perUnitPattern>දිනයට {0}</perUnitPattern>
+				<perUnitPattern>දින {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>පැය</displayName>
 				<unitPattern count="one">පැය {0}</unitPattern>
 				<unitPattern count="other">පැය {0}</unitPattern>
-				<perUnitPattern>පැයට {0}</perUnitPattern>
+				<perUnitPattern>පැය {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>මිනිත්තු</displayName>
+				<displayName>විනාඩි</displayName>
 				<unitPattern count="one">විනාඩි {0}</unitPattern>
 				<unitPattern count="other">විනාඩි {0}</unitPattern>
-				<perUnitPattern>මිනිත්තුවට {0}</perUnitPattern>
+				<perUnitPattern>විනාඩි {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>තත්පර</displayName>
 				<unitPattern count="one">තත්පර {0}</unitPattern>
 				<unitPattern count="other">තත්පර {0}</unitPattern>
-				<perUnitPattern>තත්පරයට {0}</perUnitPattern>
+				<perUnitPattern>තත්පර {0} කට</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>මිලිතත්පර</displayName>
@@ -7240,9 +7240,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">අංශක {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>චාපමිනිත්තු</displayName>
-				<unitPattern count="one">චාපමිනිත්තු {0}</unitPattern>
-				<unitPattern count="other">චාපමිනිත්තු {0}</unitPattern>
+				<displayName>චාපවිනාඩි</displayName>
+				<unitPattern count="one">චාපවිනාඩි {0}</unitPattern>
+				<unitPattern count="other">චාපවිනාඩි {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>චාපතත්පර</displayName>
@@ -7462,19 +7462,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>පැය</displayName>
 				<unitPattern count="one">පැය {0}</unitPattern>
 				<unitPattern count="other">පැය {0}</unitPattern>
-				<perUnitPattern>පැයට {0}</perUnitPattern>
+				<perUnitPattern>{0}/පැ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>මිනි</displayName>
+				<displayName>විනා</displayName>
 				<unitPattern count="one">විනා {0}</unitPattern>
 				<unitPattern count="other">විනා {0}</unitPattern>
-				<perUnitPattern>{0}/මිනි</perUnitPattern>
+				<perUnitPattern>{0}/විනා</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>තත්පර</displayName>
 				<unitPattern count="one">තත් {0}</unitPattern>
 				<unitPattern count="other">තත් {0}</unitPattern>
-				<perUnitPattern>තත්පරයට {0}</perUnitPattern>
+				<perUnitPattern>{0}/තත්</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>මිලිතත්පර</displayName>
@@ -8285,7 +8285,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>චාපමිනිත්තු</displayName>
+				<displayName>චාපවිනාඩි</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -25,7 +25,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="ada">අඩන්ග්මෙ</language>
 			<language type="ady">අඩිඝෙ</language>
 			<language type="aeb">ටියුනිසියනු අරාබි</language>
-			<language type="af">අෆ්‍රිකාන්ස්</language>
+			<language type="af">අප්‍රිකානු</language>
 			<language type="agq">ඇගම්</language>
 			<language type="ain">අයිනු</language>
 			<language type="ak">අකාන්</language>
@@ -729,7 +729,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SC">සීශෙල්ස්</territory>
 			<territory type="SD">සූඩානය</territory>
 			<territory type="SE">ස්වීඩනය</territory>
-			<territory type="SG">සිංගප්පූරුව</territory>
+			<territory type="SG">සිංගප්පුර</territory>
 			<territory type="SH">ශාන්ත හෙලේනා</territory>
 			<territory type="SI">ස්ලෝවේනියාව</territory>
 			<territory type="SJ">ස්වෙල්බර්ඩ් සහ ජේන් මයේන්</territory>
@@ -815,7 +815,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="calendar" type="gregorian">ග්‍රෙගරියානු දින දසුන</type>
 			<type key="calendar" type="hebrew">හීබෲ දින දසුන</type>
 			<type key="calendar" type="islamic">ඉස්ලාමීය දින දසුන</type>
-			<type key="calendar" type="iso8601">අඑස්ඔ-8601 දින දසුන</type>
+			<type key="calendar" type="iso8601">අයිඑස්ඕ-8601 දින දසුන</type>
 			<type key="calendar" type="japanese">ජපන් දින දසුන</type>
 			<type key="calendar" type="persian">පර්සියානු දින දසුන</type>
 			<type key="calendar" type="roc">මින්ගා දින දසුන</type>
@@ -878,7 +878,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</measurementSystemNames>
 		<codePatterns>
 			<codePattern type="language">{0} භාෂාව: සිංහල</codePattern>
-			<codePattern type="script">{0} අක්ෂර මාලාව: සිංහල</codePattern>
+			<codePattern type="script">{0} අකුරු මාලාව: සිංහල</codePattern>
 			<codePattern type="territory">කලාපය: {0}</codePattern>
 		</codePatterns>
 	</localeDisplayNames>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -798,7 +798,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<subdivision type="gbwls">වේල්සය</subdivision>
 		</subdivisions>
 		<keys>
-			<key type="calendar">දින දර්ශනය</key>
+			<key type="calendar">දින දසුන</key>
 			<key type="cf">මුදල් ආකෘති</key>
 			<key type="collation">පෙළගැස්ම</key>
 			<key type="currency">විනිමය</key>
@@ -808,17 +808,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<key type="numbers">ඉලක්කම්</key>
 		</keys>
 		<types>
-			<type key="calendar" type="buddhist">බොදු දින දර්ශනය</type>
-			<type key="calendar" type="chinese">චීන දින දර්ශනය</type>
-			<type key="calendar" type="dangi">ඩැන්ගී දින දර්ශනය</type>
-			<type key="calendar" type="ethiopic">ඉතියෝපියානු දින දර්ශනය</type>
-			<type key="calendar" type="gregorian">ග්‍රෙගරියානු දින දර්ශනය</type>
-			<type key="calendar" type="hebrew">හීබෲ දින දර්ශනය</type>
-			<type key="calendar" type="islamic">ඉස්ලාමීය දින දර්ශනය</type>
-			<type key="calendar" type="iso8601">අඑස්ඔ-8601 දින දර්ශනය</type>
-			<type key="calendar" type="japanese">ජපන් දින දර්ශනය</type>
-			<type key="calendar" type="persian">පර්සියානු දින දර්ශනය</type>
-			<type key="calendar" type="roc">මින්ගා දින දර්ශනය</type>
+			<type key="calendar" type="buddhist">බොදු දින දසුන</type>
+			<type key="calendar" type="chinese">චීන දින දසුන </type>
+			<type key="calendar" type="dangi">ඩැන්ගී දින දසුන</type>
+			<type key="calendar" type="ethiopic">ඉතියෝපියානු දින දසුන</type>
+			<type key="calendar" type="gregorian">ග්‍රෙගරියානු දින දසුන</type>
+			<type key="calendar" type="hebrew">හීබෲ දින දසුන</type>
+			<type key="calendar" type="islamic">ඉස්ලාමීය දින දසුන</type>
+			<type key="calendar" type="iso8601">අඑස්ඔ-8601 දින දසුන</type>
+			<type key="calendar" type="japanese">ජපන් දින දසුන</type>
+			<type key="calendar" type="persian">පර්සියානු දින දසුන</type>
+			<type key="calendar" type="roc">මින්ගා දින දසුන</type>
 			<type key="cf" type="account">ගිණුම්කරණ මුදල් ආකෘති</type>
 			<type key="cf" type="standard">සම්මත මුදල් ආකෘති</type>
 			<type key="collation" type="dictionary">ශබ්දකෝෂ පෙළගැස්ම</type>
@@ -1168,90 +1168,90 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">ජන</month>
-							<month type="2">පෙබ</month>
-							<month type="3">මාර්තු</month>
-							<month type="4">අප්‍රේල්</month>
-							<month type="5">මැයි</month>
-							<month type="6">ජූනි</month>
-							<month type="7">ජූලි</month>
-							<month type="8">අගෝ</month>
-							<month type="9">සැප්</month>
-							<month type="10">ඔක්</month>
-							<month type="11">නොවැ</month>
-							<month type="12">දෙසැ</month>
+							<month type="1">දුරුතු</month>
+							<month type="2">නවම්</month>
+							<month type="3">මැදින්</month>
+							<month type="4">බක්</month>
+							<month type="5">වෙසක්</month>
+							<month type="6">පොසොන්</month>
+							<month type="7">ඇසළ</month>
+							<month type="8">නිකිණි</month>
+							<month type="9">බිනර</month>
+							<month type="10">වප්</month>
+							<month type="11">ඉල්</month>
+							<month type="12">උඳු</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">ජ</month>
-							<month type="2">පෙ</month>
-							<month type="3">මා</month>
-							<month type="4">අ</month>
-							<month type="5">මැ</month>
-							<month type="6">ජූ</month>
-							<month type="7">ජූ</month>
-							<month type="8">අ</month>
-							<month type="9">සැ</month>
-							<month type="10">ඔ</month>
-							<month type="11">නෙ</month>
-							<month type="12">දෙ</month>
+							<month type="1">දු</month>
+							<month type="2">න</month>
+							<month type="3">මැ</month>
+							<month type="4">බ</month>
+							<month type="5">වෙ</month>
+							<month type="6">පො</month>
+							<month type="7">ඇ</month>
+							<month type="8">නි</month>
+							<month type="9">බි</month>
+							<month type="10">ව</month>
+							<month type="11">ඉ</month>
+							<month type="12">උ</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">ජනවාරි</month>
-							<month type="2">පෙබරවාරි</month>
-							<month type="3">මාර්තු</month>
-							<month type="4">අප්‍රේල්</month>
-							<month type="5">මැයි</month>
-							<month type="6">ජූනි</month>
-							<month type="7">ජූලි</month>
-							<month type="8">අගෝස්තු</month>
-							<month type="9">සැප්තැම්බර්</month>
-							<month type="10">ඔක්තෝබර්</month>
-							<month type="11">නොවැම්බර්</month>
-							<month type="12">දෙසැම්බර්</month>
+							<month type="1">දුරුතු</month>
+							<month type="2">නවම්</month>
+							<month type="3">මැදින්</month>
+							<month type="4">බක්</month>
+							<month type="5">වෙසක්</month>
+							<month type="6">පොසොන්</month>
+							<month type="7">ඇසළ</month>
+							<month type="8">නිකිණි</month>
+							<month type="9">බිනර</month>
+							<month type="10">වප්</month>
+							<month type="11">ඉල්</month>
+							<month type="12">උඳුවප්</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">ජන</month>
-							<month type="2">පෙබ</month>
-							<month type="3">මාර්</month>
-							<month type="4">අප්‍රේල්</month>
-							<month type="5">මැයි</month>
-							<month type="6">ජූනි</month>
-							<month type="7">ජූලි</month>
-							<month type="8">අගෝ</month>
-							<month type="9">සැප්</month>
-							<month type="10">ඔක්</month>
-							<month type="11">නොවැ</month>
-							<month type="12">දෙසැ</month>
+							<month type="1">දුරුතු</month>
+							<month type="2">නවම්</month>
+							<month type="3">මැදින්</month>
+							<month type="4">බක්</month>
+							<month type="5">වෙසක්</month>
+							<month type="6">පොසොන්</month>
+							<month type="7">ඇසළ</month>
+							<month type="8">නිකිණි</month>
+							<month type="9">බිනර</month>
+							<month type="10">වප්</month>
+							<month type="11">ඉල්</month>
+							<month type="12">උඳු</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">ජ</month>
-							<month type="2">පෙ</month>
-							<month type="3">මා</month>
-							<month type="4">අ</month>
-							<month type="5">මැ</month>
-							<month type="6">ජූ</month>
-							<month type="7">ජූ</month>
-							<month type="8">අ</month>
-							<month type="9">සැ</month>
-							<month type="10">ඔ</month>
-							<month type="11">නෙ</month>
-							<month type="12">දෙ</month>
+							<month type="1">දු</month>
+							<month type="2">න</month>
+							<month type="3">මැ</month>
+							<month type="4">බ</month>
+							<month type="5">වෙ</month>
+							<month type="6">පො</month>
+							<month type="7">ඇ</month>
+							<month type="8">නි</month>
+							<month type="9">බි</month>
+							<month type="10">ව</month>
+							<month type="11">ඉ</month>
+							<month type="12">උඳු</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">ජනවාරි</month>
-							<month type="2">පෙබරවාරි</month>
-							<month type="3">මාර්තු</month>
-							<month type="4">අප්‍රේල්</month>
-							<month type="5">මැයි</month>
-							<month type="6">ජූනි</month>
-							<month type="7">ජූලි</month>
-							<month type="8">අගෝස්තු</month>
-							<month type="9">සැප්තැම්බර්</month>
-							<month type="10">ඔක්තෝබර්</month>
-							<month type="11">නොවැම්බර්</month>
-							<month type="12">දෙසැම්බර්</month>
+							<month type="1">දුරුතු</month>
+							<month type="2">නවම්</month>
+							<month type="3">මැදින්</month>
+							<month type="4">බක්</month>
+							<month type="5">වෙසක්</month>
+							<month type="6">පොසොන්</month>
+							<month type="7">ඇසළ</month>
+							<month type="8">නිකිණි</month>
+							<month type="9">බිනර</month>
+							<month type="10">වප්</month>
+							<month type="11">ඉල්</month>
+							<month type="12">උඳුවප්</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2317,37 +2317,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="minute">
-				<displayName>මිනිත්තුව</displayName>
-				<relative type="0">මෙම මිනිත්තුව</relative>
+				<displayName>විනාඩිය</displayName>
+				<relative type="0">මෙම විනාඩිය</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">මිනිත්තු {0}කින්</relativeTimePattern>
-					<relativeTimePattern count="other">මිනිත්තු {0}කින්</relativeTimePattern>
+					<relativeTimePattern count="one">විනාඩි {0}කින්</relativeTimePattern>
+					<relativeTimePattern count="other">විනාඩි {0}කින්</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">මිනිත්තු {0}කට පෙර</relativeTimePattern>
-					<relativeTimePattern count="other">මිනිත්තු {0}කට පෙර</relativeTimePattern>
+					<relativeTimePattern count="one">විනාඩි {0}කට පෙර</relativeTimePattern>
+					<relativeTimePattern count="other">විනාඩි {0}කට පෙර</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-short">
 				<displayName>මිනි.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">මිනිත්තු {0}කින්</relativeTimePattern>
-					<relativeTimePattern count="other">මිනිත්තු {0}කින්</relativeTimePattern>
+					<relativeTimePattern count="one">විනාඩි {0}කින්</relativeTimePattern>
+					<relativeTimePattern count="other">විනාඩි {0}කින්</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">මිනිත්තු {0}කට පෙර</relativeTimePattern>
-					<relativeTimePattern count="other">මිනිත්තු {0}කට පෙර</relativeTimePattern>
+					<relativeTimePattern count="one">විනාඩි {0}කට පෙර</relativeTimePattern>
+					<relativeTimePattern count="other">විනාඩි {0}කට පෙර</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
 				<displayName>මිනි.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">මිනිත්තු {0}කින්</relativeTimePattern>
-					<relativeTimePattern count="other">මිනිත්තු {0}කින්</relativeTimePattern>
+					<relativeTimePattern count="one">විනාඩි {0}කින්</relativeTimePattern>
+					<relativeTimePattern count="other">විනාඩි {0}කින්</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">මිනිත්තු {0}කට පෙර</relativeTimePattern>
-					<relativeTimePattern count="other">මිනිත්තු {0}කට පෙර</relativeTimePattern>
+					<relativeTimePattern count="one">විනාඩි {0}කට පෙර</relativeTimePattern>
+					<relativeTimePattern count="other">විනාඩි {0}කට පෙර</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -6196,8 +6196,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>චාපමිනිත්තු</displayName>
-				<unitPattern count="one">චාපමිනිත්තු {0}</unitPattern>
-				<unitPattern count="other">චාපමිනිත්තු {0}</unitPattern>
+				<unitPattern count="one">චාපවිනාඩි {0}</unitPattern>
+				<unitPattern count="other">චාපවිනාඩි {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>චාපතත්පර</displayName>
@@ -6421,8 +6421,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-minute">
 				<displayName>මිනිත්තු</displayName>
-				<unitPattern count="one">මිනිත්තු {0}</unitPattern>
-				<unitPattern count="other">මිනිත්තු {0}</unitPattern>
+				<unitPattern count="one">විනාඩි {0}</unitPattern>
+				<unitPattern count="other">විනාඩි {0}</unitPattern>
 				<perUnitPattern>මිනිත්තුවට {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -7466,8 +7466,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-minute">
 				<displayName>මිනි</displayName>
-				<unitPattern count="one">මිනි {0}</unitPattern>
-				<unitPattern count="other">මිනි {0}</unitPattern>
+				<unitPattern count="one">විනා {0}</unitPattern>
+				<unitPattern count="other">විනා {0}</unitPattern>
 				<perUnitPattern>{0}/මිනි</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8510,9 +8510,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>මිනි</displayName>
-				<unitPattern count="one">මි {0}</unitPattern>
-				<unitPattern count="other">මි {0}</unitPattern>
+				<displayName>විනා</displayName>
+				<unitPattern count="one">වි {0}</unitPattern>
+				<unitPattern count="other">වි {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-second">


### PR DESCRIPTION
[CLDR-15166](https://unicode-org.atlassian.net/browse/CLDR-15166)

**Description**
Current date and time localization for sinhala (si) language is incorrect. See below examples for understand it and PR contain eg: traditional months names that exist since decades.

**Now**
e.g. 1: January--> ජනවාරි (pron: janavaari)
e.g. 2: February --> පෙබරවාරි (pron: pebaravaari)
e.g. 3: Minute --> මිනිත්තුව (pron: miniththuwa)

**Pull Request**
e.g. 1: January --> දුරුතු (pron: duruthu)
e.g. 2: February --> නවම් (pron: navam)
e.g. 3: Minute --> විනාඩිය (pron: vinaadiya)

Reference: https://masteranylanguage.com/c/b/o9ly878fJ/98-Sinhala-MonthsOfYear-Learn-Step-By-Step
(You can see the both 'now' and 'PR' with pronunciation)

- [x] This PR completes the ticket.
- Fix date and time localization
- Other minor fixes
