### PR TITLE
CLDR-15383 if have narrow currency symbol but non-narrow ↑↑↑ inherit no value, provide value

### DIFF
--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -5846,7 +5846,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>CUP</symbol>
 				<symbol alt="narrow">₱</symbol>
 			</currency>
 			<currency type="CVE">

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -6828,7 +6828,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Kroatian kuna</displayName>
 				<displayName count="one">Kroatian kuna</displayName>
 				<displayName count="other">Kroatian kunaa</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>HRK</symbol>
 				<symbol alt="narrow">HRK</symbol>
 			</currency>
 			<currency type="HTG">

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -5555,7 +5555,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>rublo bielorusso</displayName>
 				<displayName count="one">rublo bielorusso</displayName>
 				<displayName count="other">rubli bielorussi</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>BYN</symbol>
 				<symbol alt="narrow">Br</symbol>
 			</currency>
 			<currency type="BYR">
@@ -5708,7 +5708,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>sterlina egiziana</displayName>
 				<displayName count="one">sterlina egiziana</displayName>
 				<displayName count="other">sterline egiziane</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>EGP</symbol>
 				<symbol alt="narrow">£E</symbol>
 			</currency>
 			<currency type="ERN">
@@ -6240,7 +6240,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>corona norvegese</displayName>
 				<displayName count="one">corona norvegese</displayName>
 				<displayName count="other">corone norvegesi</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>NOK</symbol>
 				<symbol alt="narrow">NKr</symbol>
 			</currency>
 			<currency type="NPR">

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -5184,7 +5184,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>بلاروسي روبل</displayName>
 				<displayName count="one">بلاروسي روبل</displayName>
 				<displayName count="other">بلاروسي روبلز</displayName>
-				<symbol draft="contributed">↑↑↑</symbol>
+				<symbol draft="contributed">BYN</symbol>
 				<symbol alt="narrow" draft="contributed">р.</symbol>
 			</currency>
 			<currency type="BZD">

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -7408,7 +7408,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>spansk peseta</displayName>
 				<displayName count="one">spansk peseta</displayName>
 				<displayName count="other">spanska pesetas</displayName>
-				<symbol draft="contributed">↑↑↑</symbol>
+				<symbol draft="contributed">ESP</symbol>
 				<symbol alt="narrow" draft="contributed">ESP</symbol>
 			</currency>
 			<currency type="ETB">

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -7722,7 +7722,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="FJD">
 				<displayName>Tola fakafisi</displayName>
 				<displayName count="other">Tola fakafisi</displayName>
-				<symbol draft="contributed">↑↑↑</symbol>
+				<symbol draft="contributed">FJD</symbol>
 				<symbol alt="narrow" draft="contributed">F$</symbol>
 			</currency>
 			<currency type="NZD">
@@ -7739,7 +7739,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="SBD">
 				<displayName>Tola fakaʻotusolomone</displayName>
 				<displayName count="other">Tola fakaʻotusolomone</displayName>
-				<symbol draft="contributed">↑↑↑</symbol>
+				<symbol draft="contributed">SBD</symbol>
 				<symbol alt="narrow" draft="contributed">S$</symbol>
 			</currency>
 			<currency type="TOP">


### PR DESCRIPTION
CLDR-15383

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This fixes a problem where tests on the production data (in which ↑↑↑ is removed) produced errors like:
```
/Volumes/pmData/Sources/cldr-staging/production/common/main/it.xml:6110:38: error
it [Italian]	error	▸Currencies|Northern/Western_Europe|Northern_Europe:_Norway|NOK-symbol-narrow◂	〈kr〉	【】	〈NKr〉	«=»	【】	⁅missing non alt path⁆	❮Error: A path with alt is present but the corresponding path without alt is missing; a solution might be to confirm the non-alt path❯	https://st.unicode.org/cldr-apps/v#/it//7b917bf155f6cc00
/Volumes/pmData/Sources/cldr-staging/production/common/main/it.xml:5510:37: error
it [Italian]	error	▸Currencies|Southern/Eastern_Europe|Eastern_Europe:_Belarus|BYN-symbol-narrow◂	〈BYN〉	【】	〈Br〉	«=»	【】	⁅missing non alt path⁆	❮Error: A path with alt is present but the corresponding path without alt is missing; a solution might be to confirm the non-alt path❯	https://st.unicode.org/cldr-apps/v#/it//5b7cce81ce392bae
/Volumes/pmData/Sources/cldr-staging/production/common/main/it.xml:5645:37: error
it [Italian]	error	▸Currencies|Northern_Africa|Northern_Africa:_Egypt|EGP-symbol-narrow◂	〈E£〉	【】	〈£E〉	«=»	【】	⁅missing non alt path⁆	❮Error: A path with alt is present but the corresponding path without alt is missing; a solution might be to confirm the non-alt path❯	https://st.unicode.org/cldr-apps/v#/it//74348a8bb6d1992
```

This is caused by a situation like the following in Italian for example, where we have a value for symbol alt="narrow" but just ↑↑↑ for <symbol>:
```
    <currency type="EGP">
        ...
        <symbol>↑↑↑</symbol>
        <symbol alt="narrow">£E</symbol>
    </currency>
```
and where the parent(s) up through root provide no value for the non-narrow <symbol> (or no entry for the currency at all); for example root has
```
    <currency type="EGP">
        <symbol alt="narrow">E£</symbol>
    </currency>
```
The solution is just to replace ↑↑↑ with the currency code.
