### PR TITLE
CLDR-15304 ConsoleCheck to use file:line:col

### DIFF
--- a/tools/cldr-code/src/main/java/com/ibm/icu/dev/test/TestFmwk.java
+++ b/tools/cldr-code/src/main/java/com/ibm/icu/dev/test/TestFmwk.java
@@ -2001,6 +2001,10 @@ public class TestFmwk extends AbstractTestLog {
         return sourceLocation(new Throwable());
     }
 
+    /**
+     * Tuple representing the location of an error or warning.
+     * @see org.unicode.cldr.util.XMLSource.SourceLocation
+     */
     public static final class SourceLocation {
         public final int lineNumber;
         public final String file;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -56,7 +56,8 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
     transient String[] fixedPath = new String[1];
 
     /**
-     * This class represents a source location of an XPath
+     * This class represents a source location of an XPath.
+     * @see com.ibm.icu.dev.test.TestFmwk.SourceLocation
      */
     public static class SourceLocation {
         final static String FILE_PREFIX = "file://";
@@ -101,16 +102,45 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
          * and has the format 'file:line:column: '
          */
         public String toString() {
-            return getSystem() + ":" + getLine() + ":" + getColumn() + ": ";
+            return toString(null);
+        }
+
+
+        /**
+         * The toString() format is suitable for printing to the command line
+         * and has the format 'file:line:column: '
+         * A good leading base path might be CLDRPaths.BASE_DIRECTORY
+         * @param basePath path to trim
+         */
+        public String toString(final String basePath) {
+            return getSystem(basePath) + ":" + getLine() + ":" + getColumn() + ": ";
         }
 
         /**
-         * as with toString(), but skips the leading base path if identical.
+         * Format location suitable for GitHub annotations, skips leading base bath
+         * A good leading base path might be CLDRPaths.BASE_DIRECTORY
+         * @param basePath path to trim
+         * @return
+         */
+        public String forGitHub(String basePath) {
+            return "file=" + getSystem(basePath) + ",line=" + getLine() + ",col=" + getColumn();
+        }
+
+
+        /**
+         * Format location suitable for GitHub annotations
+         */
+        public String forGitHub() {
+            return forGitHub(null);
+        }
+
+        /**
+         * as with getSystem(), but skips the leading base path if identical.
          * A good leading path might be CLDRPaths.BASE_DIRECTORY
          * @param basePath path to trim
          */
-        public String toString(String basePath) {
-            String path = toString();
+        public String getSystem(String basePath) {
+            String path = getSystem();
             if (basePath != null && !basePath.isEmpty() && path.startsWith(basePath)) {
                 path = path.substring(basePath.length());
                 // Handle case where the path did NOT start with a slash

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSourceLocation.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSourceLocation.java
@@ -14,5 +14,9 @@ public class TestSourceLocation {
         assertEquals(path_f + ":123:456: ", location.toString());
         assertEquals("c/d.xml" + ":123:456: ", location.toString(path_b));
         assertEquals("c/d.xml" + ":123:456: ", location.toString(path_b + "/")); // with trailing slash
+        assertEquals("c/d.xml", location.getSystem(path_b));
+        assertEquals("c/d.xml", location.getSystem(path_b + "/")); // with trailing slash
+        assertEquals("file=c/d.xml,line=123,col=456", location.forGitHub(path_b));
+        assertEquals("file=c/d.xml,line=123,col=456", location.forGitHub(path_b + "/")); // with trailing slash
     }
 }


### PR DESCRIPTION
CLDR-15304

- supports rich GitHub annotations for console check errs
- improvements to XMLSource.SourceLocation to support GitHub
- added cross annotations with TestFmwk.SourceLocation (a similar but unrelated class)

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-15304)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
