### PR TITLE
CLDR-15323 Fix fileutilities for non-Windows

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/FileUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/FileUtilities.java
@@ -279,7 +279,7 @@ public final class FileUtilities {
             if (directory.equals("")) {
                 return new BufferedReader(new InputStreamReader(new FileInputStream(new File(file)), charset));
             } else {
-                return new BufferedReader(new InputStreamReader(new FileInputStream(new File(file, directory)), charset));
+                return new BufferedReader(new InputStreamReader(new FileInputStream(new File(directory, file)), charset));
             }
         } catch (FileNotFoundException e) {
             throw new ICUUncheckedIOException(e); // handle dang'd checked exception


### PR DESCRIPTION
- fix for 0789429c9673740d784eab73cedd087acf21fbfa #1729 
- File() arguments were swapped
- this is breaking UnicodeTools

CLDR-15323
