### PR TITLE
CLDR-15408 Remove most of Annex A Deprecated Structure, refer to DTD …

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1180,7 +1180,7 @@ LDML 1.7 or older specification used different syntax for representing unicode l
 
 |                               | EBNF |
 | ----------------------------- | ---- |
-| old_unicode_locale_extensions | `= "@" old_key "=" old_type`<br/>`(";" old_key "=" old_type)*` |
+| `old_unicode_locale_extensions` | `= "@" old_key "=" old_type`<br/>`(";" old_key "=" old_type)*` |
 
 The new specification mandates keys to be two alphanumeric characters and types to be three to eight alphanumeric characters. As the result, new codes were assigned to all existing keys and some types. For example, a new key "co" replaced the previous key "collation", a new type "phonebk" replaced the previous type "phonebook". However, the existing collation type "big5han" already satisfied the new requirement, so no new type code was assigned to the type. All new keys and types introduced after LDML 1.7 satisfy the new requirement, so they do not have aliases dedicated for the old syntax, except time zone types. The conversion between old types and new types can be done regardless of key, with one known exception (old type "traditional" is mapped to new type "trad" for collation and "traditio" for numbering system), and this relationship will be maintained in the future versions unless otherwise noted.
 
@@ -3093,143 +3093,38 @@ Processes sometimes encounter invalid number or date patterns, such as a number 
 
 ## <a name="Deprecated_Structure" href="#Deprecated_Structure">Annex A Deprecated Structure</a>
 
