### PR TITLE
CLDR-14552 update territoryInfo for GB based on Wikipedia analysis of latest UK census data

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2980,22 +2980,27 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="puu" populationPercent="9"/>	<!--Punu-->
 		</territory>
 		<territory type="GB" gdp="2925000000000" literacyPercent="99" population="65761100">	<!--United Kingdom-->
-			<languagePopulation type="en" populationPercent="99" officialStatus="official"/>	<!--English-->
-			<languagePopulation type="fr" populationPercent="19"/>	<!--French-->
-			<languagePopulation type="de" populationPercent="6"/>	<!--German-->
-			<languagePopulation type="sco" writingPercent="5" populationPercent="2.7" references="R1016"/>	<!--Scots-->
-			<languagePopulation type="pa" populationPercent="0.79"/>	<!--Punjabi-->
-			<languagePopulation type="cy" populationPercent="0.77" officialStatus="official_regional"/>	<!--Welsh-->
-			<languagePopulation type="bn" populationPercent="0.67"/>	<!--Bangla-->
-			<languagePopulation type="zh_Hant" populationPercent="0.54"/>	<!--Chinese (Traditional)-->
-			<languagePopulation type="syl" populationPercent="0.51"/>	<!--Sylheti-->
-			<languagePopulation type="el" populationPercent="0.33"/>	<!--Greek-->
-			<languagePopulation type="it" populationPercent="0.33"/>	<!--Italian-->
-			<languagePopulation type="ks" populationPercent="0.19"/>	<!--Kashmiri-->
-			<languagePopulation type="gd" writingPercent="5" populationPercent="0.099" officialStatus="official_regional" references="R1017"/>	<!--Scottish Gaelic-->
-			<languagePopulation type="yi" populationPercent="0.049" references="R1249"/>	<!--Yiddish-->
-			<languagePopulation type="ml" populationPercent="0.035" references="R1113"/>	<!--Malayalam-->
-			<languagePopulation type="ga" populationPercent="0.026" officialStatus="official_regional" references="R1139"/>	<!--Irish-->
+			<languagePopulation type="en" populationPercent="98" officialStatus="official" references="R1330"/>	<!--English-->
+			<languagePopulation type="fr" populationPercent="23" references="R1330"/>	<!--French-->
+			<languagePopulation type="de" populationPercent="9" references="R1330"/>	<!--German-->
+			<languagePopulation type="es" populationPercent="8" references="R1330"/>	<!--Spanish-->
+			<languagePopulation type="pl" populationPercent="4" references="R1330"/>	<!--Polish-->
+			<languagePopulation type="pa" populationPercent="3.6" references="R1330"/>	<!--Punjabi-->
+			<languagePopulation type="ur" populationPercent="3.5" references="R1330"/>	<!--Urdu-->
+			<languagePopulation type="ta" populationPercent="3.2" references="R1330"/>	<!--Tamil-->
+			<languagePopulation type="gu" populationPercent="2.9" references="R1330"/>	<!--Gujarati-->
+			<languagePopulation type="sco" writingPercent="5" populationPercent="2.5" references="R1016"/>	<!--Scots-->
+			<languagePopulation type="cy" populationPercent="1.3" officialStatus="official_regional" references="R1330"/>	<!--Welsh-->
+			<languagePopulation type="bn" populationPercent="0.4" references="R1330"/>	<!--Bangla-->
+			<languagePopulation type="ar" populationPercent="0.3" references="R1330"/>	<!--Arabic-->
+			<languagePopulation type="zh_Hant" populationPercent="0.3" references="R1330"/>	<!--Chinese (Traditional)-->
+			<languagePopulation type="pt" populationPercent="0.2" references="R1330"/>	<!--Portuguese-->
+			<languagePopulation type="tr" populationPercent="0.2" references="R1330"/>	<!--Turkish-->
+			<languagePopulation type="it" populationPercent="0.2" references="R1330"/>	<!--Italian-->
+			<languagePopulation type="so" populationPercent="0.2" references="R1330"/>	<!--Somali-->
+			<languagePopulation type="lt" populationPercent="0.2" references="R1330"/>	<!--Lithuanian-->
+			<languagePopulation type="ga" populationPercent="0.15" officialStatus="official_regional" references="R1330"/>	<!--Irish-->
+			<languagePopulation type="gd" writingPercent="5" populationPercent="0.11" officialStatus="official_regional" references="R1330"/>	<!--Scottish Gaelic-->
 			<languagePopulation type="kw" populationPercent="0.003" references="R1140"/>	<!--Cornish-->
 		</territory>
 		<territory type="GD" gdp="1634000000" literacyPercent="96" population="113094">	<!--Grenada-->
