### PR TITLE
CLDR-14488 sq, remove bogus narrow symbol for EUR using the ISO code

### DIFF
--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -5203,7 +5203,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">euro</displayName>
 				<displayName count="other">euro</displayName>
 				<symbol>€</symbol>
-				<symbol alt="narrow">EUR</symbol>
 			</currency>
 			<currency type="FJD">
 				<displayName>Dollari i Fixhit</displayName>


### PR DESCRIPTION
CLDR-14488

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Delete bogus narrow currency symbol in Albanian to fall back to standard € symbol (which is the narrow symbol in root).