### PR TITLE
CLDR-15291 am,ky: translate "decade" as such, not "10 years"; am,ky,be*: abbrev short or narrow decade

### DIFF
--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -6952,10 +6952,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>አስር አመታት</displayName>
-				<unitPattern count="one">{0} አስር አመታት</unitPattern>
+				<displayName>ዓሠርተ-ዓመት</displayName>
+				<unitPattern count="one">{0} ዓሠርተ-ዓመት</unitPattern>
 				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other">{0} አስር አመታት</unitPattern>
+				<unitPattern count="other">{0} ዓሠርተ-ዓመታት</unitPattern>
 				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -8155,9 +8155,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ምዕተ ዓመት</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="contributed">አስር አመታት</displayName>
-				<unitPattern count="one" draft="contributed">{0} አስር አመታት</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} አስር አመታት</unitPattern>
+				<displayName draft="contributed">ዓሠርተ-ዓመት</displayName>
+				<unitPattern count="one" draft="contributed">{0} ዓሠ.ዓ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ዓሠ.ዓ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ዓመታት</displayName>
@@ -9198,11 +9198,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">↑↑↑</displayName>
 				<unitPattern count="one">{0}ም.ዓ</unitPattern>
 				<unitPattern count="other">{0}ም.ዓ</unitPattern>
-			</unit>
-			<unit type="duration-decade">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">{0} አስርተ አመታት</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} አስርተ አመታት</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ዓመታት</displayName>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -8415,10 +8415,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>дзесяцігоддзе</displayName>
-				<unitPattern count="one">{0} дзесяцігоддзе</unitPattern>
-				<unitPattern count="few">{0} дзесяцігоддзі</unitPattern>
-				<unitPattern count="many">{0} дзесяцігоддзяў</unitPattern>
-				<unitPattern count="other">{0} дзесяцігоддзя</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} дз.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} дз.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} дз.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дз.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>г.</displayName>

--- a/common/main/be_TARASK.xml
+++ b/common/main/be_TARASK.xml
@@ -8113,10 +8113,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName draft="provisional">дзесяцігодзьдзе</displayName>
-				<unitPattern count="one" draft="provisional">{0} дзесяцігодзьдзе</unitPattern>
-				<unitPattern count="few" draft="provisional">{0} дзесяцігодзьдзі</unitPattern>
-				<unitPattern count="many" draft="provisional">{0} дзесяцігодзьдзяў</unitPattern>
-				<unitPattern count="other" draft="provisional">{0} дзесяцігодзьдзя</unitPattern>
+				<unitPattern count="one" draft="provisional">{0} дз.</unitPattern>
+				<unitPattern count="few" draft="provisional">{0} дз.</unitPattern>
+				<unitPattern count="many" draft="provisional">{0} дз.</unitPattern>
+				<unitPattern count="other" draft="provisional">{0} дз.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName draft="provisional">г.</displayName>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -6121,9 +6121,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} кылым</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} он жылдык</unitPattern>
-				<unitPattern count="other">{0} он жылдык</unitPattern>
+				<displayName draft="contributed">декада</displayName>
+				<unitPattern count="one" draft="contributed">{0} декада</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} декада</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>жыл</displayName>
@@ -7166,9 +7166,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} к.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>он жылдык</displayName>
-				<unitPattern count="one">{0} он жылдык</unitPattern>
-				<unitPattern count="other">{0} он жылдык</unitPattern>
+				<displayName draft="contributed">декада</displayName>
+				<unitPattern count="one" draft="contributed">{0} декада</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} декада</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>жыл</displayName>
@@ -8211,9 +8211,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">{0} декада</unitPattern>
-				<unitPattern count="other" draft="contributed">{0} декада</unitPattern>
+				<displayName draft="contributed">декада</displayName>
+				<unitPattern count="one" draft="contributed">{0} дек.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дек.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>жыл</displayName>


### PR DESCRIPTION
CLDR-15291

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

* am: "decade" was being translated as "10 years" which does not work well with a numeric unit; from Fesseha Atlaw get a translation that actually means "decade" (singular and plural forms), and also a suitable abbreviation to use for short (and narrow by inheritance).
* be,be_TARASK: abbreviate the short form of decade
* ky: "decade" was being translated as "10 years" in the long and short forms but as "decade" (unabbreviated) in the narrow form. Use that unabbreviated version from narrow for the long and short forms, and abbreviate it for narrow.