### PR TITLE
CLDR-15405 PersonNames coverage, PathHeader, PathDescription

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -137,6 +137,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%numberingSystem80" value="(arab(ext)?|armn(low)?|beng|deva|ethi|fullwide|geor|grek(low)?|gujr|guru|hanidec|han[st](fin)?|hebr|jpan(fin)?|khmr|knda|laoo|mlym|mymr|orya|roman(low)?|taml(dec)?|telu|thai|tibt)"/>
 		<coverageVariable key="%numberingSystem100" value="(finance|native|traditional|bali|brah|cakm|cham|diak|gong|gonm|hanidays|hmnp|java|jpanyear|kali|lana(tham)?|lepc|limb|mong|mtei|mymrshan|nkoo|olck|osma|rohg|saur|shrd|sora|sund|takr|talu|tnsa|vaii|wcho)"/>
 		<coverageVariable key="%persianCalendarTerritories" value="(AF|IR)"/>
+		<coverageVariable key="%personNameLanguages" value="(ar|de|en|es|hu|id|is|ja|ko|nl|uk)"/>
 		<coverageVariable key="%phonebookCollationLanguages" value="(de|fi)"/>
 		<coverageVariable key="%ptVariants" value="(ABL1943|AO1990|COLB1945)"/>
 		<coverageVariable key="%quarterTypes" value="([1-4])"/>
@@ -902,6 +903,24 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="typographicNames/styleName[@type='%anyAttribute'][@subtype='%anyAttribute']"/>
 		<coverageLevel value="modern" match="typographicNames/styleName[@type='%anyAttribute'][@subtype='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="typographicNames/featureName[@type='%anyAttribute']"/>
