### PR TITLE
CLDR-15307 en: add names for seed languages and others whose names will have modern coverage

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -60,6 +60,7 @@ annotations.
 			<language type="asa">Asu</language>
 			<language type="ase">American Sign Language</language>
 			<language type="ast">Asturian</language>
+			<language type="atj">Atikamekw</language>
 			<language type="av">Avaric</language>
 			<language type="avk">Kotava</language>
 			<language type="awa">Awadhi</language>
@@ -90,6 +91,7 @@ annotations.
 			<language type="bjn">Banjar</language>
 			<language type="bkm">Kom</language>
 			<language type="bla">Siksika</language>
+			<language type="blt">Tai Dam</language>
 			<language type="bm">Bambara</language>
 			<language type="bn">Bangla</language>
 			<language type="bo">Tibetan</language>
@@ -129,16 +131,25 @@ annotations.
 			<language type="ckb">Central Kurdish</language>
 			<language type="ckb" alt="menu">Kurdish, Central</language>
 			<language type="ckb" alt="variant">Kurdish, Sorani</language>
+			<language type="clc">Chilcotin</language>
 			<language type="co">Corsican</language>
 			<language type="cop">Coptic</language>
 			<language type="cps">Capiznon</language>
 			<language type="cr">Cree</language>
+			<language type="crg">Michif</language>
 			<language type="crh">Crimean Tatar</language>
+			<language type="crj">Southern East Cree</language>
+			<language type="crk">Plains Cree</language>
+			<language type="crl">Northern East Cree</language>
+			<language type="crm">Moose Cree</language>
+			<language type="crr">Carolina Algonquian</language>
 			<language type="crs">Seselwa Creole French</language>
 			<language type="cs">Czech</language>
 			<language type="csb">Kashubian</language>
+			<language type="csw">Swampy Cree</language>
 			<language type="cu">Church Slavic</language>
 			<language type="cv">Chuvash</language>
+			<language type="cwd">Woods Cree</language>
 			<language type="cy">Welsh</language>
 			<language type="da">Danish</language>
 			<language type="dak">Dakota</language>
@@ -242,12 +253,15 @@ annotations.
 			<language type="hai">Haida</language>
 			<language type="hak">Hakka Chinese</language>
 			<language type="haw">Hawaiian</language>
+			<language type="hax">Southern Haida</language>
+			<language type="hdn">Northern Haida</language>
 			<language type="he">Hebrew</language>
 			<language type="hi">Hindi</language>
 			<language type="hif">Fiji Hindi</language>
 			<language type="hil">Hiligaynon</language>
 			<language type="hit">Hittite</language>
 			<language type="hmn">Hmong</language>
+			<language type="hnj">Hmong Njua</language>
 			<language type="ho">Hiri Motu</language>
 			<language type="hr">Croatian</language>
 			<language type="hsb">Upper Sorbian</language>
@@ -255,6 +269,7 @@ annotations.
 			<language type="ht">Haitian Creole</language>
 			<language type="hu">Hungarian</language>
 			<language type="hup">Hupa</language>
+			<language type="hur">Halkomelem</language>
 			<language type="hy">Armenian</language>
 			<language type="hz">Herero</language>
 			<language type="ia">Interlingua</language>
@@ -265,6 +280,8 @@ annotations.
 			<language type="ig">Igbo</language>
 			<language type="ii">Sichuan Yi</language>
 			<language type="ik">Inupiaq</language>
+			<language type="ike">Eastern Canadian Inuktitut</language>
+			<language type="ikt">Western Canadian Inuktitut</language>
 			<language type="ilo">Iloko</language>
 			<language type="inh">Ingush</language>
 			<language type="io">Ido</language>
@@ -331,6 +348,7 @@ annotations.
 			<language type="kut">Kutenai</language>
 			<language type="kv">Komi</language>
 			<language type="kw">Cornish</language>
+			<language type="kwk">Kwakʼwala</language>
 			<language type="ky">Kyrgyz</language>
 			<language type="ky" alt="variant">Kirghiz</language>
 			<language type="la">Latin</language>
@@ -344,6 +362,7 @@ annotations.
 			<language type="lg">Ganda</language>
 			<language type="li">Limburgish</language>
 			<language type="lij">Ligurian</language>
+			<language type="lil">Lillooet</language>
 			<language type="liv">Livonian</language>
 			<language type="lkt">Lakota</language>
 			<language type="lmo">Lombard</language>
@@ -391,6 +410,7 @@ annotations.
 			<language type="mn">Mongolian</language>
 			<language type="mnc">Manchu</language>
 			<language type="mni">Manipuri</language>
