### PR TITLE
CLDR-15056 Coverage Progress Bars, fix to show at least Section Meter

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrProgress.js
+++ b/tools/cldr-apps/js/src/esm/cldrProgress.js
@@ -30,11 +30,12 @@ let sectionProgressRows = null;
 
 class MeterData {
   /**
+   * Construct a new MeterData object
    *
-   * @param {String?} description description of this meter
-   * @param {Number?} votes number of votes for this meter
-   * @param {Number?} total number of total votes for this meter
-   * @param {String?} level coverage level
+   * @param {String} description description of this meter
+   * @param {Number} votes number of votes for this meter
+   * @param {Number} total number of total votes for this meter
+   * @param {String} level coverage level
    * @returns
    */
   constructor(description, votes, total, level) {
@@ -61,7 +62,6 @@ class MeterData {
   }
 
   /**
-   *
    * @returns {Number} percentage [0…100]
    */
   getPercent() {
@@ -142,6 +142,9 @@ function refresh() {
   refreshSectionMeter();
   refreshVoterMeter();
   refreshLocaleMeter();
+  if (sectionProgressStats) {
+    progressWrapper?.setHidden(false);
+  }
 }
 
 function refreshSectionMeter() {
@@ -194,6 +197,9 @@ function updateSectionCompletion(rows) {
 }
 
 function getSectionCompletionFromRows(rows) {
+  if (!cldrStatus.getSurveyUser()) {
+    return null;
+  }
   const locale = cldrStatus.getCurrentLocale();
   if (!locale) {
     return null;


### PR DESCRIPTION
-If CAN_GET_VOTER_PROGRESS is false then the view needs un-hiding for Section Meter

-No Section Meter if not logged in

-Comments

CLDR-15056

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
