### PR TITLE
CLDR-15277 VettingParticipation2: err on out of bound locales

### DIFF
--- a/tools/cldr-apps/js/src/esm/localesTxtGenerator.mjs
+++ b/tools/cldr-apps/js/src/esm/localesTxtGenerator.mjs
@@ -41,6 +41,11 @@ function generateLocalesTxt(data, outFunction) {
   // now, per org
   for (const org of Object.keys(allOrgs).sort()) {
     const localesWithUsers = new Set(allOrgs[org].localesWithVetters);
+    const coverageLocales = new Set(allOrgs[org].coverageLocales);
+    const localesOutOfBounds = setUtils.minus(
+      localesWithUsers,
+      coverageLocales
+    );
     const localesWithVotes = new Set();
     // now look for actual votes
     outFunction(`# ${org}`);
@@ -78,6 +83,19 @@ function generateLocalesTxt(data, outFunction) {
         `#  Participation but no vetters: ` +
           setUtils.asList(participationNoVetters).join(" ")
       );
+    }
+    if (localesOutOfBounds.size !== 0) {
+      if (coverageLocales.has("*")) {
+        outFunction(
+          `# Note: '*' covers these assigned locales: ` +
+            setUtils.asList(localesOutOfBounds).join(" ")
+        );
+      } else {
+        outFunction(
+          `# ERROR: ${org} Vetters out of coverage: ` +
+            setUtils.asList(localesOutOfBounds).join(" ")
+        );
+      }
     }
     const allLocales = setUtils.union(localesWithVotes, localesWithUsers);
     if (allLocales.size == 0) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VotingParticipation.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VotingParticipation.java
@@ -194,11 +194,14 @@ public class VotingParticipation {
 
     public static class OrgParticipation {
         public String[] localesWithVetters;
+        final public String[] coverageLocales;
         public String defaultCoverage;
 
         public OrgParticipation(Organization o) {
             this.org = o;
-            this.defaultCoverage = StandardCodes.make().getDefaultLocaleCoverageLevel(o).toString();
+            StandardCodes codes = StandardCodes.make();
+            this.defaultCoverage = codes.getDefaultLocaleCoverageLevel(o).toString();
+            coverageLocales = codes.getLocaleCoverageLocales(o).toArray(new String[0]);
         }
 
         public Organization org;


### PR DESCRIPTION
Note this is on the generated Locales.txt viewable through the admin panel

- add 'coverageLocales' to each org with a list of orgs with cov
- add an `ERROR` note to the generated Locales.txt when vetters are assigned out of bounds
- add a note for orgs with a `*` coverage with out of bound vetters

CLDR-15277

- [ ] This PR completes the ticket.
