### PR TITLE
Qatar Currency (QAR) Typo Correction

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5556,8 +5556,8 @@ annotations.
 			</currency>
 			<currency type="QAR">
 				<displayName>Qatari Rial</displayName>
-				<displayName count="one">Qatari rial</displayName>
-				<displayName count="other">Qatari rials</displayName>
+				<displayName count="one">Qatari riyal</displayName>
+				<displayName count="other">Qatari riyals</displayName>
 			</currency>
 			<currency type="RHD">
 				<displayName>Rhodesian Dollar</displayName>


### PR DESCRIPTION
Typo Corrected. Qatar Currency (QAR) name corrected from "rial" to "riyal"

CLDR-15363

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
