### PR TITLE
CLDR-15291 shorter short forms for decade (in eu), permillion (in fo)

### DIFF
--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -16460,8 +16460,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>hamarkada</displayName>
-				<unitPattern count="one">{0} hamarkada</unitPattern>
-				<unitPattern count="other">{0} hamarkada</unitPattern>
+				<unitPattern count="one">{0} hamark.</unitPattern>
+				<unitPattern count="other">{0} hamark.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>urte</displayName>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -7016,8 +7016,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>partar/millión</displayName>
-				<unitPattern count="one">{0} partur/mill.</unitPattern>
-				<unitPattern count="other">{0} partar/mill.</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} pt./mill.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} pt./mill.</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>prosent</displayName>


### PR DESCRIPTION
CLDR-15291

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

* eu, short form for decade was too long; fixed by copying narrow forms to short
* fo, short for permission was too long; fixed by further abbreviating "partur/mill." and "partar/mill." as "pt./mill.", since "pt." is an abbreviation I see in Faroese Wikipedia to mean "part" (in English context, but understood in Faroese).