### PR TITLE
CLDR-15328 two more fixes for Ethiopic transform names

### DIFF
--- a/common/transforms/Ethiopic-Latin-BetaMetsehaf.xml
+++ b/common/transforms/Ethiopic-Latin-BetaMetsehaf.xml
@@ -3,7 +3,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<transforms>
-		<transform source="Ethi" target="Latn" variant="Beta_Metsehaf" direction="both" draft="contributed" alias="Ethiopic-Latin/BetaMetsehaf und-Latn-t-und-ethi-m0-betamets" backwardAlias="Latin-Ethiopic/BetaMetsehaf und-Ethi-t-und-latn-m0-betamets">
+		<transform source="Ethi" target="Latn" variant="Beta_Metsehaf" direction="both" draft="contributed" alias="Ethiopic-Latin/Beta_Metsehaf und-Latn-t-und-ethi-m0-betamets" backwardAlias="Latin-Ethiopic/Beta_Metsehaf und-Ethi-t-und-latn-m0-betamets">
 		<!-- The transform described in prose:
 		  This is a conversion from Ethiopic script (Unicode 3.0 level) to Latin script, and the reversal.
                   The conversion uses the convention (or "variant") in use by the "Beta Maṣāḥǝft" project.

--- a/common/transforms/Ethiopic-Latin-IES_JES_1964.xml
+++ b/common/transforms/Ethiopic-Latin-IES_JES_1964.xml
@@ -3,7 +3,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<transforms>
-		<transform source="Ethi" target="Latn" variant="IES_JES_1964" direction="both" draft="contributed" alias="Ethiopic-Latin/IES-JES-1964 und-Latn-t-und-ethi-m0-iesjes-1964" backwardAlias="Latin-Ethiopic/IES-JES-1964 und-Ethi-t-und-latn-m0-iesjes-1964">
+		<transform source="Ethi" target="Latn" variant="IES_JES_1964" direction="both" draft="contributed" alias="Ethiopic-Latin/IES_JES_1964 und-Latn-t-und-ethi-m0-iesjes-1964" backwardAlias="Latin-Ethiopic/IES_JES_1964 und-Ethi-t-und-latn-m0-iesjes-1964">
 		<!-- The transform described in prose:
 		  This is a conversion from Ethiopic script (Unicode 3.0 level) to Latin script, and the reversal.
                   The conversion uses the convention (or "variant") in use by the Journal of Ethiopian Studies.


### PR DESCRIPTION
CLDR-15328

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Two more fixes for Ethiopic transform names (not the BCP47 versions): The complete variant part needs to be a valid UnicodeIdentifier (no hyphens), and should be used consistently.