### PR TITLE
CLDR-14745 First steps for WHAT_GETROW to modern api

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -787,6 +787,7 @@ function loadExclamationPoint() {
 }
 
 function loadAllRows(itemLoadInfo, theDiv) {
+  // TODO: curId (aka strid) appears to be ignored by the server; if so, remove it from the request
   const curId = cldrStatus.getCurrentId();
   const curPage = cldrStatus.getCurrentPage();
   const curLocale = cldrStatus.getCurrentLocale();
@@ -795,7 +796,19 @@ function loadAllRows(itemLoadInfo, theDiv) {
       locmap.getLocaleName(curLocale) + "/" + curPage + "/" + curId
     )
   );
-  const url =
+  const url = getPageUrl(curLocale, curPage, curId);
+  $("#nav-page").show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
+  myLoad(url, "section", function (json) {
+    loadAllRowsFromJson(json, theDiv);
+  });
+}
+
+function getPageUrl(curLocale, curPage, curId) {
+  if (cldrTable.TABLE_USES_NEW_API) {
+    const api = "voting/" + curLocale + "/page/" + curPage;
+    return cldrAjax.makeApiUrl(api, null);
+  }
+  return (
     cldrStatus.getContextPath() +
     "/SurveyAjax?what=getrow&_=" +
     curLocale +
@@ -805,11 +818,8 @@ function loadAllRows(itemLoadInfo, theDiv) {
     curId +
     "&s=" +
     cldrStatus.getSessionId() +
-    cldrSurvey.cacheKill();
-  $("#nav-page").show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
-  myLoad(url, "section", function (json) {
-    loadAllRowsFromJson(json, theDiv);
-  });
+    cldrSurvey.cacheKill()
+  );
 }
 
 function loadAllRowsFromJson(json, theDiv) {

--- a/tools/cldr-apps/js/src/esm/cldrStatus.js
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.js
@@ -277,19 +277,6 @@ function getSessionId() {
   return sessionId;
 }
 
-/**
- * Return header needed for login.
- * @param {Object} h headers to append to
- * @returns {Object} header map for fetch
- */
-function sessionHeaders(h) {
-  h = h || {};
-  if (getSessionId()) {
-    h["X-SurveyTool-Session"] = getSessionId();
-  }
-  return h;
-}
-
 function setSessionId(i) {
   if (i !== sessionId) {
     sessionId = i;
@@ -457,7 +444,6 @@ export {
   logoIcon,
   on,
   runningStampChanged,
-  sessionHeaders,
   setAutoImportBusy,
   setContextPath,
   setCurrentId,

--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -23,6 +23,9 @@ import * as cldrVote from "./cldrVote.js";
 import * as cldrXPathUtils from "./cldrXpathUtils.js";
 
 const CLDR_TABLE_DEBUG = false;
+
+const TABLE_USES_NEW_API = false;
+
 /*
  * ALWAYS_REMOVE_ALL_CHILD_NODES and NEVER_REUSE_TABLE should both be false for efficiency,
  * but if necessary they can be made true to revert to old less efficient behavior.
@@ -375,8 +378,18 @@ function singleRowErrHandler(err, tr, onFailure) {
 }
 
 function getSingleRowUrl(tr, theRow) {
+  if (TABLE_USES_NEW_API) {
+    const loc = cldrStatus.getCurrentLocale();
+    const xpath = tr.rowHash;
+    const api = "voting/" + loc + "/row/" + xpath;
+    let p = null;
+    if (cldrGui.dashboardIsVisible()) {
+      p = new URLSearchParams();
+      p.append("dashboard", "true");
+    }
+    return cldrAjax.makeApiUrl(api, p);
+  }
   const p = new URLSearchParams();
-  // TODO: switch to new API; WHAT_GETROW is deprecated
   p.append("what", "getrow"); // cf. WHAT_GETROW in SurveyAjax.java
   p.append("_", cldrStatus.getCurrentLocale());
   p.append("xpath", theRow.xpathId);
@@ -1291,6 +1304,7 @@ function getValidWinningValue(theRow) {
 
 export {
   NO_WINNING_VALUE,
+  TABLE_USES_NEW_API,
   appendExample,
   getRowApprovalStatusClass,
   insertRows,

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
@@ -3,7 +3,10 @@
 //
 //  Created by Steven R. Loomis on 18/11/2005.
 //  Copyright 2005-2014 IBM. All rights reserved.
-//
+
+// "Section" is now a misnomer, since this class now handles one "page" at a time, not one "section".
+// A section is like "Locale Display Names"; a page is like "Languages (A-D)". Generally one section
+// contains multiple pages.
 
 //  TODO: this class now has lots of knowledge about specific data types.. so does SurveyMain
 //  Probably, it should be concentrated in one side or another- perhaps SurveyMain should call this
@@ -1717,8 +1720,6 @@ public class DataSection implements JSONString {
      * @param matcher
      *
      * Called only by DataSection.make
-     *
-     * Old parameter ptype was always "comprehensive"
      */
     DataSection(PageId pageId, SurveyMain sm, CLDRLocale loc, String prefix, XPathMatcher matcher) {
         this.locale = loc;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -2445,11 +2445,11 @@ public class SurveyAjax extends HttpServlet {
      * @throws IOException
      * @throws JSONException
      *
-     * @deprecated - use /api/vote instead
+     * @deprecated - use /api/voting instead
      *
      * TODO: in spite of being deprecated, this is used constantly in Survey Tool. Its intended
-     * replacement in /api/vote is not actually used yet, and isn't ready to be used since it
-     * fails to implement the "dashboard=true" query parameter for calling Dashboard.getErrorOnPath.
+     * replacement in /api/voting is not actually used yet, and isn't ready to be used since it
+     * does not produce json compatible with the front end
      * Reference: https://unicode-org.atlassian.net/browse/CLDR-14745
      */
     @Deprecated

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
@@ -58,7 +58,6 @@ public final class SurveyJSONWrapper {
         return new JSONObject() {
             {
                 put("message", cs.getMessage());
-                put("htmlMessage", cs.getHTMLMessage());
                 put("type", cs.getType());
                 if (cs.getCause() != null) {
                     put("cause", wrap(cs.getCause()));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -772,7 +772,6 @@ abstract public class CheckCLDR {
         private Subtype subtype = Subtype.none;
         private String messageFormat;
         private Object[] parameters;
-        private String htmlMessage;
         private CheckCLDR cause;
         private boolean checkOnSubmit = true;
 
@@ -826,23 +825,6 @@ abstract public class CheckCLDR {
                 }
             }
             return message.replace('\t', ' ');
-        }
-
-        /**
-         * @deprecated
-         */
-        @Deprecated
-        public String getHTMLMessage() {
-            return htmlMessage;
-        }
-
-        /**
-         * @deprecated
-         */
-        @Deprecated
-        public CheckStatus setHTMLMessage(String message) {
-            htmlMessage = message;
-            return this;
         }
 
         public CheckStatus setMessage(String message) {
@@ -1153,7 +1135,7 @@ abstract public class CheckCLDR {
     /**
      * Returns any examples in the result parameter. Both examples and demos can
      * be returned. A demo will have getType() == CheckStatus.demoType. In that
-     * case, there will be no getMessage or getHTMLMessage available; instead,
+     * case, there will be no getMessage available; instead,
      * call getDemo() to get the demo, then call getHTML() to get the initial
      * HTML.
      */


### PR DESCRIPTION
-New boolean cldrTable.TABLE_USES_NEW_API to test calling api/voting instead of SurveyAjax.getRow

-Keep cldrTable.TABLE_USES_NEW_API false until new api works correctly

-Enable old-fashioned sendXhr request to use modern session header for api

-Encapsulate X-SurveyTool-Session, and adding session header, in cldrAjax.js

-Minor refactoring of cldrAjax.js, more subroutines

-Make ST_AJAX_DEBUG false; debugging should be off unless specifically needed

-Fix VoteAPIHelper to call getErrorOnPath as when required by front end

-Add convenience functions VoteAPIHelper.handleGetOneRow/handleGetOnePage

-Add convenience class VoteAPIHelper.ArgsForGet, shorten parameter lists

-Remove dead deprecated CheckCLDR.get/setHTMLMessage

-Fix deprecation warnings for SurveyLog.logException

-Formatting

-Comments

CLDR-14745

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
