### PR TITLE
CLDR-15021 v41 Add COMMIT_METADATA.md with commits to skip

### DIFF
--- a/.github/COMMIT_METADATA.md
+++ b/.github/COMMIT_METADATA.md
@@ -1,0 +1,20 @@
+# Commit Metadata
+
+### The following list of commits is parsed by the ICU/CLDR commit checker.
+### It has the following structure:
+### `- <commit> <bug id or hyphen> <message>`
+
+- 00decafbad CLDR-0000 Bad commit message
+- 50257a7a3eba7bbed634961a2aa74e77b12810bf - Early commit, no bug id
+- 283dc84d81cfc47fb15cd664fce4b0151d070ea6 - Early commit, no bug id
+
+### The following are items to skip for a certain CLDR version
+### Format: `# SKIP v00` followed by a list of commits to skip for that version
+
+# SKIP v41
+
+- 56ca5d5 CLDR-14877 split ticket
+- 56ca5d563cf57990a7598f570cb9be51956cb9de - v40 commit
+- 382f36702d763713f010a3bf87d34605c0226ebd - v40 commit
+- bc8a79f9b1b71b00c716b8b4c8e0185515a6d0b8 - v40 commit
+- 4b87f2d718dd9cab45517ebe7f996ac10b6b1fff - v40 commit

--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           echo "::group::Setup Checker"
           END_HASH=$(cd ${GITHUB_WORKSPACE}/cldr ; git rev-parse --short HEAD )
-          REPORT="CLDR-Report-"$(date +"%Y-%m-%d")-v38-${END_HASH}
+          REPORT="CLDR-Report-"$(date +"%Y-%m-%d")-v${FV}-${END_HASH}
           echo $REPORT
           cd icu/tools/commit-checker
           command -v pipenv >/dev/null 2>/dev/null || sudo pip3 install pipenv
@@ -56,6 +56,8 @@ jobs:
           --nocopyright \
           --jira-query "project=CLDR AND fixVersion=${FV}" \
           --repo-root ${GITHUB_WORKSPACE}/cldr \
+          --fix-version ${FV} \
+          --commit-metadata ${GITHUB_WORKSPACE}/cldr/.github/COMMIT_METADATA.md \
           --github-url https://github.com/unicode-org/cldr \
           --rev-range "release-${LV}..${END_REF}" > ${GITHUB_WORKSPACE}/${REPORT}.md
           echo "::endgroup::"


### PR DESCRIPTION
CLDR-15021

- add a .github/COMMIT_METADATA.md
- Update commit checker workflow
- ~Also temporarily use the srl295 branch of the commit checker~ no, you will have to manually put this in.
- Fixes the hardcoded and increasingly-inaccurate `v38` in the report URL!
