### PR TITLE
CLDR-15056 Coverage Progress Bars front end

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.js
+++ b/tools/cldr-apps/js/src/esm/cldrGui.js
@@ -274,8 +274,10 @@ const topTitle =
         </span>
       </span>
       <span id="CompletionSpan"></span>
-      <button class="cldr-nav-btn cldr-nav-right open-dash" type="button">Open Dashboard</button>
-      <button class="cldr-nav-btn toggle-right" type="button">Toggle Info Panel</button>
+      <span>
+        <button class="cldr-nav-btn btn-primary open-dash" type="button">Open Dashboard</button>
+        <button class="cldr-nav-btn btn-primary toggle-right" type="button">Toggle Info Panel</button>
+      </span>
     </nav>
   </header>
 `;
@@ -474,7 +476,7 @@ function updateWidgetsWithCoverage(newLevel) {
   if (dashboardVisible) {
     dashboardWidgetWrapper?.handleCoverageChanged(newLevel);
   }
-  cldrProgress.updateWidgetsWithCoverage(newLevel);
+  cldrProgress.updateWidgetsWithCoverage();
 }
 
 /**
@@ -536,7 +538,7 @@ function hideDashboard() {
     dash.style.display = "none";
     let els = document.getElementsByClassName("open-dash");
     for (let i = 0; i < els.length; i++) {
-      els[i].style.display = "inherit";
+      els[i].style.display = "inline";
     }
     dashboardVisible = false;
   }

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -1093,6 +1093,7 @@ function flipToEmptyOther() {
 
 function coverageUpdate() {
   cldrCoverage.updateCoverage(flipper.get(pages.data));
+  handleCoverageChanged(cldrCoverage.effectiveName());
 }
 
 function setLoading(loading) {

--- a/tools/cldr-apps/js/src/esm/cldrStatus.js
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.js
@@ -56,7 +56,6 @@ function updateAll(status) {
 /**
  * When this changes from one non-null value to another, the server has restarted
  * a.k.a. org.unicode.cldr.web.SurveyMain.surveyRunningStamp
- * a.k.a. status.surveyRunningStamp
  */
 let runningStamp = null;
 
@@ -120,7 +119,12 @@ function getCurrentId() {
 }
 
 function setCurrentId(id) {
-  currentId = idIsAllowed(id) ? id : "";
+  if (!id) {
+    currentId = "";
+  } else {
+    id = id.toString();
+    currentId = idIsAllowed(id) ? id : "";
+  }
 }
 
 function idIsAllowed(id) {
@@ -139,7 +143,6 @@ function idIsAllowed(id) {
 
 /**
  * A string such as '' (empty), 'Gregorian', 'Languages_K_N'
- * a.k.a. surveyCurrentPage
  */
 let currentPage = "";
 
@@ -171,7 +174,7 @@ function setCurrentSpecial(special) {
 
 /**
  * A string such as 'en', 'fr', etc., identifying a locale
- * a.k.a. surveyCurrentLocale
+ *
  * Caution: cldrLoad.updateHashAndMenus makes a distinction between null and
  * empty string "" for getCurrentLocale, seemingly with the assumption that
  * null is the original value. Later it may become empty string "", and
@@ -189,7 +192,6 @@ function setCurrentLocale(loc) {
 
 /**
  * A string such as 'French', etc., naming a locale
- * a.k.a. surveyCurrentLocaleName
  */
 let currentLocaleName = null;
 
@@ -203,7 +205,6 @@ function setCurrentLocaleName(name) {
 
 /**
  * A string such as 'Timezones', etc., naming a data section
- * a.k.a. surveyCurrentSection
  */
 let currentSection = "";
 
@@ -269,7 +270,6 @@ function setIsPhaseBeta(i) {
 
 /**
  * A string such as 'B0752471848DE78128A234F992BB3116', etc., identifying an HttpSession
- * a.k.a. surveySessionId
  */
 let sessionId = null;
 
@@ -355,7 +355,6 @@ function setOrganizationName(n) {
 
 /**
  * An object describing the current user's permissions
- * a.k.a. surveyUserPerms
  */
 let permissions = null;
 

--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -347,10 +347,10 @@ function singleRowLoadHandler(json, tr, theRow, onSuccess, onFailure) {
       onSuccess(theRow);
       cldrGui.updateDashboardRow(json);
       cldrInfo.showRowObjFunc(tr, tr.proposedcell, tr.proposedcell.showFn);
-      cldrProgress.updateSectionCompletionOneVote(theRow.hasVoted);
+      cldrProgress.updateCompletionOneVote(theRow.hasVoted);
       /*
        * TODO: refreshCounterVetting here may be partly redundant after we
-       * have called cldrProgress.updateSectionCompletionOneVote
+       * have called cldrProgress.updateCompletionOneVote
        * -- however,refreshCounterVetting may also update
        * forum data and other counters -- "singleRowLoadHandler" isn't necessarily
        * the best time to update the forum data, though...

--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -61,7 +61,7 @@
           class="glyphicon glyphicon-user tip-log"
           v-bind:title="org"
         ></span>
-        &nbsp;|&nbsp;
+        &nbsp;
         <cldr-loginbutton />
       </li>
     </ul>

--- a/tools/cldr-apps/js/src/views/ProgressMeters.vue
+++ b/tools/cldr-apps/js/src/views/ProgressMeters.vue
@@ -1,24 +1,24 @@
 <template>
   <section id="ProgressMeters" v-if="!hide">
     <a-progress
-      :percent="sectionBar.percent"
-      :title="sectionBar.title"
+      :percent="sectionMeter.getPercent()"
+      :title="sectionMeter.getTitle()"
       strokeColor="blue"
       type="circle"
       :width="32"
     />
     &nbsp;
     <a-progress
-      :percent="voterBar.percent"
-      :title="voterBar.title"
+      :percent="voterMeter.getPercent()"
+      :title="voterMeter.getTitle()"
       strokeColor="orange"
       type="circle"
       :width="32"
     />
     &nbsp;
     <a-progress
-      :percent="localeBar.percent"
-      :title="localeBar.title"
+      :percent="localeMeter.getPercent()"
+      :title="localeMeter.getTitle()"
       strokeColor="green"
       type="circle"
       :width="32"
@@ -27,39 +27,16 @@
 </template>
 
 <script>
-import * as cldrLoad from "../esm/cldrLoad.js";
 import * as cldrProgress from "../esm/cldrProgress.js";
-import * as cldrStatus from "../esm/cldrStatus.js";
 
 export default {
   props: [],
   data() {
     return {
       hide: true,
-      locale: null,
-      localeName: null,
-      level: null,
-      sectionBar: {
-        description: "Your voting in this section",
-        votes: -1,
-        total: -1,
-        percent: -1,
-        title: "",
-      },
-      voterBar: {
-        description: "Your voting in this locale",
-        votes: -1,
-        total: -1,
-        percent: -1,
-        title: "",
-      },
-      localeBar: {
-        description: "Completion for all vetters in this locale",
-        votes: -1,
-        total: -1,
-        percent: -1,
-        title: "",
-      },
+      sectionMeter: new cldrProgress.MeterData("", 0, 0, 0),
+      voterMeter: new cldrProgress.MeterData("", 0, 0, 0),
+      localeMeter: new cldrProgress.MeterData("", 0, 0, 0),
     };
   },
 
@@ -68,49 +45,17 @@ export default {
       this.hide = hidden;
     },
 
-    setLevel(level) {
-      this.level = level;
+    updateSectionMeter(meterData) {
+      this.sectionMeter = meterData;
     },
 
-    setLocale(locale) {
-      this.locale = locale;
-      this.localeName = cldrLoad.getLocaleName(locale);
-      console.log(
-        "VotingCompletion setting temporary placeholder values 33/100 for locale completion"
-      );
-      this.updateLocaleVotesAndTotal(33, 100); // TODO: fetch data for localeBar
+    updateVoterMeter(meterData) {
+      this.voterMeter = meterData;
     },
 
-    updateSectionVotesAndTotal(votes, total) {
-      this.makeBar(this.sectionBar, votes, total);
+    updateLocaleMeter(meterData) {
+      this.localeMeter = meterData;
     },
-
-    updateVoterVotesAndTotal(votes, total) {
-      this.makeBar(this.voterBar, votes, total);
-    },
-
-    updateLocaleVotesAndTotal(votes, total) {
-      this.makeBar(this.localeBar, votes, total);
-    },
-
-    makeBar(bar, votes, total) {
-      bar.votes = votes;
-      bar.total = total;
-      // do not round 99.9 up to 100
-      bar.percent = Math.floor((100 * votes) / total);
-      bar.title =
-        `${bar.description}:` +
-        "\n" +
-        `${votes} / ${total} = ${bar.percent}%` +
-        "\n" +
-        `Locale: ${this.localeName} (${this.locale})` +
-        "\n" +
-        `Coverage: ${this.level}`;
-    },
-  },
-
-  computed: {
-    console: () => console,
   },
 };
 </script>

--- a/tools/cldr-apps/js/test/TestCldrStatus.js
+++ b/tools/cldr-apps/js/test/TestCldrStatus.js
@@ -42,11 +42,23 @@ describe("cldrStatus.runningStampChanged", function () {
 });
 
 describe("cldrStatus.getCurrentId and setCurrentId", function () {
-  const id1 = 42;
+  const id1 = "42abc";
   cldrStatus.setCurrentId(id1);
   const id2 = cldrStatus.getCurrentId();
 
   it("should get what is set", function () {
     assert(id2 === id1, "id2 = " + id2 + " should be same as id1 = " + id1);
+  });
+
+  const id3number = 1234;
+  const id3string = id3number.toString();
+  cldrStatus.setCurrentId(id3number);
+  const id4 = cldrStatus.getCurrentId();
+
+  it("should convert a number to a string", function () {
+    assert(
+      id4 === id3string,
+      "id4 = " + id4 + " should be same as id3string = " + id3string
+    );
   });
 });

--- a/tools/cldr-apps/src/main/webapp/css/redesign.css
+++ b/tools/cldr-apps/src/main/webapp/css/redesign.css
@@ -1110,10 +1110,6 @@ html {
 	border-radius: 3px;
 }
 
-.cldr-nav-right {
-	margin-left: auto !important;
-}
-
 .nav-progress {
 	width: 150px;
 	height: 20px;


### PR DESCRIPTION
-Bug fix: filter for coverage when count rows in section

-Bug fix: avoid division by zero

-Make user-friendly percentage, never round down to zero or up to 100

-Implement a front end for locale completion

-Update voter completion after vote/abstain, updateStatsOneVote just as for section completion

-Call cldrLoad.handleCoverageChanged from cldrLoad.coverageUpdate, do not wait for menu choice

-Improve layout and style consistency of nav-page

-Refactor with new class MeterData; the vue component only has display logic

-Improve cldrStatus.setCurrentId and its unit test: normalize to string

-Remove unneeded timeout for cldrProgress.insertWidget

-Remove some unused imports and exports

-Comments

CLDR-15056

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
