### PR TITLE
CLDR-15328 ks, fix number symbols for arabext (decimal & group were the same)

### DIFF
--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -928,7 +928,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<characters>
 		<exemplarCharacters>[ء آ أ ٲ ؤ ا ب پ ت ث ٹ ج چ ح خ د ذ ڈ ر ز ڑ ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن ں ھ ہ و ۄ ۆ ی ۍ ؠ ے]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[\u200E\u200F \u064E \u064F \u0650 \u0654 \u0655 \u065F \u0656 \u0657]</exemplarCharacters>
-		<exemplarCharacters type="numbers">[\u200E \- ‑ , . % ‰ + 0۰ 1۱ 2۲ 3۳ 4۴ 5۵ 6۶ 7۷ 8۸ 9۹]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[\u200E \- ‑ , ٫ ٬ . % ‰ + 0۰ 1۱ 2۲ 3۳ 4۴ 5۵ 6۶ 7۷ 8۸ 9۹]</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="contributed">[\- ‐ ‑ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
 	</characters>
 	<delimiters>
@@ -3535,8 +3535,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<native>arabext</native>
 		</otherNumberingSystems>
 		<symbols numberSystem="arabext">
-			<decimal>،</decimal>
-			<group>،</group>
+			<decimal>٫</decimal>
+			<group>٬</group>
 			<percentSign>↑↑↑</percentSign>
 			<plusSign>↑↑↑</plusSign>
 			<minusSign>↑↑↑</minusSign>


### PR DESCRIPTION
CLDR-15328

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

ks (Kashmiri) uses 'arabext' digits by default, but for arabext had the same value for &lt;decimal&gt; and &lt;group&gt;: "،" U+060C ARABIC COMMA. This caused parse failures in ICU4J number tests.

The other relevant locales such as pa_Arab, ur, fa (and root) have the following for 'arabext':
&lt;decimal&gt;: "٫" U+066B ARABIC DECIMAL SEPARATOR
&lt;group&gt;: "٬" U+066C ARABIC THOUSANDS SEPARATOR (which looks almost identical to U+060C ARABIC COMMA)
So switched ks/arabext to have the same &lt;decimal&gt; and &lt;group&gt; as those, and also added U+066B and U+066C to the ks number exemplars.

Note that ks has the following for 'latn' digits
&lt;decimal&gt;: "." U+002E FULL STOP
&lt;group&gt;:  "،" U+060C ARABIC COMMA
The &lt;group&gt; here may also be an error but is not causing parse failures so I did not change it.