+			<language type="moe">Innu-aimun</language>
 			<language type="moh">Mohawk</language>
 			<language type="mos">Mossi</language>
 			<language type="mr">Marathi</language>
@@ -444,6 +464,12 @@ annotations.
 			<language type="nzi">Nzima</language>
 			<language type="oc">Occitan</language>
 			<language type="oj">Ojibwa</language>
+			<language type="ojb">Northwestern Ojibwa</language>
+			<language type="ojc">Central Ojibwa</language>
+			<language type="ojg">Eastern Ojibwa</language>
+			<language type="ojs">Oji-Cree</language>
+			<language type="ojw">Western Ojibwa</language>
+			<language type="oka">Okanagan</language>
 			<language type="om">Oromo</language>
 			<language type="or">Odia</language>
 			<language type="os">Ossetic</language>
@@ -467,6 +493,7 @@ annotations.
 			<language type="pms">Piedmontese</language>
 			<language type="pnt">Pontic</language>
 			<language type="pon">Pohnpeian</language>
+			<language type="pqm">Malecite</language>
 			<language type="prg">Prussian</language>
 			<language type="pro">Old Provençal</language>
 			<language type="ps">Pashto</language>
@@ -530,6 +557,7 @@ annotations.
 			<language type="sid">Sidamo</language>
 			<language type="sk">Slovak</language>
 			<language type="sl">Slovenian</language>
+			<language type="slh">Southern Lushootseed</language>
 			<language type="sli">Lower Silesian</language>
 			<language type="sly">Selayar</language>
 			<language type="sm">Samoan</language>
@@ -554,6 +582,7 @@ annotations.
 			<language type="ssy">Saho</language>
 			<language type="st">Southern Sotho</language>
 			<language type="stq">Saterland Frisian</language>
+			<language type="str">Straits Salish</language>
 			<language type="su">Sundanese</language>
 			<language type="suk">Sukuma</language>
 			<language type="sus">Susu</language>
@@ -566,6 +595,7 @@ annotations.
 			<language type="syr">Syriac</language>
 			<language type="szl">Silesian</language>
 			<language type="ta">Tamil</language>
+			<language type="tce">Southern Tutchone</language>
 			<language type="tcy">Tulu</language>
 			<language type="te">Telugu</language>
 			<language type="tem">Timne</language>
@@ -573,7 +603,9 @@ annotations.
 			<language type="ter">Tereno</language>
 			<language type="tet">Tetum</language>
 			<language type="tg">Tajik</language>
+			<language type="tgx">Tagish</language>
 			<language type="th">Thai</language>
+			<language type="tht">Tahltan</language>
 			<language type="ti">Tigrinya</language>
 			<language type="tig">Tigre</language>
 			<language type="tiv">Tiv</language>
@@ -592,10 +624,12 @@ annotations.
 			<language type="tr">Turkish</language>
 			<language type="tru">Turoyo</language>
 			<language type="trv">Taroko</language>
+			<language type="trw">Torwali</language>
 			<language type="ts">Tsonga</language>
 			<language type="tsd">Tsakonian</language>
 			<language type="tsi">Tsimshian</language>
 			<language type="tt">Tatar</language>
+			<language type="ttm">Northern Tutchone</language>
 			<language type="ttt">Muslim Tat</language>
 			<language type="tum">Tumbuka</language>
 			<language type="tvl">Tuvalu</language>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -414,7 +414,9 @@ public class TestCoverageLevel extends TestFmwkPlus {
             + "kj|anp|an|niu|mni|dv|swb|pau|gor|nqo|krc|crs|gwi|zza|mad|nog|lez|byn|sad|ssy|mag|iba|"
             + "tpi|kum|wal|mos|dzg|gez|io|tn|snk|mai|ady|chy|mwl|sco|av|efi|war|mic|loz|scn|smj|tem|"
             + "dgr|mak|inh|lun|ts|fj|na|kpe|sr_ME|trv|rap|bug|ban|xal|oc|alt|nia|myv|ain|rar|krl|ay|"
-            + "syr|kv|umb|cu|prg|vo)");
+            + "syr|kv|umb|cu|prg|vo|"
+            + "atj|blt|clc|crg|crj|crk|crl|crm|crr|csw|cwd|hax|hdn|hnj|hur|ike|ikt|"
+            + "kwk|lil|moe|ojb|ojc|ojg|ojs|ojw|oka|pqm|slh|str|tce|tgx|tht|trw|ttm)");
 
         /**
          * Recommended scripts that are allowed for comprehensive coverage.


### PR DESCRIPTION
…
CLDR-15307

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Add English display names for languages:
* which have locales in seed but currently no display names in English
* whose names will be added for moden coverage in CLDR 42 (but useful to have the English names now)