### PR TITLE
CLDR-13606 G in skeleton => pattern should have G (or r,U); test, fix patterns

### DIFF
--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -1616,7 +1616,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="Gy">G y թ.</dateFormatItem>
 						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">G y թ. MMM</dateFormatItem>
-						<dateFormatItem id="GyMMMd">d MMM, y թ.</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM, y թ. G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">G y թ. MMM d, E</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">H</dateFormatItem>

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -455,7 +455,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="Ehms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EHms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd">dd-MM-y</dateFormatItem>
+						<dateFormatItem id="GyMd">dd-MM-y G</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM G y</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -1842,7 +1842,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="Gy">G y</dateFormatItem>
 						<dateFormatItem id="GyMd">d/M/GGGGG y</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM, G y</dateFormatItem>
-						<dateFormatItem id="GyMMMd">d MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM, G y</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM, G y</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -1449,7 +1449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">G y</dateFormatItem>
-						<dateFormatItem id="GyMd">d/M/y</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM G y</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM G y</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM G y</dateFormatItem>
@@ -2978,7 +2978,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="d">E d MMM – E d MMM G y</greatestDifference>
 							<greatestDifference id="G">E d MMM G y – E d MMM G y</greatestDifference>
 							<greatestDifference id="M">E d MMM – E d MMM G y</greatestDifference>
-							<greatestDifference id="y">E d MMM y – E d MMM y</greatestDifference>
+							<greatestDifference id="y">E d MMM G y – E d MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -1728,7 +1728,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
 							<greatestDifference id="d">G d MMM E – d MMM E y</greatestDifference>
-							<greatestDifference id="G">d MMM y E – d MMM y E</greatestDifference>
+							<greatestDifference id="G">G d MMM y E – G d MMM y E</greatestDifference>
 							<greatestDifference id="M">G d MMM E – d MMM E y</greatestDifference>
 							<greatestDifference id="y">G d MMM y E – d MMM y E</greatestDifference>
 						</intervalFormatItem>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
@@ -293,6 +293,10 @@ class FlexibleDateFromCLDR {
                 if (strippedPattern.indexOf('H') >= 0 || strippedPattern.indexOf('k') >= 0) { // but pattern uses 24...
                     failure = "Skeleton uses 12-hour cycle (h,K) but pattern uses 24-hour (H,k)";
                 }
+            } else if (skeleton.indexOf('G') >= 0 && strippedPattern.indexOf('G') < 0 &&
+                        strippedPattern.indexOf('r') < 0 && strippedPattern.indexOf('U') < 0) {
+                // If skeleton has G, pattern should have G (or for cyclic calendars like chinese/dangi, r and/or U)
+                failure = "Skeleton includes 'G' (era) but pattern does not have 'G' (or 'r' or 'U' for chinese/dangi calendars)";
             }
         }
         return failure;


### PR DESCRIPTION
CLDR-13606

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

If a skeleton for availableFormats or intervalFormats includes G, then the corresponding pattern (for calendars other than chinese/dangi) must include G (for chinese/dangi, it should preferably include r, or at least U). Add the test for this, then fix a few patterns that then failed the test - look at similar patterns or generic patterns for guidance.

Note that the ordering of patterns in some locales (like hy Armenian) is pretty inconsistent. That is another problem, probably to fix using Survey Tool.