### PR TITLE
CLDR-15405 Add initialPatterns, sampleNames & data; PathHeader functions for ordering

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3164,7 +3164,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST annotation draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 
-<!ELEMENT personNames ( alias | ( nameOrder*, personName+, special* ) ) >
+<!ELEMENT personNames ( alias | ( nameOrder*, initialPattern*, personName+, sampleName*, special* ) ) >
 
 <!ELEMENT nameOrder EMPTY >
 <!ATTLIST nameOrder nameLocales NMTOKENS #REQUIRED >
@@ -3174,6 +3174,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST nameOrder draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST nameOrder references CDATA #IMPLIED >
+    <!--@METADATA-->
+
+<!ELEMENT initialPattern ( #PCDATA ) >
+<!ATTLIST initialPattern type (initial|initialSequence) #REQUIRED >
+<!ATTLIST initialPattern alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST initialPattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+<!ATTLIST initialPattern references CDATA #IMPLIED >
     <!--@METADATA-->
 
 <!ELEMENT personName ( alias | ( namePattern+, special* ) ) >
@@ -3187,10 +3196,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:set/literal/surnameFirst, givenFirst-->
 
 <!ELEMENT namePattern ( #PCDATA ) >
-<!ATTLIST namePattern alt (2|3) #IMPLIED >
+<!ATTLIST namePattern alt (1|2) #IMPLIED >
 <!ATTLIST namePattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST namePattern references CDATA #IMPLIED >
+    <!--@METADATA-->
+
+<!ELEMENT sampleName ( alias | ( nameField+, special* ) ) >
+<!ATTLIST sampleName item (minimal|simple|full|multiword) #REQUIRED >
+
+<!ELEMENT nameField ( #PCDATA ) >
+<!ATTLIST nameField type CDATA #REQUIRED >
+    <!--@MATCH:any--> <!--until we have a better sense, or maybe validity data, for all of the combinations here-->
+<!ATTLIST nameField alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST nameField draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+<!ATTLIST nameField references CDATA #IMPLIED >
     <!--@METADATA-->
 
 <!-- ######################################################### -->

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9129,6 +9129,8 @@ annotations.
 		<featureName type="zero">slashed zero</featureName>
 	</typographicNames>
 	<personNames>
+		<initialPattern type="initial">{0}.</initialPattern>
+		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<personName>
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
@@ -9246,5 +9248,26 @@ annotations.
 		<personName length="monogramNarrow" style="informal" order="givenFirst">
 			<namePattern>{given-informal-initial}</namePattern>
 		</personName>
+		<sampleName item="minimal">
+			<nameField type="given">Katherine</nameField>
+			<nameField type="surname">Johnson</nameField>
+		</sampleName>
+		<sampleName item="simple">
+			<nameField type="given">Alberto</nameField>
+			<nameField type="given2">Pedro</nameField>
+			<nameField type="surname">Calderón</nameField>
+		</sampleName>
+		<sampleName item="full">
+			<nameField type="prefix">Dr.</nameField>
+			<nameField type="given">Dorothy</nameField>
+			<nameField type="given2">Lavinia</nameField>
+			<nameField type="surname">Brown</nameField>
+			<nameField type="suffix">M.D.</nameField>
+		</sampleName>
+		<sampleName item="multiword">
+			<nameField type="given">Erich Oswald</nameField>
+			<nameField type="given2">Hans Carl Maria</nameField>
+			<nameField type="surname">von Stroheim</nameField>
+		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5369,6 +5369,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrder nameLocales="und" order="surnameFirst"/>
+		<initialPattern type="initial">{0}.</initialPattern>
+		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<!-- fallback/any pattern -->
 		<personName>
 			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -907,6 +907,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="typographicNames/featureName[@type='%anyAttribute']"/>
 
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrder[@nameLocales='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/initialPattern[@type='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/initialPattern[@type='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='addressing'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='addressing'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='referring'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
@@ -917,6 +919,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern[@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/sampleName[@item='%anyAttribute']/nameField[@type='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/sampleName[@item='%anyAttribute']/nameField[@type='%anyAttribute']"/>
 
 		<coverageLevel value="modern" match="annotations/annotation[@cp='%modernEmoji'][@type='%anyAttribute']"/>
 		<coverageLevel value="modern" match="annotations/annotation[@cp='%modernEmoji']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -37,7 +37,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                         .setMessage("Invalid placeholder (missing terminator) in value \"" + value + "\""));
                 } else {
                     String placeHolderString = value.substring(startPlaceHolder + 1, endPlaceHolder);
-                    Matcher matcher = (path.contains("/personNames/"))?
+                    Matcher matcher = (path.contains("/personNames/personName"))?
                         PLACEHOLDER_PATTERN_PERS_NAMES.matcher(placeHolderString):
                         PLACEHOLDER_PATTERN.matcher(placeHolderString);
                     if (!matcher.matches()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -476,6 +476,9 @@ public class ExampleGenerator {
         // Sample:
         //ldml/personNames/personName[@length="long"][@usage="addressing"][@style="formal"][@order="givenFirst"]/namePattern => {prefix} {surname}
         // but for this code we don't need to know what the parameters are, we just format the name pattern
+        if (parts.contains("nameOrder") || parts.contains("initialPattern") || parts.contains("sampleName")) {
+            return null; // TODO: we do not handle these yet
+        }
 
         // We might need the alt, however: String alt = parts.getAttributeValue(-1, "alt");
         List<String> examples = new ArrayList<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -382,9 +382,17 @@ public class PathDescription {
         + RegexLookup.SEPARATOR
         + "Person name order for languages. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/initialPattern\\[@type=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "Initials patterns for person name formats. For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/personName"
         + RegexLookup.SEPARATOR
         + "Person name formats by length, usage, style, order. For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/sampleName"
+        + RegexLookup.SEPARATOR
+        + "Sample names for person name forma examples. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
 
         + "^//ldml/numbers/([a-z]*)Formats(\\[@numberSystem=\"([^\"]*)\"])?/\\1FormatLength/\\1Format\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]$"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1851,6 +1851,57 @@ public class PathHeader implements Comparable<PathHeader> {
                     return source;
                 }
             });
+
+            functionMap.put("personNameOrder", new Transform<String, String>() {
+                @Override
+                public String transform(String source) {
+                    // The various personName attribute values in desired sort order
+                    final List<String> allValues = Arrays.asList(
+                        "long", "medium", "short", "monogram", "monogramNarrow", // length values
+                        "addressing", "referring", "sorting", // usage values
+                        "formal", "informal", // style values
+                        "surnameFirst", "givenFirst"); //order values
+
+                    List<String> parts = HYPHEN_SPLITTER.splitToList(source);
+                    order = 0;
+                    for (String part: parts) {
+                        if (allValues.contains(part)) {
+                            order += (1 << allValues.indexOf(part));
+                        } else {
+                            order += (1 << allValues.size());
+                        }
+                    }
+                    return source;
+                }
+            });
+
+            functionMap.put("sampleNameOrder", new Transform<String, String>() {
+                @Override
+                public String transform(String source) {
+                    final List<String> sampleItemValues = Arrays.asList("minimal", "simple", "full", "multiword");
+                    final List<String> fieldTypeValues = Arrays.asList("prefix", "given", "given2", "surname", "surname2", "suffix");
+
+                    List<String> parts = HYPHEN_SPLITTER.splitToList(source);
+                    if (parts.size() >= 2) {
+                        order = 0;
+                        if (sampleItemValues.contains(parts.get(0))) {
+                            order += sampleItemValues.indexOf(parts.get(0)) * 16;
+                        } else {
+                            order += sampleItemValues.size() * 16;
+                        }
+                        if (fieldTypeValues.contains(parts.get(1))) {
+                            order += fieldTypeValues.indexOf(parts.get(1)) * 2;
+                        }
+                        if (parts.size() > 2) {
+                            order += 1;
+                        }
+                    } else {
+                        order = 128;
+                    }
+                    return source;
+                }
+            });
+
             functionMap.put("alphaOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -1020,8 +1020,8 @@ public class PersonNameFormatter {
         Set<Pair<ParameterMatcher, NamePattern>> ordered = new TreeSet<>();
         // read out the data and order it properly
         for (String path : cldrFile) {
-            if (path.startsWith("//ldml/personNames")) {
-                // eg //ldml/personNames/personName[@length="long"][@usage="sorting"]/namePattern[alt="7"]
+            if (path.startsWith("//ldml/personNames/personName")) { // TODO: for now this does not handle nameOrder, initialPattern, sampleName
+                // eg //ldml/personNames/personName[@length="long"][@usage="sorting"]/namePattern[alt="2"]
                 // value = {surname}, {given} {given2} {suffix}
                 String value = cldrFile.getStringValue(path);
                 XPathParts parts = XPathParts.getFrozenInstance(path);
@@ -1035,7 +1035,7 @@ public class PersonNameFormatter {
                     );
                 NamePattern np = NamePattern.from(rank, value);
                 if (np.toString().isBlank()) {
-                    throw new IllegalArgumentException("No emplty patterns allowed: " + pm);
+                    throw new IllegalArgumentException("No empty patterns allowed: " + pm);
                 }
                 boolean added = ordered.add(Pair.of(pm, np));
                 if (!added) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -286,14 +286,19 @@
 //ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"%A\"]        ; Misc ; Minimal Pairs ; Gender (for measurement units) ; &genderNumber($1) ; LTR_ALWAYS
 
 //ldml/personNames/nameOrder[@nameLocales=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Languages ; $1
+//ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; Initial Patterns ; $1-$2
+//ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; Initial Patterns ; $1
 //ldml/personNames/personName/namePattern[@alt=\"%A\"]      ; Misc ; Person Name Formats ; Fallback Name Pattern ; any-$1
 //ldml/personNames/personName/namePattern           ; Misc ; Person Name Formats ; Fallback Name Pattern ; any
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4-$5
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3-$4
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; $1-$2-$3
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4-$5)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3)
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item $1 ; &sampleNameOrder($1-$2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item $1 ; &sampleNameOrder($1-$2)
+
 
 #Emoji, etc.
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -245,3 +245,7 @@
 ^//ldml/characters/ellipsis\[@type="word-final"] ; {0}=FIRST_PART_OF_TEXT very long
 ^//ldml/characters/ellipsis\[@type="word-initial"] ; {0}=LAST_PART_OF_TEXT long name
 ^//ldml/characters/ellipsis\[@type="word-medial"] ; {0}=FIRST_PART_OF_TEXT very l; {1}=LAST_PART_OF_TEXT long
+
+//ldml/personNames/initialPattern\[@type="initial"] ; {0}=NAME_INITIAL J
+//ldml/personNames/initialPattern\[@type="initialSequence"] ; {0}=PREVIOUS_NAME_INITIALS J.R.; {1}=ADD_NAME_INITIAL R.
+

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
@@ -90,10 +90,12 @@ class LdmlConvertRulesTest {
 
         //Temporary skip while in development CLDR-15384
         dtdSplittableAttrs.remove(Pair.of("nameOrder", "nameLocales"));
+        dtdSplittableAttrs.remove(Pair.of("initialPattern", "type"));
         dtdSplittableAttrs.remove(Pair.of("personName", "length"));
         dtdSplittableAttrs.remove(Pair.of("personName", "order"));
         dtdSplittableAttrs.remove(Pair.of("personName", "style"));
         dtdSplittableAttrs.remove(Pair.of("personName", "usage"));
+        dtdSplittableAttrs.remove(Pair.of("sampleName", "item"));
 
 
         SetView<Pair<String, String>> onlyInDtd = Sets.difference(dtdSplittableAttrs, jsonSplittableAttrs);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -470,8 +470,11 @@ public class TestDtdData extends TestFmwk {
                 || (elementName.equals("genderMinimalPairs") && attribute.equals("gender"))
                 || (elementName.equals("caseMinimalPairs") && attribute.equals("case"))
                 || (elementName.equals("nameOrder") && attribute.equals("nameLocales"))
+                || (elementName.equals("initialPattern") && attribute.equals("type"))
                 || (elementName.equals("personName") && (attribute.equals("length") || attribute.equals("usage") ||
                                                          attribute.equals("style") || attribute.equals("order")))
+                || (elementName.equals("sampleName") && attribute.equals("item"))
+                || (elementName.equals("nameField") && attribute.equals("type"))
                 ;
 
         case ldmlBCP47:

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -189,6 +189,8 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard", // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
 
         "//ldml/personNames/nameOrder[@nameLocales=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName/namePattern", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
@@ -196,7 +198,10 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern" // CLDR-15384
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern", // CLDR-15384
+        "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"]" // CLDR-15384
+
         );
     // Add to above if the example SHOULD appear, but we don't have it yet. TODO Add later
 


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Finish up the remaining changes to dtd, coverage, PathHeader etc. modulo discussion about changing some of the added items, and add new data items for root/English:
- Add initialPattern element with type=initial|initialSequence, and data for root/English. Since this is PCDATA, it is also required to have an alt attribute, so it allows alt=variant.
- Add sampleName element with item=minimal|simple|full|multiword, and child element nameField with type=prefix|given|given2|surname|surname2|suffix, and initial data for English. Since nameField is PCDATA, it also allows alt=variant. **Note: we need to discuss (in meeting): (1) whether "item" is the best name for the sampleName attribute; (2) what additional values might be needed besides minimal|simple|full|multiword; and (3) whether the initial English data is what we want.**
- Fix the namePattern alt attribute to be 1|2, not 2|3.
- Update coverage, PathHeader, PathDescription, TextExampleGenerator, etc. for the above changes.
- Add PathHeader ordering functions personNameOrder and sampleNameOrder, use them in  PathHeader.txt for correct ordering of paths.
 