### PR TITLE
CLDR-15131 spec fix links into cldr.unicode.org and repo maint branch

### DIFF
--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -2439,7 +2439,7 @@ The cp value may contain sequences, but does not contain any Emoji or Text Varia
 
 ### 14.1 <a name="SynthesizingNames" href="#SynthesizingNames">Synthesizing Sequence Names</a>
 
-Many emoji are represented by sequences of characters. When there are no `annotation` elements for that string, the short name can be synthesized as follows. **Note:** The process details may change after the release of this specification, and may further change in the future if other sequences are added. Please see the [Known Issues](https://cldr.unicode.org/index/downloads/cldr-40#h.uanqoyl5dqt3) section of the CLDR download page for any updates.
+Many emoji are represented by sequences of characters. When there are no `annotation` elements for that string, the short name can be synthesized as follows. **Note:** The process details may change after the release of this specification, and may further change in the future if other sequences are added. Please see the [Known Issues](https://cldr.unicode.org/index/downloads/cldr-41#h.qa3jolg7zi2s) section of the CLDR download page for any updates.
 
 1.  If **sequence** is an **emoji flag sequence**, look up the territory name in CLDR for the corresponding ASCII characters and return as the short name. For example, the regional indicator symbols P+F would map to “Französisch-Polynesien” in German.
 2.  If **sequence** is an **emoji tag sequence**, look up the subdivision name in CLDR for the corresponding ASCII characters and return as the short name. For example, the TAG characters gbsct would map to “Schottland” in German.

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -560,7 +560,7 @@ Here is an example of the approvalRequirements section.
 <approvalRequirements>
     <!--  "high bar" items -->
     <approvalRequirement votes="20" locales="*" paths="//ldml/numbers/symbols[^/]++/(decimal|group)"/>
-    <!--  established locales - http://cldr.unicode.org/index/process#TOC-Draft-Status-of-Optimal-Field-Value -->
+    <!--  established locales - https://cldr.unicode.org/index/process#h.rm00w9v03ia8 -->
     <approvalRequirement votes="8" locales="ar ca cs da de el es fi fr he hi hr hu it ja ko nb nl pl pt pt_PT ro ru sk sl sr sv th tr uk vi zh zh_Hant" paths=""/>
     <!--  all other items -->
     <approvalRequirement votes="4" locales="*" paths=""/>

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -6,11 +6,11 @@
 <table><tbody>
 <tr><td>Version</td><td>41</td></tr>
 <tr><td>Editors</td><td>Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.html#Acknowledgments">other CLDR committee members</a></td></tr>
-<tr><td>Date</td><td>2022-03-21</td></tr>
+<tr><td>Date</td><td>2022-03-22</td></tr>
 <tr><td>This Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-66/tr35.html">https://www.unicode.org/reports/tr35/tr35-66/tr35.html</a></td></tr>
 <tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-65/tr35.html">https://www.unicode.org/reports/tr35/tr35-65/tr35.html</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>
-<tr><td>Corrigenda</td><td><a href="https://cldr.unicode.org/index/corrigenda-and-errata">https://cldr.unicode.org/index/corrigenda-and-errata</a></td></tr>
+<tr><td>Corrigenda</td><td><a href="https://cldr.unicode.org/index/corrigenda">https://cldr.unicode.org/index/corrigenda</a></td></tr>
 <tr><td>Latest Proposed Update</td><td><a href="https://unicode-org.github.io/cldr/ldml/tr35.html">https://unicode-org.github.io/cldr/ldml/tr35.html</a></td></tr>
 <tr><td>Namespace</td><td><a href="https://unicode.org/cldr/">https://unicode.org/cldr/</a></td></tr>
 <tr><td>DTDs</td><td><a href="https://www.unicode.org/cldr/dtd/41/">https://www.unicode.org/cldr/dtd/41/</a></td></tr>
@@ -255,25 +255,25 @@ A _Unicode language identifier_ has the following structure (provided in EBNF (P
     <td><a name="unicode_language_subtag" href="#unicode_language_subtag"><code>unicode_language_subtag</code></a></td>
     <td><pre>= alpha{2,3} | alpha{5,8};</pre></td>
     <td><a href="#unicode_language_subtag_validity">validity</a><br/>
-        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/language.xml">latest-data</a></td>
+        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/language.xml">latest-data</a></td>
 </tr>
 <tr>
     <td><a name="unicode_script_subtag" href="#unicode_script_subtag"><code>unicode_script_subtag</code></a></td>
     <td><pre>= alpha{4} ;</pre></td>
     <td><a href="#unicode_script_subtag_validity">validity</a><br/>
-        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/script.xml">latest-data</a></td>
+        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/script.xml">latest-data</a></td>
 </tr>
 <tr>
     <td><a name="unicode_region_subtag" href="#unicode_region_subtag"><code>unicode_region_subtag</code></a>
     <td><pre>= (alpha{2} | digit{3}) ;</pre></td>
     <td><a href="#unicode_region_subtag_validity">validity</a><br/>
-        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/region.xml">latest-data</a></td>
+        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/region.xml">latest-data</a></td>
 </tr>
 <tr>
     <td><a name="unicode_variant_subtag" href="#unicode_variant_subtag"><code>unicode_variant_subtag</code></a>
     <td><pre>= (alphanum{5,8}<br/>| digit alphanum{3}) ;</pre></td>
     <td><a href="#unicode_variant_subtag_validity">validity</a><br/>
-        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/variant.xml">latest-data</a></td>
+        <a href="https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/variant.xml">latest-data</a></td>
 </tr>
    <tr><td><code>sep</code></td>     <td><pre>= [-_] ;</pre></td></tr>
 <tr><td><code>digit</code></td>   <td><pre>= [0-9] ;</pre></td></tr>
@@ -300,14 +300,14 @@ As is often the case, the complete syntactic constraints are not easily captured
 | <a name="pu_extensions" href="#pu_extensions">`pu_extensions`</a>                                     | `= sep [xX]`<br/>`  (sep alphanum{1,8})+ ;` |
 | <a name="other_extensions" href="#other_extensions">`other_extensions`</a>                            | `= sep [alphanum-[tTuUxX]]`<br/>`  (sep alphanum{2,8})+ ;` |
 | `keyword`<br/>(Also known as `ufield`)                                                                | `= key (sep type)? ;` |
-| `key`<br/>(Also known as `ukey`)                                                                      | `= alphanum alpha ;`<br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with tkey.) | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47) |
-| `type`<br/>(Also known as `uvalue`)                                                                   | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47) |
+| `key`<br/>(Also known as `ukey`)                                                                      | `= alphanum alpha ;`<br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with tkey.) | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
+| `type`<br/>(Also known as `uvalue`)                                                                   | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
 | `attribute`                                                                                           | `= alphanum{3,8} ;` |
