### PR TITLE
CLDR-15405 Fully enumerated paths in root (with aliases) and en; namePattern no longer @ORDERED

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3178,7 +3178,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT personName ( alias | ( namePattern+, special* ) ) >
 <!ATTLIST personName length NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/long, medium, short, monogram, monogram-narrow-->
+    <!--@MATCH:set/literal/long, medium, short, monogram, monogramNarrow-->
 <!ATTLIST personName usage NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/addressing, referring, sorting-->
 <!ATTLIST personName style NMTOKENS #IMPLIED >
@@ -3187,9 +3187,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:set/literal/surnameFirst, givenFirst-->
 
 <!ELEMENT namePattern ( #PCDATA ) >
-    <!--@ORDERED-->
-<!ATTLIST namePattern alt NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/variant-->
+<!ATTLIST namePattern alt (2|3) #IMPLIED >
 <!ATTLIST namePattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST namePattern references CDATA #IMPLIED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9129,50 +9129,122 @@ annotations.
 		<featureName type="zero">slashed zero</featureName>
 	</typographicNames>
 	<personNames>
-		<personName length="monogram-narrow" style="informal">
-			<namePattern>{given-informal-initial}</namePattern>
-		</personName>
-		<personName length="monogram-narrow">
-			<namePattern>{surname-initial}</namePattern>
-		</personName>
-		<personName length="monogram" style="informal">
-			<namePattern>{given-informal-initial}{surname-initial}</namePattern>
-		</personName>
-		<personName length="monogram">
-			<namePattern>{given-initial}{given2-initial}{surname-initial}</namePattern>
-		</personName>
-		<personName usage="addressing" style="informal">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName usage="addressing">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName usage="sorting" style="informal">
-			<namePattern>{surname}, {given-informal}</namePattern>
-		</personName>
-		<personName length="long" usage="sorting">
-			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
-		</personName>
-		<personName length="medium" usage="sorting">
-			<namePattern>{surname}, {given} {given2-initial}. {suffix}</namePattern>
-		</personName>
-		<personName length="short" usage="sorting">
-			<namePattern>{surname}, {given-initial}. {given2-initial}.</namePattern>
-		</personName>
-		<personName length="long" usage="referring" style="formal">
-			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
-		</personName>
-		<personName length="medium" usage="referring" style="formal">
-			<namePattern>{given} {given2-initial}. {surname} {suffix}</namePattern>
-		</personName>
-		<personName length="short" usage="referring" style="formal">
-			<namePattern>{given-initial}. {given2-initial}. {surname}</namePattern>
-		</personName>
-		<personName length="short" usage="referring" style="informal">
-			<namePattern>{given-informal} {surname-initial}. {suffix}</namePattern>
-		</personName>
 		<personName>
 			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="givenFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="givenFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="formal" order="surnameFirst">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="formal" order="givenFirst">
+			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="informal" order="surnameFirst">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="informal" order="givenFirst">
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="sorting" style="formal">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName length="long" usage="sorting" style="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
+			<namePattern>{surname}, {given} {given2-initial}. {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="formal" order="givenFirst">
+			<namePattern>{given} {given2-initial}. {surname} {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="informal" order="givenFirst">
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName length="medium" usage="sorting" style="formal">
+			<namePattern>{surname}, {given} {given2-initial}. {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="sorting" style="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="givenFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="givenFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="formal" order="surnameFirst">
+			<namePattern>{surname}, {given-initial}. {given2-initial}.</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="formal" order="givenFirst">
+			<namePattern>{given-initial}. {given2-initial}. {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="informal" order="surnameFirst">
+			<namePattern>{surname}, {given-initial}.</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="informal" order="givenFirst">
+			<namePattern>{given-informal} {surname-initial}.</namePattern>
+		</personName>
+		<personName length="short" usage="sorting" style="formal">
+			<namePattern>{surname}, {given-initial}. {given2-initial}.</namePattern>
+		</personName>
+		<personName length="short" usage="sorting" style="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="monogram" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial}{given-initial}{given2-initial}</namePattern>
+		</personName>
+		<personName length="monogram" style="formal" order="givenFirst">
+			<namePattern>{given-initial}{given2-initial}{surname-initial}</namePattern>
+		</personName>
+		<personName length="monogram" style="informal" order="surnameFirst">
+			<namePattern>{surname-initial}{given-informal-initial}</namePattern>
+		</personName>
+		<personName length="monogram" style="informal" order="givenFirst">
+			<namePattern>{given-informal-initial}{surname-initial}</namePattern>
+		</personName>
+		<personName length="monogramNarrow" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial}</namePattern>
+		</personName>
+		<personName length="monogramNarrow" style="formal" order="givenFirst">
+			<namePattern>{surname-initial}</namePattern>
+		</personName>
+		<personName length="monogramNarrow" style="informal" order="surnameFirst">
+			<namePattern>{given-informal-initial}</namePattern>
+		</personName>
+		<personName length="monogramNarrow" style="informal" order="givenFirst">
+			<namePattern>{given-informal-initial}</namePattern>
 		</personName>
 	</personNames>
 </ldml>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5367,4 +5367,129 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="tnum">tabular numbers</featureName>
 		<featureName type="zero">slashed zero</featureName>
 	</typographicNames>
+	<personNames>
+		<nameOrder nameLocales="und" order="surnameFirst"/>
+		<!-- fallback/any pattern -->
+		<personName>
+			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="referring" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="referring" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="referring" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="referring" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<!-- for usage="sorting", ignore order -->
+		<personName length="long" usage="sorting" style="formal">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="sorting" style="informal">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="referring" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="referring" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<!-- for usage="sorting", ignore order -->
+		<personName length="medium" usage="sorting" style="formal">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="sorting" style="informal">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="referring" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="referring" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="referring" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="referring" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<!-- for usage="sorting", ignore order -->
+		<personName length="short" usage="sorting" style="formal">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="sorting" style="informal">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<!-- for length="monogram" or "monogramNarrow", ignore usage -->
+		<personName length="monogram" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogram" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogram" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogram" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogramNarrow" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogramNarrow" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogramNarrow" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogramNarrow" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+	</personNames>
 </ldml>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -138,6 +138,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%numberingSystem100" value="(finance|native|traditional|bali|brah|cakm|cham|diak|gong|gonm|hanidays|hmnp|java|jpanyear|kali|lana(tham)?|lepc|limb|mong|mtei|mymrshan|nkoo|olck|osma|rohg|saur|shrd|sora|sund|takr|talu|tnsa|vaii|wcho)"/>
 		<coverageVariable key="%persianCalendarTerritories" value="(AF|IR)"/>
 		<coverageVariable key="%personNameLanguages" value="(ar|de|en|es|hu|id|is|ja|ko|nl|uk)"/>
+		<coverageVariable key="%personNameNonMonograms" value="(long|medium|short)"/>
+		<coverageVariable key="%personNameMonograms" value="(monogram|monogramNarrow)"/>
 		<coverageVariable key="%phonebookCollationLanguages" value="(de|fi)"/>
 		<coverageVariable key="%ptVariants" value="(ABL1943|AO1990|COLB1945)"/>
 		<coverageVariable key="%quarterTypes" value="([1-4])"/>
@@ -904,23 +906,17 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="typographicNames/styleName[@type='%anyAttribute'][@subtype='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="typographicNames/featureName[@type='%anyAttribute']"/>
 
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrder[@nameLocales='%anyAttribute'][@order='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute'][@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@usage='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@style='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@order='%anyAttribute']/namePattern[@_q='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern[@_q='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrder[@nameLocales='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='addressing'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='addressing'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='referring'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='referring'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='sorting'][@style='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='sorting'][@style='%anyAttribute']/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern"/>
 
 		<coverageLevel value="modern" match="annotations/annotation[@cp='%modernEmoji'][@type='%anyAttribute']"/>
 		<coverageLevel value="modern" match="annotations/annotation[@cp='%modernEmoji']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -378,7 +378,7 @@ public class PathDescription {
         + "Minimal pairs for genders. For more information, please see "
         + CLDRURLS.GRAMMATICAL_INFLECTION + ".\n"
 
-        + "^//ldml/personNames/nameOrder\\[@nameLocales=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
+        + "^//ldml/personNames/nameOrder\\[@nameLocales=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
         + "Person name order for languages. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -285,26 +285,15 @@
 //ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"%A\"]        ; Misc ; Minimal Pairs ; Case (for measurement units) ; &caseNumber($1) ; LTR_ALWAYS
 //ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"%A\"]        ; Misc ; Minimal Pairs ; Gender (for measurement units) ; &genderNumber($1) ; LTR_ALWAYS
 
-//ldml/personNames/nameOrder[@nameLocales=\"%A\"][@order=\"%A\"]    ; Misc ; Person Name Formats ; Name Order For Languages ; $1
-//ldml/personNames/personName/namePattern[@_q=\"%A\"]               ; Misc ; Person Name Formats ; Fallback Name Pattern ; null
-
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]  ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-$3-order-$4
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-$3-order-any
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-any-order-$3
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"]/namePattern[@_q=\"%A\"]                ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-$2-style-any-order-any
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-$2-order-$3
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"]/namePattern[@_q=\"%A\"]                ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-$2-order-any
-//ldml/personNames/personName[@length=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]                ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-any-order-$2
-//ldml/personNames/personName[@length=\"%A\"]/namePattern[@_q=\"%A\"]                       ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; usage-any-style-any-order-any
-
-//ldml/personNames/personName[@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]         ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-$2-order-$3
-//ldml/personNames/personName[@usage=\"%A\"][@style=\"%A\"]/namePattern[@_q=\"%A\"]                 ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-$2-order-any
-//ldml/personNames/personName[@usage=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]                 ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-any-order-$2
-//ldml/personNames/personName[@usage=\"%A\"]/namePattern[@_q=\"%A\"]                        ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-$1-style-any-order-any
-//ldml/personNames/personName[@style=\"%A\"][@order=\"%A\"]/namePattern[@_q=\"%A\"]                 ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-any-style-$1-order-$2
-//ldml/personNames/personName[@style=\"%A\"]/namePattern[@_q=\"%A\"]                        ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-any-style-$1-order-any
-//ldml/personNames/personName[@order=\"%A\"]/namePattern[@_q=\"%A\"]                        ; Misc ; Person Name Formats ; Name Patterns for Length any ; usage-any-style-any-order-$1
-
+//ldml/personNames/nameOrder[@nameLocales=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Languages ; $1
+//ldml/personNames/personName/namePattern[@alt=\"%A\"]      ; Misc ; Person Name Formats ; Fallback Name Pattern ; any-$1
+//ldml/personNames/personName/namePattern           ; Misc ; Person Name Formats ; Fallback Name Pattern ; any
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4-$5
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3
 
 #Emoji, etc.
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -380,9 +380,6 @@ public class TestDtdData extends TestFmwk {
             // <suppressions> children
             "suppression",
 
-            // <personName> children
-            "namePattern",
-
             // DTD: supplementalData
             // <territory> children
             // "languagePopulation",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -188,13 +188,15 @@ public class TestExampleGenerator extends TestFmwk {
 
         "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard", // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
 
-        "//ldml/personNames/personName/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@usage=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@_q=\"([^\"]*+)\"]" // CLDR-15384
+        "//ldml/personNames/nameOrder[@nameLocales=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName/namePattern", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern" // CLDR-15384
         );
     // Add to above if the example SHOULD appear, but we don't have it yet. TODO Add later
 


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-15405)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Changes from what we discussed in meeting:
- We had said the monogram lengths should ignore attributes except for order. But we need style too, as shown in the English examples in our own spec.
- We had said the data paths would include all attribute combinations, and where we were ignoring one (like usage for monogram lengths, or order for sorting), we would alias one to the other and use coverage to exclude the non-used one. But that does not make much sense; better to just have the fleshed-out paths in xml data not include the ignored attribute value, then no aliasing necessary.
- I had to add the English data for order=surnameFirst, that was not in the spec.
- I have not yet added the patterns for initial and initial sequence.

dtd changes (affects other items like data, coverage, PathHeader)
- length attibute value `monogram-narrow` -> `monogramNarrow`
- namePattern element is not longer `@ORDERED`, instead can have alt="2" or alt="3" (oops, I guess this was supposed to be "1" or "2", will fix in next round)

data changes
- root: Add all paths with non-ignored attributes, and alias to fallback path.
- en: Re-order and flesh out all paths, including adding new data for oder=surnameFirst.

other
- Update coverage, PathDescription, tests, etc.
