### PR TITLE
CLDR-15323 fix FileUtilities.openWriter NPE

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/FileUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/FileUtilities.java
@@ -70,7 +70,7 @@ public final class FileUtilities {
 
     public static PrintWriter openWriter(File dir, String filename, Charset encoding) throws IOException {
         File file;
-        if (dir.equals("")) {
+        if (dir == null) {
             file = new File(filename);
         } else {
             file = new File(dir, filename);


### PR DESCRIPTION
dir is an object and not a string

CLDR-15323

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