-| <a name="unicode_subdivision_id" href="#unicode_subdivision_id">`unicode_subdivision_id`</a>          | `= `[`unicode_region_subtag`](#unicode_region_subtag)` unicode_subdivision_suffix ;` | [`validity`](#unicode_subdivision_subtag_validity)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/subdivision.xml) |
+| <a name="unicode_subdivision_id" href="#unicode_subdivision_id">`unicode_subdivision_id`</a>          | `= `[`unicode_region_subtag`](#unicode_region_subtag)` unicode_subdivision_suffix ;` | [`validity`](#unicode_subdivision_subtag_validity)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/subdivision.xml) |
 | `unicode_subdivision_suffix`                                                                          | `= alphanum{1,4} ;` |
-| <a name="unicode_measure_unit" href="#unicode_measure_unit">`unicode_measure_unit`</a>                | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Validity_Data)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/validity/unit.xml) |
+| <a name="unicode_measure_unit" href="#unicode_measure_unit">`unicode_measure_unit`</a>                | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Validity_Data)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/unit.xml) |
 | `tlang`                                                                                               | `= unicode_language_subtag`<br/>`  (sep unicode_script_subtag)?`<br/>`  (sep unicode_region_subtag)?`<br/>`  (sep unicode_variant_subtag)* ;` | same as in unicode_language_id |