+
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrder[@nameLocales='%anyAttribute'][@order='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute'][@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern[@_q='%anyAttribute']"/>
 
 		<coverageLevel value="modern" match="annotations/annotation[@cp='%modernEmoji'][@type='%anyAttribute']"/>
 		<coverageLevel value="modern" match="annotations/annotation[@cp='%modernEmoji']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -37,7 +37,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                         .setMessage("Invalid placeholder (missing terminator) in value \"" + value + "\""));
                 } else {
                     String placeHolderString = value.substring(startPlaceHolder + 1, endPlaceHolder);
-                    Matcher matcher = (path.contains("personNames"))?
+                    Matcher matcher = (path.contains("/personNames/"))?
                         PLACEHOLDER_PATTERN_PERS_NAMES.matcher(placeHolderString):
                         PLACEHOLDER_PATTERN.matcher(placeHolderString);
                     if (!matcher.matches()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -118,6 +118,7 @@ public abstract class CLDRURLS {
     public static final String NUMBERS_SHORT = "https://cldr.unicode.org/translation/number-currency-formats/number-and-currency-patterns#h.eradhhuxzqqz";
     public static final String NUMBER_PATTERNS = "https://cldr.unicode.org/translation/number-currency-formats/number-and-currency-patterns#h.j899g3kk2p1z";
     public static final String PARSE_LENIENT = "https://cldr.unicode.org/translation/core-data/alphabetic-information#h.j3x0cwalqgqt";
+    public static final String PERSON_NAME_FORMATS = "https://cldr.unicode.org/translation/miscellaneous-person-name-formats";
     public static final String PLURALS_HELP = "https://cldr.unicode.org/translation/getting-started/plurals-units";
     public static final String PLURALS_HELP_MINIMAL = "https://cldr.unicode.org/translation/getting-started/plurals-units#h.pnla5cp3nl4l";
     public static final String SCRIPT_NAMES = "https://cldr.unicode.org/translation/displaynames/script-names";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -378,6 +378,15 @@ public class PathDescription {
         + "Minimal pairs for genders. For more information, please see "
         + CLDRURLS.GRAMMATICAL_INFLECTION + ".\n"
 
+        + "^//ldml/personNames/nameOrder\\[@nameLocales=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "Person name order for languages. For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/personName"
+        + RegexLookup.SEPARATOR
+        + "Person name formats by length, usage, style, order. For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+
         + "^//ldml/numbers/([a-z]*)Formats(\\[@numberSystem=\"([^\"]*)\"])?/\\1FormatLength/\\1Format\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]$"
         + RegexLookup.SEPARATOR
         + "Special pattern used to compose {1} numbers. Note: before translating, be sure to read "

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -240,6 +240,7 @@ public class PathHeader implements Comparable<PathHeader> {
 
         Displaying_Lists( SectionId.Misc, "Displaying Lists"),
         MinimalPairs(SectionId.Misc, "Minimal Pairs"),
+        PersonNameFormats(SectionId.Misc, "Person Name Formats"),
         Transforms( SectionId.Misc),
 
         Identity( SectionId.Special),

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -285,6 +285,27 @@
 //ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"%A\"]        ; Misc ; Minimal Pairs ; Case (for measurement units) ; &caseNumber($1) ; LTR_ALWAYS
 //ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"%A\"]        ; Misc ; Minimal Pairs ; Gender (for measurement units) ; &genderNumber($1) ; LTR_ALWAYS
 
+//ldml/personNames/nameOrder[@nameLocales=\"%A\"][@order=\"%A\"]    ; Misc ; Person Name Formats ; Name Order For Languages ; $1
+//ldml/personNames/personName/namePattern[@_q=\"%A\"]               ; Misc ; Person Name Formats ; Fallback Name Pattern ; null
+
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]  ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-$3-order-$4
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-$3-order-any
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-any-order-$3
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"]/namePattern[@_q=\"%A\"]                ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-any-order-any
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-$2-order-$3
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"]/namePattern[@_q=\"%A\"]                ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-$2-order-any
+//ldml/personNames/personName[@length=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]                ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-any-order-$2
+//ldml/personNames/personName[@length=\"%A\"]/namePattern[@_q=\"%A\"]                       ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-any-order-any
+
+//ldml/personNames/personName[@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-$2-order-$3
+//ldml/personNames/personName[@usage=\"%A\"][@style=\"%A\"]/namePattern[@_q=\"%A\"]                 ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-$2-order-any
+//ldml/personNames/personName[@usage=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]                 ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-any-order-$2
+//ldml/personNames/personName[@usage=\"%A\"]/namePattern[@_q=\"%A\"]                        ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-any-order-any
+//ldml/personNames/personName[@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]                 ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-any-style-$1-order-$2
+//ldml/personNames/personName[@style=\"%A\"]/namePattern[@_q=\"%A\"]                        ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-any-style-$1-order-any
+//ldml/personNames/personName[@order=\"%A\"]/namePattern[@_q=\"%A\"]                        ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-any-style-any-order-$1
+
+
 #Emoji, etc.
 
 //ldml/characterLabels/characterLabelPattern[@type="%A"][@count="%A"]	; Characters ; Category ; Pattern ; $1-$2
@@ -323,9 +344,6 @@
 //ldml/collations/collation[@type="%A"]/(%E)(.*)	; Misc ; Linguistic Elements ; Collation ; $1-$2-$3 ; HIDE
 //ldml/collations/collation[@type="%A"]	; Misc ; Linguistic Elements ; Collation ; $1 ; HIDE
 
-
-# HIDE FOR NOW CLDR-15384
-//ldml/personNames/(.*)         ; Special ; Suppress ; PersonNames ; $1 ; HIDE
 
 # HIDE OTHERS
 //ldml/layout/orientation/(%E)                              ; Special ; Alphabetic Information ; Layout ; $1 ; HIDE

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -666,8 +666,6 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 }
             } else if (xpp.contains("posix")) {
                 continue;
-            } else if (path.startsWith("//ldml/personNames/")) { // CLDR-15384
-                continue;
             }
 
             errln("Comprehensive & no exception for path =>\t" + path);


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fill out coverage, PathHeader, and PathDescription for Person Name Formats data (but not yet AttributeValueValidity). I did not find any place in PathHeader where I needed to do something special for the nameFormat placeholders.

Note that as part of this I created a stub translation guidelines page for Person Name Formats, since PathDescription needed to refer to it: https://cldr.unicode.org/translation/miscellaneous-person-name-formats