### PR TITLE
CLDR-15261 Arabic spellout rules render a stray space after the conjunction

### DIFF
--- a/common/rbnf/ar.xml
+++ b/common/rbnf/ar.xml
@@ -41,21 +41,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%spellout-numbering→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%spellout-numbering→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%spellout-numbering→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000">ألفين[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000">ألفين[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%spellout-numbering→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-feminine">
@@ -83,21 +83,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%spellout-numbering→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%spellout-numbering→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%spellout-numbering→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000">ألفي[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000">ألفي[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%spellout-numbering→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering-m" access="private">
@@ -123,21 +123,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%%spellout-numbering-m→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%%spellout-numbering-m→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%%spellout-numbering-m→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000">ألفي[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000">ألفي[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-masculine">
@@ -165,21 +165,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%%spellout-numbering-m→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%%spellout-numbering-m→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%%spellout-numbering-m→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000">ألفي[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000">ألفي[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="ordinal-ones-feminine" access="private">
@@ -220,21 +220,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="81">→%%ordinal-ones-feminine→ والثمانون;</rbnfrule>
                 <rbnfrule value="90">التسعون;</rbnfrule>
                 <rbnfrule value="91">→%%ordinal-ones-feminine→ والتسعون;</rbnfrule>
-                <rbnfrule value="100">المائة[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="200">المائتان[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000">الألف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000">الألفي[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-cardinal-feminine← آلاف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%spellout-cardinal-feminine← ألف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000">المليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-feminine← الألف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000000">المليار[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← مليار[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← ترليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← كوادرليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="100">المائة[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="200">المائتان[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000">الألف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000">الألفي[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-cardinal-feminine← آلاف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%spellout-cardinal-feminine← ألف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000">المليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← الألف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000000">المليار[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← مليار[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← ترليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← كوادرليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="ordinal-ones-masculine" access="private">
@@ -275,21 +275,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="81">→%%ordinal-ones-masculine→ والثمانون;</rbnfrule>
                 <rbnfrule value="90">التسعون;</rbnfrule>
                 <rbnfrule value="91">→%%ordinal-ones-masculine→ والتسعون;</rbnfrule>
-                <rbnfrule value="100">المائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="200">المائتان[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000">الألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000">الألفي[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000">المليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← الألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000">المليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="100">المائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="200">المائتان[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000">الألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000">الألفي[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000">المليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← الألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000">المليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -524,14 +524,10 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Michif; ?; ? } => { Michif; Latin; Canada }-->
 		<likelySubtag from="crh" to="crh_Cyrl_UA"/>
 		<!--{ Crimean Tatar; ?; ? } => { Crimean Tatar; Cyrillic; Ukraine }-->
-		<likelySubtag from="crj" to="crj_Cans_CA"/>
-		<!--{ Southern East Cree; ?; ? } => { Southern East Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="crk" to="crk_Cans_CA"/>
 		<!--{ Plains Cree; ?; ? } => { Plains Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="crl" to="crl_Cans_CA"/>
 		<!--{ Northern East Cree; ?; ? } => { Northern East Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
-		<likelySubtag from="crm" to="crm_Cans_CA"/>
-		<!--{ Moose Cree; ?; ? } => { Moose Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="crs" to="crs_Latn_SC"/>
 		<!--{ Seselwa Creole French; ?; ? } => { Seselwa Creole French; Latin; Seychelles }-->
 		<likelySubtag from="cs" to="cs_Latn_CZ"/>
@@ -1044,8 +1040,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Inupiaq; ?; ? } => { Inupiaq; Latin; United States }-->
 		<likelySubtag from="ikk" to="ikk_Latn_ZZ"/>
 		<!--{ Ika; ?; ? } => { Ika; Latin; Unknown Region }-->
-		<likelySubtag from="ikt" to="ikt_Latn_CA"/>
-		<!--{ Inuinnaqtun; ?; ? } => { Inuinnaqtun; Latin; Canada }-->
 		<likelySubtag from="ikw" to="ikw_Latn_ZZ"/>
 		<!--{ Ikwere; ?; ? } => { Ikwere; Latin; Unknown Region }-->
 		<likelySubtag from="ikx" to="ikx_Latn_ZZ"/>
@@ -2166,8 +2160,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Sicilian; ?; ? } => { Sicilian; Latin; Italy }-->
 		<likelySubtag from="sco" to="sco_Latn_GB"/>
 		<!--{ Scots; ?; ? } => { Scots; Latin; United Kingdom }-->
-		<likelySubtag from="scs" to="scs_Latn_CA"/>
-		<!--{ North Slavey; ?; ? } => { North Slavey; Latin; Canada }-->
 		<likelySubtag from="sd" to="sd_Arab_PK"/>
 		<!--{ Sindhi; ?; ? } => { Sindhi; Arabic; Pakistan }-->
 		<likelySubtag from="sd_Deva" to="sd_Deva_IN"/>
@@ -3498,10 +3490,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Traditional; Canada } => { Cantonese; Traditional; Canada }-->
 		<likelySubtag from="und_Hebr" to="he_Hebr_IL"/>
 		<!--{ ?; Hebrew; ? } => { Hebrew; Hebrew; Israel }-->
-		<likelySubtag from="und_Hebr_CA" to="yi_Hebr_CA"/>
-		<!--{ ?; Hebrew; Canada } => { Yiddish; Hebrew; Canada }-->
-		<likelySubtag from="und_Hebr_GB" to="yi_Hebr_GB"/>
-		<!--{ ?; Hebrew; United Kingdom } => { Yiddish; Hebrew; United Kingdom }-->
 		<likelySubtag from="und_Hebr_SE" to="yi_Hebr_SE"/>
 		<!--{ ?; Hebrew; Sweden } => { Yiddish; Hebrew; Sweden }-->
 		<likelySubtag from="und_Hebr_UA" to="yi_Hebr_UA"/>

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE supplementalData SYSTEM "../../common/dtd/ldmlSupplemental.dtd">
 <!--
-Copyright © 1991-2021 Unicode, Inc.
+Copyright © 1991-2022 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -340,6 +340,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Buhid; ?; ? } => { Buhid; Latin; Philippines }-->
 		<likelySubtag from="bkv" to="bkv_Latn_ZZ"/>
 		<!--{ Bekwarra; ?; ? } => { Bekwarra; Latin; Unknown Region }-->
+		<likelySubtag from="bla" to="bla_Latn_CA"/>
+		<!--{ Siksika; ?; ? } => { Siksika; Latin; Canada }-->
 		<likelySubtag from="blg" to="blg_Latn_MY"/>
 		<!--{ Balau; ?; ? } => { Balau; Latin; Malaysia }-->
 		<likelySubtag from="blt" to="blt_Tavt_VN"/>
@@ -521,7 +523,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="crg" to="crg_Latn_CA"/>
 		<!--{ Michif; ?; ? } => { Michif; Latin; Canada }-->
 		<likelySubtag from="crh" to="crh_Cyrl_UA"/>
-		<!--{ Crimean Turkish; ?; ? } => { Crimean Turkish; Cyrillic; Ukraine }-->
+		<!--{ Crimean Tatar; ?; ? } => { Crimean Tatar; Cyrillic; Ukraine }-->
 		<likelySubtag from="crj" to="crj_Cans_CA"/>
 		<!--{ Southern East Cree; ?; ? } => { Southern East Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="crk" to="crk_Cans_CA"/>
@@ -1632,6 +1634,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Mauwake; ?; ? } => { Mauwake; Latin; Unknown Region }-->
 		<likelySubtag from="mi" to="mi_Latn_NZ"/>
 		<!--{ Māori; ?; ? } => { Māori; Latin; New Zealand }-->
+		<likelySubtag from="mic" to="mic_Latn_CA"/>
+		<!--{ Mi'kmaq; ?; ? } => { Mi'kmaq; Latin; Canada }-->
 		<likelySubtag from="mif" to="mif_Latn_ZZ"/>
 		<!--{ Mofu-Gudur; ?; ? } => { Mofu-Gudur; Latin; Unknown Region }-->
 		<likelySubtag from="min" to="min_Latn_ID"/>
@@ -1681,7 +1685,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="moa" to="moa_Latn_ZZ"/>
 		<!--{ Mwan; ?; ? } => { Mwan; Latin; Unknown Region }-->
 		<likelySubtag from="moe" to="moe_Latn_CA"/>
-		<!--{ Innu; ?; ? } => { Innu; Latin; Canada }-->
+		<!--{ Innu-aimun; ?; ? } => { Innu-aimun; Latin; Canada }-->
 		<likelySubtag from="moh" to="moh_Latn_CA"/>
 		<!--{ Mohawk; ?; ? } => { Mohawk; Latin; Canada }-->
 		<likelySubtag from="mos" to="mos_Latn_BF"/>
@@ -1930,6 +1934,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Occitan; ?; ? } => { Occitan; Latin; France }-->
 		<likelySubtag from="ogc" to="ogc_Latn_ZZ"/>
 		<!--{ Ogbah; ?; ? } => { Ogbah; Latin; Unknown Region }-->
+		<likelySubtag from="oj" to="oj_Cans_CA"/>
+		<!--{ Ojibwa; ?; ? } => { Ojibwa; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="ojs" to="ojs_Cans_CA"/>
 		<!--{ Oji-Cree; ?; ? } => { Oji-Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="oka" to="oka_Latn_CA"/>
@@ -3336,8 +3342,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Arabic; Cocos (Keeling) Islands } => { Malay; Arabic; Cocos (Keeling) Islands }-->
 		<likelySubtag from="und_Arab_CN" to="ug_Arab_CN"/>
 		<!--{ ?; Arabic; China } => { Uyghur; Arabic; China }-->
-		<likelySubtag from="und_Arab_GB" to="ks_Arab_GB"/>
-		<!--{ ?; Arabic; United Kingdom } => { Kashmiri; Arabic; United Kingdom }-->
+		<likelySubtag from="und_Arab_GB" to="ur_Arab_GB"/>
+		<!--{ ?; Arabic; United Kingdom } => { Urdu; Arabic; United Kingdom }-->
 		<likelySubtag from="und_Arab_ID" to="ms_Arab_ID"/>
 		<!--{ ?; Arabic; Indonesia } => { Malay; Arabic; Indonesia }-->
 		<likelySubtag from="und_Arab_IN" to="ur_Arab_IN"/>
@@ -3394,8 +3400,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Buhid; ? } => { Buhid; Buhid; Philippines }-->
 		<likelySubtag from="und_Cakm" to="ccp_Cakm_BD"/>
 		<!--{ ?; Chakma; ? } => { Chakma; Chakma; Bangladesh }-->
-		<likelySubtag from="und_Cans" to="cr_Cans_CA"/>
-		<!--{ ?; Unified Canadian Aboriginal Syllabics; ? } => { Cree; Unified Canadian Aboriginal Syllabics; Canada }-->
+		<likelySubtag from="und_Cans" to="iu_Cans_CA"/>
+		<!--{ ?; Unified Canadian Aboriginal Syllabics; ? } => { Inuktitut; Unified Canadian Aboriginal Syllabics; Canada }-->
 		<likelySubtag from="und_Cari" to="xcr_Cari_TR"/>
 		<!--{ ?; Carian; ? } => { Carian; Carian; Turkey }-->
 		<likelySubtag from="und_Cham" to="cjm_Cham_VN"/>
@@ -3418,8 +3424,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Cyrillic; Albania } => { Macedonian; Cyrillic; Albania }-->
 		<likelySubtag from="und_Cyrl_BA" to="sr_Cyrl_BA"/>
 		<!--{ ?; Cyrillic; Bosnia & Herzegovina } => { Serbian; Cyrillic; Bosnia & Herzegovina }-->
-		<likelySubtag from="und_Cyrl_GE" to="os_Cyrl_GE"/>
-		<!--{ ?; Cyrillic; Georgia } => { Ossetic; Cyrillic; Georgia }-->
+		<likelySubtag from="und_Cyrl_GE" to="ab_Cyrl_GE"/>
+		<!--{ ?; Cyrillic; Georgia } => { Abkhazian; Cyrillic; Georgia }-->
 		<likelySubtag from="und_Cyrl_GR" to="mk_Cyrl_GR"/>
 		<!--{ ?; Cyrillic; Greece } => { Macedonian; Cyrillic; Greece }-->
 		<likelySubtag from="und_Cyrl_MD" to="uk_Cyrl_MD"/>
@@ -3488,6 +3494,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ ?; Simplified; ? } => { Chinese; Simplified; China }-->
 		<likelySubtag from="und_Hant" to="zh_Hant_TW"/>
 		<!--{ ?; Traditional; ? } => { Chinese; Traditional; Taiwan }-->
+		<likelySubtag from="und_Hant_CA" to="yue_Hant_CA"/>
+		<!--{ ?; Traditional; Canada } => { Cantonese; Traditional; Canada }-->
 		<likelySubtag from="und_Hebr" to="he_Hebr_IL"/>
 		<!--{ ?; Hebrew; ? } => { Hebrew; Hebrew; Israel }-->
 		<likelySubtag from="und_Hebr_CA" to="yi_Hebr_CA"/>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1797,8 +1797,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<defaultContent locales="
 			aa_ET ab_GE af_ZA agq_CM ak_GH am_ET an_ES ar_001 arn_CL as_IN asa_TZ ast_ES
 			az_Arab_IR az_Cyrl_AZ az_Latn az_Latn_AZ
-			ba_RU bal_Arab bal_Arab_PK bal_Latn_PK bas_CM be_BY bem_ZM bez_TZ bg_BG bgn_PK blt_VN bm_ML bm_Nkoo_ML bn_BD
-			bo_CN br_FR brx_IN bs_Cyrl_BA bs_Latn bs_Latn_BA bss_CM byn_ER
+			ba_RU bal_Arab bal_Arab_PK bal_Latn_PK bas_CM be_BY bem_ZM bez_TZ bg_BG bgn_PK
+			blt_VN bm_ML bm_Nkoo_ML bn_BD bo_CN br_FR brx_IN bs_Cyrl_BA bs_Latn bs_Latn_BA
+			bss_CM byn_ER
 			ca_ES cad_US cch_NG ccp_BD ce_RU ceb_PH cgg_UG chr_US cic_US ckb_IQ co_FR cs_CZ
 			cu_RU cv_RU cy_GB
 			da_DK dav_KE de_DE dje_NE doi_IN dsb_DE dua_CM dv_MV dyo_SN dz_BT

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/FileUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/FileUtilities.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -47,8 +48,16 @@ public final class FileUtilities {
         return openReader(dir, filename, "UTF-8");
     }
 
+    public static BufferedReader openUTF8Reader(File file) throws IOException {
+        return openReader(file, "UTF-8");
+    }
+
     public static BufferedReader openReader(String dir, String filename, String encoding) throws IOException {
         File file = dir.length() == 0 ? new File(filename) : new File(dir, filename);
+        return openReader(file, encoding);
+    }
+
+    private static BufferedReader openReader(File file, String encoding) throws UnsupportedEncodingException, FileNotFoundException {
         if (SHOW_FILES && log != null) {
             log.println("Opening File: "
                 + getNormalizedPathString(file));
@@ -68,6 +77,10 @@ public final class FileUtilities {
         return openWriter(dir, filename, StandardCharsets.UTF_8);
     }
 
+    public static PrintWriter openUTF8Writer(File file) throws IOException {
+        return openWriter(file, StandardCharsets.UTF_8);
+    }
+
     public static PrintWriter openWriter(File dir, String filename, Charset encoding) throws IOException {
         File file;
         if (dir == null) {
@@ -75,6 +88,10 @@ public final class FileUtilities {
         } else {
             file = new File(dir, filename);
         }
+        return openWriter(file, encoding);
+    }
+
+    private static PrintWriter openWriter(File file, Charset encoding) throws IOException {
         if (SHOW_FILES && log != null) {
             log.println("Creating File: " + getNormalizedPathString(file));
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -375,7 +375,7 @@ public class LikelySubtagsTest extends TestFmwk {
         TreeSet<String> sorted = new TreeSet<>(
             ScriptMetadata.getScripts());
         Set<String> exceptions2 = new HashSet<>(
-            Arrays.asList("zh_Hans_CN", "hnj_Hmnp_US", "hnj_Hmng_LA"));
+            Arrays.asList("zh_Hans_CN", "hnj_Hmnp_US", "hnj_Hmng_LA", "iu_Cans_CA"));
         for (String script : sorted) {
             if (exceptions.contains(script) || script.equals("Latn")
                 || script.equals("Dsrt")) {
@@ -391,8 +391,8 @@ public class LikelySubtagsTest extends TestFmwk {
             String likelyExpansion = likely.get(undScript);
             if (likelyExpansion == null) {
                 if (!KNOWN_SCRIPTS_WITHOUT_LIKELY_SUBTAGS.contains(script)) {
-                    String msg = "Missing likely language for script (und_" + script
-                        + ")  should be something like:\t "
+                    String msg = "likelySubtags.xml missing language for script (und_" + script
+                        + "). Script Metadata suggests that it should be something like:\t "
                         + showOverride(script, originCountry, langScript);
                     if (i.age.compareTo(icuUnicodeVersion) <= 0) {
                         // Error: Missing data for a script in ICU's Unicode version.
@@ -413,9 +413,9 @@ public class LikelySubtagsTest extends TestFmwk {
                 // + ", but something like:\t " + showOverride(script,
                 // originCountry, langScript));
                 // } else {
-                errln("Wrong likely language for script (und_" + script
+                errln("likelySubtags.xml has wrong language for script (und_" + script
                     + "). Should not be " + likelyExpansion
-                    + ", but something like:\t "
+                    + ", but Script Metadata suggests something like:\t "
                     + showOverride(script, originCountry, langScript));
                 // }
             } else {


### PR DESCRIPTION
This ticket provided additional feedback that the changes were incomplete. I have confirmed that 138000 comes out as the following as per the feedback:
مائة وثمانية وثلاثون ألف وأربعة مائة
Also 1111111111111 comes out as the following:
ترليون ومائة وإحدى عشر مليار ومائة وإحدى عشر مليون ومائة وإحدى عشر ألف ومائة وإحدى عشر

The fix was performed by searching and replacing all instances of the and (و) surrounded by spaces.

CLDR-15261

- [x] This PR completes the ticket.