### PR TITLE
CLDR-15394 remove invalid test in TestCheckNewRootFailure

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -550,8 +550,14 @@ public class TestCheckCLDR extends TestFmwk {
         Map<String, String> options = new HashMap<>();
         for (Phase phase : Phase.values()) {
             options.put(Options.Option.phase.getKey(), phase.toString());
-            for (String value : Arrays.asList("E10-836", CldrUtility.INHERITANCE_MARKER)) {
-
+            String value = "E10-836";
+            // The following code used to check values of both "E10-836" and CldrUtility.INHERITANCE_MARKER="↑↑↑",
+            // but the latter does not make sense; "↑↑↑" will be followed up through its parent chain, either
+            // yielding a real value or the root value (but never "↑↑↑"). In regular CLDR data the root value will
+            // be like "E10-836" but in production data those root entreis are stripped and the root value will be
+            // null. Hence CheckNew.handleCheck only checks for entries like "E10-836", not "↑↑↑", and the test
+            // should only check those as well.
+            {
                 // make a fake locale, starting with real root
 
                 CLDRFile root = annotationsFactory.make("root", false);


### PR DESCRIPTION
CLDR-15394

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This is a follow-on to [PR-552](https://github.com/unicode-org/cldr/pull/552), which updated the test CheckNew.handleCheck to make sure that root-style emoji annotations like "E10-836" were not finding their way into non-root data (either explicitly or by inheritance), and added a new test TestCheckCLDR.TestCheckNewRootFailure to verify that the updated CheckNew.handleCheck was working correctly. However, the latter test tried to verify that an error was generated for both "E10-836" and "↑↑↑"; the latter test is not valid, and caused problems in production code, so it is removed here.

For entries like "↑↑↑", the value is obtained by following the parent chain until an explicit value if found (which may be in root, in which case for regular CLDR data it will be an entry like "E10-836". In production data the root entries are removed, so if root is reached the value is null, and CheckNew.handleCheck doe not generate an error (so TestCheckCLDR.TestCheckNewRootFailure did).