### PR TITLE
CLDR-15276 XML fixes to main/hi_Latn and annotations/dsb

### DIFF
--- a/common/annotations/dsb.xml
+++ b/common/annotations/dsb.xml
@@ -832,7 +832,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧑‍⚕">chórobny sotša | gójc | gójc/gójcowka | strowotnistwo | terapeut</annotation>
 		<annotation cp="🧑‍⚕" type="tts">gójc/gójcowka</annotation>
 		<annotation cp="👨‍⚕">doktor | gójc | gójcojski kitel</annotation>
-		<annotation cp="👨‍⚕" type="tts"/>
 		<annotation cp="👩‍⚕">gójcojski kitel | gójcowka</annotation>
 		<annotation cp="👩‍⚕" type="tts">gójcowka</annotation>
 		<annotation cp="🧑‍🎓">absolwent | student | student(ka)</annotation>

--- a/seed/main/hi_Latn.xml
+++ b/seed/main/hi_Latn.xml
@@ -631,7 +631,6 @@ annotations.
 			<script type="Mero">Meroitic</script>
 			<script type="Mlym">Malayalam</script>
 			<script type="Mong">Mongolian</script>
-			<script type="Moon">Moon</script>
 			<script type="Mtei">Meitei Mayek</script>
 			<script type="Moon">Moon</script>
 			<script type="Nkoo">N’Ko</script>


### PR DESCRIPTION
CLDR-15276

These errs don't show up locally but do show up on the build system.
Perhaps a JDK or XML parser version difference.

```
Error:  (TestPaths.java:437)  Error: Inconsistency:	file=annotations/dsb.xml	elementType=PCDATA	value=«»	path=//ldml/annotations/annotation[@cp="👨‍⚕"][@type="tts"]

Error:  (TestPaths.java:468)  Error: Duplicate: hi_Latn.xml, //ldml/localeDisplayNames/scripts/script[@type="Moon"
```