### PR TITLE
CLDR-15222 mul: remove 'Test Locales' divider

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrMenu.js
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.js
@@ -113,7 +113,6 @@ function addTopLocales(theDiv, locmap) {
     }
   }
   if (cldrStatus.getIsUnofficial()) {
-    $(theDiv).append($("<hr/><h4>Test Locales</h4>"));
     for (let n in locmap.locmap.topLocales) {
       const topLoc = locmap.locmap.topLocales[n];
       const topLocInfo = locmap.getLocaleInfo(topLoc);


### PR DESCRIPTION
CLDR-15222

- [X] This PR completes the ticket.

On smoketest, [there "used" to be a 'Test Locales' subsection on the left sidebar](https://github.com/unicode-org/cldr/pull/1657#issuecomment-989345149). It had a bug where that subsection heading was always present, even if a specific locale was selected.

 Now that each test locale says 'Test Locale', I don't think that subheading is needed. 

This one line fix changes the left sidebar (on smoketest!) to the following:

![image](https://user-images.githubusercontent.com/855219/145878773-75e536b8-e91b-4dd1-a147-1063427fbcd3.png)

