### PR TITLE
CLDR-15176 ansible-lint: workaround for version problem

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,6 +14,8 @@ jobs:
       uses: ansible/ansible-lint-action@c37fb7b4bda2c8cb18f4942716bae9f11b0dc9bc
       with:
         targets: tools/scripts/ansible/*-playbook.yml
+        override-deps: |
+          rich>=9.5.1,<11.0.0
     - name: Cache lint npm repository
       uses: actions/cache@v2
       with:
@@ -34,7 +36,7 @@ jobs:
       timeout-minutes: 10
       run: (cd tools/cldr-apps/js && npm t)
   build:
-    runs-on: macos-latest
+    runs-on: macos-10.15  # see https://github.com/actions/virtual-environments/issues/4060
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Fix the ansible-lint job which was failing due to two (2) issues:

ansible-lint issue:  https://github.com/ansible-community/ansible-lint/issues/1795
vagrant issue: pin macos per https://github.com/actions/virtual-environments/issues/4060

CLDR-15176

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
