### PR TITLE
CLDR-14311 remove xerces to avoid conflict in eclipse

### DIFF
--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -53,11 +53,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.myanmartools</groupId>
 			<artifactId>myanmar-tools</artifactId>
 		</dependency>

--- a/tools/cldr-rdf/pom.xml
+++ b/tools/cldr-rdf/pom.xml
@@ -72,10 +72,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -84,12 +84,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>xerces</groupId>
-				<artifactId>xercesImpl</artifactId>
-				<version>2.12.2</version>
-			</dependency>
-
-			<dependency>
 				<groupId>com.google.myanmartools</groupId>
 				<artifactId>myanmar-tools</artifactId>
 				<version>1.1.1</version>


### PR DESCRIPTION
CLDR-14311

xerces provides org.xml.sax, which causes eclipse to complain that it is already available (as part of JDK11+). 

- [ ] This PR completes the ticket.