-The [DTD Annotations](#DTD_Annotations) in Section 5.7 are used to determine whether elements, attributes, or attribute values are deprecated.
+The [DTD Annotations](#DTD_Annotations) in Section 5.7 are used to determine whether DTD items such as elements, attributes, or attribute values are deprecated.
 
-While valid LDML, they are strongly discouraged, and no longer used in CLDR.
+Though such deprecated items are still valid LDML, they are strongly discouraged, and are no longer used in CLDR.
 
-The remainder of this section describes selected cases of deprecated structure that were present in previous versions of CLDR.
+The CLDR [DTD Deltas](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/dtd_deltas.html) chart shows which DTD items have been deprecated in which version of CLDR.
+
+The remainder of this section describes selected cases of deprecated structure, and what (if any) should be used instead.
 
 ### <a name="Fallback_Elements" href="#Fallback_Elements">A.1 Element fallback</a>
 
-```xml
-<!ELEMENT fallback (#PCDATA) >
-```
-
-The `fallback` element is deprecated. Implementations should use instead the information in _[Section 4.4 Language Matching](#LanguageMatching)_ for doing language fallback.
+Implementations should use instead the information in [Section 4.4 Language Matching](#LanguageMatching) for doing language fallback.
 
 ### <a name="BCP47_Keyword_Mapping" href="#BCP47_Keyword_Mapping">A.2 BCP 47 Keyword Mapping</a>
 
-**Note:** _This structure is deprecated and replaced with [Section 3.6.4 U Extension Data Files](#Unicode_Locale_Extension_Data_Files)._
-
-```xml
-<!ELEMENT bcp47KeywordMappings ( mapKeys?, mapTypes* ) >
-<!ELEMENT mapKeys ( keyMap* ) >
-<!ELEMENT keyMap EMPTY >
-<!ATTLIST keyMap type NMTOKEN #REQUIRED >
-<!ATTLIST keyMap bcp47 NMTOKEN #REQUIRED >
-<!ELEMENT mapTypes ( typeMap* ) >
-<!ATTLIST mapTypes type NMTOKEN #REQUIRED >
-<!ELEMENT typeMap EMPTY >
-<!ATTLIST typeMap type CDATA #REQUIRED >
-<!ATTLIST typeMap bcp47 NMTOKEN #REQUIRED >
-```
-
-This section defines mappings between old Unicode locale identifier key/type values and their BCP 47 'u' extension subtag representations. The 'u' extension syntax described in [Section 3.6 Unicode BCP 47 U Extension](#u_Extension) restricts a key to two ASCII alphanumerics and a type to three to eight ASCII alphanumerics. A key or a type which does not meet that syntax requirement is converted according to the mapping data defined by the `mapKeys` or `mapTypes` elements. For example, a keyword `"collation=phonebook"` is converted to BCP 47 'u' extension subtags "co-phonebk" by the mapping data below:
-
-```xml
-<mapKeys>
-    ...
-    <keyMap type="collation" bcp47="co" />
-    ...
-</mapKeys>
-<mapTypes type="collation">
-    ...
-    <typeMap type="phonebook" bcp47="phonebk" />
-    ...
-</mapTypes>
-```
+Instead use the mechanisms descibed in [Section 3.6.4 U Extension Data Files](#Unicode_Locale_Extension_Data_Files).
 
 ### <a name="Choice_Patterns" href="#Choice_Patterns">A.3 Choice Patterns</a>
 
-**Note:** _This structure is deprecated and replaced with count attributes._
-
-A choice pattern is a string that chooses among a number of strings, based on numeric value. It has the following form:
-
-```
-<choice_pattern> = <choice> ( '|' <choice> )*
-<choice> = <number><relation><string>
-<number> = ('+' | '-')? ('∞' | [0-9]+ ('.' [0-9]+)?)
-<relation> = '<' | ' ≤'
-```
-
-The interpretation of a choice pattern is that given a number N, the pattern is scanned from right to left, for each choice evaluating \<number> \<relation> N. The first choice that matches results in the corresponding string. If no match is found, then the first string is used. For example:
-
-<!-- HTML: rowspan -->
-<table><thead>
-<tr><th>Pattern</th><th>N</th><th>Result</th>
-</thead><tbody>
-<tr><td rowspan="4">0≤Rf|1≤Ru|1&lt;Re</td>
-    <td>-∞, -3, -1, -0.000001</td>      <td>Rf (defaulted to first string)</td></tr>
-<tr><td>0, 0.01, 0.9999</td>            <td>Rf</td></tr>
-<tr><td>1</td>                          <td>Ru</td></tr>
-<tr><td>1.00001, 5, 99, ∞</td>          <td>Re</td></tr>
-</tbody></table>
-
-Quoting is done using ' characters, as in date or number formats.
+Instead use `count` attributes.
 
 ### <a name="Element_default" href="#Element_default">A.4 Element default</a>
 
-**Note:** _This structure is deprecated._ Use replacement structure instead, for example:
+Instead use replacement structure, for example:
 
 * For `<collations>`, now use the `<defaultCollation>` element.
 * For `<calendars>`, the default calendar type for a locale is now specified by _[Calendar Preference Data](tr35-dates.md#Calendar_Preference_Data)_.
-
-In some cases, a number of elements are present. The default element can be used to indicate which of them is the default, in the absence of other information. The value of the `choice` attribute is to match the value of the `type` attribute for the selected item.
-
-```xml
-<timeFormats>
-    <default choice="medium" />
-    <timeFormatLength type="full">
-        <timeFormat type="standard">
-            <pattern type="standard">h:mm:ss a z</pattern>
-        </timeFormat>
-    </timeFormatLength>
-    <timeFormatLength type="long">
-        <timeFormat type="standard">
-            <pattern type="standard">h:mm:ss a z</pattern>
-        </timeFormat>
-    </timeFormatLength>
-    <timeFormatLength type="medium">
-        <timeFormat type="standard">
-            <pattern type="standard">h:mm:ss a</pattern>
-        </timeFormat>
-    </timeFormatLength>
-    ...
-```
-
-Like all other elements, the `<default>` element is inherited. Thus, it can also refer to inherited resources. For example, suppose that the above resources are present in fr, and that in fr_BE we have the following:
-
-```xml
-<timeFormats>
-  <default choice="long" />
-</timeFormats>
-```
-
-In that case, the default time format for fr_BE would be the inherited "long" resource from fr. Now suppose that we had in fr_CA:
-
-```xml
-<timeFormatLength type="medium">
-    <timeFormat type="standard">
-        <pattern type="standard">...</pattern>
-    </timeFormat>
-</timeFormatLength>
-```
-
-In this case, the `<default>` is inherited from fr, and has the value "medium". It thus refers to this new "medium" pattern in this resource bundle.
 
 ### <a name="Deprecated_Common_Attributes" href="#Deprecated_Common_Attributes">A.5 Deprecated Common Attributes</a>
 
 #### <a name="Attribute_standard" href="#Attribute_standard">A.5.1 Attribute standard</a>
 
-**Note:** This attribute is deprecated. Instead, use a `reference` element with the attribute `standard="true"`.
-
-The value of this attribute is a list of strings representing standards: international, national, organization, or vendor standards. The presence of this attribute indicates that the data in this element is compliant with the indicated standards. Where possible, for uniqueness, the string should be a URL that represents that standard. The strings are separated by commas; leading or trailing spaces on each string are not significant. Examples:
-
-```xml
-<collation standard="MSA 200:2002">
-    ...
-    <dateFormatStyle standard=”https://www.iso.org/iso/en/CatalogueDetailPage.CatalogueDetail?CSNUMBER=26780&amp;ICS1=1&amp;ICS2=140&amp;ICS3=30”>
-```
+Instead, use a `reference` element with the attribute `standard="true"`.
 
 #### <a name="Attribute_draft_nonLeaf" href="#Attribute_draft_nonLeaf">A.5.2 Attribute draft in non-leaf elements</a>
 
@@ -3237,17 +3132,11 @@ The `draft` attribute is deprecated except in leaf elements (elements that do no
 
 ### <a name="Element_base" href="#Element_base">A.6 Element base</a>
 
-**Note:** _This element is deprecated._ Use the collation `<import>` element instead.
-
-The optional base element `<base>...</base>` , contains an `alias` element that points to another data source that defines a _base_ collation. If present, it indicates that the settings and rules in the collation are modifications applied on _top of the_ respective elements in the base collation. That is, any successive settings, where present, override what is in the base as described in [Setting Options](tr35-collation.md#Setting_Options). Any successive rules are concatenated to the end of the rules in the base. The results of multiple rules applying to the same characters is covered in [Orderings](tr35-collation.md#Orderings).
+Instead use the collation `<import>` element.
 
 ### <a name="Element_rules" href="#Element_rules">A.7 Element rules</a>
 
-**Note:** _The XML collation syntax is deprecated; this includes the `<rules>` element and its subelements, except that the `<import>` element has been moved up to be a subelement of `<collation>`._ Use the basic collation syntax with the [`<cr>` element](tr35-collation.md#Rules) instead.
-
-```xml
-<!ELEMENT rules (alias | ( ( reset | import ), ( reset | import | p | pc | s | sc | t | tc | i | ic | x)* )) >
-```
+Instead use the basic collation syntax with the [`<cr>` element](tr35-collation.md#Rules).
 
 ### <a name="Deprecated_subelements_of_dates" href="#Deprecated_subelements_of_dates">A.8 Deprecated subelements of `<dates>`</a>
 
@@ -3256,19 +3145,17 @@ The optional base element `<base>...</base>` , contains an `alias` element that 
 
 ### <a name="Deprecated_subelements_of_calendars" href="#Deprecated_subelements_of_calendars">A.9 Deprecated subelements of `<calendars>`</a>
 
-* `<monthNames>` and `<monthAbbr>`; month name forms are specified in the `<months>` element. The older `monthNames`, `monthAbbr` are equivalent to: using the `months` element with the context `type="format"` and the width `type="wide"` (for ...Names) and `type="narrow"` (for ...Abbr), respectively.
-* `<dayNames>` and `<dayAbbr>`; weekday name forms are specified in the `<days>` element. The older dayNames, dayAbbr are equivalent to: using the `days` element with the context `type="format"` and the width `type="wide"` (for ...Names) and `type="narrow"` (for ...Abbr), respectively.
+* The deprecated `<monthNames>` and `<monthAbbr>` are replaced by the `months` element with the context `type="format"` and the width `type="wide"` (for ...Names) and `type="narrow"` (for ...Abbr), respectively.
+* The deprecated `<dayNames>` and `<dayAbbr>` are replaced by the `days` element with the context `type="format"` and the width `type="wide"` (for ...Names) and `type="narrow"` (for ...Abbr), respectively.
 * <a name="week" href="#week">`<week>`</code></a> is deprecated in the main LDML files, because the data is more appropriately organized as connected to territories, not to linguistic data. Use the supplemental `<weekData>` element instead.
-* `<am>` and `<pm>`; these are now included as part of the `<dayPeriods>` element
+* The standalone `<am>` and `<pm>` are deprecated, and the data are instead included as part of the `<dayPeriods>` element
 * `<fields>` is deprecated as a subelement of `<calendars>` instead, a `<fields>` element should be located just under a `<dates>` element. See [Calendar Fields](tr35-dates.md#Calendar_Fields).
 
 ### <a name="Deprecated_subelements_of_timeZoneNames" href="#Deprecated_subelements_of_timeZoneNames">A.10 Deprecated subelements of `<timeZoneNames>`</a>
 
-* `<hoursFormat>` e.g. "{0}/{1}" for "-0800/-0700"
-* <a name="fallbackRegionFormat" href="#fallbackRegionFormat">`<fallbackRegionFormat>`</a> (deprecated), e.g. "{0} Time ({1})" for "United States Time (New York)"
-* `<abbreviationFallback>`
-* `<preferenceOrdering>`, a preference ordering among modern zones; use metazones instead.
-* `<singleCountries>`, use [Primary Zones](tr35-dates.md#Primary_Zones)
+* `<preferenceOrdering>`: use metazones instead.
+* `<singleCountries>`:use [Primary Zones](tr35-dates.md#Primary_Zones)
+* `<hoursFormat>`, <a name="fallbackRegionFormat" href="#fallbackRegionFormat">`<fallbackRegionFormat>`</a>, `<abbreviationFallback>`
 
 ### <a name="Deprecated_subelements_of_zone_metazone" href="#Deprecated_subelements_of_zone_metazone">A.11 Deprecated subelements of `<zone>` and `<metazone>`</a>
 
@@ -3285,13 +3172,11 @@ The `<contextTransformUsage>` element was introduced in CLDR 21. The values for 
 
 ### <a name="Deprecated_subelements_of_segmentations" href="#Deprecated_subelements_of_segmentations">A.13 Deprecated subelements of `<segmentations>`</a>
 
-* `<exceptions>` and `<exceptions>` were deprecated and replaced with `<suppressions>` and `<suppression>`.
+* `<exceptions>` and `<exceptions>`: Replaced with `<suppressions>` and `<suppression>`.
 
 ### <a name="Element_cp" href="#Element_cp">A.14 Element cp</a>
 
-The `cp` element was used to escape characters that cannot be represented in XML, even with NCRs. These escapes were only allowed in certain elements, according to the DTD.
-
-However, this mechanism is very clumsy, and was replaced by specialized syntax.
+The `cp` element was used in certain elements to escape characters that cannot be represented in XML, even with NCRs. This mechanism was replaced by specialized syntax:
 
 | Code Point | XML Example    |
 | ---------- | -------------- |
@@ -3299,43 +3184,15 @@ However, this mechanism is very clumsy, and was replaced by specialized syntax.
 
 ### <a name="validSubLocales" href="#validSubLocales">A.15 Attribute validSubLocales</a>
 
-The attribute `validSubLocales` allowed sublocales in a given tree to be treated as though a file for them were present when there was not one. It only had an effect for locales that inherit from the current file where a file is missing.
-
-**Example 1.** Suppose that in a particular LDML tree, there are no region locales for German, for example, there is a de.xml file, but no files for de_AT.xml, de_CH.xml, or de_DE.xml. Then no elements are valid for any of those region locales. If we want to mark one of those files as having valid elements, then we introduce an empty file, such as the following.
-
-```xml
-<ldml version="1.1">
-    <identity>
-        <version number="1.1" />
-        <language type="de" />
-        <territory type="AT" />
-    </identity>
-</ldml>
-```
-
-With the `validSubLocales` attribute, instead of adding the empty files for de_AT.xml, de_CH.xml, and de_DE.xml, in the de file we could add to the parent locale a list of the child locales that should behave as if files were present.
-
-```xml
-<ldml version="1.1" validSubLocales="de_AT de_CH de_DE">
-    <identity>
-        <version number="1.1" />
-        <language type="de" />
-    </identity>
-    ...
-</ldml>
-```
-
-Now that the `validSubLocales` attribute has been deprecated, it is recommended to simply add empty files to specify which sublocales are valid. This convention is used throughout the CLDR.
+Instead of using `validSubLocales`, it is recommended to simply add empty files to specify which sublocales are valid. This convention is used throughout the CLDR.
 
 ### <a name="postCodeElements" href="#postCodeElements">A.16 Elements postalCodeData, postCodeRegex</a>
 
-The postal code validation data has been deprecated. Please see other services that are kept up to date, such as:
+Instead please see other services that are kept up to date, such as:
 
 * [https://i18napis.appspot.com/address/data/US](https://i18napis.appspot.com/address/data/US)
 * [https://i18napis.appspot.com/address/data/CH](https://i18napis.appspot.com/address/data/CH)
 * ...
-
-See [Postal Code Validation](tr35-info.md#Postal_Code_Validation)
 
 ### <a name="telephoneCodeData" href="#telephoneCodeData">A.17 Element telephoneCodeData</a>
 


### PR DESCRIPTION
…Delta charts

CLDR-15408

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Remove most of spec Part 1 Annex A Deprecated Structure, instead referring to the [DTD Deltas](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/dtd_deltas.html) chart. But keep the following:
- Anchors in the Deprecated Structure section that could be the target of links from other places.
- Information about replacements for deprecated items (and a few other useful tidbits that are not about explaining the deprecated structure).