### PR TITLE
CLDR-15369 Priority Items Summary, schedule automatic snapshots

### DIFF
--- a/tools/cldr-apps/js/src/views/AboutPanel.vue
+++ b/tools/cldr-apps/js/src/views/AboutPanel.vue
@@ -22,11 +22,7 @@
               <!-- Looks like a URL -->
               <a class="aboutValue" v-bind:href="v">{{ v }}</a>
             </span>
-            <span
-              v-else-if="
-                /^[a-fA-F0-9]{6,40}$/.test(v) && aboutData.CLDR_COMMIT_BASE
-              "
-            >
+            <span v-else-if="valueIsHash(v, k)">
               <!-- Looks like a Git hash, 6…40 hex chars.
                    We need to check that CLDR_COMMIT_BASE is set, because that’s the
                    base URL for the linkification -->
@@ -50,15 +46,29 @@
 
 <script>
 export default {
-  data: function () {
+  data() {
     return {
       aboutData: null,
     };
   },
-  created: function () {
+
+  created() {
     fetch("api/about")
       .then((r) => r.json())
       .then((data) => (this.aboutData = data));
+  },
+
+  methods: {
+    valueIsHash(value, key) {
+      if (
+        this.aboutData.CLDR_COMMIT_BASE &&
+        key.includes("HASH") &&
+        /^[a-fA-F0-9]{6,40}$/.test(value)
+      ) {
+        return true;
+      }
+      return false;
+    },
   },
 };
 </script>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/QueueMemberId.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/QueueMemberId.java
@@ -1,0 +1,78 @@
+package org.unicode.cldr.web;
+
+import java.util.Hashtable;
+
+/**
+ * Uniquely identify members that participate in queues to receive data; associate
+ * an arbitrary object with each member
+ *
+ * A member may be (1) a user (maybe logged in), identified by their CookieSession, or
+ * (2) an automatically scheduled background operation not initiated by a particular user
+ *
+ * Multiple HTTP requests and responses may be required for the same user to fetch the same
+ * data set -- gathering the data is assumed to be a potentially long-running task
+ *
+ * When there are concurrent requests by multiple users, the CookieSession is used
+ * for determining which requests are from the same user
+ *
+ * The associated object could be anything, depending on the caller; for VettingViewerQueue,
+ * the object might belong to the class org.unicode.cldr.web.VettingViewerQueue.QueueEntry
+ *
+ * The "key" parameter for the put/set methods enables reusing this class for different kinds of queue
+ *
+ * For VettingViewerQueue, the key might be VettingViewerQueue.class.getName(); other kinds of
+ * queues should have distinct keys
+ *
+ * For a given key, there is assumed to be no more than one "automatic" queue member at a time
+ *
+ * This class is meant to be re-usable and not to depend on VettingViewerQueue
+ */
+public class QueueMemberId {
+
+    /**
+     * The hash of objects associated with the automatic member
+     * -- null if the member is not automatic
+     */
+    private Hashtable<String, Object> autoEntryHash = null;
+
+    /**
+     * The CookieSession that identifies a member who is a user
+     * -- null if the member is automatic
+     */
+    private CookieSession cs = null;
+
+    /**
+     * This constructor is only intended for automatically scheduled operations,
+     * not for operations initiated by a particular user
+     */
+    public QueueMemberId() {
+        autoEntryHash = new Hashtable<String, Object>();
+    }
+
+    /**
+     * This constructor is for usage initiated by a particular user
+     *
+     * @param cs the CookieSession identifying the user
+     */
+    public QueueMemberId(CookieSession cs) {
+        this.cs = cs;
+    }
+
+    public void put(String key, Object entry) {
+        if (autoEntryHash != null) {
+            autoEntryHash.put(key, entry);
+        } else if (cs != null) {
+            cs.put(key, entry);
+        }
+    }
+
+    public Object get(String key) {
+        if (autoEntryHash != null) {
+            return autoEntryHash.get(key);
+        } else if (cs != null) {
+            return cs.get(key);
+        } else {
+            return null;
+        }
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -91,6 +91,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.web.UserRegistry.User;
 import org.unicode.cldr.web.WebContext.HTMLDirection;
+import org.unicode.cldr.web.api.Summary;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -425,8 +426,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         if (!startUpDatabase()) {
             return;
         }
-        // TODO: call Summary.scheduleAutomaticSnapshots here or in doStartup
-        // Reference: https://unicode-org.atlassian.net/browse/CLDR-15369
+        Summary.scheduleAutomaticSnapshots();
 
         // TODO: check whether doStartup and startUpDatabase have a synchronization problem,
         // sometimes this.dbUtils null when doStartup calls doStartupDb
@@ -3117,6 +3117,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             logger.warning("SurveyTool shutting down.. r" + getCurrevCldrApps());
             progress.update("shutting down mail... " + destroyTimer);
             MailSender.shutdown();
+            progress.update("shutting down summary snapshots... " + destroyTimer);
+            Summary.shutdown();
             progress.update("shutting down SurveyThreadManager... " + destroyTimer);
             startupThread.shutdown();
             progress.update("Shutting down database..." + destroyTimer);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -475,7 +475,7 @@ public class UserRegistry {
             }
         }
 
-        Organization vrOrg() {
+        public Organization vrOrg() {
             return Organization.fromString(voterOrg());
         }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/About.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/About.java
@@ -99,14 +99,14 @@ public class About {
                 r.put("dbInfo", d.getDBInfo());
             }
         }
-        r.put("memory", getMemoryStats());
+        putMemoryStats(r);
         return Response.ok(r).build();
     }
 
-    private static String getMemoryStats() {
+    private void putMemoryStats(Map<String, String> r) {
         Runtime rt = Runtime.getRuntime();
-        return "total: " + rt.totalMemory() +
-            "; max: " + rt.maxMemory() +
-            "; free: " + rt.freeMemory();
+        r.put("memoryTotal", Long.toString(rt.totalMemory()));
+        r.put("memoryMax", Long.toString(rt.maxMemory()));
+        r.put("memoryFree", Long.toString(rt.freeMemory()));
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MemoryHelper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MemoryHelper.java
@@ -1,0 +1,63 @@
+package org.unicode.cldr.util;
+
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
+
+public class MemoryHelper {
+
+    /**
+     * Get the amount of memory still available for us to allocate,
+     * including not only freeMemory but also maxMemory - totalMemory
+     *
+     * https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html#freeMemory()
+     *
+     * Generally: freeMemory <= totalMemory <= maxMemory
+     *
+     * @param callerId a string identifying the caller, used in log if verbose
+     * @param verbose if true, log the stats
+     * @return the available memory, in bytes
+     */
+    public static synchronized long availableMemory(String callerId, boolean verbose) {
+        final Runtime r = Runtime.getRuntime();
+        long freeMem = r.freeMemory();
+        long maxMem = r.maxMemory();
+        long totalMem = r.totalMemory();
+        if (freeMem > totalMem || totalMem > maxMem) {
+            log(callerId, "Values returned by Runtime violate assumptions!");
+            verbose = true;
+        }
+        long availMem = freeMem + maxMem - totalMem;
+        if (verbose) {
+            log(callerId, "Available memory: " + humanReadableByteCountSI(availMem) +
+                "; free: " +  humanReadableByteCountSI(freeMem) +
+                "; max: " +  humanReadableByteCountSI(maxMem) +
+                "; total: " +  humanReadableByteCountSI(totalMem));
+        }
+        return availMem;
+    }
+
+    private static void log(String callerId, String message) {
+        System.out.println("MemoryHelper[" + callerId + "]: " + message);
+    }
+
+    /**
+     * Convert a byte count to a human readable string
+     * Use SI (1 k = 1,000), not Binary (1 K = 1,024)
+     *
+     * @param bytes the number such as 1234567890
+     * @return the formatted string such as "1.2 GB"
+     *
+     * Source: https://programming.guide/java/formatting-byte-size-to-human-readable-format.html
+    */
+    public static String humanReadableByteCountSI(long bytes) {
+        if (-1000 < bytes && bytes < 1000) {
+            return bytes + " B";
+        }
+        CharacterIterator ci = new StringCharacterIterator("kMGTPE");
+        while (bytes <= -999_950 || bytes >= 999_950) {
+            bytes /= 1000;
+            ci.next();
+        }
+        return String.format("%.1f %cB", bytes / 1000.0, ci.current());
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -66,8 +66,12 @@ public class VettingViewer<T> {
 
     private static final Set<CheckCLDR.CheckStatus.Subtype> OK_IF_VOTED = EnumSet.of(Subtype.sameAsEnglish);
 
+    public static Organization getNeutralOrgForSummary() {
+        return Organization.surveytool;
+    }
+
     private static boolean orgIsNeutralForSummary(Organization org) {
-        return org.equals(Organization.surveytool);
+        return org.equals(getNeutralOrgForSummary());
     }
 
     /**
@@ -918,6 +922,9 @@ public class VettingViewer<T> {
         private void computeOne(int n) {
             if (progressCallback.isStopped()) {
                 throw new RuntimeException("Requested to stop");
+            }
+            if (DEBUG) {
+                MemoryHelper.availableMemory("VettingViewer.WriteAction.computeOne", true);
             }
             final String name = context.localeNames.get(n);
             final String localeID = context.localeIds.get(n);


### PR DESCRIPTION
-Schedule auto snapshots if cldr.properties has CLDR_AUTO_SNAP=true

-Summary.java has new methods scheduleAutomaticSnapshots, etc.

-For testing only, first snapshot is scheduled two minutes after startup

-Cancel scheduled snapshot when Survey Tool shuts down

-New class QueueMemberId to solve the problem of snapshot without CookieSession

-Refactor getPriorityItemsSummaryOutput to avoid long parameter list, new classes Args/Results

-Revise About panel memory reporting, separate lines for total/max/free

-New module MemoryHelper with method availableMemory called by VettingViewer only if DEBUG

CLDR-15369

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
