### PR TITLE
CLDR-15183 enable Rohingya, Bodo, Kashmiri

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -1385,7 +1385,7 @@ public class ChartDelta extends Chart {
          * @return true or false
          */
         private static boolean localeIsHighLevel(String locale) {
-            return SubmissionLocales.CLDR_LOCALES.contains(locale)
+            return SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES.contains(locale)
                 || "supplementalData".equals(locale);
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -690,7 +690,7 @@ public class TestUtilities extends TestFmwkPlus {
         final Set<String> eightVoteSublocales = new HashSet<>(Arrays.asList("pt_PT", "zh_Hant"));
         final VoteResolver<String> resolver = new VoteResolver<>();
         final String path = "//ldml/annotations/annotation[@cp=\"🌏\"][@type=\"tts\"]";
-        for (String locale : SubmissionLocales.CLDR_LOCALES) {
+        for (String locale : SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES) {
             if (locale.contains("_")) {
                 int expectedRequiredVotes = eightVoteSublocales.contains(locale) ? TWO_VETTER_BAR : ONE_VETTER_BAR;
                 verifyRequiredVotes(resolver, locale, path, Status.approved, expectedRequiredVotes);


### PR DESCRIPTION
As a result, paths should be votable if:

1. they are in any of these 3 locales, OR
2. they are long units in grammar locales

SubmissionLocales.java
- Restructured to make this easier in the future. Mostly renaming of constants for clarity, which percolated into 3 other files.

TestCheckCLDR.java
- Dropped some old code that checked for scripts (without being needed).
- Added the ability to print out the results of the allowed paths for sanity checking.

ChartDelta.java, TestUtilities.java
- Just the results from renaming constants in SubmissionLocales.java

CLDR-15183

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
