### PR TITLE
CLDR-15456 Currency: SLL should have 0 digits

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -61,7 +61,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <info iso4217="RWF" digits="0" rounding="0"/>
             <info iso4217="SEK" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
             <info iso4217="SLE" digits="2" rounding="0"/>
-            <info iso4217="SLL" digits="2" rounding="0"/>
+            <info iso4217="SLL" digits="0" rounding="0"/>
             <info iso4217="SOS" digits="0" rounding="0"/>
             <info iso4217="STD" digits="0" rounding="0"/>
             <info iso4217="SYP" digits="0" rounding="0"/>


### PR DESCRIPTION
- SLL on the ground does not use subunits per @roozbehp 
- partial revert of c2c9723e653b703e92fc008eb6467f2be00d6643 (#1825)

CLDR-15456

- [X] This PR completes the ticket.

see https://github.com/unicode-org/cldr/pull/1825#issuecomment-1075834540