### PR TITLE
CLDR-14543 reduce memory use of the getSourceLocation() calls

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -235,7 +235,7 @@ public class SimpleXMLSource extends XMLSource {
     @Override
     public XMLSource addSourceLocation(String currentFullXPath, SourceLocation location) {
         if (!isFrozen()) {
-            locationHash.put(currentFullXPath, location);
+            locationHash.put(currentFullXPath.intern(), location);
         } else {
             System.err.println("SimpleXMLSource::addSourceLocationAttempt to modify frozen source location");
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -76,17 +76,18 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
         }
 
         public SourceLocation(String system, int line, int column) {
-            // trim this prefix off
-            if (system.startsWith(FILE_PREFIX)) {
-                system = system.substring(FILE_PREFIX.length());
-            }
-            this.system = system;
+            this.system = system.intern();
             this.line = line;
             this.column = column;
         }
 
         public String getSystem() {
-            return system;
+            // Trim prefix lazily.
+            if (system.startsWith(FILE_PREFIX)) {
+                return system.substring(FILE_PREFIX.length());
+            } else {
+                return system;
+            }
         }
 
         public int getLine() {


### PR DESCRIPTION
- intern the xpath string (cost only on read)
- instead of substringing the system name (which starts with file://…) at construction
time, substring it later only when (if) the user uses it

CLDR-14543

- [ ] This PR completes the ticket.