### PR TITLE
CLDR-15366 BRS v41: likelySubtags update #0

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE supplementalData SYSTEM "../../common/dtd/ldmlSupplemental.dtd">
 <!--
-Copyright © 1991-2021 Unicode, Inc.
+Copyright © 1991-2022 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -340,6 +340,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Buhid; ?; ? } => { Buhid; Latin; Philippines }-->
 		<likelySubtag from="bkv" to="bkv_Latn_ZZ"/>
 		<!--{ Bekwarra; ?; ? } => { Bekwarra; Latin; Unknown Region }-->
+		<likelySubtag from="bla" to="bla_Latn_CA"/>
+		<!--{ Siksika; ?; ? } => { Siksika; Latin; Canada }-->
 		<likelySubtag from="blg" to="blg_Latn_MY"/>
 		<!--{ Balau; ?; ? } => { Balau; Latin; Malaysia }-->
 		<likelySubtag from="blt" to="blt_Tavt_VN"/>
@@ -521,7 +523,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="crg" to="crg_Latn_CA"/>
 		<!--{ Michif; ?; ? } => { Michif; Latin; Canada }-->
 		<likelySubtag from="crh" to="crh_Cyrl_UA"/>
-		<!--{ Crimean Turkish; ?; ? } => { Crimean Turkish; Cyrillic; Ukraine }-->
+		<!--{ Crimean Tatar; ?; ? } => { Crimean Tatar; Cyrillic; Ukraine }-->
 		<likelySubtag from="crj" to="crj_Cans_CA"/>
 		<!--{ Southern East Cree; ?; ? } => { Southern East Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="crk" to="crk_Cans_CA"/>
@@ -1632,6 +1634,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Mauwake; ?; ? } => { Mauwake; Latin; Unknown Region }-->
 		<likelySubtag from="mi" to="mi_Latn_NZ"/>
 		<!--{ Māori; ?; ? } => { Māori; Latin; New Zealand }-->
+		<likelySubtag from="mic" to="mic_Latn_CA"/>
+		<!--{ Mi'kmaq; ?; ? } => { Mi'kmaq; Latin; Canada }-->
 		<likelySubtag from="mif" to="mif_Latn_ZZ"/>
 		<!--{ Mofu-Gudur; ?; ? } => { Mofu-Gudur; Latin; Unknown Region }-->
 		<likelySubtag from="min" to="min_Latn_ID"/>
@@ -1681,7 +1685,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="moa" to="moa_Latn_ZZ"/>
 		<!--{ Mwan; ?; ? } => { Mwan; Latin; Unknown Region }-->
 		<likelySubtag from="moe" to="moe_Latn_CA"/>
-		<!--{ Innu; ?; ? } => { Innu; Latin; Canada }-->
+		<!--{ Innu-aimun; ?; ? } => { Innu-aimun; Latin; Canada }-->
 		<likelySubtag from="moh" to="moh_Latn_CA"/>
 		<!--{ Mohawk; ?; ? } => { Mohawk; Latin; Canada }-->
 		<likelySubtag from="mos" to="mos_Latn_BF"/>
@@ -1930,6 +1934,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Occitan; ?; ? } => { Occitan; Latin; France }-->
 		<likelySubtag from="ogc" to="ogc_Latn_ZZ"/>
 		<!--{ Ogbah; ?; ? } => { Ogbah; Latin; Unknown Region }-->
+		<likelySubtag from="oj" to="oj_Cans_CA"/>
+		<!--{ Ojibwa; ?; ? } => { Ojibwa; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="ojs" to="ojs_Cans_CA"/>
 		<!--{ Oji-Cree; ?; ? } => { Oji-Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="oka" to="oka_Latn_CA"/>
@@ -3336,8 +3342,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Arabic; Cocos (Keeling) Islands } => { Malay; Arabic; Cocos (Keeling) Islands }-->
 		<likelySubtag from="und_Arab_CN" to="ug_Arab_CN"/>
 		<!--{ ?; Arabic; China } => { Uyghur; Arabic; China }-->
-		<likelySubtag from="und_Arab_GB" to="ks_Arab_GB"/>
-		<!--{ ?; Arabic; United Kingdom } => { Kashmiri; Arabic; United Kingdom }-->
+		<likelySubtag from="und_Arab_GB" to="ur_Arab_GB"/>
+		<!--{ ?; Arabic; United Kingdom } => { Urdu; Arabic; United Kingdom }-->
 		<likelySubtag from="und_Arab_ID" to="ms_Arab_ID"/>
 		<!--{ ?; Arabic; Indonesia } => { Malay; Arabic; Indonesia }-->
 		<likelySubtag from="und_Arab_IN" to="ur_Arab_IN"/>
@@ -3394,8 +3400,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Buhid; ? } => { Buhid; Buhid; Philippines }-->
 		<likelySubtag from="und_Cakm" to="ccp_Cakm_BD"/>
 		<!--{ ?; Chakma; ? } => { Chakma; Chakma; Bangladesh }-->
