### PR TITLE
CLDR-10991 Fix name for "crh" (Crimean Tatar) in en and a few other languages

### DIFF
--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -128,7 +128,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="cop">koptština</language>
 			<language type="cps">kapiznonština</language>
 			<language type="cr">kríjština</language>
-			<language type="crh">turečtina (krymská)</language>
+			<language type="crh">tatarština (krymská)</language>
 			<language type="crs">kreolština (seychelská)</language>
 			<language type="cs">čeština</language>
 			<language type="csb">kašubština</language>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -111,7 +111,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="co">korsikansk</language>
 			<language type="cop">koptisk</language>
 			<language type="cr">cree</language>
-			<language type="crh">krim-tyrkisk</language>
+			<language type="crh">krimtatarisk</language>
 			<language type="crs">seselwa (kreol-fransk)</language>
 			<language type="cs">tjekkisk</language>
 			<language type="csb">kasjubisk</language>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -133,7 +133,7 @@ annotations.
 			<language type="cop">Coptic</language>
 			<language type="cps">Capiznon</language>
 			<language type="cr">Cree</language>
-			<language type="crh">Crimean Turkish</language>
+			<language type="crh">Crimean Tatar</language>
 			<language type="crs">Seselwa Creole French</language>
 			<language type="cs">Czech</language>
 			<language type="csb">Kashubian</language>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -128,7 +128,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="cop">copte</language>
 			<language type="cps">capiznon</language>
 			<language type="cr">cree</language>
-			<language type="crh">turc de Crimée</language>
+			<language type="crh">tatar de Crimée</language>
 			<language type="crs">créole seychellois</language>
 			<language type="cs">tchèque</language>
 			<language type="csb">kachoube</language>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -111,7 +111,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="co">corso</language>
 			<language type="cop">copta</language>
 			<language type="cr">cree</language>
-			<language type="crh">turco da Crimeia</language>
+			<language type="crh">tártara da Crimeia</language>
 			<language type="crs">crioulo francês seichelense</language>
 			<language type="cs">tcheco</language>
 			<language type="csb">kashubian</language>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -130,7 +130,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="cop">Kıptice</language>
 			<language type="cps">Capiznon</language>
 			<language type="cr">Krice</language>
-			<language type="crh">Kırım Türkçesi</language>
+			<language type="crh">Kırım Tatarcası</language>
 			<language type="crs">Seselwa Kreole Fransızcası</language>
 			<language type="cs">Çekçe</language>
 			<language type="csb">Kashubian</language>


### PR DESCRIPTION
CLDR-10991

- [x ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix display name for "crh" to be "Crimean Tatar" (not "Crimean Turkish") in English, and the equivalent in a few other languages (many CLDR languages already had "crh" as the equivalent of "Crimean Tatar"). Note that this display name is in comprehensive coverage so vetters do not normally see it.