### PR TITLE
CLDR-15195 build jar sources when deploying to maven

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: >
-          mvn -s .github/workflows/mvn-settings.xml -B compile install package --file tools/pom.xml
+          mvn -s .github/workflows/mvn-settings.xml -B compile source:jar install package --file tools/pom.xml
           -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CLDR-15195

This builds jar sources before attaching. 

I'm going to see if I can include javadoc also… if possible. If not I'll merge this as is.

- [ ] This PR completes the ticket.