### PR TITLE
CLDR-14543 disable tracking XMLSource.sourceLocation unless UNITTEST 

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleFactory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleFactory.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 
+import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.XMLSource.ResolvingSource;
 
@@ -634,6 +635,10 @@ public class SimpleFactory extends Factory {
      */
     public static CLDRFile makeSupplemental(String localeName) {
         XMLSource source = new SimpleXMLSource(localeName);
+        // Only enable source location for UNITTEST
+        if (CLDRConfig.getInstance().getEnvironment() == Environment.UNITTEST) {
+            source.enableSourceLocation();
+        }
         CLDRFile result = new CLDRFile(source);
         result.setNonInheriting(true);
         return result;
@@ -694,6 +699,10 @@ public class SimpleFactory extends Factory {
      */
     public static CLDRFile makeFile(String localeName) {
         XMLSource source = new SimpleXMLSource(localeName);
+        // Only enable source location for UNITTEST
+        if (CLDRConfig.getInstance().getEnvironment() == Environment.UNITTEST) {
+            source.enableSourceLocation();
+        }
         return new CLDRFile(source);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 
 import org.unicode.cldr.util.XPathParts.Comments;
 
-import com.ibm.icu.dev.util.CollectionUtilities;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.UnicodeSet;
@@ -38,7 +37,11 @@ public class SimpleXMLSource extends XMLSource {
         this.xpath_fullXPath = copyAsLockedFrom.xpath_fullXPath;
         this.xpath_comments = copyAsLockedFrom.xpath_comments;
         this.setLocaleID(copyAsLockedFrom.getLocaleID());
-        this.locationHash = Collections.unmodifiableMap(copyAsLockedFrom.locationHash);
+        if (copyAsLockedFrom.locationHash == null) {
+            this.locationHash = null;
+        } else {
+            this.locationHash = Collections.unmodifiableMap(copyAsLockedFrom.locationHash);
+        }
         locked = true;
     }
 
@@ -105,7 +108,9 @@ public class SimpleXMLSource extends XMLSource {
         result.xpath_comments = (Comments) result.xpath_comments.clone();
         result.xpath_fullXPath = CldrUtility.newConcurrentHashMap(result.xpath_fullXPath);
         result.xpath_value = CldrUtility.newConcurrentHashMap(result.xpath_value);
-        result.locationHash.putAll(result.locationHash);
+        if (result.locationHash != null) {
+            result.locationHash = CldrUtility.newConcurrentHashMap(result.locationHash);
+        }
         return result;
     }
 
@@ -230,12 +235,30 @@ public class SimpleXMLSource extends XMLSource {
         return dtdVersionInfo;
     }
 
-    private Map<String, SourceLocation> locationHash = new HashMap<>();
+    private Map<String, SourceLocation> locationHash = null;
+
+    @Override
+    public
+    XMLSource enableSourceLocation() {
+        if (sourceLocationEnabled()) {
+            locationHash = CldrUtility.newConcurrentHashMap();
+        }
+        return this;
+    }
+
+    @Override
+    public
+    boolean sourceLocationEnabled() {
+        return (locationHash != null);
+    }
 
     @Override
     public XMLSource addSourceLocation(String currentFullXPath, SourceLocation location) {
         if (!isFrozen()) {
-            locationHash.put(currentFullXPath.intern(), location);
+            if (sourceLocationEnabled()) {
+                // may be null if sourceLocation was not requested
+                locationHash.put(currentFullXPath.intern(), location);
+            }
         } else {
             System.err.println("SimpleXMLSource::addSourceLocationAttempt to modify frozen source location");
         }
@@ -244,6 +267,9 @@ public class SimpleXMLSource extends XMLSource {
 
     @Override
     public SourceLocation getSourceLocation(String fullXPath) {
+        if (!sourceLocationEnabled()) {
+            return null;
+        }
         return locationHash.get(fullXPath);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLNormalizingLoader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLNormalizingLoader.java
@@ -312,8 +312,10 @@ public class XMLNormalizingLoader{
                 }
             }
             value = trimWhitespaceSpecial(value);
-            source.add(fullXPath, value)
-            .addSourceLocation(fullXPath, new XMLSource.SourceLocation(documentLocator));
+            source.add(fullXPath, value);
+            if (source.sourceLocationEnabled()) {
+                source.addSourceLocation(fullXPath, new XMLSource.SourceLocation(documentLocator));
+            }
         }
 
         private void pop(String qName) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -102,6 +102,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
          * The toString() format is suitable for printing to the command line
          * and has the format 'file:line:column: '
          */
+        @Override
         public String toString() {
             return toString(null);
         }
@@ -1875,6 +1876,18 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 return true;
             }
         }
+        return false;
+    }
+
+    /**
+     * Enable SourceLocation in this Source. Call this once before populating the XMLSource.
+     * @return
+     */
+    public XMLSource enableSourceLocation() {
+        return this;
+    }
+
+    public boolean sourceLocationEnabled() {
         return false;
     }
 


### PR DESCRIPTION
only enable source location tracking in UNITTEST

reduces memory use and object creation

CLDR-14543

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
