### PR TITLE
CLDR-15151 Tag does not work for Push to Production

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       git-ref:
-        description: Git Ref to Deploy (main, hash, tag)
+        description: 'Git Ref to Deploy (hash: 40 hex digits)'
         required: true
       option:
         description: use --override to allow any ref


### PR DESCRIPTION
-Change the prompt from ...(main, hash, tag) to ...(hash: 40 hex digits)

CLDR-15151

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
