### PR TITLE
CLDR-15182 Remove warnings from Locales.txt

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -472,7 +472,7 @@ Cldr	;	et	;	modern	;	T3	Estonian
 Cldr	;	is	;	modern	;	T3	Icelandic
 Cldr	;	ms	;	modern	;	T3	Malay
 Cldr	;	mr	;	modern	;	T3	Marathi
-Cldr	;	sw	;	modern	;	T3	Swahili 
+Cldr	;	sw	;	modern	;	T3	Swahili
 Cldr	;	ta	;	modern	;	T3	Tamil
 Cldr	;	km	;	modern	;	T3.1	Khmer
 Cldr	;	lo	;	modern	;	T3.1	Lao
@@ -856,7 +856,8 @@ Netflix ; sr ; modern
 #Netflix ; sv ; modern
 
 nyiakeng_puachue_hmong ; hnj      ; modern ; Green Hmong (hnj_Hmnp) - default content
-nyiakeng_puachue_hmong ; mww_Hmnp ; modern ; White Hmong (mww_Hmnp)
+#The following is not in CLDR (yet)
+#nyiakeng_puachue_hmong ; mww_Hmnp ; modern ; White Hmong (mww_Hmnp)
 
 Facebook	;	ar	;	modern
 Facebook ; az ; moderate ;
@@ -887,7 +888,7 @@ Facebook ; tg ; moderate ;
 Facebook ; tr ; moderate ;
 Facebook ; vi ; moderate ;
 
-Mozilla	;	und	;	modern
+Mozilla	;	mul	;	modern
 # ^no votes in 30…40 for this org
 
 Rodakych ; pcm ; modern ; Nigerian Pidgin
@@ -949,10 +950,9 @@ wikimedia ; sw ; moderate ;
 wikimedia ; ta ; moderate ;
 wikimedia ; ti ; moderate ;
 wikimedia ; uk ; moderate ;
-wikimedia ; und ; moderate ;
 wikimedia ; yi ; moderate ;
 wikimedia ; zh ; moderate ;
 wikimedia ; * ; moderate ;
 
-yahoo ; und ; modern ;
+yahoo ; mul ; modern ;
 # ^no votes in 30…40 for this org

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -61,8 +61,11 @@ public class StandardCodesTest extends TestFmwk {
                 locs = sc.getLocaleCoverageLocales(org,
                     EnumSet.of(Level.MODERATE, Level.MODERN));
                 for (String loc : locs) {
-                    if (loc.equals("*"))
+                    if (loc.equals("*") || loc.equals("mul")) {
+                        // Skip * as wildcard
+                        // Skip sandbox locale 'mul'
                         continue;
+                    }
                     if (!availableLocales.contains(loc)) {
                         warnln("Locales.txt:\t" + loc + " ("
                             + CLDRLocale.getInstance(loc).getDisplayName()


### PR DESCRIPTION
- allow 'mul' (sandbox) for orgs that have not set any other coverage yet.
- Such orgs will be prohibited from adding users to locales, at runtime.
- Cleanup nits in Locales.txt

CLDR-15182

- [X] This PR completes the ticket.