### PR TITLE
CLDR-15056 Coverage Progress Bars, enable Locale Progress meter

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -416,7 +416,7 @@ function insertLocaleSpecialNote(theDiv) {
  * @param {Boolean} brief if true, keep it short
  * @param {Boolean} plain if true, strip to plain text
  */
- function localeSpecialNote(bund, brief) {
+function localeSpecialNote(bund, brief) {
   if (!bund) return null;
   let msg = null;
   if (bund.dcParent) {

--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -489,6 +489,8 @@ const strings = {
 
   progress_page: "Your voting in this page",
   progress_voter: "Your voting in this locale",
+  progress_voter_disabled:
+    "This meter will be enabled if you open the Dashboard",
   progress_all_vetters: "Completion for all vetters in this locale",
 };
 

--- a/tools/cldr-apps/js/src/views/ProgressMeters.vue
+++ b/tools/cldr-apps/js/src/views/ProgressMeters.vue
@@ -1,26 +1,29 @@
 <template>
   <section id="ProgressMeters" v-if="!hide">
-    <a-tooltip v-if="pageMeter.getPresent()" :title="pageMeter.getTitle()">
+    <a-tooltip v-if="pageMeter.isVisible()" :title="pageMeter.getTitle()">
       <a-progress
         :percent="pageMeter.getPercent()"
+        :showInfo="!pageMeter.isExceptional()"
         strokeColor="blue"
         type="circle"
         :width="32"
       />
     </a-tooltip>
     &nbsp;
-    <a-tooltip v-if="voterMeter.getPresent()" :title="voterMeter.getTitle()">
+    <a-tooltip v-if="voterMeter.isVisible()" :title="voterMeter.getTitle()">
       <a-progress
         :percent="voterMeter.getPercent()"
+        :showInfo="!voterMeter.isExceptional()"
         strokeColor="orange"
         type="circle"
         :width="32"
       />
     </a-tooltip>
     &nbsp;
-    <a-tooltip v-if="localeMeter.getPresent()" :title="localeMeter.getTitle()">
+    <a-tooltip v-if="localeMeter.isVisible()" :title="localeMeter.getTitle()">
       <a-progress
         :percent="localeMeter.getPercent()"
+        :showInfo="!localeMeter.isExceptional()"
         strokeColor="green"
         type="circle"
         :width="32"

--- a/tools/cldr-apps/js/test/TestCldrChecksum.js
+++ b/tools/cldr-apps/js/test/TestCldrChecksum.js
@@ -137,16 +137,20 @@ describe("cldrTable.cldrChecksum", function () {
       const c = cldrTable.cldrChecksum(sLong);
       assert(c === cLong, "c should equal cLong");
     }
+    // This occasionally failed on github, which presumably is sometimes slow
+    // for reasons beyond our control. Therefore, don't assert, just send a
+    // warning message to the console.
     const duration = Date.now() - startTime; // typically 15 ms
-    assert(
-      duration < MAX_MILLISECS,
-      "Duration was " +
-        duration +
-        " ms; " +
-        ITERATIONS +
-        " iterations should take less than " +
-        MAX_MILLISECS +
-        " ms"
-    );
+    if (duration > MAX_MILLISECS) {
+      console.log(
+        "WARNING: cldrChecksum duration was " +
+          duration +
+          " ms; " +
+          ITERATIONS +
+          " iterations should take less than " +
+          MAX_MILLISECS +
+          " ms"
+      );
+    }
   });
 });


### PR DESCRIPTION
-CAN_GET_LOCALE_PROGRESS = true in cldrProgress.js

-Ensure that Page, Voter, Locale meters are displayed as 1st, 2nd, 3rd respectively

-If Page meter is visible, make Voter meter visible even if no Dashboard data yet

-If Voter meter is visible but no data yet, display with special message and appearance

-TestCldrChecksum.js: warn without failure if time is excessive

-Format unrelated cldrLoad.js by running sh tools/cldr-apps/js/test/pretty.sh

CLDR-15056

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
