### PR TITLE
CLDR-13992 remove redundant GEL-symbol-variant

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -5156,7 +5156,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Georgiese lari</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ghanese cedi (1979–2007)</displayName>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -5793,7 +5793,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">የጆርጅያ ላሪ</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>የጋና ሴዲ</displayName>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -6984,7 +6984,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">لاري جورجي</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>سيدي غاني</displayName>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -5603,7 +5603,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Gürcüstan larisi</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Qana Sedisi (1979–2007)</displayName>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -5626,7 +5626,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">грузінскага лары</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ганскі седзі</displayName>

--- a/common/main/be_TARASK.xml
+++ b/common/main/be_TARASK.xml
@@ -5357,7 +5357,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other" draft="provisional">грузінскага лары</displayName>
 				<symbol draft="provisional">GEL</symbol>
 				<symbol alt="narrow" draft="provisional">₾</symbol>
-				<symbol alt="variant" draft="provisional">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName draft="provisional">ганскі сэдзі</displayName>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -5607,7 +5607,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">грузински лари</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ганайско седи (1979–2007)</displayName>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -6666,7 +6666,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">জর্জিয়ান লারি</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ঘানা সেডি (১৯৭৯–২০০৭)</displayName>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -6034,7 +6034,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">laris</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>cedi ghanès (1979–2007)</displayName>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -5281,7 +5281,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">𑄎𑄧𑄢𑄴𑄎𑄨𑄠𑄚𑄴 𑄣𑄢𑄨</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>𑄊𑄚 𑄥𑄬𑄓𑄨 (𑄷𑄿𑄽𑄿-𑄸𑄶𑄶𑄽)</displayName>

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -4205,7 +4205,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">Гуьржийчоьнан лари</displayName>
 				<displayName count="other">Гуьржийчоьнан лариш</displayName>
 				<symbol draft="contributed">GEL</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Ганан седи</displayName>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -10899,7 +10899,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">gruzínských lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ghanský cedi (1979–2007)</displayName>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -6373,7 +6373,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">lari Georgia</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Cedi Ghana (1979–2007)</displayName>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -6057,7 +6057,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">georgiske lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ghanesisk cedi (1979–2007)</displayName>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -6595,7 +6595,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Georgische Lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ghanaischer Cedi (1979–2007)</displayName>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -6357,7 +6357,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">λάρι Γεωργίας</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Σέντι Γκάνας (1979–2007)</displayName>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -6453,7 +6453,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">laris</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>cedi ghanés (1979–2007)</displayName>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -5562,7 +5562,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">laris</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>cedi</displayName>

--- a/common/main/es_AR.xml
+++ b/common/main/es_AR.xml
@@ -352,9 +352,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="ARS">
 				<symbol>$</symbol>
 			</currency>
-			<currency type="GEL">
-				<symbol alt="variant" draft="contributed">GEL</symbol>
-			</currency>
 			<currency type="USD">
 				<symbol>US$</symbol>
 			</currency>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -5176,7 +5176,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>↑↑↑</displayName>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -5243,7 +5243,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other" draft="contributed">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>↑↑↑</displayName>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -6701,7 +6701,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">لاری گرجستان</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>سدی غنا</displayName>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -7237,7 +7237,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Georgian laris</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Ghanaian Cedi</displayName>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -8490,7 +8490,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">lari géorgiens</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>cédi</displayName>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -6075,7 +6075,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">GEL</symbol>
-				<symbol alt="variant">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>cédi ghanéen</displayName>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -5251,7 +5251,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">laris xeorxianos</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>cedi ghanés</displayName>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -6130,7 +6130,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">જ્યોર્જિઅન લારી</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ઘાનાઇયન સેડી</displayName>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -7487,7 +7487,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">לארי גאורגי</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>סדי גאני</displayName>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -6849,7 +6849,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">gruzijskih lara</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ganski cedi (1979.–2007.)</displayName>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -6373,7 +6373,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">grúz lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ghánai cedi (1979–2007)</displayName>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -7703,7 +7703,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">georgískir larar</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ganverskur sedi</displayName>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -5778,7 +5778,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">lari georgiani</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">↑↑↑</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>cedi del Ghana</displayName>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -7807,7 +7807,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ジョージア ラリ</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ガーナ セディ (1979–2007)</displayName>

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -5874,7 +5874,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Jiórja Rari ag</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Gỹnỹ Senhi (1979–2007)</displayName>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -5070,7 +5070,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Грузия лариі</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Гана седиі</displayName>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -4873,7 +4873,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ឡារី​​ហ្សកហ្ស៊ី</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ស៊ីឌី​ហ្គាណា</displayName>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -6790,7 +6790,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ಜಾರ್ಜಿಯಾದ ಲಾರಿಗಳು</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ಘಾನಾದ ಸೆದಿ</displayName>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -7001,7 +7001,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">조지아 라리</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>가나 시디 (1979–2007)</displayName>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -5046,7 +5046,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Грузия лариси</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Гана седиси</displayName>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -8039,7 +8039,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Gruzijos larių</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ganos sedis (1979–2007)</displayName>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -5951,7 +5951,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Gruzijas lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Ganas sedi</displayName>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -6357,7 +6357,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Грузиски лари</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ганајски Седи</displayName>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -6422,7 +6422,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ജോർജ്ജിയൻ ലാറിസ്</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ഘാന കെഡി (1979–2007)</displayName>

