### PR TITLE
CLDR-14047 Add Abstained notifications to Dashboard

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -487,6 +487,26 @@ const strings = {
   lock_account_success:
     "The account has been locked successfully. Thank you for using the Survey Tool. If you have difficulty still, contact the person who set up your account.",
 
+  notification_category_abstained:
+    "You have abstained, or not yet voted for any value.",
+  notification_category_changed:
+    "The winning value was altered from the baseline value. (Informational)",
+  notification_category_disputed:
+    "Different organizations are choosing different values. Please review to approve or reach consensus.",
+  notification_category_english_changed:
+    "The English value has changed in CLDR, but the corresponding value for your language has not. " +
+    "Check if any changes are needed in your language.",
+  notification_category_error:
+    "The Survey Tool detected an error in the winning value.",
+  notification_category_losing:
+    "The value that your organization chose (overall) is either not the winning value, or doesn’t have enough votes to be approved. " +
+    "This might be due to a dispute between members of your organization.",
+  notification_category_missing:
+    "Your current coverage level requires the item to be present. " +
+    "(During the vetting phase, this is informational: you can’t add new values.)",
+  notification_category_provisional:
+    "There are not enough votes for this item to be approved (and used).",
+
   progress_page: "Your voting in this page",
   progress_voter: "Your voting in this locale",
   progress_voter_disabled:

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -35,9 +35,7 @@
               :notification="n.notification"
               class="scrollto cldr-nav-btn"
               v-on:click.prevent="scrollToCategory"
-              :title="
-                categoryComment[n.notification] || humanize(n.notification)
-              "
+              :title="describe(n.notification)"
             >
               {{ humanize(n.notification) }} ({{ n.total }})
             </button>
@@ -81,10 +79,7 @@
                   >
                     <span
                       class="notification"
-                      :title="
-                        categoryComment[n.notification] ||
-                        humanize(n.notification)
-                      "
+                      :title="describe(n.notification)"
                       >{{ abbreviate(n.notification) }}</span
                     >
                     <span class="section-page" title="section—page">{{
@@ -147,6 +142,7 @@ import * as cldrDash from "../esm/cldrDash.js";
 import * as cldrGui from "../esm/cldrGui.js";
 import * as cldrLoad from "../esm/cldrLoad.js";
 import * as cldrStatus from "../esm/cldrStatus.js";
+import * as cldrText from "../esm/cldrText.js";
 
 export default {
   props: [],
@@ -160,12 +156,6 @@ export default {
       locale: null,
       localeName: null,
       level: null,
-      categoryComment: {
-        Provisional:
-          "The item is provisional, and needs additional votes for confirmation",
-        English_Changed:
-          "The English version has changed, but the locale has not",
-      },
     };
   },
 
@@ -273,15 +263,33 @@ export default {
       cldrGui.hideDashboard();
     },
 
-    abbreviate(str) {
-      if (str === "English_Changed") {
+    abbreviate(category) {
+      // The category is like "English_Changed"; also allow "English Changed" with space not underscore
+      if (category.toLowerCase().replaceAll(" ", "_") === "english_changed") {
         return "EC";
       } else {
-        return str.substr(0, 1); // first letter, e.g., "E" for "Error"
+        return category.substr(0, 1); // first letter, e.g., "E" for "Error"
       }
     },
 
+    describe(category) {
+      // The category is like "English_Changed" or "English Changed"
+      // The corresponding key is like "notification_category_english_changed"
+      const key =
+        "notification_category_" + category.toLowerCase().replaceAll(" ", "_");
+      let description = cldrText.get(key);
+      if (description === key) {
+        console.error(
+          "Dashboard is missing a description for the category: " + category
+        );
+        description = humanize(category);
+      }
+      return description;
+    },
+
     humanize(str) {
+      // For notification categories like "English_Changed", page names like "Languages_K_N",
+      // and section names like "Locale_Display_Names"
       return str.replaceAll("_", " ");
     },
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -235,7 +235,7 @@ public class Dashboard {
          * Reference: https://unicode-org.atlassian.net/browse/CLDR-15056
          */
         VettingViewer<Organization>.DashboardData dd;
-        dd = vv.generateFileInfoReview(choiceSet, loc, user.id, usersOrg, usersLevel, sourceFile, baselineFile);
+        dd = vv.generateDashboard(choiceSet, loc, user.id, usersOrg, usersLevel, sourceFile, baselineFile);
         return reallyGet(sourceFile, baselineFile, dd, locale, user.id);
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
@@ -289,9 +289,8 @@ public class VettingViewerQueue {
         }
 
         private void processCriticalWork(final CLDRProgressTask progress) {
-            VettingViewer<Organization> vv;
             status = "Beginning Process, Calculating";
-
+            VettingViewer<Organization> vv;
             vv = new VettingViewer<>(sm.getSupplementalDataInfo(), sm.getSTFactory(),
                 new STUsersChoice(sm));
             progress.update("Got VettingViewer");
@@ -302,11 +301,12 @@ public class VettingViewerQueue {
             vv.setProgressCallback(new CLDRProgressCallback(progress, Thread.currentThread()));
 
             EnumSet<VettingViewer.Choice> choiceSet = VettingViewer.getChoiceSetForOrg(usersOrg);
+            choiceSet.remove(VettingViewer.Choice.abstained);
 
             if (DEBUG) {
-                System.out.println("Starting summary gen..");
+                System.out.println("Starting generation of Priority Items Summary");
             }
-            vv.generateSummaryHtmlErrorTables(aBuffer, choiceSet, usersOrg);
+            vv.generatePriorityItemsSummary(aBuffer, choiceSet, usersOrg);
             if (myThread.isAlive()) {
                 aBuffer.append("<hr/>" + PRE + "Processing time: " + ElapsedTimer.elapsedTime(start) + POST);
                 entry.output.put(usersOrg, new VVOutput(aBuffer));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -66,14 +66,16 @@ public class VettingViewer<T> {
 
     private static Set<CheckCLDR.CheckStatus.Subtype> OK_IF_VOTED = EnumSet.of(Subtype.sameAsEnglish);
 
+    /**
+     * Notification categories
+     */
     public enum Choice {
         /**
          * There is a console-check error
          */
         error('E',
             "Error",
-            "The Survey Tool detected an error in the winning value.",
-            1),
+            "The Survey Tool detected an error in the winning value."),
 
         /**
          * Given the users' coverage, some items are missing
@@ -81,24 +83,21 @@ public class VettingViewer<T> {
         missingCoverage('M',
             "Missing",
             "Your current coverage level requires the item to be present. "
-                + "(During the vetting phase, this is informational: you can’t add new values.)",
-            2),
+                + "(During the vetting phase, this is informational: you can’t add new values.)"),
 
         /**
          * Provisional: there are not enough votes to be approved
          */
         notApproved('P',
             "Provisional",
-            "There are not enough votes for this item to be approved (and used).",
-            3),
+            "There are not enough votes for this item to be approved (and used)."),
 
         /**
          * There is a dispute.
          */
         hasDispute('D',
             "Disputed",
-            "Different organizations are choosing different values. Please review to approve or reach consensus.",
-            4),
+            "Different organizations are choosing different values. Please review to approve or reach consensus."),
 
         /**
          * My choice is not the winning item
@@ -106,16 +105,14 @@ public class VettingViewer<T> {
         weLost('L',
             "Losing",
             "The value that your organization chose (overall) is either not the winning value, or doesn’t have enough votes to be approved. "
-                + "This might be due to a dispute between members of your organization.",
-            5),
+                + "This might be due to a dispute between members of your organization."),
 
         /**
          * There is a console-check warning
          */
         warning('W',
             "Warning",
-            "The Survey Tool detected a warning about the winning value.",
-            6),
+            "The Survey Tool detected a warning about the winning value."),
 
         /**
          * The English value for the path changed AFTER the current value for
@@ -124,30 +121,40 @@ public class VettingViewer<T> {
         englishChanged('U',
             "English Changed",
             "The English value has changed in CLDR, but the corresponding value for your language has not. "
-                + "Check if any changes are needed in your language.",
-            7),
+                + "Check if any changes are needed in your language."),
 
         /**
          * The value changed from the baseline
          */
         changedOldValue('C',
             "Changed",
-            "The winning value was altered from the baseline value. (Informational)",
-            8),
+            "The winning value was altered from the baseline value. (Informational)"),
+
+        /**
+         * You have abstained, or not yet voted for any value
+         */
+        abstained('A',
+            "Abstained",
+            "You have abstained, or not yet voted for any value."),
             ;
 
         public final char abbreviation;
         public final String buttonLabel;
         public final String jsonLabel;
-        public final String description;
-        public final int order;
 
-        Choice(char abbreviation, String label, String description, int order) {
+        /**
+         * This human-readable description is used for Priority Items Summary, which still
+         * creates html on the back end. For Dashboard, identical descriptions are on the
+         * front end. When Priority Items Summary is modernized to be more like Dashboard,
+         * these descriptions on the back end should become unnecessary.
+         */
+        public final String description;
+
+        Choice(char abbreviation, String label, String description) {
             this.abbreviation = abbreviation;
             this.jsonLabel = label.replace(' ', '_');
             this.buttonLabel = TransliteratorUtilities.toHTML.transform(label);
             this.description = TransliteratorUtilities.toHTML.transform(description);
-            this.order = order;
         }
 
         private <T extends Appendable> void appendDisplay(String htmlMessage, T target) throws IOException {
@@ -402,11 +409,7 @@ public class VettingViewer<T> {
         public VoterProgress voterProgress = new VoterProgress();
     }
 
-    /**
-     * Give the list of errors for the Dashboard
-     * Not used for Priority Items Summary
-     */
-    public DashboardData generateFileInfoReview(EnumSet<Choice> choices,
+    public DashboardData generateDashboard(EnumSet<Choice> choices,
         String localeID, int userId, T organization,
         Level usersLevel, CLDRFile sourceFile, CLDRFile baselineFile) {
 
@@ -566,7 +569,7 @@ public class VettingViewer<T> {
             if (!onlyRecordErrors) {
                 recordLosingDisputedEtc(path, voteStatus, missingStatus);
             }
-            updateVoterProgress(path, pathLevelIsTooHigh);
+            updateVotedOrAbstained(path, pathLevelIsTooHigh);
             if (specificSinglePath == null && !problems.isEmpty() && sorted != null) {
                 reasonsToPaths.clear();
                 R2<SectionId, PageId> group = Row.of(ph.getSectionId(), ph.getPageId());
@@ -574,7 +577,7 @@ public class VettingViewer<T> {
             }
         }
 
-        private void updateVoterProgress(String path, boolean pathLevelIsTooHigh) {
+        private void updateVotedOrAbstained(String path, boolean pathLevelIsTooHigh) {
             if (voterProgress == null || voterId == 0) {
                 return;
             }
@@ -584,13 +587,10 @@ public class VettingViewer<T> {
             voterProgress.incrementVotablePathCount();
             if (userVoteStatus.userDidVote(voterId, cldrLocale, path)) {
                 voterProgress.incrementVotedPathCount();
+            } else if (choices.contains(Choice.abstained)) {
+                problems.add(Choice.abstained);
+                vc.problemCounter.increment(Choice.abstained);
             }
-            /*
-             * Else, path is votable but the user hasn't voted on it yet.
-             * We could add path to a list of such paths and present it to the user,
-             * maybe as another category in the Dashboard, related to Missing, yet
-             * different since Missing is per organization, and this is per user.
-             */
         }
 
         private boolean skipForLimitedSubmission(String path, ErrorChecker.Status errorStatus, String oldValue) {
@@ -724,7 +724,7 @@ public class VettingViewer<T> {
         }
     }
 
-    public void generateSummaryHtmlErrorTables(Appendable output, EnumSet<Choice> choices, T organization) {
+    public void generatePriorityItemsSummary(Appendable output, EnumSet<Choice> choices, T organization) {
         try {
             output
                 .append("<p>The following summarizes the Priority Items across locales, " +

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
@@ -67,7 +67,7 @@ class TestVettingViewer {
         CLDRFile baselineFile = baselineFactory.make(loc, true);
         Relation<R2<SectionId, PageId>, VettingViewer<Organization>.WritingInfo> sorted;
         final Level usersLevel = Level.MODERN;
-        VettingViewer<Organization>.DashboardData dd = vv.generateFileInfoReview(choiceSet, loc, 0, usersOrg, usersLevel, sourceFile, baselineFile);
+        VettingViewer<Organization>.DashboardData dd = vv.generateDashboard(choiceSet, loc, 0, usersOrg, usersLevel, sourceFile, baselineFile);
         boolean foundAny = false;
         for (Entry<R2<SectionId, PageId>, VettingViewer<Organization>.WritingInfo> e : dd.sorted.entrySet()) {
             for(Choice problem : e.getValue().problems) {


### PR DESCRIPTION
-New notification category: VettingViewer.Choice.abstained

-FileInfo.updateVotedOrAbstained adds to Dashboard if votable but not voted

-Omit Choice.abstained for Priority Items Summary

-Remove unused Choice.order

-Rename from generateFileInfoReview to generateDashboard

-Rename from generateSummaryHtmlErrorTables to generatePriorityItemsSummary

-Minor clean-up at start of processCriticalWork

-On the front end, add a description of each category, same as in back end VettingViewer.Choice

-Comments

CLDR-14047

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
