### PR TITLE
CLDR-15261 Arabic spellout rules render a stray space after the conjunction

### DIFF
--- a/common/rbnf/ar.xml
+++ b/common/rbnf/ar.xml
@@ -41,21 +41,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%spellout-numbering→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%spellout-numbering→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%spellout-numbering→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000">ألفين[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000">ألفين[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%spellout-numbering→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-feminine">
@@ -83,21 +83,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%spellout-numbering→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%spellout-numbering→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%spellout-numbering→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000">ألفي[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000">ألفي[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%spellout-numbering→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering-m" access="private">
@@ -123,21 +123,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%%spellout-numbering-m→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%%spellout-numbering-m→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%%spellout-numbering-m→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000">ألفي[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000">ألفي[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-cardinal-masculine">
@@ -165,21 +165,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="70">[→%%spellout-numbering-m→ و]سبعون;</rbnfrule>
                 <rbnfrule value="80">[→%%spellout-numbering-m→ و]ثمانون;</rbnfrule>
                 <rbnfrule value="90">[→%%spellout-numbering-m→ و]تسعون;</rbnfrule>
-                <rbnfrule value="100">مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="200">مائتان[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000">ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000">ألفي[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000">مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000">مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="100">مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="200">مائتان[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000">ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000">ألفي[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000">مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← مليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000">مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="ordinal-ones-feminine" access="private">
@@ -220,21 +220,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="81">→%%ordinal-ones-feminine→ والثمانون;</rbnfrule>
                 <rbnfrule value="90">التسعون;</rbnfrule>
                 <rbnfrule value="91">→%%ordinal-ones-feminine→ والتسعون;</rbnfrule>
-                <rbnfrule value="100">المائة[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="200">المائتان[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000">الألف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000">الألفي[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-cardinal-feminine← آلاف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%spellout-cardinal-feminine← ألف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000">المليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000">←%spellout-cardinal-feminine← الألف[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000000">المليار[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← مليار[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← ترليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← كوادرليون[ و →%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="100">المائة[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="200">المائتان[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000">الألف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000">الألفي[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-cardinal-feminine← آلاف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%spellout-cardinal-feminine← ألف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000">المليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000">←%spellout-cardinal-feminine← الألف[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000000">المليار[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000000">←%spellout-cardinal-feminine← مليار[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%spellout-cardinal-feminine← ترليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%spellout-cardinal-feminine← كوادرليون[ و→%spellout-cardinal-feminine→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="ordinal-ones-masculine" access="private">
@@ -275,21 +275,21 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="81">→%%ordinal-ones-masculine→ والثمانون;</rbnfrule>
                 <rbnfrule value="90">التسعون;</rbnfrule>
                 <rbnfrule value="91">→%%ordinal-ones-masculine→ والتسعون;</rbnfrule>
-                <rbnfrule value="100">المائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="200">المائتان[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="300">←%spellout-numbering← مائة[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000">الألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000">الألفي[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000">المليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000">←%%spellout-numbering-m← الألف[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000">المليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000">ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="1000000000000000">كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
-                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و →%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="100">المائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="200">المائتان[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="300">←%spellout-numbering← مائة[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000">الألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000">الألفي[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="3000">←%spellout-numbering← آلاف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="11000" radix="1000">←%%spellout-numbering-m← ألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000">المليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000">←%%spellout-numbering-m← الألف[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000">المليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000">←%%spellout-numbering-m← مليار[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000">ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000">←%%spellout-numbering-m← ترليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="1000000000000000">كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
+                <rbnfrule value="2000000000000000">←%%spellout-numbering-m← كوادرليون[ و→%%spellout-numbering-m→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>


### PR DESCRIPTION
CLDR-15261

This ticket provided additional feedback that the changes were incomplete. I have confirmed that 138000 comes out as the following as per the feedback:
مائة وثمانية وثلاثون ألف وأربعة مائة
Also 1111111111111 comes out as the following:
ترليون ومائة وإحدى عشر مليار ومائة وإحدى عشر مليون ومائة وإحدى عشر ألف ومائة وإحدى عشر

The fix was performed by searching and replacing all instances of the "and" (و) surrounded by spaces. FYI و means "and" in Arabic. Since testing the result requires ICU and there isn't an easy way to convert this XML to ICU syntax, there isn't an easy way to add a test for this value. This is a resubmission of https://github.com/unicode-org/cldr/pull/1782 to the maint-41 branch.

- [x] This PR completes the ticket.