### PR TITLE
CLDR-15488 db: improve issue with hang on derby table create

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserSettingsData.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserSettingsData.java
@@ -155,6 +155,7 @@ public class UserSettingsData {
                 sql = ("create table " + SET_KINDS + "(set_id INT NOT NULL " + DBUtils.DB_SQL_IDENTITY + ", "
                     + "set_name varchar(128) not null UNIQUE " + (!DBUtils.db_Mysql ? ",primary key(set_id)" : "") + ")");
                 s.execute(sql);
+                conn.commit();
                 if (DBUtils.hasTable(conn, SET_VALUES)) {
                     if (progress != null)
                         progress.update("Clearing old values");


### PR DESCRIPTION
- a 'commit' was missing before an operation which depended on a settled state of the DB
- minor, only occurs during derby db setup (i.e. unit tests)
- could be the cause of intermittent test hang or failure

(cherry picked from commit 709d0bbe5e855f7e942009f3581a867601a0cfc7)

CLDR-15488

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
