### PR TITLE
CLDR-15328 add @ORDERED for icu:extension, remove restrictions on using @ORDERED for icu: elements

### DIFF
--- a/common/dtd/ldmlICU.dtd
+++ b/common/dtd/ldmlICU.dtd
@@ -49,6 +49,7 @@ NOTE: Unlike the other DTDs, this file is manually maintained.
 <!ELEMENT icu:extensions (alias | (icu:extension*)) >
 
 <!ELEMENT icu:extension ( #PCDATA ) >
+    <!--@ORDERED-->
 
 <!ELEMENT icu:lstm (alias | (icu:lstmdata*)) >
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/api/CldrPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/api/CldrPaths.java
@@ -205,8 +205,9 @@ final class CldrPaths {
      * sort index).
      */
     static boolean isOrdered(CldrDataType dtdType, String elementName) {
-        // Elements with namespaces unknown the the DTD are never ordered.
-        if (elementName.indexOf(':') != -1) {
+        // Elements with namespaces unknown to the DTD are never ordered
+        // (but it knows about icu: elements).
+        if (elementName.indexOf(':') != -1 && !elementName.startsWith("icu:")) {
             return false;
         }
         // Returns empty set if DTD unknown, but it might also be the case that a valid DTD has no

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1202,9 +1202,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
     public boolean isOrdered(String elementName) {
         Element element = nameToElement.get(elementName);
         if (element == null) {
-            if (elementName.startsWith("icu:")) {
-                return false;
-            }
+            // No longer need to always return false for icu: elements per CLDR-8614,
+            // nameToElement should now know about them (see getInstance above).
             throw new IllegalByDtdException(elementName, null, null);
         }
         return element.isOrderedElement;


### PR DESCRIPTION
CLDR-15328

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Add the @ORDERED metadata item for the icu:extension element to generate a distinguished path, and remove obsolete restrictions on using @ORDERED with icu:-namespace elements.