### PR TITLE
CLDR-15224 make it clearer that you are in a limited submission locale

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrEvent.js
+++ b/tools/cldr-apps/js/src/esm/cldrEvent.js
@@ -177,9 +177,11 @@ function toggleLockedRead(event) {
     }
   } else {
     if (type == "read") {
-      $(".locName:not(.canmodify):not(.locked)").parent().addClass("hide");
+      $(".locName:not(.canmodify):not(.locked):not(.shown_but_locked)")
+        .parent()
+        .addClass("hide");
     } else {
-      $(".locName.locked").parent().addClass("hide");
+      $(".locName.locked:not(.shown_but_locked)").parent().addClass("hide");
     }
   }
   filterAllLocale();
@@ -233,7 +235,8 @@ function checkLocaleShow(element, size) {
     (!element.hasClass("canmodify") &&
       $("#show-read").is(":checked") &&
       !element.hasClass("locked")) ||
-    element.hasClass("canmodify")
+    element.hasClass("canmodify") ||
+    element.hasClass("shown_but_locked") // Always show these
   ) {
     return true;
   }

--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -336,11 +336,17 @@ const strings = {
     "This locale, ${name} is the <i><a target='CLDR-ST-DOCS' href='http://cldr.unicode.org/translation/default-content'>default content locale</a></i> for <b><a class='notselected' href='#/${dcParent}'>${dcParentName}</a></b>, and thus editing or viewing is disabled.",
   defaultContentChild_msg:
     "This locale, ${name}, supplies the <i><a target='CLDR-ST-DOCS' href='http://cldr.unicode.org/translation/default-content'>default content</a></i> for <b><a class='notselected' href='#/${dcChild}'>${dcChildName}</a></b>. Please make sure that all the changes that you make here are appropriate for <b>${dcChildName}</b>. If there are multiple acceptable choices, please try to pick the one that would work for the most other sublocales.",
+  defaultContent_brief_msg:
+    "${name} is a default content locale and may not be edited",
   defaultContent_header_msg: "= ${dcChild}",
   defaultContent_titleLink: "content",
-  readonly_msg: "This locale may not be edited.<br/> ${msg}",
+  readonly_msg: "This locale (${locale}) may not be edited.<br/> ${msg}",
   readonly_unknown: "Reason: Administrative Policy.",
   scratch_locale: "Test Locale",
+  readonly_in_limited:
+    "It is not open for submission during this limited cycle.",
+  readonly_in_limited_brief:
+    "Not open for submission during this limited cycle.",
   beta_msg:
     "The SurveyTool is currently in Beta. Any data added here will NOT go into CLDR.",
   sidewaysArea_desc: "view of what the votes are in other, sister locales",

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -35,6 +35,7 @@ import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.test.CheckForCopy;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
+import org.unicode.cldr.test.SubmissionLocales;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
 import org.unicode.cldr.util.CLDRConfig;
@@ -1170,6 +1171,13 @@ public class SurveyAjax extends HttpServlet {
                 locale.put("readonly", true);
             } else if (dcParent != null) {
                 locale.put("readonly", true);
+            } else {
+                // Readonly if in limited
+                if (CheckCLDR.LIMITED_SUBMISSION && !SubmissionLocales.LOCALES_ALLOWED_IN_LIMITED.contains(loc.getBaseName())) {
+                    locale.put("readonly", true);
+                    // Readonly due to limited submission
+                    locale.put("readonly_in_limited", true);
+                }
             }
             final SpecialLocales.Type localeType = SpecialLocales.getType(loc);
             if(localeType != null) {

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -829,21 +829,24 @@ tr.warnrow {
 	content: " (TEST) ";
 }
 
-.subLocale a.locked.locName {
+.subLocale a.locked.locName, .topLocaleRow a.locked.locName {
     color:  silver;
 }
 
 .canmodify::before {
-	content:"\270f  ";
+	content:"\270f  "; /* pencil */
 	font-family: 'Glyphicons Halflings';
 }
 
+.locked::before {
+    font-family:"Glyphicons Halflings";
+    content:"\e014 ";  /* X */
+    margin-top:2px;
+}
 
 .name_var {
     font-style: oblique;
 }
-
-
 
 .inputbox {
 	width: 95%;
@@ -2994,12 +2997,6 @@ td.v-path {
 .dijitDialogUnderlay, .claro .dijitDialogUnderlay {
     opacity: 0.5 !important;
     background-color: #b1b56a !important;
-}
-
-.locked::before {
-    font-family:"Glyphicons Halflings";
-    content:"\e014 ";
-    margin-top:2px;
 }
 
 .mailListChunk, .mailContentChunk {


### PR DESCRIPTION
- refactor hover / locale message code for locale sidebar
- indicate locales that are not open due to limited submission
- for locales that the user *would* be able to edit if not due to limited submission,
maintain those locales as visible even if other locked locales would be hidden
- gray out top level (not just sublocale) that are 'locked'
(old bug)

CLDR-15224

- [ ] This PR completes the ticket.