### PR TITLE
CLDR-15340 add icu:extensions element to ldmlICU.dtd

### DIFF
--- a/common/dtd/ldmlICU.dtd
+++ b/common/dtd/ldmlICU.dtd
@@ -19,8 +19,8 @@ NOTE: Unlike the other DTDs, this file is manually maintained.
 <!ATTLIST special icu:version CDATA #IMPLIED>
 
 <!ELEMENT icu:version EMPTY>
-<!ATTLIST icu:version icu:specialVersion  CDATA #FIXED "1.7" >
-<!ATTLIST icu:version icu:requiredLDMLVersion CDATA #FIXED "1.7" >
+<!ATTLIST icu:version icu:specialVersion  CDATA #FIXED "41" >
+<!ATTLIST icu:version icu:requiredLDMLVersion CDATA #FIXED "41" >
 
 <!-- ICU Scripts -->
 
@@ -40,11 +40,15 @@ NOTE: Unlike the other DTDs, this file is manually maintained.
 <!ATTLIST icu:ruleBasedNumberFormat type NMTOKEN #IMPLIED >
 
 <!-- RBBI data -->
-<!ELEMENT icu:breakIteratorData (alias | (icu:boundaries?, icu:dictionaries?, icu:lstm?)) >
+<!ELEMENT icu:breakIteratorData (alias | (icu:boundaries?, icu:dictionaries?, icu:extensions?, icu:lstm?)) >
 
 <!ELEMENT icu:boundaries (alias | (icu:grapheme?, icu:word?, icu:line*, icu:sentence?, icu:title?, icu:xgc?)) >
 
 <!ELEMENT icu:dictionaries (alias | (icu:dictionary*)) >
+
+<!ELEMENT icu:extensions (alias | (icu:extension*)) >
+
+<!ELEMENT icu:extension ( #PCDATA ) >
 
 <!ELEMENT icu:lstm (alias | (icu:lstmdata*)) >
 


### PR DESCRIPTION
CLDR-15340

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Add the icu::extensions element (and its subelement icu:extension) to ldmlICU.dtd. This will not be used for any data in ICU; rather it will be used for data in ICU xml files in icu4c/source/data/xml/brkitr/ that are converted to ICU .txt format during the CLDR-ICU conversion process.

At the moment this is very simple, and just has one type of extensions data for different break types (really only useful for word and line). In the future, if we need to we can add support for different data for different break types.