-| `tfield`                                                                                              | `= tkey tvalue;` | [`validity`](#BCP47_T_Extension)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47) |
+| `tfield`                                                                                              | `= tkey tvalue;` | [`validity`](#BCP47_T_Extension)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
 | `tkey`                                                                                                | `= alpha digit ;` |
 | `tvalue`                                                                                              | `= (sep alphanum{3,8})+ ;` |
 
@@ -870,7 +870,7 @@ Additional keys or types might be added in future versions. Implementations of L
 
 #### <a name="Numbering%20System%20Data" href="#Numbering%20System%20Data">3.6.2 Numbering System Data</a>
 
-LDML supports multiple numbering systems. The identifiers for those numbering systems are defined in the file **bcp47/number.xml**. For example, for the 'trunk' version of the data see [bcp47/number.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/number.xml).
+LDML supports multiple numbering systems. The identifiers for those numbering systems are defined in the file **bcp47/number.xml**. For example, for the 'trunk' version of the data see [bcp47/number.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/number.xml).
 
 Details about those numbering systems are defined in **supplemental/numberingSystems.xml**. For example, for the 'trunk' version of the data see [supplemental/numberingSystems.xml](https://github.com/unicode-org/cldr/releases/tag/latest/common/supplemental/numberingSystems.xml).
 
@@ -920,9 +920,9 @@ The Croat is not forced to pick "Serbia time" (Europe/Belgrade) nor the Serb for
 
 #### <a name="Unicode_Locale_Extension_Data_Files" href="#Unicode_Locale_Extension_Data_Files">3.6.4 U Extension Data Files</a>
 
-The 'u' extension data is stored in multiple XML files located under common/bcp47 directory in CLDR. Each file contains the locale extension key/type values and their backward compatibility mappings appropriate for a particular domain. [common/bcp47/collation.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/collation.xml) contains key/type values for collation, including optional collation parameters and valid type values for each key.
+The 'u' extension data is stored in multiple XML files located under common/bcp47 directory in CLDR. Each file contains the locale extension key/type values and their backward compatibility mappings appropriate for a particular domain. [common/bcp47/collation.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/collation.xml) contains key/type values for collation, including optional collation parameters and valid type values for each key.
 
-The 't' extension data is stored in [common/bcp47/transform.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform.xml).
+The 't' extension data is stored in [common/bcp47/transform.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform.xml).
 
 ```xml
 <!ELEMENT keyword ( key* )>
@@ -1124,13 +1124,13 @@ The following keys are defined for the -t- extension:
 
 | Keys   | Description | Values in latest release |
 | ------ | ----------- | ------------------------ |
-| m0     | **Transform extension mechanism:** to reference an authority or rules for a type of transformation | [​transform.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform.xml) |
-| s0, d0 | **Transform source/destination:** for non-languages/scripts, such as fullwidth-halfwidth conversion. | [​transform-destination.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform-destination.xml) |
-| i0     | **Input Method Engine transform:** Used to indicate an input method transformation, such as one used by a client-side input method. The first subfield in a sequence would typically be a 'platform' or vendor designation. | [​transform_ime.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform_ime.xml) |
-| k0     | **Keyboard transform:** Used to indicate a keyboard transformation, such as one used by a client-side virtual keyboard. The first subfield in a sequence would typically be a 'platform' designation, representing the platform that the keyboard is intended for. The keyboard might or might not correspond to a keyboard mapping shipped by the vendor for the platform. One or more subsequent fields may occur, but are only added where needed to distinguish from others. | [​transform_keyboard.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform_keyboard.xml) |
-| t0     | **Machine Translation:** Used to indicate content that has been machine translated, or a request for a particular type of machine translation of content. The first subfield in a sequence would typically be a 'platform' or vendor designation. | [​transform_mt.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform_mt.xml) |
-| h0     | **Hybrid Locale Identifiers:** h0 with the value 'hybrid' indicates that the -t- value is a language that is mixed into the main language tag to form a hybrid. For more information, and examples, see _Section 3.10.2 [Hybrid Locale Identifiers](#Hybrid_Locale)._ | [​transform_hybrid.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform_hybrid.xml) |
-| x0     | **Private use transform** | [​transform_private_use.xml](https://github.com/unicode-org/cldr/blob/maint/maint-40/common/bcp47/transform_private_use.xml) |
+| m0     | **Transform extension mechanism:** to reference an authority or rules for a type of transformation | [​transform.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform.xml) |
+| s0, d0 | **Transform source/destination:** for non-languages/scripts, such as fullwidth-halfwidth conversion. | [​transform-destination.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform-destination.xml) |
+| i0     | **Input Method Engine transform:** Used to indicate an input method transformation, such as one used by a client-side input method. The first subfield in a sequence would typically be a 'platform' or vendor designation. | [​transform_ime.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_ime.xml) |
+| k0     | **Keyboard transform:** Used to indicate a keyboard transformation, such as one used by a client-side virtual keyboard. The first subfield in a sequence would typically be a 'platform' designation, representing the platform that the keyboard is intended for. The keyboard might or might not correspond to a keyboard mapping shipped by the vendor for the platform. One or more subsequent fields may occur, but are only added where needed to distinguish from others. | [​transform_keyboard.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_keyboard.xml) |
+| t0     | **Machine Translation:** Used to indicate content that has been machine translated, or a request for a particular type of machine translation of content. The first subfield in a sequence would typically be a 'platform' or vendor designation. | [​transform_mt.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_mt.xml) |
+| h0     | **Hybrid Locale Identifiers:** h0 with the value 'hybrid' indicates that the -t- value is a language that is mixed into the main language tag to form a hybrid. For more information, and examples, see _Section 3.10.2 [Hybrid Locale Identifiers](#Hybrid_Locale)._ | [​transform_hybrid.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_hybrid.xml) |
+| x0     | **Private use transform** | [​transform_private_use.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_private_use.xml) |
 
 #### <a name="Transformed_Content_Data_File" href="#Transformed_Content_Data_File">3.7.1 T Extension Data Files</a>
 
@@ -3567,10 +3567,10 @@ The above algorithm is a logical statement of the process, but would obviously n
 | [<a name="UNM49" href="#UNM49">UNM49</a>]                | UN M.49: UN Statistics Division<br/>Country or area & region codes<br/>[https://unstats.un.org/unsd/methods/m49/m49.htm](https://unstats.un.org/unsd/methods/m49/m49.htm)<br/>Composition of macro geographical (continental) regions, geographical sub-regions, and selected economic and other groupings<br/>[https://unstats.un.org/unsd/methods/m49/m49regin.htm](https://unstats.un.org/unsd/methods/m49/m49regin.htm) |
 | [<a name="XMLSchema" href="#XMLSchema">XML Schema</a>]   | W3C XML Schema<br/>[https://www.w3.org/XML/Schema](https://www.w3.org/XML/Schema) |
 | General                                                  | _The following are general references from the text:_ |
-| [<a name="ByType" href="#ByType">ByType</a>]             | CLDR Comparison Charts<br/>[https://www.unicode.org/cldr/comparison_charts.html](https://www.unicode.org/cldr/comparison_charts.html) |
+| [<a name="ByType" href="#ByType">ByType</a>]             | CLDR Comparison Charts<br/>[https://cldr.unicode.org/index/charts](https://cldr.unicode.org/index/charts) |
 | [<a name="Calendars" href="#Calendars">Calendars</a>]    | Calendrical Calculations: The Millennium Edition by Edward M. Reingold, Nachum Dershowitz; Cambridge University Press; Book and CD-ROM edition (July 1, 2001); ISBN: 0521777526. Note that the algorithms given in this book are copyrighted. |
-| [<a name="Comparisons" href="#Comparisons">Comparisons</a>]             | Comparisons between locale data from different sources<br/>[https://unicode-org.github.io/cldr-staging/charts/38/supplemental/dtd_deltas.html](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/dtd_deltas.html) |
-| [<a name="CurrencyInfo" href="#CurrencyInfo">CurrencyInfo</a>]          | UNECE Currency Data<br/>[https://www.currency-iso.org/en/home/tables.html](https://www.currency-iso.org/en/home/tables.html) |
+| [<a name="Comparisons" href="#Comparisons">Comparisons</a>]             | Comparisons between locale data from different sources<br/>[https://unicode-org.github.io/cldr-staging/charts/latest/by_type/index.html](https://unicode-org.github.io/cldr-staging/charts/latest/by_type/index.html) |
+| [<a name="CurrencyInfo" href="#CurrencyInfo">CurrencyInfo</a>]          | UNECE Currency Data<br/>[https://www.iso.org/iso-4217-currency-codes.html](https://www.iso.org/iso-4217-currency-codes.html) |
 | [<a name="DataFormats" href="#DataFormats">DataFormats</a>]             | CLDR Translation Guidelines<br/>[http://cldr.unicode.org/translation](http://cldr.unicode.org/translation) |
 | [<a name="LDML" href="#LDML">Example</a>]                               | A sample in Locale Data Markup Language<br/>[https://unicode.org/cldr/dtd/1.1/ldml-example.xml](https://unicode.org/cldr/dtd/1.1/ldml-example.xml) |
 | [<a name="ICUCollation" href="#ICUCollation">ICUCollation</a>]          | ICU rule syntax<br/>[https://unicode-org.github.io/icu/userguide/collation/customization/](https://unicode-org.github.io/icu/userguide/collation/customization/) |
@@ -3578,7 +3578,7 @@ The above algorithm is a logical statement of the process, but would obviously n
 | [<a name="ICUUnicodeSet" href="#ICUUnicodeSet">ICUUnicodeSet</a>]       | ICU UnicodeSet<br/>[https://unicode-org.github.io/icu/userguide/strings/unicodeset.html<br/>](https://unicode-org.github.io/icu/userguide/strings/unicodeset.html)API<br/>[https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/text/UnicodeSet.html](https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/text/UnicodeSet.html) |
 | [<a name="ITUE164" href="#ITUE164">ITUE164</a>]                         | International Telecommunication Union: List Of ITU Recommendation E.164 Assigned Country Codes<br/>available at [https://www.itu.int/opb/publications.aspx?parent=T-SP&view=T-SP2](https://www.itu.int/opb/publications.aspx?parent=T-SP&view=T-SP2) |
 | [<a name="LocaleExplorer" href="#LocaleExplorer">LocaleExplorer</a>]    | ICU Locale Explorer<br/>[https://icu4c-demos.unicode.org/icu-bin/locexp](https://icu4c-demos.unicode.org/icu-bin/locexp) |
-| [<a name="localeProject" href="#localeProject">LocaleProject</a>]       | Common Locale Data Repository Project<br/>[https://unicode.org/cldr/](https://unicode.org/cldr/) |
+| [<a name="localeProject" href="#localeProject">LocaleProject</a>]       | Common Locale Data Repository Project<br/>[https://cldr.unicode.org](https://cldr.unicode.org) |
 | [<a name="NamingGuideline" href="#NamingGuideline">NamingGuideline</a>] | OpenI18N Locale Naming Guideline<br/>formerly at https://www.openi18n.org/docs/text/LocNameGuide-V10.txt |
 | [<a name="RBNF" href="#RBNF">RBNF</a>]                                  | Rule-Based Number Format<br/>[https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1RuleBasedNumberFormat.html](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1RuleBasedNumberFormat.html) |
 | [<a name="RBBI" href="#RBBI">RBBI</a>]                                  | Rule-Based Break Iterator<br/>[https://unicode-org.github.io/icu/userguide/boundaryanalysis](https://unicode-org.github.io/icu/userguide/boundaryanalysis) |


### PR DESCRIPTION
CLDR-15131

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix some spec links into the CLDR Sites pages. In one case - for https://cldr.unicode.org/index/cldr-spec/transliteration-guidelines - I instead had to restore the old URL of the Sires pages, from "unicode-transliteration-guidelines" back to just "transliteration-guidelines".

Also update some links that went to the maint-40 branch or downloads/cldr-40 page to go to the 41 version.