### PR TITLE
CLDR-15347 add likelySubtag sd_IN → sd_Deva_IN and supporting demographics

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -2166,6 +2166,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Sindhi; ?; ? } => { Sindhi; Arabic; Pakistan }-->
 		<likelySubtag from="sd_Deva" to="sd_Deva_IN"/>
 		<!--{ Sindhi; Devanagari; ? } => { Sindhi; Devanagari; India }-->
+		<likelySubtag from="sd_IN" to="sd_Deva_IN"/>
+		<!--{ Sindhi; ?; India } => { Sindhi; Devanagari; India }-->
 		<likelySubtag from="sd_Khoj" to="sd_Khoj_IN"/>
 		<!--{ Sindhi; Khojki; ? } => { Sindhi; Khojki; India }-->
 		<likelySubtag from="sd_Sind" to="sd_Sind_IN"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -3236,6 +3236,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="tcy" populationPercent="0.15"/>	<!--Tulu-->
 			<languagePopulation type="wbr" populationPercent="0.15"/>	<!--Wagdi-->
 			<languagePopulation type="khn" populationPercent="0.15"/>	<!--Khandesi-->
+			<languagePopulation type="sd_Deva" populationPercent="0.14" officialStatus="official_regional" references="R1102"/>	<!--Sindhi (Devanagari)-->
 			<languagePopulation type="brx" populationPercent="0.14"/>	<!--Bodo-->
 			<languagePopulation type="noe" populationPercent="0.13"/>	<!--Nimadi-->
 			<languagePopulation type="bhb" populationPercent="0.12"/>	<!--Bhili-->
@@ -3255,7 +3256,6 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="srx" populationPercent="0.035" references="R1196"/>	<!--Sirmauri-->
 			<languagePopulation type="saz" populationPercent="0.029"/>	<!--Saurashtra-->
 			<languagePopulation type="ccp" populationPercent="0.028"/>	<!--Chakma-->
-			<languagePopulation type="sd_Deva" populationPercent="0.026" officialStatus="official_regional" references="R1102"/>	<!--Sindhi (Devanagari)-->
 			<languagePopulation type="bfq" populationPercent="0.023"/>	<!--Badaga-->
 			<languagePopulation type="njo" populationPercent="0.023"/>	<!--Ao Naga-->
 			<languagePopulation type="ria" populationPercent="0.013"/>	<!--Riang [India]-->
@@ -5467,7 +5467,7 @@ XXX Code for transations where no currency is involved
 		<reference type="R1099" uri="http://www.ethnologue.com/show_language.asp?code=efi">[missing]</reference>
 		<reference type="R1100" uri="http://www.ethnologue.com/show_language.asp?code=tbw">[missing]</reference>
 		<reference type="R1101" uri="http://www.ethnologue.com/show_language.asp?code=mhr">[missing]</reference>
-		<reference type="R1102" uri="http://www.lmp.ucla.edu/Profile.aspx?menu=004&amp;LangID=201">- Not widely used; set to 10%.</reference>
+		<reference type="R1102" uri="https://en.wikipedia.org/wiki/Languages_with_official_status_in_India#Writing_systems">Deva is the official script for sd in India; set to 55%. Arab, Guru, Khoj also used.</reference>
 		<reference type="R1103" uri="http://www.ethnologue.com/show_language.asp?code=srn">The lingua franca of 80% of the population</reference>
 		<reference type="R1104" uri="http://www.ethnologue.com/show_language.asp?code=bem">[missing]</reference>
 		<reference type="R1105" uri="https://www.ethnologue.com/language/mro">and https://en.wikipedia.org/wiki/Mru_language</reference>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population_raw.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population_raw.txt
@@ -581,7 +581,7 @@ India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Santali	sat	"
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Saurashtra	saz	"372,000"			
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Shekhawati	swv	"3,610,000"			
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Sindhi	sd	"3,380,000"			
-India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Sindhi (Devanagari)	sd_Deva	"338,000"			http://www.lmp.ucla.edu/Profile.aspx?menu=004&LangID=201 - Not widely used; set to 10%.
+India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Sindhi (Devanagari)	sd_Deva	"1,860,000"			https://en.wikipedia.org/wiki/Languages_with_official_status_in_India#Writing_systems Deva is the official script for sd in India; set to 55%. Arab, Guru, Khoj also used.
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Sirmauri	srx	"452,000"			"http://www.himachalonline.com/temp/languages.htm Sirmauri (srx) Mahasui = Himachali, Pahari, Sirmouri, Sirmuri"
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Tamil	ta	5.9%			https://www.cia.gov/library/publications/the-world-factbook/geos/in.html
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"	official_regional	Telugu	te	7.2%			https://www.cia.gov/library/publications/the-world-factbook/geos/in.html


### PR DESCRIPTION
CLDR-15347

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Add likelySubtags from sd_IN to sd_Deva_IN; Deva is the official script for Sindhi in India (Arab, Guru, Koj also used); in Pakistan it is Arab.

Update the territoryInfo for sd_Deva in IN.