### PR TITLE
CLDR-15285 Derived annotations [maint-40] (#1708)

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Annotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Annotations.java
@@ -282,7 +282,9 @@ public class Annotations {
             }
             String sourceLocale = cldrFile2.getSourceLocaleID(xpath, null);
             if (sourceLocale.equals(XMLSource.CODE_FALLBACK_ID) || sourceLocale.equals(XMLSource.ROOT_ID)) {
-                return MISSING_MARKER + result;
+                if (!xpath.equals("//ldml/characterLabels/characterLabelPattern[@type=\"category-list\"]")) {
+                    return MISSING_MARKER + result;
+                }
             }
             return result;
         }


### PR DESCRIPTION
- improve error output of GenerateDerivedAnnotations
- allow pattern category-list to inherit from root
- minor improvement to tool
- Regenerate Derived Annotations

(cherry picked from commit b3999016827d728daf41c6eb74382b50f94ad9e1)

CLDR-15285

- [X] This PR completes the ticket.
