### PR TITLE
CLDR-15291 jv,kab: copy a narrow unit to short; brx: add standard form for 3 zones

### DIFF
--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -2735,6 +2735,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Apia">
 				<long>
 					<generic>आपिया सम</generic>
+					<standard>आपिया थाखोआरि सम</standard>
 					<daylight>आपिया सान सम</daylight>
 				</long>
 			</metazone>
@@ -3246,12 +3247,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Mexico_Northwest">
 				<long>
 					<generic>साहा-सोनाब मेक्सिक’ सम</generic>
+					<standard>साहासोनाब मेक्सिक’ थाखोआरि सम</standard>
 					<daylight>साहासोनाब मेक्सिक’ सान सम</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Pacific">
 				<long>
 					<generic>मेक्सिकनि पेसिफिक सम</generic>
+					<standard>मेक्सिक’आरि पेसिफिक थाखोआरि सम</standard>
 					<daylight>मेक्सिक’आरि पेसिफिक सान सम</daylight>
 				</long>
 			</metazone>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -6292,7 +6292,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>bagean/yuta</displayName>
-				<unitPattern count="other">{0} bagean saben yuta</unitPattern>
+				<unitPattern count="other">{0}bpj</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>persen</displayName>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -7189,8 +7189,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-byte">
 				<displayName draft="unconfirmed">aṭamḍan</displayName>
-				<unitPattern count="one" draft="unconfirmed">{0} aṭamḍan</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">{0} iṭamḍanen</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} aṭ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} Aṭ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName draft="unconfirmed">abit</displayName>


### PR DESCRIPTION
CLDR-15291

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

* brx: Add missing standard form for 3 zones by being the standard time suffix used in other complete zone sets with the same style for generic/daylight (e.g. America_Eastern)
* kab: short digital-byte was too wide, copy the forms from narrow
* jv: short permillion was too wide, copy the form from narrow