### PR TITLE
CLDR-15456 Currency: SLL»SLE

### DIFF
--- a/common/bcp47/currency.xml
+++ b/common/bcp47/currency.xml
@@ -238,6 +238,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="shp" description="Saint Helena Pound"/>
             <type name="sit" description="Slovenian Tolar" since="1.9"/>
             <type name="skk" description="Slovak Koruna"/>
+            <type name="sle" description="Sierra Leonean New Leone"/>
             <type name="sll" description="Sierra Leonean Leone"/>
             <type name="sos" description="Somali Shilling"/>
             <type name="srd" description="Surinamese Dollar"/>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5654,6 +5654,11 @@ annotations.
 				<displayName count="one">Sierra Leonean leone</displayName>
 				<displayName count="other">Sierra Leonean leones</displayName>
 			</currency>
+			<currency type="SLE">
+				<displayName>Sierra Leonean New Leone</displayName>
+				<displayName count="one">Sierra Leonean new leone</displayName>
+				<displayName count="other">Sierra Leonean new leones</displayName>
+			</currency>
 			<currency type="SOS">
 				<displayName>Somali Shilling</displayName>
 				<displayName count="one">Somali shilling</displayName>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -60,7 +60,8 @@ For terms of use, see http://www.unicode.org/copyright.html
             <info iso4217="RSD" digits="0" rounding="0"/>
             <info iso4217="RWF" digits="0" rounding="0"/>
             <info iso4217="SEK" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
-            <info iso4217="SLL" digits="0" rounding="0"/>
+            <info iso4217="SLE" digits="2" rounding="0"/>
+            <info iso4217="SLL" digits="2" rounding="0"/>
             <info iso4217="SOS" digits="0" rounding="0"/>
             <info iso4217="STD" digits="0" rounding="0"/>
             <info iso4217="SYP" digits="0" rounding="0"/>
@@ -955,6 +956,7 @@ The printed version of ISO-4217:2001
             <currency iso4217="CSK" from="1953-06-01" to="1992-12-31"/>
         </region>
         <region iso3166="SL">
+            <currency iso4217="SLE" from="2022-04-01" tender="false"/>
             <currency iso4217="SLL" from="1964-08-04"/>
             <currency iso4217="GBP" from="1808-11-30" to="1966-02-04"/>
         </region>

--- a/common/validity/currency.xml
+++ b/common/validity/currency.xml
@@ -42,7 +42,7 @@
 		</id>
 		<!-- Deprecated values are those that are not legal tender in some country after 2022.
 			 More detailed usage information needed for some implementations is in supplemental data. -->
-		<id type='currency' idStatus='deprecated'>		<!-- 148 items -->
+		<id type='currency' idStatus='deprecated'>		<!-- 149 items -->
 			ADP AFA ALK AOK AON AOR ARA ARL~M ARP ATS AZM
 			BAD BAN BEC BEF BEL BGL~M BGO BOL BOP BOV BRB~C BRE BRN BRR BRZ BUK BYB BYR
 			CHE CHW CLE~F CNH CNX COU CSD CSK CYP
@@ -58,7 +58,7 @@
 			NIC NLG
 			PEI PES PLZ PTE
 			RHD ROL RUR
-			SDD SDP SIT SKK SRG STD SUR SVC
+			SDD SDP SIT SKK SLE SRG STD SUR SVC
 			TJR TMM TPE TRL
 			UAK UGS USN USS UYI UYP UYW
 			VEB VED VEF VNN

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -1815,6 +1815,12 @@ public class ExampleGenerator {
                 value = cf.format(NUMBER_SAMPLE);
             }
             String result;
+            if (value == null) {
+                throw new NullPointerException(
+                    cldrFile.getSourceLocation(fullPath) +
+                    ": " + cldrFile.getLocaleID()+ ": " +
+                    ": Error: no currency symbol for " + currency);
+            }
             DecimalFormat x = icuServiceBuilder.getCurrencyFormat(currency, value);
             result = x.format(NUMBER_SAMPLE);
             result = setBackground(result).replace(value, backgroundEndSymbol + value + backgroundStartSymbol);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -642,6 +642,12 @@ public class ICUServiceBuilder {
             if (currencySymbol == null) {
                 currencySymbol = cldrFile.getWinningValueWithBailey(prefix + "symbol");
             }
+            if (currencySymbol == null) {
+                throw new NullPointerException(
+                    cldrFile.getSourceLocation(prefix + "symbol") +
+                    ": " + cldrFile.getLocaleID()+ ": " +
+                    ": null currencySymbol for " + prefix + "symbol");
+            }
             String currencyDecimal = cldrFile.getWinningValueWithBailey(prefix + "decimal");
             if (currencyDecimal != null) {
                 (symbols = cloneIfNeeded(symbols)).setMonetaryDecimalSeparator(currencyDecimal.charAt(0));

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/ISO4217.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/ISO4217.txt
@@ -223,6 +223,7 @@ currency	|	CSD	|	Serbian Dinar	|	CS	|	SERBIA AND MONTENEGRO	|	C
 currency	|	EUR	|	Euro	|	CS	|	SERBIA AND MONTENEGRO	|	C
 currency	|	SCR	|	Seychelles Rupee	|	SC	|	SEYCHELLES	|	C
 currency	|	SLL	|	Leone	|	SL	|	SIERRA LEONE	|	C
+currency	|	SLE	|	Leone	|	SL	|	SIERRA LEONE	|	F
 currency	|	SGD	|	Singapore Dollar	|	SG	|	SINGAPORE	|	C
 currency	|	SKK	|	Slovak Koruna	|	SK	|	SLOVAKIA	|	C
 currency	|	SIT	|	Tolar	|	SI	|	SLOVENIA	|	O

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1511,6 +1511,10 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         for (String currency : nonModernCurrencyCodes.keySet()) {
             final String name = testInfo.getEnglish().getName(
                 CLDRFile.CURRENCY_NAME, currency);
+            if (name == null) {
+                errln("No English name for currency " + currency);
+                continue;
+            }
             if (newMatcher.reset(name).find()
                 && !EXCEPTION_CURRENCIES_WITH_NEW.contains(currency)) {
                 logln("Has 'new' in name but NOT used since "


### PR DESCRIPTION
CLDR-15456

- [X] This PR completes the ticket. (but will need a followon to track in v42)

- There’s an undetermined transition period. SLE is an internal code until that transition period is announced.
- For now SLE is 'new leone' but it will eventually just be 'leone' when SLE is in circulation.
- Updated ISO4217 and currency validity. SLE is not available in the 4217 lists yet.
- Also update tests that would otherwise fail on NPEs found during development

https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl_currency_iso_amendment_171.pdf