### PR TITLE
CLDR-15222 hide sandbox in production, identify

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -953,6 +953,10 @@ function appendLocaleLink(subLocDiv, subLoc, subInfo, fullTitle) {
   if (fullTitle) {
     name = locmap.getLocaleName(subLoc);
   }
+  if (subInfo.special_type === "scratch") {
+    cldrDom.addClass(subLocDiv, "scratch_locale");
+    name = `${cldrText.get("scratch_locale")}: ${name}`;
+  }
   const clickyLink = cldrDom.createChunk(name, "a", "locName");
   clickyLink.href = linkToLocale(subLoc);
   subLocDiv.appendChild(clickyLink);

--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -340,6 +340,7 @@ const strings = {
   defaultContent_titleLink: "content",
   readonly_msg: "This locale may not be edited.<br/> ${msg}",
   readonly_unknown: "Reason: Administrative Policy.",
+  scratch_locale: "Test Locale",
   beta_msg:
     "The SurveyTool is currently in Beta. Any data added here will NOT go into CLDR.",
   sidewaysArea_desc: "view of what the votes are in other, sister locales",

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -825,6 +825,10 @@ tr.warnrow {
 	text-decoration: none;
 }
 
+.scratch_locale a::after {
+	content: " (TEST) ";
+}
+
 .subLocale a.locked.locName {
     color:  silver;
 }


### PR DESCRIPTION
- on production, hide the sandbox locales
- on smoketest/dev, show sandbox locales in a separate section

CLDR-15222

- [X] This PR completes the ticket.

-----

On smoketest it will look like the following, on production will be hidden:

<img width="268" alt="image" src="https://user-images.githubusercontent.com/855219/145267476-5c57ee24-c702-4d51-8a41-cd16897c18de.png">