@@ -5690,5 +5695,6 @@ XXX Code for transations where no currency is involved
 		<reference type="R1327" uri="https://pt.wikipedia.org/wiki/Nheengatu">[missing]</reference>
 		<reference type="R1328" uri="https://statisticsmaldives.gov.mv/statistical-release-iii-education/">2014 Maldives: 98% literacy in Divehi, 75% in English</reference>
 		<reference type="R1329" uri="https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/dt-td/Rp-eng.cfm?TABID=2&amp;Lang=E&amp;APATH=3&amp;DETAIL=0&amp;DIM=0&amp;FL=A&amp;FREE=0&amp;GC=0&amp;GID=1235625&amp;GK=0&amp;GRP=1&amp;PID=110212&amp;PRID=10&amp;PTYPE=109445&amp;S=0&amp;SHOWALL=0&amp;SUB=0&amp;Temporal=2016&amp;THEME=118&amp;VID=0&amp;VNAMEE=&amp;VNAMEF=&amp;D1=0&amp;D2=0&amp;D3=0&amp;D4=0&amp;D5=0&amp;D6=0">Canada 2016 census language data; official status from Wikipedia Languages_of_Canada</reference>
+		<reference type="R1330" uri="https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom">Analyzed from 2011 UK census and other sources</reference>
 	</references>
 </supplementalData>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -974,6 +974,7 @@ North Macedonia	MK	"2,118,945"	97%	"31,030,000,000"		Turkish	tr	3.5%
 Northern Mariana Islands	MP	"51,994"	97%	"1,242,000,000"		Chamorro	ch	"9,270"			
 Northern Mariana Islands	MP	"51,994"	97%	"1,242,000,000"	de_facto_official	English	en	97%			
 Norway	NO	"5,372,191"	100%	"381,200,000,000"	official_regional	Northern Sami	se	"15,600"			
+Norway	NO	"5,372,191"	100%	"381,200,000,000"	official	Norwegian	no	100%			
 Norway	NO	"5,372,191"	100%	"381,200,000,000"	official	Norwegian Bokmål	nb	100%			
 Norway	NO	"5,372,191"	100%	"381,200,000,000"	official	Norwegian Nynorsk	nn	25%			
 Oman	OM	"3,494,116"	87%	"190,100,000,000"	official	Arabic	ar	81%			
@@ -1367,23 +1368,28 @@ United Arab Emirates	AE	"9,701,315"	90%	"696,000,000,000"		English	en	50%
 United Arab Emirates	AE	"9,701,315"	90%	"696,000,000,000"		Malayalam	ml	7%			
 United Arab Emirates	AE	"9,701,315"	90%	"696,000,000,000"		Pashto	ps	"286,000"			
 United Arab Emirates	AE	"9,701,315"	90%	"696,000,000,000"		Persian	fa	"181,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Bangla	bn	"438,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Chinese (Traditional)	zh_Hant	"353,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Cornish	kw	"2,000"			http://en.wikipedia.org/wiki/Cornish_language The 2008 estimate is ~2000 speakers due to revival efforts
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official	English	en	99%			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		French	fr	19%			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		German	de	6%			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Greek	el	"218,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official_regional	Irish	ga	"17,100"			"As with IE, we have to adjust the figures for real usage  "
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Italian	it	"218,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Kashmiri	ks	"126,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Malayalam	ml	"23,000"			http://www.ethnologue.com/show_country.asp?name=United+Kingdom
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Punjabi	pa	"516,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Scots	sco	"1,760,000"	5%		"http://www.ethnologue.com/show_language.asp?code=sco 100k+ native, plus 1.5 mil 2nd lang speakers. For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official_regional	Scottish Gaelic	gd	"64,300"	5%		"For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Sylheti	syl	"329,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official_regional	Welsh	cy	"501,000"			
-United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Yiddish	yi	"32,100"			http://en.wikipedia.org/wiki/Yiddish_language#Numbers_of_speakers
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official	English	en	98%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		French	fr	23%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		German	de	9%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Spanish	es	8%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Polish	pl	4%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Punjabi	pa	3.6%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Urdu	ur	3.5%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Tamil	ta	3.2%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Gujarati	gu	2.9%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Scots	sco	2.5%	5%		"http://www.ethnologue.com/show_language.asp?code=sco 100k+ native, plus 1.5 mil 2nd lang speakers. For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official_regional	Welsh	cy	1.3%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Bangla	bn	0.4%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Arabic	ar	0.3%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Chinese (Traditional)	zh_Hant	0.3%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Portuguese	pt	0.2%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Turkish	tr	0.2%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Italian	it	0.2%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Somali	so	0.2%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Lithuanian	lt	0.2%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official_regional	Irish	ga	0.15%			https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"	official_regional	Scottish Gaelic	gd	0.11%	5%		https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom Analyzed from 2011 UK census and other sources
+United Kingdom	GB	"65,105,246"	99%	"2,925,000,000,000"		Cornish	kw	0.003%			http://en.wikipedia.org/wiki/Cornish_language The 2008 estimate is ~2000 speakers due to revival efforts
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Caddo	cad	"25"
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Cajun French	frc	"27,800"			
 United States	US	"329,256,465"	99%	"19,490,000,000,000"		Central Yupik	esu	"20,600"			


### PR DESCRIPTION
CLDR-14552

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Update territoryInfo for GB based on https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom, which is in turn based primarily on an analysis of latest data from the 2011 census (plus a few other sources).

This also fixes a leftover item from https://github.com/unicode-org/cldr/pull/1730, updating country_language_population_raw.txt for "no" in "NO". 