### PR TITLE
CLDR-15235 add feminine to nn

### DIFF
--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -6602,8 +6602,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pluralMinimalPairs count="one">{0} dag</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">{0} dagar</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Ta {0}. sving til høgre.</ordinalMinimalPairs>
-			<genderMinimalPairs gender="masculine">Min {0} han har tre kantar</genderMinimalPairs>
-			<genderMinimalPairs gender="neuter">Mitt {0} det har tre kantar</genderMinimalPairs>
+			<genderMinimalPairs gender="masculine">Det tek ein heil {0} å …</genderMinimalPairs>
+			<genderMinimalPairs gender="feminine">Det tek ei heil {0} å …</genderMinimalPairs>
+			<genderMinimalPairs gender="neuter">Det tek eit heilt {0} å …</genderMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -13964,8 +13964,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<ordinalMinimalPairs ordinal="other">Ta {0}. sving til høyre.</ordinalMinimalPairs>
 			<caseMinimalPairs case="nominative">Intervall på {0}</caseMinimalPairs>
 			<caseMinimalPairs case="genitive">På {0} avstand</caseMinimalPairs>
-			<genderMinimalPairs gender="masculine">Min {0} den har tre kanter</genderMinimalPairs>
-			<genderMinimalPairs gender="neuter">Mitt {0} det har tre kanter</genderMinimalPairs>
+			<genderMinimalPairs gender="masculine">Det tar en hel {0} å …</genderMinimalPairs>
+			<genderMinimalPairs gender="feminine">Det tar ei hel {0} å …</genderMinimalPairs>
+			<genderMinimalPairs gender="neuter">Det tar et helt {0} å …</genderMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/supplemental/grammaticalFeatures.xml
+++ b/common/supplemental/grammaticalFeatures.xml
@@ -177,10 +177,15 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
       <grammaticalDefiniteness values="definite indefinite"/>
       <!-- Gender is only used for expressing human activities/professions. -->
     </grammaticalFeatures>
-    <grammaticalFeatures targets="nominal" locales="nb nn no">
+    <grammaticalFeatures targets="nominal" locales="nb no">
       <grammaticalCase values="nominative genitive"/>
       <grammaticalGender values="masculine feminine neuter"/>
       <grammaticalGender scope="units" values="masculine neuter"/>
+      <grammaticalDefiniteness values="definite indefinite"/>
+    </grammaticalFeatures>
+    <grammaticalFeatures targets="nominal" locales="nn">
+      <grammaticalCase values="nominative genitive"/>
+      <grammaticalGender values="masculine feminine neuter"/>
       <grammaticalDefiniteness values="definite indefinite"/>
     </grammaticalFeatures>
     <grammaticalFeatures targets="nominal" locales="uk">

--- a/common/supplemental/grammaticalFeatures.xml
+++ b/common/supplemental/grammaticalFeatures.xml
@@ -177,13 +177,7 @@ plurals.xml and ordinals.xml. See those files and the LDML spec for more informa
       <grammaticalDefiniteness values="definite indefinite"/>
       <!-- Gender is only used for expressing human activities/professions. -->
     </grammaticalFeatures>
-    <grammaticalFeatures targets="nominal" locales="nb no">
-      <grammaticalCase values="nominative genitive"/>
-      <grammaticalGender values="masculine feminine neuter"/>
-      <grammaticalGender scope="units" values="masculine neuter"/>
-      <grammaticalDefiniteness values="definite indefinite"/>
-    </grammaticalFeatures>
-    <grammaticalFeatures targets="nominal" locales="nn">
+    <grammaticalFeatures targets="nominal" locales="nb nn no">
       <grammaticalCase values="nominative genitive"/>
       <grammaticalGender values="masculine feminine neuter"/>
       <grammaticalDefiniteness values="definite indefinite"/>


### PR DESCRIPTION
Note: this is done by removing the gender unit override. It also needs the minimalPair patterns for feminine. All 3 were changed to make more general and parallel.

CLDR-15235

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
