### PR TITLE
CLDR-15461 for final: update ICU4J libs to maint-71 as of 2022-03-31, update readme

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -12,16 +12,16 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 41</h3>
-    <p>Last updated: 2022-Mar-21</p>
+    <p>Last updated: 2022-Mar-31</p>
 
     <!--<p><b>Note:</b> CLDR 41 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 41, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
     <!--<p><b>Note:</b> This is a preliminary version of CLDR 41, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <p><b>Note:</b> This is a pre-release candidate version of CLDR 41, intended for testing.
-    It is not recommended for production use.</p>
-    <!--<p>This is the final release version of CLDR 41.</p>-->
+    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 41, intended for testing.
+    It is not recommended for production use.</p>-->
+    <p>This is the final release version of CLDR 41.</p>
 
     <p><strong>Important notes for CLDR 36 and later:</strong></p>
     <ul>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>71.1-SNAPSHOT-release-71-rc</icu4j.version>
+		<icu4j.version>71.1-cldr-2022-03-31</icu4j.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-15461

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

The last update ot ICU4J libs in CLDR 41, picking up ICU maint/maint-71 branch as of 2022-03-31 including CLDR beta2 integration and Yoshito's addition for SLE.

Also updated readme to say final release.