### PR TITLE
CLDR-15266 Add static rules to digits-ordinal for Russian

### DIFF
--- a/common/rbnf/ru.xml
+++ b/common/rbnf/ru.xml
@@ -1459,5 +1459,107 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="21001">=0=.;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
+        <rulesetGrouping type="OrdinalRules">
+            <ruleset type="digits-ordinal">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=.;</rbnfrule>
+            </ruleset>
+            <ruleset type="digits-ordinal-masculine">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-й;</rbnfrule>
+            </ruleset>
+            <ruleset type="digits-ordinal-neuter">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-е;</rbnfrule>
+            </ruleset>
+            <ruleset type="digits-ordinal-feminine">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-я;</rbnfrule>
+            </ruleset>
+            <ruleset type="digits-ordinal-plural">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-e;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-masculine-genitive">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-го;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-neuter-genitive">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-го;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-feminine-genitive">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-й;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-plural-genitive">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-х;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-masculine-dative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-му;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-neuter-dative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-му;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-feminine-dative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-й;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-plural-dative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-м;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-masculine-accusative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-й;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-neuter-accusative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-е;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-feminine-accusative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-ю;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-plural-accusative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-e;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-masculine-locative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-м;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-neuter-locative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-м;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-feminine-locative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-й;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-plural-locative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-х;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-masculine-ablative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-м;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-neuter-ablative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-м;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-feminine-ablative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-й;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-ordinal-plural-ablative">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-ми;</rbnfrule>
+            </ruleset>
+        </rulesetGrouping>
     </rbnf>
 </ldml>


### PR DESCRIPTION
CLDR-15266

- [x] This PR completes the ticket.

These changes just mirror the set of rules for ordinals for spellout. The animate rules will be considered with CLDR 15267. Also the values are already available with other names.