--- a/common/main/mzn.xml
+++ b/common/main/mzn.xml
@@ -1320,7 +1320,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>گرجستون ِلاری</displayName>
 				<displayName count="other">گرجستون ِلاری</displayName>
 				<symbol draft="contributed">GEL</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>غنای ِسدی</displayName>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -5325,7 +5325,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">जर्जियन लारी</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>घानाली सेडी</displayName>

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -5489,7 +5489,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">georgiske lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">↑↑↑</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ghanesiske cedi (1979–2007)</displayName>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -12519,7 +12519,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">georgiske lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ghanesisk cedi (1979–2007)</displayName>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -6099,7 +6099,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ਜਾਰਜੀਆਈ ਲਾਰੀ</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ਘਾਨਾਈ ਸੇਡੀ</displayName>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -6620,7 +6620,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">lari gruzińskiego</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>cedi ghańskie (1979–2007)</displayName>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -5976,7 +5976,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Laris georgianos</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Cedi de Gana (1979–2007)</displayName>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -5648,7 +5648,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">laris georgianos</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName draft="unconfirmed">Cedi do Gana</displayName>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -6806,7 +6806,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">lari georgieni</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>cedi Ghana (1979–2007)</displayName>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -7102,7 +7102,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">грузинского лари</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">ლ</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ганский седи (1979–2007)</displayName>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -5308,7 +5308,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ජෝජියානු ලැරී</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>ඝානා සෙඩි</displayName>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -6647,7 +6647,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">gruzínskych lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ghanské cedi (1979 – 2007)</displayName>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -5912,7 +5912,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">gruzijskih larijev</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>stari ganski cedi (1979–2007)</displayName>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -6385,7 +6385,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">грузијских ларија</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">ლ</symbol>
-				<symbol alt="variant">ლ</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Гански цеди (1979–2007)</displayName>

--- a/common/main/sr_Cyrl_BA.xml
+++ b/common/main/sr_Cyrl_BA.xml
@@ -5270,7 +5270,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other" draft="contributed">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName draft="contributed">↑↑↑</displayName>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -6251,7 +6251,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">gruzijskih larija</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">ლ</symbol>
-				<symbol alt="variant">ლ</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Ganski cedi (1979–2007)</displayName>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -7469,7 +7469,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">georgiska lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ghanansk cedi (1979–2007)</displayName>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -5160,7 +5160,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">lari za Jojia</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Sedi ya Ghana</displayName>

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -5034,7 +5034,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">lari za Jiojia</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Sidi ya Ghana</displayName>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -6084,7 +6084,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ஜார்ஜியன் லாரிகள்</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>கானயன் சேடி</displayName>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -6127,7 +6127,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">జార్జియన్ లారీలు</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>గానెయన్ సెడి</displayName>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -7389,7 +7389,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">ลารีจอร์เจีย</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>เซดีกานา (1979–2007)</displayName>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -5003,7 +5003,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">gruzin larisi</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Gano sedisi</displayName>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -6588,7 +6588,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Gürcistan larisi</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Gana Sedisi (1979–2007)</displayName>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -6800,7 +6800,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">грузинського ларі</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>ганський седі (1979–2007)</displayName>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -5767,7 +5767,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">جارجیائی لاری</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>گھانا کا سیڈی</displayName>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -5198,7 +5198,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Gruziya larisi</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Gana sedisi</displayName>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -8084,7 +8084,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Lari Georgia</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName draft="contributed">Cedi Ghana (1979–2007)</displayName>

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -5869,7 +5869,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">Rari-ita geugiyanu</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>Sedi Ganawara (1979–2007)</displayName>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -7471,7 +7471,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">喬治亞拉里</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>迦納賽地 (1979–2007)</displayName>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -7401,7 +7401,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">乔治亚拉里</displayName>
 				<symbol draft="contributed">GEL</symbol>
 				<symbol alt="narrow" draft="contributed">₾</symbol>
-				<symbol alt="variant" draft="contributed">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>迦纳赛地 (1979–2007)</displayName>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -9304,7 +9304,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">格鲁吉亚拉里</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>加纳塞第</displayName>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -12816,7 +12816,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">喬治亞拉里</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>迦納賽地 (1979–2007)</displayName>

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -11501,7 +11501,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">格魯吉亞拉里</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
-				<symbol alt="variant">↑↑↑</symbol>
 			</currency>
 			<currency type="GHC">
 				<displayName>↑↑↑</displayName>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -5760,7 +5760,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="other">i-Georgian Lari</displayName>
 				<symbol>GEL</symbol>
 				<symbol alt="narrow">₾</symbol>
-				<symbol alt="variant">₾</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>i-Ghanaian Cedi</displayName>


### PR DESCRIPTION
CLDR-13992

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

GEL-symbol-variant was already deleted from root and en, but was still present in many locales in which it was redundant (same as main or narrow variant). That leaves 4 in which it is different so for these the variant will still show up in Survey Tool:
```
hi
	<symbol>GEL</symbol>
	<symbol alt="narrow">₾</symbol>
	<symbol alt="variant">ლ</symbol>
lo
	<symbol>GEL</symbol>
	<symbol alt="narrow">₾</symbol>
	<symbol alt="variant" draft="contributed">ລາຣີ</symbol>
mr
	<symbol>GEL</symbol>
	<symbol alt="narrow">₾</symbol>
	<symbol alt="variant">[₾]</symbol>
nl
	<symbol>GEL</symbol>
	<symbol alt="narrow">₾</symbol>
	<symbol alt="variant">ლ</symbol>
```
