### PR TITLE
CLDR-15195 build jar sources on maven release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: >
-          mvn -s .github/workflows/mvn-settings.xml -B compile source:jar install package --file tools/pom.xml
+          mvn -s .github/workflows/mvn-settings.xml -B compile install package --file tools/pom.xml
           -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,6 +36,6 @@ jobs:
         # only for head fork
         if: github.repository == 'unicode-org/cldr'
         run: |
-          mvn -s .github/workflows/mvn-settings.xml  --file tools/pom.xml deploy
+          mvn -s .github/workflows/mvn-settings.xml  --file tools/pom.xml source:jar deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- needed to build sources after the version number change

CLDR-15195

- [ ] This PR completes the ticket.

Markus, 
 I've tried this myself with my own repo and it is actually attaching the sources properly. (partial extract below).

So if this looks good let's try once again.

```
     8868  12-03-2021 17:20   org/unicode/cldr/util/ExtractCollationRules.java
     2478  12-03-2021 17:20   org/unicode/cldr/util/RangeAbbreviator.java
     4077  12-03-2021 17:20   org/unicode/cldr/util/Visitor.java
    10829  12-03-2021 17:20   org/unicode/cldr/util/With.java
     9247  12-03-2021 17:20   org/unicode/cldr/util/SpecialLocales.java
    25293  12-03-2021 17:20   org/unicode/cldr/util/MatchValue.java
     5134  12-03-2021 17:20   org/unicode/cldr/util/Differ.java
    49492  12-03-2021 17:20   org/unicode/cldr/util/DateTimeFormats.java
    23188  12-03-2021 17:20   org/unicode/cldr/util/LsrvCanonicalizer.java
     2541  12-03-2021 17:20   org/unicode/cldr/util/GrammarDerivation.java
     1862  12-03-2021 17:20   org/unicode/cldr/util/DelegatingIterator.java
    12727  12-03-2021 17:20   org/unicode/cldr/util/XMLValidator.java
    20432  12-03-2021 17:20   org/unicode/cldr/util/Dictionary.java
```