### PR TITLE
CLDR-15405 first cut personNames dtd & en data, plus tooling updates/skips

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 
-<!ELEMENT ldml ( identity, ( alias | ( fallback*, localeDisplayNames?, layout?, contextTransforms?, characters?, delimiters?, measurement?, dates?, numbers?, units?, listPatterns?, collations?, posix?, characterLabels?, segmentations?, rbnf?, typographicNames?, annotations?, metadata?, references?, special* ) ) ) >
+<!ELEMENT ldml ( identity, ( alias | ( fallback*, localeDisplayNames?, layout?, contextTransforms?, characters?, delimiters?, measurement?, dates?, numbers?, units?, listPatterns?, collations?, posix?, characterLabels?, segmentations?, rbnf?, typographicNames?, personNames?, annotations?, metadata?, references?, special* ) ) ) >
 <!ATTLIST ldml version CDATA #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED-->
@@ -3162,6 +3162,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST annotation alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST annotation draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+
+<!ELEMENT personNames ( alias | ( nameOrder*, personName+, special* ) ) >
+
+<!ELEMENT nameOrder EMPTY >
+<!ATTLIST nameOrder nameLocales NMTOKENS #REQUIRED >
+    <!--@MATCH:set/validity/locale-->
+<!ATTLIST nameOrder order (surnameFirst | givenFirst) #REQUIRED >
+    <!--@VALUE-->
+<!ATTLIST nameOrder draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+<!ATTLIST nameOrder references CDATA #IMPLIED >
+    <!--@METADATA-->
+
+<!ELEMENT personName ( alias | ( namePattern+, special* ) ) >
+<!ATTLIST personName length NMTOKENS #IMPLIED >
+    <!--@MATCH:set/literal/long, medium, short, monogram, monogram-narrow-->
+<!ATTLIST personName usage NMTOKENS #IMPLIED >
+    <!--@MATCH:set/literal/addressing, referring, sorting-->
+<!ATTLIST personName style NMTOKENS #IMPLIED >
+    <!--@MATCH:set/literal/formal, informal-->
+<!ATTLIST personName order NMTOKENS #IMPLIED >
+    <!--@MATCH:set/literal/surnameFirst, givenFirst-->
+
+<!ELEMENT namePattern ( #PCDATA ) >
+    <!--@ORDERED-->
+<!ATTLIST namePattern alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST namePattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+<!ATTLIST namePattern references CDATA #IMPLIED >
     <!--@METADATA-->
 
 <!-- ######################################################### -->

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9128,4 +9128,51 @@ annotations.
 		<featureName type="tnum">tabular numbers</featureName>
 		<featureName type="zero">slashed zero</featureName>
 	</typographicNames>
+	<personNames>
+		<personName length="monogram-narrow" style="informal">
+			<namePattern>{given-informal-initial}</namePattern>
+		</personName>
+		<personName length="monogram-narrow">
+			<namePattern>{surname-initial}</namePattern>
+		</personName>
+		<personName length="monogram" style="informal">
+			<namePattern>{given-informal-initial}{surname-initial}</namePattern>
+		</personName>
+		<personName length="monogram">
+			<namePattern>{given-initial}{given2-initial}{surname-initial}</namePattern>
+		</personName>
+		<personName usage="addressing" style="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName usage="addressing">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName usage="sorting" style="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="sorting">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="sorting">
+			<namePattern>{surname}, {given} {given2-initial}. {suffix}</namePattern>
+		</personName>
+		<personName length="short" usage="sorting">
+			<namePattern>{surname}, {given-initial}. {given2-initial}.</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="formal">
+			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="formal">
+			<namePattern>{given} {given2-initial}. {surname} {suffix}</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="formal">
+			<namePattern>{given-initial}. {given2-initial}. {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="informal">
+			<namePattern>{given-informal} {surname-initial}. {suffix}</namePattern>
+		</personName>
+		<personName>
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+	</personNames>
 </ldml>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -11,6 +11,7 @@ import org.unicode.cldr.util.XPathParts;
 public class CheckPlaceHolders extends CheckCLDR {
 
     private static final Pattern PLACEHOLDER_PATTERN = PatternCache.get("([0-9]|[1-9][0-9]+)");
+    private static final Pattern PLACEHOLDER_PATTERN_PERS_NAMES = PatternCache.get("([a-z][a-z23-]+?)"); // CLDR-15384 need alpha, -
     private static final Pattern SKIP_PATH_LIST = Pattern
         .compile("//ldml/characters/(exemplarCharacters|parseLenient).*");
 
@@ -33,15 +34,17 @@ public class CheckPlaceHolders extends CheckCLDR {
                     result.add(new CheckStatus().setCause(this)
                         .setMainType(CheckStatus.errorType)
                         .setSubtype(Subtype.invalidPlaceHolder)
-                        .setMessage("Invalid placeholder in value \"" + value + "\""));
+                        .setMessage("Invalid placeholder (missing terminator) in value \"" + value + "\""));
                 } else {
                     String placeHolderString = value.substring(startPlaceHolder + 1, endPlaceHolder);
-                    Matcher matcher = PLACEHOLDER_PATTERN.matcher(placeHolderString);
+                    Matcher matcher = (path.contains("personNames"))?
+                        PLACEHOLDER_PATTERN_PERS_NAMES.matcher(placeHolderString):
+                        PLACEHOLDER_PATTERN.matcher(placeHolderString);
                     if (!matcher.matches()) {
                         result.add(new CheckStatus().setCause(this)
                             .setMainType(CheckStatus.errorType)
                             .setSubtype(Subtype.invalidPlaceHolder)
-                            .setMessage("Invalid placeholder in value \"" + value + "\""));
+                            .setMessage("Invalid placeholder (contents \"" + placeHolderString + "\") in value \"" + value + "\""));
                     }
                     startPlaceHolder = endPlaceHolder;
                 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -324,6 +324,9 @@
 //ldml/collations/collation[@type="%A"]	; Misc ; Linguistic Elements ; Collation ; $1 ; HIDE
 
 
+# HIDE FOR NOW CLDR-15384
+//ldml/personNames/(.*)         ; Special ; Suppress ; PersonNames ; $1 ; HIDE
+
 # HIDE OTHERS
 //ldml/layout/orientation/(%E)                              ; Special ; Alphabetic Information ; Layout ; $1 ; HIDE
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
@@ -88,6 +88,13 @@ class LdmlConvertRulesTest {
         //Keep these as not-a-set for compatibility
         jsonSplittableAttrs.add(Pair.of("paradigmLocales", "locales"));
 
+        //Temporary skip while in development CLDR-15384
+        dtdSplittableAttrs.remove(Pair.of("nameOrder", "nameLocales"));
+        dtdSplittableAttrs.remove(Pair.of("personName", "length"));
+        dtdSplittableAttrs.remove(Pair.of("personName", "order"));
+        dtdSplittableAttrs.remove(Pair.of("personName", "style"));
+        dtdSplittableAttrs.remove(Pair.of("personName", "usage"));
+
 
         SetView<Pair<String, String>> onlyInDtd = Sets.difference(dtdSplittableAttrs, jsonSplittableAttrs);
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -374,7 +374,9 @@ public class TestCLDRFile extends TestFmwk {
                         + status)
                     + ")");
             if (path.startsWith("//ldml/localeDisplayNames/")
-                || path.contains("[@alt=\"accounting\"]")) {
+                || path.contains("[@alt=\"accounting\"]")
+                || path.startsWith("//ldml/personNames/") // CLDR-15384
+                ) {
                 logln("+" + engName + ", -" + locales + "\t" + path);
             } else {
                 errln("+" + engName + ", -" + locales + "\t" + path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFactory.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFactory.java
@@ -172,7 +172,11 @@ public class TestCldrFactory extends TestFmwkPlus {
             System.out.println(temp);
         }
         CLDRFile enDoubleWithoutAnnotations = cldrFileFromString(temp);
-        assertEquals("enMain == enDoubleWithoutAnnotations", null, differentPathValue(enMain, enDoubleWithoutAnnotations));
+        String differentPath = differentPathValue(enMain, enDoubleWithoutAnnotations);
+        if (differentPath == null || !differentPath.startsWith("//ldml/personNames/") ||
+                !logKnownIssue("CLDR-15406", "TestCldrFactory.testWrite issue with personNames")) {
+             assertEquals("enMain == enDoubleWithoutAnnotations", null, differentPathValue(enMain, enDoubleWithoutAnnotations));
+        }
 
         temp = cldrFileToString(enDouble, keepAnnotations);
         if (DEBUG) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -666,6 +666,8 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 }
             } else if (xpp.contains("posix")) {
                 continue;
+            } else if (path.startsWith("//ldml/personNames/")) { // CLDR-15384
+                continue;
             }
 
             errln("Comprehensive & no exception for path =>\t" + path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -380,6 +380,9 @@ public class TestDtdData extends TestFmwk {
             // <suppressions> children
             "suppression",
 
+            // <personName> children
+            "namePattern",
+
             // DTD: supplementalData
             // <territory> children
             // "languagePopulation",
@@ -469,6 +472,9 @@ public class TestDtdData extends TestFmwk {
                 || (elementName.equals("compoundUnitPattern1") && (attribute.equals("case") || attribute.equals("gender")))
                 || (elementName.equals("genderMinimalPairs") && attribute.equals("gender"))
                 || (elementName.equals("caseMinimalPairs") && attribute.equals("case"))
+                || (elementName.equals("nameOrder") && attribute.equals("nameLocales"))
+                || (elementName.equals("personName") && (attribute.equals("length") || attribute.equals("usage") ||
+                                                         attribute.equals("style") || attribute.equals("order")))
                 ;
 
         case ldmlBCP47:

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -186,7 +186,15 @@ public class TestExampleGenerator extends TestFmwk {
 
         "//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"([^\"]*+)\"]",
 
-        "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard" // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
+        "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard", // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
+
+        "//ldml/personNames/personName/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@usage=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]" // CLDR-15384
         );
     // Add to above if the example SHOULD appear, but we don't have it yet. TODO Add later
 


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

DTD enhancements corresponding to the structure proposed in [CLDRPerson Name Formatting](https://docs.google.com/document/d/1uvv6gdkuFwtbNV26Pk7ddfZult4unYwR6DnnKYbujUo/edit#heading=h.spx0ljsttgli). In order to test the DTD I also had to roll in the English structure proposed there as well.

DTD notes:
- For namePattern element:
    - Since there can be more than one without distinguishing attributes, I added @ORDERED.
    - TestBasic.TestDtdCompatibility specifies that "ldml DTD elements with PCDATA must have 'alt' attributes", so I added the possibility for an alt=variant attribute. We need to consider this more.
- For all leaf elements, added draft & references attributes (usual practice), which are @METADATA
- All attributes are distinguishing except for the @METADATA ones and for the order attribute of the nameOrder element.

Test updates:
- I added PLACEHOLDER_PATTERN_PERS_NAMES to allow for the namePattern style of placeholder, e.g. {given2-initial} instead  {0}, {1}, etc.
- I updated TestDtdData so that isDistinguishingOld() includes the new distinguished attributes, and isOrderedOld() includes namePattern.

Temporary skips (updating is part of later subtasks of [CLDR-15384](https://unicode-org.atlassian.net/browse/CLDR-15384)):
- PathHeader: Currently just hiding all personNames paths
- JSON converter: Currently skipping personNames
- TestCLDRFile.testExtraPaths: Currently ignoring personNames paths in English that are not in [ar, fr, ja, root]
- TestCoverageLevel.TestCoverageCompleteness: Currently add exception for personNames until we have them in coverage
- TextExampleGenerator: Currently allow exception for personNames paths until we have ExampleGenerator coverage for them.

Known issues:
- There is an issue flagged in TestCldrFactory.testWrite: `enMain == enDoubleWithoutAnnotations: expected null, got "//ldml/personNames/personName/namePattern[@_q="0"]"`. Currently this is skipped with a logKnownIssue on [CLDR-15406](https://unicode-org.atlassian.net/browse/CLDR-15406).


