### PR TITLE
CLDR-14703 modernize General Info

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrEvent.js
+++ b/tools/cldr-apps/js/src/esm/cldrEvent.js
@@ -412,11 +412,12 @@ function unpackMenuSideBar(json) {
   $(".review-link").click(function () {
     $("#left-sidebar").removeClass("active");
     toggleOverlay();
-    $("#OtherSection").hide();
     const url = $(this).data("url");
     if (url === "dashboard") {
+      cldrStatus.setCurrentSpecial("general");
       cldrGui.insertDashboard();
     } else {
+      $("#OtherSection").hide(); // Don't hide the other section when showing the dashboard.
       cldrStatus.setCurrentSpecial(url);
       cldrStatus.setCurrentId("");
       cldrStatus.setCurrentPage("");

--- a/tools/cldr-apps/js/src/specialToComponentMap.js
+++ b/tools/cldr-apps/js/src/specialToComponentMap.js
@@ -1,6 +1,7 @@
 import AboutPanel from "./views/AboutPanel.vue";
 import AddUser from "./views/AddUser.vue";
 import AutoImport from "./views/AutoImport.vue";
+import GeneralInfo from "./views/GeneralInfo.vue";
 import LockAccount from "./views/LockAccount.vue";
 import LookUp from "./views/LookUp.vue";
 import MainMenu from "./views/MainMenu.vue";
@@ -18,6 +19,7 @@ const specialToComponentMap = {
   about: AboutPanel,
   add_user: AddUser,
   auto_import: AutoImport,
+  general: GeneralInfo,
   lock_account: LockAccount,
   lookup: LookUp,
   menu: MainMenu,

--- a/tools/cldr-apps/js/src/views/GeneralInfo.vue
+++ b/tools/cldr-apps/js/src/views/GeneralInfo.vue
@@ -1,0 +1,74 @@
+<!--
+    This replaces cldrLoad.loadGeneral(itemLoadInfo);
+    Note that there isn't any provision for showPossibleProblems, which seems to be
+    entirely dead code.
+-->
+
+<template>
+  <div>
+    <div class="warnText" v-if="localeSpecialNote" v-html="localeSpecialNote" />
+    <div class="warnText" v-if="betaNote" v-html="betaNote" />
+    <p class="special_general" v-if="specialGeneral" v-html="specialGeneral" />
+    <button
+      @click="insertDashboard"
+      class="cldr-nav-btn btn-primary open-dash general-open-dash"
+      type="button"
+    >
+      Open Dashboard
+    </button>
+  </div>
+</template>
+
+<script>
+import * as cldrGui from "../esm/cldrGui.js";
+import * as cldrLoad from "../esm/cldrLoad.js";
+import * as cldrStatus from "../esm/cldrStatus.js";
+import * as cldrText from "../esm/cldrText.js";
+
+export default {
+  data() {
+    return {
+      localeSpecialNote: null,
+      betaNote: null,
+      specialGeneral: null,
+    };
+  },
+  mounted() {
+    const locmap = cldrLoad.getTheLocaleMap();
+    const bund = locmap.getLocaleInfo(cldrStatus.getCurrentLocale());
+    let msg = cldrLoad.localeSpecialNote(bund, false);
+    if (msg) {
+      msg = locmap.linkify(msg);
+      this.localeSpecialNote = msg;
+    } else {
+      this.localeSpecialNote = null;
+    }
+
+    // setup beta note
+    if (cldrStatus.getIsPhaseBeta()) {
+      this.betaNote = cldrText.sub("beta_msg", {
+        info: bund,
+        locale: cldrStatus.getCurrentLocale(),
+        msg: msg,
+      });
+    } else {
+      this.betaNote = null;
+    }
+
+    // setup specialGeneral
+    this.specialGeneral = cldrText.get("special_general");
+  },
+  methods: {
+    insertDashboard() {
+      cldrGui.insertDashboard();
+    },
+  },
+};
+</script>
+
+<style>
+button.general-open-dash {
+  /* We only want THIS button to float, not all Open Dashboard buttons. */
+  float: right;
+}
+</style>


### PR DESCRIPTION
CLDR-14703 fix 'empty space' above dashboard, modernize General Info

- modernize the 'General Info' area into Vue, remove hard coded javascript
- don't hide the OtherSection when the dashboard is shown and we were in
the General Info panel
- delete some dead code around the unused Possible Errors display - also see CLDR-15254

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
