### PR TITLE
CLDR-15056 Coverage Progress Bars, hide 2nd meter, fix dashboard reload

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrMenu.js
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.js
@@ -310,8 +310,11 @@ function getMenusFromServer(s) {
       return; // busted?
     }
     // Note: since the url has "locmap=false", we never get json.locmap or json.canmodify here
+    const covName = cldrCoverage.effectiveName();
     cldrCoverage.updateCovFromJson(json);
-    cldrLoad.coverageUpdate();
+    if (cldrCoverage.effectiveName() !== covName) {
+      cldrLoad.coverageUpdate();
+    }
     unpackMenus(json);
     cldrEvent.unpackMenuSideBar(json);
     updateMenus(_thePages);

--- a/tools/cldr-apps/js/src/esm/cldrProgress.js
+++ b/tools/cldr-apps/js/src/esm/cldrProgress.js
@@ -17,6 +17,8 @@ import { createCldrApp } from "../cldrVueRouter";
 import { notification } from "ant-design-vue";
 
 const USE_NEW_PROGRESS_WIDGET = true;
+const CAN_GET_VOTER_PROGRESS = false;
+const CAN_GET_LOCALE_PROGRESS = false;
 
 let progressWrapper = null;
 
@@ -271,7 +273,11 @@ function updateStatsOneVote(stats, hasVoted) {
 }
 
 function fetchVoterData() {
-  if (!progressWrapper || !cldrStatus.getSurveyUser()) {
+  if (
+    !CAN_GET_VOTER_PROGRESS ||
+    !progressWrapper ||
+    !cldrStatus.getSurveyUser()
+  ) {
     return;
   }
   const locale = cldrStatus.getCurrentLocale();
@@ -317,7 +323,11 @@ function reallyFetchVoterData(locale, level) {
 }
 
 function fetchLocaleData() {
-  if (!progressWrapper || !cldrStatus.getSurveyUser()) {
+  if (
+    !CAN_GET_LOCALE_PROGRESS ||
+    !progressWrapper ||
+    !cldrStatus.getSurveyUser()
+  ) {
     return;
   }
   const locale = cldrStatus.getCurrentLocale();

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -199,8 +199,9 @@ export default {
     },
 
     handleCoverageChanged(level) {
-      console.log("Dashboard changing level: " + level);
-      this.reloadDashboard();
+      if (this.level !== level) {
+        this.reloadDashboard();
+      }
     },
 
     reloadDashboard() {


### PR DESCRIPTION
-Hide the 2nd meter (Voter Completion) until the back end works

-Do not try to fetch data for 2nd or 3rd meter until the back end works

-New booleans in cldrProgress.js: CAN_GET_VOTER_PROGRESS, CAN_GET_LOCALE_PROGRESS

-Fix bug: Dashboard would reload after all-row getrow request though coverage unchanged

-In cldrMenu.js, do not call cldrLoad.coverageUpdate unless effectiveName changes

-In DashboardWidget.vue, do not call this.reloadDashboard unless this.level changes

CLDR-15056

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