-		<likelySubtag from="und_Cans" to="cr_Cans_CA"/>
-		<!--{ ?; Unified Canadian Aboriginal Syllabics; ? } => { Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
+		<likelySubtag from="und_Cans" to="iu_Cans_CA"/>
+		<!--{ ?; Unified Canadian Aboriginal Syllabics; ? } => { Inuktitut; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="und_Cari" to="xcr_Cari_TR"/>
 		<!--{ ?; Carian; ? } => { Carian; Carian; Turkey }-->
 		<likelySubtag from="und_Cham" to="cjm_Cham_VN"/>
@@ -3418,8 +3424,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Cyrillic; Albania } => { Macedonian; Cyrillic; Albania }-->
 		<likelySubtag from="und_Cyrl_BA" to="sr_Cyrl_BA"/>
 		<!--{ ?; Cyrillic; Bosnia & Herzegovina } => { Serbian; Cyrillic; Bosnia & Herzegovina }-->
-		<likelySubtag from="und_Cyrl_GE" to="os_Cyrl_GE"/>
-		<!--{ ?; Cyrillic; Georgia } => { Ossetic; Cyrillic; Georgia }-->
+		<likelySubtag from="und_Cyrl_GE" to="ab_Cyrl_GE"/>
+		<!--{ ?; Cyrillic; Georgia } => { Abkhazian; Cyrillic; Georgia }-->
 		<likelySubtag from="und_Cyrl_GR" to="mk_Cyrl_GR"/>
 		<!--{ ?; Cyrillic; Greece } => { Macedonian; Cyrillic; Greece }-->
 		<likelySubtag from="und_Cyrl_MD" to="uk_Cyrl_MD"/>
@@ -3488,6 +3494,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Simplified; ? } => { Chinese; Simplified; China }-->
 		<likelySubtag from="und_Hant" to="zh_Hant_TW"/>
 		<!--{ ?; Traditional; ? } => { Chinese; Traditional; Taiwan }-->
+		<likelySubtag from="und_Hant_CA" to="yue_Hant_CA"/>
+		<!--{ ?; Traditional; Canada } => { Cantonese; Traditional; Canada }-->
 		<likelySubtag from="und_Hebr" to="he_Hebr_IL"/>
 		<!--{ ?; Hebrew; ? } => { Hebrew; Hebrew; Israel }-->
 		<likelySubtag from="und_Hebr_CA" to="yi_Hebr_CA"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -375,7 +375,7 @@ public class LikelySubtagsTest extends TestFmwk {
         TreeSet<String> sorted = new TreeSet<>(
             ScriptMetadata.getScripts());
         Set<String> exceptions2 = new HashSet<>(
-            Arrays.asList("zh_Hans_CN", "hnj_Hmnp_US", "hnj_Hmng_LA"));
+            Arrays.asList("zh_Hans_CN", "hnj_Hmnp_US", "hnj_Hmng_LA", "iu_Cans_CA"));
         for (String script : sorted) {
             if (exceptions.contains(script) || script.equals("Latn")
                 || script.equals("Dsrt")) {
@@ -391,8 +391,8 @@ public class LikelySubtagsTest extends TestFmwk {
             String likelyExpansion = likely.get(undScript);
             if (likelyExpansion == null) {
                 if (!KNOWN_SCRIPTS_WITHOUT_LIKELY_SUBTAGS.contains(script)) {
-                    String msg = "Missing likely language for script (und_" + script
-                        + ")  should be something like:\t "
+                    String msg = "likelySubtags.xml missing language for script (und_" + script
+                        + "). Script Metadata suggests that it should be something like:\t "
                         + showOverride(script, originCountry, langScript);
                     if (i.age.compareTo(icuUnicodeVersion) <= 0) {
                         // Error: Missing data for a script in ICU's Unicode version.
@@ -413,9 +413,9 @@ public class LikelySubtagsTest extends TestFmwk {
                 // + ", but something like:\t " + showOverride(script,
                 // originCountry, langScript));
                 // } else {
-                errln("Wrong likely language for script (und_" + script
+                errln("likelySubtags.xml has wrong language for script (und_" + script
                     + "). Should not be " + likelyExpansion
-                    + ", but something like:\t "
+                    + ", but Script Metadata suggests something like:\t "
                     + showOverride(script, originCountry, langScript));
                 // }
             } else {


### PR DESCRIPTION
- update test to be clearer (related to CLDR-15391)
- add 'less disruptive' likely subtag changes

CLDR-15366

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
