### PR TITLE
CLDR-15206 spec: section numbers outside of anchors, table caption

### DIFF
--- a/docs/ldml/tr35-collation.md
+++ b/docs/ldml/tr35-collation.md
@@ -58,28 +58,28 @@ The LDML specification is divided into the following parts:
 * 3 [Collation Tailorings](#Collation_Tailorings)
   * 3.1 [Collation Types](#Collation_Types)
     * 3.1.1 [Collation Type Fallback](#Collation_Type_Fallback)
-      * [Sample requested and actual collation locales and types](#Sample_requested_and_actual_collation_locales_and_types)
+      * Table: [Sample requested and actual collation locales and types](#Sample_requested_and_actual_collation_locales_and_types)
   * 3.2 [Version](#Collation_Version)
   * 3.3 [Collation Element](#Collation_Element)
   * 3.4 [Setting Options](#Setting_Options)
-    * [Collation Settings](#Collation_Settings)
+    * Table: [Collation Settings](#Collation_Settings)
     * 3.4.1 [Common settings combinations](#Common_Settings)
     * 3.4.2 [Notes on the normalization setting](#Normalization_Setting)
     * 3.4.3 [Notes on variable top settings](#Variable_Top_Settings)
   * 3.5 [Collation Rule Syntax](#Rules)
   * 3.6 [Orderings](#Orderings)
-    * [Specifying Collation Ordering](#Specifying_Collation_Ordering)
-    * [Abbreviating Ordering Specifications](#Abbreviating_Ordering_Specifications)
+    * Table: [Specifying Collation Ordering](#Specifying_Collation_Ordering)
+    * Table: [Abbreviating Ordering Specifications](#Abbreviating_Ordering_Specifications)
   * 3.7 [Contractions](#Contractions)
-    * [Specifying Contractions](#Specifying_Contractions)
+    * Table: [Specifying Contractions](#Specifying_Contractions)
   * 3.8 [Expansions](#Expansions)
   * 3.9 [Context Before](#Context_Before)
-    * [Specifying Previous Context](#Specifying_Previous_Context)
+    * Table: [Specifying Previous Context](#Specifying_Previous_Context)
   * 3.10 [Placing Characters Before Others](#Placing_Characters_Before_Others)
   * 3.11 [Logical Reset Positions](#Logical_Reset_Positions)
-    * [Specifying Logical Positions](#Specifying_Logical_Positions)
+    * Table: [Specifying Logical Positions](#Specifying_Logical_Positions)
   * 3.12 [Special-Purpose Commands](#Special_Purpose_Commands)
-    * [Special-Purpose Elements](#Special_Purpose_Elements)
+    * Table: [Special-Purpose Elements](#Special_Purpose_Elements)
   * 3.13 [Collation Reordering](#Script_Reordering)
     * 3.13.1 [Interpretation of a reordering list](#Interpretation_reordering)
     * 3.13.2 [Reordering Groups for allkeys.txt](#Reordering_Groups_allkeys)
@@ -572,7 +572,7 @@ For example, assume that we have collation data for the following tailorings. ("
 * zh/stroke
 * zh-Hant/defaultCollation=stroke
 
-###### <a name="Sample_requested_and_actual_collation_locales_and_types" href="#Sample_requested_and_actual_collation_locales_and_types">Sample requested and actual collation locales and types</a>
+###### Table: <a name="Sample_requested_and_actual_collation_locales_and_types" href="#Sample_requested_and_actual_collation_locales_and_types">Sample requested and actual collation locales and types</a>
 
 | requested         | actual        | comment |
 | ----------------- | ------------- | ------- |
@@ -615,7 +615,7 @@ Parametric settings can be specified in language tags or in rule syntax (in the 
 
 If a setting is not present, the CLDR default (or the default for the locale, if there is one) is used. That default is listed in bold italics. Where there is a UCA default that is different, it is listed in bold with (**UCA default**). Note that the default value for a locale may be different than the normal default value for the setting.
 
-###### <a name="Collation_Settings" href="#Collation_Settings">Collation Settings</a>
+###### Table: <a name="Collation_Settings" href="#Collation_Settings">Collation Settings</a>
 
 <table><tbody>
 <tr><th>BCP47 Key</th><th>BCP47 Value</th><th>Rule Syntax</th><th>Description</th></tr>
@@ -730,7 +730,7 @@ The root collation mappings form the initial state. Mappings are added and remov
 
 A rule chain consists of a reset followed by one or more relations. The reset position is a string which maps to one or more collation elements according to the current state. A relation consists of an operator and a string; it maps the string to the current collation elements, modified according to the operator.
 
-###### <a name="Specifying_Collation_Ordering" href="#Specifying_Collation_Ordering">Specifying Collation Ordering</a>
+###### Table: <a name="Specifying_Collation_Ordering" href="#Specifying_Collation_Ordering">Specifying Collation Ordering</a>
 
 | Relation Operator | Example | Description |
 | ----------------- | ------- | ----------- |
@@ -777,7 +777,7 @@ Some additional operators are provided to save space with large tailorings. The 
 
 A starred relation operator is followed by a sequence of characters with the same quoting/escaping rules as normal relation strings. Such a sequence can also be followed by one or more pairs of ‘-’ and another sequence of characters. The single characters adjacent to the ‘-’ establish a code point order range. The same character cannot be both the end of a range and the start of another range. (For example, `<a-d-g` is not allowed.)
 
-###### <a name="Abbreviating_Ordering_Specifications" href="#Abbreviating_Ordering_Specifications">Abbreviating Ordering Specifications</a>
+###### Table: <a name="Abbreviating_Ordering_Specifications" href="#Abbreviating_Ordering_Specifications">Abbreviating Ordering Specifications</a>
 
 | Relation Operator | Example                 | Equivalent |
 | ----------------- | ----------------------- | ---------- |
@@ -791,7 +791,7 @@ A starred relation operator is followed by a sequence of characters with the sam
 
 A multi-character relation string defines a contraction.
 
-###### <a name="Specifying_Contractions" href="#Specifying_Contractions">Specifying Contractions</a>
+###### Table: <a name="Specifying_Contractions" href="#Specifying_Contractions">Specifying Contractions</a>
 
 | Example          | Description |
 | ---------------- | ----------- |
@@ -817,7 +817,7 @@ A relation string can have a prefix (context before) which makes the mapping fro
 
 For example, suppose that "-" is sorted like the previous vowel. Then one could have rules that take "a-", "e-", and so on. However, that means that every time a very common character (a, e, ...) is encountered, a system will slow down as it looks for possible contractions. An alternative is to indicate that when "-" is encountered, and it comes after an 'a', it sorts like an 'a', and so on.
 
-###### <a name="Specifying_Previous_Context" href="#Specifying_Previous_Context">Specifying Previous Context</a>
+###### Table: <a name="Specifying_Previous_Context" href="#Specifying_Previous_Context">Specifying Previous Context</a>
 
 | Rules |
 | ----- |
@@ -846,7 +846,7 @@ It is an error if the strength of the reset-before differs from the strength of 
 
 The CLDR table (based on UCA) has the following overall structure for weights, going from low to high.
 
-###### <a name="Specifying_Logical_Positions" href="#Specifying_Logical_Positions">Specifying Logical Positions</a>
+###### Table: <a name="Specifying_Logical_Positions" href="#Specifying_Logical_Positions">Specifying Logical Positions</a>
 
 | Name                                                           | Description      | UCA Examples |
 | -------------------------------------------------------------- | ---------------- | ------------ |
@@ -893,7 +893,7 @@ _Examples:_
 * `[import und-u-co-search]` (not "root-...")
 * `[import ja-u-co-private-kana]` (language "ja" required even when this import itself is in another "ja" tailoring.)
 
-###### <a name="Special_Purpose_Elements" href="#Special_Purpose_Elements">Special-Purpose Elements</a>
+###### Table: <a name="Special_Purpose_Elements" href="#Special_Purpose_Elements">Special-Purpose Elements</a>
 
 | Rule Syntax |
 | ----------- |

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -47,26 +47,26 @@ The LDML specification is divided into the following parts:
   * 2.5 [Element timeFormats](#timeFormats)
   * 2.6 [Element dateTimeFormats](#dateTimeFormats)
     * 2.6.1 [Element dateTimeFormat](#dateTimeFormat)
-      * [Date-Time Combination Examples](#Date_Time_Combination_Examples)
+      * Table: [Date-Time Combination Examples](#Date_Time_Combination_Examples)
     * 2.6.2 [Elements availableFormats, appendItems](#availableFormats_appendItems)
-      * [Mapping Requested Time Skeletons To Patterns](#Mapping_Requested_Time_Skeletons_To_Patterns)
-      * [2.6.2.1 Matching Skeletons](#Matching_Skeletons)
-      * [2.6.2.2 Missing Skeleton Fields](#Missing_Skeleton_Fields)
+      * Table: [Mapping Requested Time Skeletons To Patterns](#Mapping_Requested_Time_Skeletons_To_Patterns)
+      * 2.6.2.1 [Matching Skeletons](#Matching_Skeletons)
+      * 2.6.2.2 [Missing Skeleton Fields](#Missing_Skeleton_Fields)
     * 2.6.3 [Element intervalFormats](#intervalFormats)
 * 3 [Calendar Fields](#Calendar_Fields)
 * 4 [Supplemental Calendar Data](#Supplemental_Calendar_Data)
   * 4.1 [Calendar Data](#Calendar_Data)
   * 4.2 [Calendar Preference Data](#Calendar_Preference_Data)
   * 4.3 [Week Data](#Week_Data)
-    * [Week Designation Types](#Week_Designation_Types)
+    * Table: [Week Designation Types](#Week_Designation_Types)
   * 4.4 [Time Data](#Time_Data)
   * 4.5 [Day Period Rule Sets](#Day_Period_Rule_Sets)
     * 4.5.1 [Day Period Rules](#Day_Period_Rules)
-      * [4.5.1.1 Fixed periods](#Fixed_periods)
-      * [4.5.1.2 Variable periods](#Variable_periods)
-      * [4.5.1.3 Parsing Day Periods](#Parsing_Day_Periods)
+      * 4.5.1.1 [Fixed periods](#Fixed_periods)
+      * 4.5.1.2 [Variable periods](#Variable_periods)
+      * 4.5.1.3 [Parsing Day Periods](#Parsing_Day_Periods)
 * 5 [Time Zone Names](#Time_Zone_Names)
-  * [<timeZoneNames> Elements Used for Fallback](#timeZoneNames_Elements_Used_for_Fallback)
+  * Table: [<timeZoneNames> Elements Used for Fallback](#timeZoneNames_Elements_Used_for_Fallback)
   * 5.1 [Metazone Names](#Metazone_Names)
 * 6 [Supplemental Time Zone Data](#Supplemental_Time_Zone_Data)
   * 6.1 [Metazones](#Metazones)
@@ -77,8 +77,8 @@ The LDML specification is divided into the following parts:
   * 7.2 [Goals](#Time_Zone_Goals)
   * 7.3 [Parsing](#Time_Zone_Parsing)
 * 8 [Date Format Patterns](#Date_Format_Patterns)
-  * [Date Format Pattern Examples](#Date_Format_Pattern_Examples)
-  * [Date Field Symbol Table](#Date_Field_Symbol_Table)
+  * Table: [Date Format Pattern Examples](#Date_Format_Pattern_Examples)
+  * Table: [Date Field Symbol Table](#Date_Field_Symbol_Table)
   * 8.1 [Localized Pattern Characters (deprecated)](#Localized_Pattern_Characters)
   * 8.2 [AM / PM](#Date_Patterns_AM_PM)
   * 8.3 [Eras](#Date_Patterns_Eras)
@@ -629,7 +629,7 @@ The `dateTimeFormat` element works like the dateFormats and timeFormats, except 
 
 When combining a standard date pattern with a standard time pattern, the type of dateTimeFormat used to combine them is determined by the type of the date pattern. For example:
 
-###### <a name="Date_Time_Combination_Examples" href="#Date_Time_Combination_Examples">Date-Time Combination Examples</a>
+###### Table: <a name="Date_Time_Combination_Examples" href="#Date_Time_Combination_Examples">Date-Time Combination Examples</a>
 
 | Date-Time Combination   | dateTimeFormat            | Results |
 | ----------------------- | ------------------------- | ------- |
@@ -672,7 +672,7 @@ Locales that use 12-hour-cycle time formats with B may provide availableFormats 
 
 When matching a requested skeleton containing b or B to the skeletons actually available in the data, if there is no skeleton matching the specified day period field, then find a match in which the b or B matches an explicit or implicit 'a' in the skeleton, but replace the 'a' in the corresponding pattern with the requested day period b or B. The following table illustrates how requested skeletons map to patterns with different sets of `availableFormats` data:
 
-###### <a name="Mapping_Requested_Time_Skeletons_To_Patterns" href="#Mapping_Requested_Time_Skeletons_To_Patterns">Mapping Requested Time Skeletons To Patterns</a>
+###### Table: <a name="Mapping_Requested_Time_Skeletons_To_Patterns" href="#Mapping_Requested_Time_Skeletons_To_Patterns">Mapping Requested Time Skeletons To Patterns</a>
 
 <!-- HTML: spanning columns, header cells on non-first row -->
 <table><tbody>
@@ -693,7 +693,7 @@ The hour input skeleton symbols 'j', 'J', and 'C' can be used to select the best
 
 The dateFormatItems inherit from their parent locale, so the inherited items need to be considered when processing.
 
-##### <a name="Matching_Skeletons" href="#Matching_Skeletons">2.6.2.1 Matching Skeletons</a>
+##### 2.6.2.1 <a name="Matching_Skeletons" href="#Matching_Skeletons">Matching Skeletons</a>
 
 It is not necessary to supply `dateFormatItem`s with skeletons for every field length; fields in the skeleton and pattern are expected to be adjusted in parallel to handle a request.
 
@@ -736,7 +736,7 @@ If this is the best match for a requested skeleton yMMMM, automatic expansion sh
 
 If the requested skeleton included both seconds and fractional seconds and the dateFormatItem skeleton included seconds but not fractional seconds, then the seconds field of the corresponding pattern should be adjusted by appending the locale’s decimal separator, followed by the sequence of ‘S’ characters from the requested skeleton.
 
-##### <a name="Missing_Skeleton_Fields" href="#Missing_Skeleton_Fields">2.6.2.2 Missing Skeleton Fields</a>
+##### 2.6.2.2 <a name="Missing_Skeleton_Fields" href="#Missing_Skeleton_Fields">Missing Skeleton Fields</a>
 
 If a client-requested set of fields includes both date and time fields, and if the `availableFormats` data does not include a `dateFormatItem` whose skeleton matches the same set of fields, then the request should be handled as follows:
 
@@ -1067,7 +1067,7 @@ What is meant by the weekend varies from country to country. It is typically whe
 
 Each `weekOfPreference` element provides, for its specified locales, an ordered list of the preferred types of week designations for that set of locales. There are four types of week designations, each of which makes use of date patterns available in the locale, as follows:
 
-###### <a name="Week_Designation_Types" href="#Week_Designation_Types">Week Designation Types</a>
+###### Table: <a name="Week_Designation_Types" href="#Week_Designation_Types">Week Designation Types</a>
 
 <!-- HTML: row spans -->
 <table><tbody>
@@ -1169,7 +1169,7 @@ As with plurals, the exact set of periods used for any language may be different
 
 Here are the requirements for a rule set.
 
-##### <a name="Fixed_periods" href="#Fixed_periods">4.5.1.1 Fixed periods</a>
+##### 4.5.1.1 <a name="Fixed_periods" href="#Fixed_periods">Fixed periods</a>
 
 There are 4 dayPeriods that are fixed; am/pm are always defined, and always have the same meaning and definition for every locale. Midnight and noon are optional, however if they are defined, they have the same meaning and definition as in all other locales where they are defined.
 
@@ -1188,7 +1188,7 @@ All locales must support am/pm, but not all support **noon** or **midnight**; th
 
 It is strongly recommended that implementations provide for the ability to specify whether **midnight** is supported or not (and for either 00:00 or 24:00 or both), since only the caller knows enough of the context to determine what to use. In the absence of such information, 24:00 may be the best choice.
 
-##### <a name="Variable_periods" href="#Variable_periods">4.5.1.2 Variable periods</a>
+##### 4.5.1.2 <a name="Variable_periods" href="#Variable_periods">Variable periods</a>
 
 1. If a locale has a set of dayPeriodRules for variable periods, it needs to completely cover the 24 hours in a day (from 0:00 before 24:00), with **no** overlaps between any dayPeriodRules. They may overlap with the **Fixed Periods**.
    If it does not have a rule set for variable periods, behavior should fall back to using the fixed periods (am, pm).
@@ -1207,7 +1207,7 @@ It is strongly recommended that implementations provide for the ability to speci
      * `<dayPeriod type = "night1" from="21:00" to="24:00"/>`
 9. 24:00 is _only_ allowed in _before_="24:00".
 
-##### <a name="Parsing_Day_Periods" href="#Parsing_Day_Periods">4.5.1.3 Parsing Day Periods</a>
+##### 4.5.1.3 <a name="Parsing_Day_Periods" href="#Parsing_Day_Periods">Parsing Day Periods</a>
 
 When parsing, if the hour is present with a strict parse the dayperiod is checked for consistency with the hour. If there is no hour, the center of the first matching dayPeriodRule can be chosen (starting from 0:00). However, if there is other information available when parsing, a different point within the interval may be chosen.
 
@@ -1330,7 +1330,7 @@ For more information, see [[Data Formats](tr35.md#DataFormats)].
 
 The following subelements of `<timeZoneNames>` are used to control the fallback process described in [Using Time Zone Names](#Using_Time_Zone_Names).
 
-###### <a name="timeZoneNames_Elements_Used_for_Fallback" href="#timeZoneNames_Elements_Used_for_Fallback">&lt;timeZoneNames&gt; Elements Used for Fallback</a>
+###### Table: <a name="timeZoneNames_Elements_Used_for_Fallback" href="#timeZoneNames_Elements_Used_for_Fallback">&lt;timeZoneNames&gt; Elements Used for Fallback</a>
 
 <table><tbody>
 <tr><th>Element Name</th><th>Data Examples</th><th>Results/Comment</th></tr>
@@ -1851,7 +1851,7 @@ A date pattern is a character string consisting of two types of elements:
 
 The following are examples:
 
-###### <a name="Date_Format_Pattern_Examples" href="#Date_Format_Pattern_Examples">Date Format Pattern Examples</a>
+###### Table: <a name="Date_Format_Pattern_Examples" href="#Date_Format_Pattern_Examples">Date Format Pattern Examples</a>
 
 | Pattern | Result (in a particular locale) |
 | ------- | ------------------------------- |
@@ -1902,7 +1902,7 @@ Notes for the table below:
 * Any sequence of pattern characters other than those listed below is invalid. Invalid pattern fields should be handled for formatting and parsing as described in [Handling Invalid Patterns](tr35.md#Invalid_Patterns).
 * The examples in the table below are merely illustrative and may not reflect current actual data.
 
-###### <a name="Date_Field_Symbol_Table" href="#Date_Field_Symbol_Table">Date Field Symbol Table</a>
+###### Table: <a name="Date_Field_Symbol_Table" href="#Date_Field_Symbol_Table">Date Field Symbol Table</a>
 
 <!-- HTML: spanned rows, spanned columns, vertical header cells -->
 <table><tbody>

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -92,26 +92,26 @@ The LDML specification is divided into the following parts:
 * 11 [List Patterns](#ListPatterns)
   * 11.1 [Gender of Lists](#List_Gender)
 * 12 [ContextTransform Elements](#Context_Transform_Elements)
-  * [Element contextTransformUsage type attribute values](#contextTransformUsage_type_attribute_values)
+  * Table: [Element contextTransformUsage type attribute values](#contextTransformUsage_type_attribute_values)
 * 13 [Choice Patterns](#Choice_Patterns)
 * 14 [Annotations and Labels](#Annotations)
   * 14.1 [Synthesizing Sequence Names](#SynthesizingNames)
-    * [Synthesized Emoji Sequence Names](#synthesized-emoji-sequence-names)
+    * [Table: Synthesized Emoji Sequence Names](#table-synthesized-emoji-sequence-names)
   * 14.2 [Annotations Character Labels](#Character_Labels)
-    * [characterLabelPattern](#characterlabelpattern)
-    * [characterLabel](#characterlabel)
+    * [Table: characterLabelPattern](#table-characterlabelpattern)
+    * [Table: characterLabel](#table-characterlabel)
   * 14.3 [Typographic Names](#Typographic_Names)
 * 15 [Grammatical Features](#Grammatical_Features)
 * [Features](#features)
   * 15.1 [Gender](#Gender)
     * [Example](#example)
-    * [Values](#values)
+    * [Table: Values](#table-values)
   * 15.2 [Case](#Case)
-    * [Case](#case)
+    * [Table: Case](#table-case)
       * [Example](#example)
-      * [Values](#values)
+        * [Table: Values](#table-values)
   * [Definiteness](#definiteness)
-    * [Values](#values)
+    * [Table: Values](#table-values)
 * 16 [Grammatical Derivations](#Grammatical_Derivations)
   * 16.1 [Deriving the Gender of Compound Units](#gender_compound_units)
   * 16.2 [Deriving the Plural Category of Unit Components](#plural_compound_units)
@@ -2351,7 +2351,7 @@ Example:
 </contextTransforms>
 ```
 
-###### <a name="contextTransformUsage_type_attribute_values" href="#contextTransformUsage_type_attribute_values">Element contextTransformUsage type attribute values</a>
+###### Table: <a name="contextTransformUsage_type_attribute_values" href="#contextTransformUsage_type_attribute_values">Element contextTransformUsage type attribute values</a>
 
 | type attribute value             | Description |
 | -------------------------------- | ----------- |
@@ -2479,7 +2479,7 @@ The synthesized keywords can follow a similar process.
 
 Some examples for English data (v30) are given in the following table.
 
-###### Synthesized Emoji Sequence Names
+###### Table: Synthesized Emoji Sequence Names
 
 | Sequence | Short Name | Keywords |
 | --------- | ---------- | -------- |
@@ -2533,7 +2533,7 @@ The character labels can be used for categories or groups of characters in a cha
 
 The following are special patterns used in composing labels.
 
-###### characterLabelPattern
+###### Table: characterLabelPattern
 
 | Type          | English             | Description of the group specified. |
 | ------------- | ------------------- | ----------------------------------- |
@@ -2552,7 +2552,7 @@ The following are special patterns used in composing labels.
 
 The following are character labels. Where the meaning of the label is fairly clear (like "animal") or is in the Unicode glossary, it is omitted.
 
-###### characterLabel
+###### Table: characterLabel
 
 | Type                        | English                 | Description of the group specified. |
 | --------------------------- | ----------------------- | ----------------------------------- |
@@ -2677,14 +2677,14 @@ The @scope attributes are targeted at messages created by computers, thus a feat
 
 Feature that classifies nouns in classes. This is grammatical gender, which may be assigned on the basis of sex in some languages, but may be completely separate in others. Also used to tag elements in CLDR that should agree with a particular gender of an associated noun. (adapted from: [linguistics-ontology.org/gold/2010/GenderProperty](http://linguistics-ontology.org/gold/2010/GenderProperty))
 
-###### Example
+#### Example
 
 ```xml
 <grammaticalFeatures targets="nominal" locales="es fr it pt">
    <grammaticalGender values="masculine feminine"/>
 ```
 
-#### Values
+#### Table: Values
 
 | Value     | Definition | References |
 | --------- | ---------- | ---------- |
@@ -2698,18 +2698,18 @@ Feature that classifies nouns in classes. This is grammatical gender, which may 
 
 ### 15.2 <a name="Case" href="#Case">Case</a>
 
-#### Case
+#### Table: Case
 
 Feature that encodes the syntactic (and sometimes semantic) relationship of a noun with the other constituents of the sentence. (adapted from [linguistics-ontology.org/gold/2010/CaseProperty](http://linguistics-ontology.org/gold/2010/CaseProperty))
 
-###### Example
+##### Example
 
 ```xml
 <grammaticalFeatures targets="nominal" locales="de">
    <grammaticalCase values="nominative accusative genitive dative"/>
 ```
 
-###### Values
+###### Table: Values
 
 | Value              | Definition | References |
 | ------------------ | ---------- | ---------- |
@@ -2746,7 +2746,7 @@ Feature that encodes the syntactic (and sometimes semantic) relationship of a no
 
 Feature that encodes the fact that a noun has been already mentioned, or is familiar in the discourse. (adapted from [https://glossary.sil.org/term/definiteness](https://glossary.sil.org/term/definiteness) )
 
-#### Values
+#### Table: Values
 
 | Value       | Definition | References |
 | ----------- | ---------- | ---------- |

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -58,7 +58,7 @@ The LDML specification is divided into the following parts:
   * 8.3 [Default Values](#Coverage_Level_Default_Values)
 * 9 [Supplemental Metadata](#Appendix_Supplemental_Metadata)
   * 9.1 [Supplemental Alias Information](#Supplemental_Alias_Information)
-    * [Alias Attribute Values](#Alias_Attribute_Values)
+    * Table: [Alias Attribute Values](#Alias_Attribute_Values)
   * 9.2 ~~[Supplemental Deprecated Information (Deprecated)](#Supplemental_Deprecated_Information)~~
   * 9.3 [Default Content](#Default_Content)
 * 10 [Locale Metadata Elements](#Metadata_Elements)
@@ -690,7 +690,7 @@ This element provides information as to parts of locale IDs that should be subst
 
 Attribute values for the \*Alias values include the following:
 
-###### <a name="Alias_Attribute_Values" href="#Alias_Attribute_Values">Alias Attribute Values</a>
+###### Table: <a name="Alias_Attribute_Values" href="#Alias_Attribute_Values">Alias Attribute Values</a>
 
 | Attribute   | Value         | Description |
 | ----------- | ------------- | ----------- |

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -63,7 +63,7 @@ The LDML specification is divided into the following parts:
   * 5.6 [Element: name](#Element_name)
   * 5.7 [Element: settings](#Element_settings)
   * 5.8 [Element: keyMap](#Element_keyMap)
-    * [Possible Modifier Keys](#Possible_Modifier_Keys)
+    * Table: [Possible Modifier Keys](#Possible_Modifier_Keys)
   * 5.9 [Element: map](#Element_map)
     * 5.9.1 [Elements: flicks, flick](#Element_flicks)
   * 5.10 [Element: import](#Element_import)
@@ -86,7 +86,7 @@ The LDML specification is divided into the following parts:
   * 6.3 [Element: map](#Element_hardwareMap_map)
 * 7 [Invariants](#Invariants)
 * 8 [Data Sources](#Data_Sources)
-  * [Key Map Data Sources](#Key_Map_Data_Sources)
+  * Table: [Key Map Data Sources](#Key_Map_Data_Sources)
 * 9 [Keyboard IDs](#Keyboard_IDs)
   * 9.1 [Principles for Keyboard Ids](#Principles_for_Keyboard_Ids)
 * 10 [Platform Behaviors in Edge Cases](#Platform_Behaviors_in_Edge_Cases)
@@ -547,7 +547,7 @@ Within a combination, the presence of a modifier WITHOUT the '?' suffix indicate
 
 Here is an exhaustive list of all possible modifier keys:
 
-###### <a name="Possible_Modifier_Keys" href="#Possible_Modifier_Keys">Possible Modifier Keys</a>
+###### Table: <a name="Possible_Modifier_Keys" href="#Possible_Modifier_Keys">Possible Modifier Keys</a>
 
 | Modifier Keys |          | Comments                        |
 |---------------|----------|---------------------------------|
@@ -1890,7 +1890,7 @@ Beyond what the DTD imposes, certain other restrictions on the data are imposed 
 
 Here is a list of the data sources used to generate the initial key map layouts:
 
-###### <a name="Key_Map_Data_Sources" href="#Key_Map_Data_Sources">Key Map Data Sources</a>
+###### Table: <a name="Key_Map_Data_Sources" href="#Key_Map_Data_Sources">Key Map Data Sources</a>
 
 | Platform | Source | Notes |
 |----------|--------|-------|

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -50,15 +50,15 @@ The LDML specification is divided into the following parts:
   * 2.6 [Minimal Pairs](#Minimal_Pairs)
 * 3 [Number Format Patterns](#Number_Format_Patterns)
   * 3.1 [Number Patterns](#Number_Patterns)
-    * [Number Pattern Examples](#Number_Pattern_Examples)
+    * Table: [Number Pattern Examples](#Number_Pattern_Examples)
   * 3.2 [Special Pattern Characters](#Special_Pattern_Characters)
-    * [Number Pattern Character Definitions](#Number_Pattern_Character_Definitions)
-    * [Sample Patterns and Results](#Sample_Patterns_and_Results)
+    * Table: [Number Pattern Character Definitions](#Number_Pattern_Character_Definitions)
+    * Table: [Sample Patterns and Results](#Sample_Patterns_and_Results)
     * 3.2.1 [Explicit Plus Signs](#Explicit_Plus)
   * 3.3 [Formatting](#Formatting)
   * 3.4 [Scientific Notation](#sci)
   * 3.5 [Significant Digits](#sigdig)
-    * [Significant Digits Examples](#Significant_Digits_Examples)
+    * Table: [Significant Digits Examples](#Significant_Digits_Examples)
   * 3.6 [Padding](#Padding)
   * 3.7 [Rounding](#Rounding)
   * 3.8 [Quoting Rules](#Quoting_Rules)
@@ -68,13 +68,13 @@ The LDML specification is divided into the following parts:
   * [Explicit 0 and 1 rules](#Explicit_0_1_rules)
   * 5.1 [Plural rules syntax](#Plural_rules_syntax)
     * 5.1.1 [Operands](#Operands)
-      * [Plural Operand Meanings](#Plural_Operand_Meanings)
-      * [Plural Operand Examples](#Plural_Operand_Examples)
+      * Table: [Plural Operand Meanings](#Plural_Operand_Meanings)
+      * Table: [Plural Operand Examples](#Plural_Operand_Examples)
     * 5.1.2 [Relations](#Relations)
-      * [Relations Examples](#Relations_Examples)
-      * [Plural Rules Examples](#Plural_Rules_Examples)
+      * Table: [Relations Examples](#Relations_Examples)
+      * Table: [Plural Rules Examples](#Plural_Rules_Examples)
     * 5.1.3 [Samples](#Samples)
-      * [Plural Samples Examples](#Plural_Samples_Examples)
+      * Table: [Plural Samples Examples](#Plural_Samples_Examples)
     * 5.1.4 [Using Cardinals](#Using_cardinals)
   * 5.2 [Plural Ranges](#Plural_Ranges)
 * 6 [Rule-Based Number Formatting](#Rule-Based_Number_Formatting)
@@ -525,7 +525,7 @@ For more information, see [Plural Rules](http://cldr.unicode.org/index/cldr-spec
 
 Number patterns affect how numbers are interpreted in a localized context. Here are some examples, based on the French locale. The "." shows where the decimal point should go. The "," shows where the thousands separator should go. A "0" indicates zero-padding: if the number is too short, a zero (in the locale's numeric set) will go there. A "#" indicates no padding: if the number is too short, nothing goes there. A "¤" shows where the currency sign will go. The following illustrates the effects of different patterns for the French locale, with the number "1234.567". Notice how the pattern characters ',' and '.' are replaced by the characters appropriate for the locale.
 
-###### <a name="Number_Pattern_Examples" href="#Number_Pattern_Examples">Number Pattern Examples</a>
+###### Table: <a name="Number_Pattern_Examples" href="#Number_Pattern_Examples">Number Pattern Examples</a>
 
 | Pattern | Currency | Text |
 | --- | --- | --- |
@@ -551,7 +551,7 @@ To insert a special character in a pattern as a literal, that is, without any sp
 
 Invalid sequences of special characters (such as “¤¤¤¤¤¤” in current CLDR) should be handled for formatting and parsing as described in [Handling Invalid Patterns](tr35.md#Invalid_Patterns).
 
-###### <a name="Number_Pattern_Character_Definitions" href="#Number_Pattern_Character_Definitions">Number Pattern Character Definitions</a>
+###### Table: <a name="Number_Pattern_Character_Definitions" href="#Number_Pattern_Character_Definitions">Number Pattern Character Definitions</a>
 
 | Symbol | Location | Localized Replacement | Meaning |
 | :-- | :-- | :-- | :-- |
@@ -589,7 +589,7 @@ Decimal|"#,##0¤00"
 
 Below is a sample of patterns, special characters, and results:
 
-###### <a name="Sample_Patterns_and_Results" href="#Sample_Patterns_and_Results">Sample Patterns and Results</a>
+###### Table: <a name="Sample_Patterns_and_Results" href="#Sample_Patterns_and_Results">Sample Patterns and Results</a>
 
 <table><tbody>
 <tr><th>explicit pattern:</th><td colspan="2">0.00;-0.00</td><td colspan="2">0.00;0.00-</td><td colspan="2">0.00+;0.00-</td></tr>
@@ -689,7 +689,7 @@ Numbers in scientific notation are expressed as the product of a mantissa and a 
 
 There are two ways of controlling how many digits are shows: (a) significant digits counts, or (b) integer and fraction digit counts. Integer and fraction digit counts are described above. When a formatter is using significant digits counts, it uses however many integer and fraction digits are required to display the specified number of significant digits. It may ignore min/max integer/fraction digits, or it may use them to the extent possible.
 
-###### <a name="Significant_Digits_Examples" href="#Significant_Digits_Examples">Significant Digits Examples</a>
+###### Table: <a name="Significant_Digits_Examples" href="#Significant_Digits_Examples">Significant Digits Examples</a>
 
 | Pattern | Minimum significant digits | Maximum significant digits | Number | Output |
 | :-- | :-- | :-- | :-- | :-- |
@@ -1122,7 +1122,7 @@ The operands are numeric values corresponding to features of the *source number 
 Note that, contrary to source numbers, operands are treated numerically.
 Although some of them are used to describe insignificant 0s in the source number, any insignificant 0s in the operands themselves are ignored, e.g., f=03 is equivalent to f=3.
 
-###### <a name="Plural_Operand_Meanings" href="#Plural_Operand_Meanings">Plural Operand Meanings</a>
+###### Table: <a name="Plural_Operand_Meanings" href="#Plural_Operand_Meanings">Plural Operand Meanings</a>
 
 | Symbol | Value |
 | --- | --- |
@@ -1139,7 +1139,7 @@ Although some of them are used to describe insignificant 0s in the source number
 So for 1.2c3, the n, i, f, t, v, and w values are the same as those of 1200:  i=1200 and f=0.
 Similarly, 1.2005c3 has i=1200 and f=5 (corresponding to 1200.5).
 
-###### <a name="Plural_Operand_Examples" href="#Plural_Operand_Examples">Plural Operand Examples</a>
+###### Table: <a name="Plural_Operand_Examples" href="#Plural_Operand_Examples">Plural Operand Examples</a>
 
 | source | n | i | v | w | f | t | e |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -1162,7 +1162,7 @@ Similarly, 1.2005c3 has i=1200 and f=5 (corresponding to 1200.5).
 
 The positive relations are of the format **x = y** and **x = y mod z**. The **y** value can be a comma-separated list, such as **n = 3, 5, 7..15**, and is treated as if each relation were expanded into an OR statement. The range value **a..b** is equivalent to listing all the _**integers**_ between **a** and **b**, inclusive. When **!=** is used, it means the entire relation is negated.
 
-###### <a name="Relations_Examples" href="#Relations_Examples">Relations Examples</a>
+###### Table: <a name="Relations_Examples" href="#Relations_Examples">Relations Examples</a>
 
 | Expression | Meaning |
 | --- | --- |
@@ -1191,7 +1191,7 @@ The values of relations are defined according to the operand as follows. Importa
    * if starti ≤ BV ≤ endi then return R.
 7. Otherwise return !R.
 
-###### <a name="Plural_Rules_Examples" href="#Plural_Rules_Examples">Plural Rules Examples</a>
+###### Table: <a name="Plural_Rules_Examples" href="#Plural_Rules_Examples">Plural Rules Examples</a>
 
 | Rules | Comments |
 | --- | --- |
@@ -1209,7 +1209,7 @@ The sampleRanges have a special notation: **start**~**end**. The **start** and *
 
 Samples must indicate whether they are infinite or not. The '…' marker must be present if and only infinitely many values (integer or decimal) can satisfy the rule. If a set is not infinite, it must list all the possible values.
 
-###### <a name="Plural_Samples_Examples" href="#Plural_Samples_Examples">Plural Samples Examples</a>
+###### Table: <a name="Plural_Samples_Examples" href="#Plural_Samples_Examples">Plural Samples Examples</a>
 
 | Rules | Comments |
 | --- | --- |

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -45,109 +45,109 @@ The LDML specification is divided into the following parts:
 
 ## <a name="Contents" href="#Contents">Contents of Part 1, Core</a>
 
-* [1 Introduction](#Introduction)
-  * [1.1 Conformance](#Conformance)
-* [2 What is a Locale?](#Locale)
-* [3 Unicode Language and Locale Identifiers](#Unicode_Language_and_Locale_Identifiers)
+* 1 [Introduction](#Introduction)
+  * 1.1 [Conformance](#Conformance)
+* 2 [What is a Locale?](#Locale)
+* 3 [Unicode Language and Locale Identifiers](#Unicode_Language_and_Locale_Identifiers)
   * _[3.1 Unicode Language Identifier](#Unicode_language_identifier)_
   * _[3.2 Unicode Locale Identifier](#Unicode_locale_identifier)_
-    * [3.2.1 Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers)
-  * [3.3 BCP 47 Conformance](#BCP_47_Conformance)
-    * [3.3.1 BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion)
-      * [BCP 47 Language Tag to Unicode BCP 47 Locale Identifier](#Language_Tag_to_Locale_Identifier)
+    * 3.2.1 [Canonical Unicode Locale Identifiers](#Canonical_Unicode_Locale_Identifiers)
+  * 3.3 [BCP 47 Conformance](#BCP_47_Conformance)
+    * 3.3.1 [BCP 47 Language Tag Conversion](#BCP_47_Language_Tag_Conversion)
+      * Table: [BCP 47 Language Tag to Unicode BCP 47 Locale Identifier](#Language_Tag_to_Locale_Identifier) Examples
       * [Unicode Locale Identifier: CLDR to BCP 47](#Unicode_Locale_Identifier_CLDR_to_BCP_47)
       * [Unicode Locale Identifier: BCP 47 to CLDR](#Unicode_Locale_Identifier_BCP_47_to_CLDR)
       * [Truncation](#truncation)
-  * [3.4 Language Identifier Field Definitions](#Field_Definitions)
+  * 3.4 [Language Identifier Field Definitions](#Field_Definitions)
     * [`unicode_language_subtag`](#unicode_language_subtag_validity) (also known as a _Unicode base language code_)
     * [`unicode_script_subtag`](#unicode_script_subtag_validity) (also known as a _Unicode script code_)
     * [`unicode_region_subtag`](#unicode_region_subtag_validity) (also known as a _Unicode region code,_ or a _Unicode territory code_)
     * [`unicode_variant_subtag`](#unicode_variant_subtag_validity) (also known as a _Unicode language variant code_)
-  * [3.5 Special Codes](#Special_Codes)
-    * [3.5.1 Unknown or Invalid Identifiers](#Unknown_or_Invalid_Identifiers)
-    * [3.5.2 Numeric Codes](#Numeric_Codes)
+  * 3.5 [Special Codes](#Special_Codes)
+    * 3.5.1 [Unknown or Invalid Identifiers](#Unknown_or_Invalid_Identifiers)
+    * 3.5.2 [Numeric Codes](#Numeric_Codes)
     * 3.5.3 [Private Use Codes](#Private_Use_Codes)
-      * [Private Use Codes in CLDR](#Private_Use_CLDR)
-  * [3.6 Unicode BCP 47 U Extension](#u_Extension)
-    * [3.6.1 Key And Type Definitions](#Key_And_Type_Definitions_)
-      * [Key/Type Definitions](#Key_Type_Definitions)
-    * [3.6.2 Numbering System Data](#Numbering%20System%20Data)
-    * [3.6.3 Time Zone Identifiers](#Time_Zone_Identifiers)
-    * [3.6.4 U Extension Data Files](#Unicode_Locale_Extension_Data_Files)
-    * [3.6.5 Subdivision Codes](#Unicode_Subdivision_Codes)
-      * [3.6.5.1 Validity](#Validity)
-  * [3.7 Unicode BCP 47 T Extension](#BCP47_T_Extension)
-    * [3.7.1 T Extension Data Files](#Transformed_Content_Data_File)
-  * [3.8 Compatibility with Older Identifiers](#Compatibility_with_Older_Identifiers)
-    * [3.8.1 Old Locale Extension Syntax](#Old_Locale_Extension_Syntax)
-      * [Locale Extension Mappings](#Locale_Extension_Mappings)
-    * [3.8.2 Legacy Variants](#Legacy_Variants)
-      * [Legacy Variant Mappings](#Legacy_Variant_Mappings)
-    * [3.8.3 Relation to OpenI18n](#Relation_to_OpenI18n)
-  * [3.9 Transmitting Locale Information](#Transmitting_Locale_Information)
-    * [3.9.1 Message Formatting and Exceptions](#Message_Formatting_and_Exceptions)
-  * [3.10 Unicode Language and Locale IDs](#Language_and_Locale_IDs)
-    * [3.10.1 Written Language](#Written_Language)
-    * [3.10.2 Hybrid Locale Identifiers](#Hybrid_Locale)
-  * [3.11 Validity Data](#Validity_Data)
-* [4 Locale Inheritance and Matching](#Locale_Inheritance)
-  * [4.1 Lookup](#Lookup)
-    * [4.1.1 Bundle vs Item Lookup](#Bundle_vs_Item_Lookup)
-      * [Lookup Differences](#Lookup-Differences)
-    * [4.1.2 Lateral Inheritance](#Lateral_Inheritance)
-      * [Count Fallback: normal](#Count_Fallback_normal)
-      * [Count Fallback: currency](#Count_Fallback_currency)
-    * [4.1.3 Parent Locales](#Parent_Locales)
-  * [4.2 Inheritance and Validity](#Inheritance_and_Validity)
-    * [4.2.1 Definitions](#Definitions)
-    * [4.2.2 Resolved Data File](#Resolved_Data_File)
-    * [4.2.3 Valid Data](#Valid_Data)
-    * [4.2.4 Checking for Draft Status](#Checking_for_Draft_Status)
-    * [4.2.5 Keyword and Default Resolution](#Keyword_and_Default_Resolution)
-    * [4.2.6 Inheritance vs Related Information](#Inheritance_vs_Related)
-  * [4.3 Likely Subtags](#Likely_Subtags)
-  * [4.4 Language Matching](#LanguageMatching)
-    * [4.4.1 Enhanced Language Matching](#EnhancedLanguageMatching)
-* [5 XML Format](#XML_Format)
-  * [5.1 Common Elements](#Common_Elements)
-    * [5.1.1 Element special](#special)
-      * [5.1.1.1 Sample Special Elements](#Sample_Special_Elements)
-    * [5.1.2 Element alias](#Alias_Elements)
-      * [Inheritance with `source="locale"`](#Inheritance_with_source_locale_)
-    * [5.1.3 Element displayName](#Element_displayName)
-    * [5.1.4 Escaping Characters](#Escaping_Characters)
-  * [5.2 Common Attributes](#Common_Attributes)
-    * [5.2.1 Attribute type](#Attribute_type)
-    * [5.2.2 Attribute draft](#Attribute_draft)
-    * [5.2.3 Attribute alt](#alt_attribute)
-    * [5.2.4 Attribute references](#references_attribute)
-  * [5.3 Common Structures](#Common_Structures)
-    * [5.3.1 Date and Date Ranges](#Date_Ranges)
-    * [5.3.2 Text Directionality](#Text_Directionality)
-    * [5.3.3 Unicode Sets](#Unicode_Sets)
-      * [5.3.3.1 Lists of Code Points](#Lists_of_Code_Points)
-      * [5.3.3.2 Unicode Properties](#Unicode_Properties)
-      * [5.3.3.3 Boolean Operations](#Boolean_Operations)
-      * [5.3.3.4 UnicodeSet Examples](#UnicodeSet_Examples)
-    * [5.3.4 String Range](#String_Range)
-  * [5.4 Identity Elements](#Identity_Elements)
-  * [5.5 Valid Attribute Values](#Valid_Attribute_Values)
-  * [5.6 Canonical Form](#Canonical_Form)
-    * [5.6.1 Content](#Content)
-    * [5.6.2 Ordering](#Ordering)
-    * [5.6.3 Comments](#Comments)
-  * [5.7 DTD Annotations](#DTD_Annotations)
+      * Table: [Private Use Codes in CLDR](#Private_Use_CLDR)
+  * 3.6 [Unicode BCP 47 U Extension](#u_Extension)
+    * 3.6.1 [Key And Type Definitions](#Key_And_Type_Definitions_)
+      * Table: [Key/Type Definitions](#Key_Type_Definitions)
+    * 3.6.2 [Numbering System Data](#Numbering%20System%20Data)
+    * 3.6.3 [Time Zone Identifiers](#Time_Zone_Identifiers)
+    * 3.6.4 [U Extension Data Files](#Unicode_Locale_Extension_Data_Files)
+    * 3.6.5 [Subdivision Codes](#Unicode_Subdivision_Codes)
+      * 3.6.5.1 [Validity](#Validity)
+  * 3.7 [Unicode BCP 47 T Extension](#BCP47_T_Extension)
+    * 3.7.1 [T Extension Data Files](#Transformed_Content_Data_File)
+  * 3.8 [Compatibility with Older Identifiers](#Compatibility_with_Older_Identifiers)
+    * 3.8.1 [Old Locale Extension Syntax](#Old_Locale_Extension_Syntax)
+      * Table: [Locale Extension Mappings](#Locale_Extension_Mappings)
+    * 3.8.2 [Legacy Variants](#Legacy_Variants)
+      * Table: [Legacy Variant Mappings](#Legacy_Variant_Mappings)
+    * 3.8.3 [Relation to OpenI18n](#Relation_to_OpenI18n)
+  * 3.9 [Transmitting Locale Information](#Transmitting_Locale_Information)
+    * 3.9.1 [Message Formatting and Exceptions](#Message_Formatting_and_Exceptions)
+  * 3.10 [Unicode Language and Locale IDs](#Language_and_Locale_IDs)
+    * 3.10.1 [Written Language](#Written_Language)
+    * 3.10.2 [Hybrid Locale Identifiers](#Hybrid_Locale)
+  * 3.11 [Validity Data](#Validity_Data)
+* 4 [Locale Inheritance and Matching](#Locale_Inheritance)
+  * 4.1 [Lookup](#Lookup)
+    * 4.1.1 [Bundle vs Item Lookup](#Bundle_vs_Item_Lookup)
+      * Table: [Lookup Differences](#Lookup-Differences)
+    * 4.1.2 [Lateral Inheritance](#Lateral_Inheritance)
+      * Table: [Count Fallback: normal](#Count_Fallback_normal)
+      * Table: [Count Fallback: currency](#Count_Fallback_currency)
+    * 4.1.3 [Parent Locales](#Parent_Locales)
+  * 4.2 [Inheritance and Validity](#Inheritance_and_Validity)
+    * 4.2.1 [Definitions](#Definitions)
+    * 4.2.2 [Resolved Data File](#Resolved_Data_File)
+    * 4.2.3 [Valid Data](#Valid_Data)
+    * 4.2.4 [Checking for Draft Status](#Checking_for_Draft_Status)
+    * 4.2.5 [Keyword and Default Resolution](#Keyword_and_Default_Resolution)
+    * 4.2.6 [Inheritance vs Related Information](#Inheritance_vs_Related)
+  * 4.3 [Likely Subtags](#Likely_Subtags)
+  * 4.4 [Language Matching](#LanguageMatching)
+    * 4.4.1 [Enhanced Language Matching](#EnhancedLanguageMatching)
+* 5 [XML Format](#XML_Format)
+  * 5.1 [Common Elements](#Common_Elements)
+    * 5.1.1 [Element special](#special)
+      * 5.1.1.1 [Sample Special Elements](#Sample_Special_Elements)
+    * 5.1.2 [Element alias](#Alias_Elements)
+      * Table: [Inheritance with `source="locale"`](#Inheritance_with_source_locale_)
+    * 5.1.3 [Element displayName](#Element_displayName)
+    * 5.1.4 [Escaping Characters](#Escaping_Characters)
+  * 5.2 [Common Attributes](#Common_Attributes)
+    * 5.2.1 [Attribute type](#Attribute_type)
+    * 5.2.2 [Attribute draft](#Attribute_draft)
+    * 5.2.3 [Attribute alt](#alt_attribute)
+    * 5.2.4 [Attribute references](#references_attribute)
+  * 5.3 [Common Structures](#Common_Structures)
+    * 5.3.1 [Date and Date Ranges](#Date_Ranges)
+    * 5.3.2 [Text Directionality](#Text_Directionality)
+    * 5.3.3 [Unicode Sets](#Unicode_Sets)
+      * 5.3.3.1 [Lists of Code Points](#Lists_of_Code_Points)
+      * 5.3.3.2 [Unicode Properties](#Unicode_Properties)
+      * 5.3.3.3 [Boolean Operations](#Boolean_Operations)
+      * 5.3.3.4 [UnicodeSet Examples](#UnicodeSet_Examples)
+    * 5.3.4 [String Range](#String_Range)
+  * 5.4 [Identity Elements](#Identity_Elements)
+  * 5.5 [Valid Attribute Values](#Valid_Attribute_Values)
+  * 5.6 [Canonical Form](#Canonical_Form)
+    * 5.6.1 [Content](#Content)
+    * 5.6.2 [Ordering](#Ordering)
+    * 5.6.3 [Comments](#Comments)
+  * 5.7 [DTD Annotations](#DTD_Annotations)
     * 5.7.1 [Attribute Value Constraints](#match_expressions)
-* [6 Property Data](#Property_Data)
-  * [6.1 Script Metadata](#Script_Metadata)
-  * [6.2 Extended Pictographic](#Extended_Pictographic)
-  * [6.3 Labels.txt](#Labels.txt)
-  * [6.4 Segmentation Tests](#Segmentation_Tests)
-* [7 Issues in Formatting and Parsing](#Format_Parse_Issues)
-  * [7.1 Lenient Parsing](#Lenient_Parsing)
-    * [7.1.1 Motivation](#Motivation)
-    * [7.1.2 Loose Matching](#Loose_Matching)
-  * [7.2 Handling Invalid Patterns](#Invalid_Patterns)
+* 6 [Property Data](#Property_Data)
+  * 6.1 [Script Metadata](#Script_Metadata)
+  * 6.2 [Extended Pictographic](#Extended_Pictographic)
+  * 6.3 [Labels.txt](#Labels.txt)
+  * 6.4 [Segmentation Tests](#Segmentation_Tests)
+* 7 [Issues in Formatting and Parsing](#Format_Parse_Issues)
+  * 7.1 [Lenient Parsing](#Lenient_Parsing)
+    * 7.1.1 [Motivation](#Motivation)
+    * 7.1.2 [Loose Matching](#Loose_Matching)
+  * 7.2 [Handling Invalid Patterns](#Invalid_Patterns)
 * [Annex A Deprecated Structure](#Deprecated_Structure)
   * [A.1 Element fallback](#Fallback_Elements)
   * [A.2 BCP 47 Keyword Mapping](#BCP47_Keyword_Mapping)
@@ -169,12 +169,12 @@ The LDML specification is divided into the following parts:
   * [A.16 Elements postalCodeData, postCodeRegex](#postCodeElements)
   * [A.17 Element telephoneCodeData](#telephoneCodeData)
 * [Annex B Links to Other Parts](#Links_to_Other_Parts)
-  * [Part 2 Links](#Part_2_Links): [General](tr35-general.md) (display names & transforms, etc.)
-  * [Part 3 Links](#Part_3_Links): [Numbers](tr35-numbers.md) (number & currency formatting)
-  * [Part 4 Links](#Part_4_Links): [Dates](tr35-dates.md) (date, time, time zone formatting)
-  * [Part 5 Links](#Part_5_Links): [Collation](tr35-collation.md) (sorting, searching, grouping)
-  * [Part 6 Links](#Part_6_Links): [Supplemental](tr35-info.md) (supplemental data)
-  * [Part 7 Links](#Part_7_Links): [Keyboards](tr35-keyboards.md) (keyboard mappings)
+  * Table: [Part 2 Links](#Part_2_Links): [General](tr35-general.md) (display names & transforms, etc.)
+  * Table: [Part 3 Links](#Part_3_Links): [Numbers](tr35-numbers.md) (number & currency formatting)
+  * Table: [Part 4 Links](#Part_4_Links): [Dates](tr35-dates.md) (date, time, time zone formatting)
+  * Table: [Part 5 Links](#Part_5_Links): [Collation](tr35-collation.md) (sorting, searching, grouping)
+  * Table: [Part 6 Links](#Part_6_Links): [Supplemental](tr35-info.md) (supplemental data)
+  * Table: [Part 7 Links](#Part_7_Links): [Keyboards](tr35-keyboards.md) (keyboard mappings)
 * [Annex C. LocaleId Canonicalization](#LocaleId_Canonicalization)
   * [Definitions](#definitions)
     * [1. Multimap interpretation](#1.-multimap-interpretation)
@@ -191,7 +191,7 @@ The LDML specification is divided into the following parts:
 * [Acknowledgments](#Acknowledgments)
 * [Modifications](#Modifications)
 
-## <a name="Introduction" href="#Introduction">1 Introduction</a>
+## 1 <a name="Introduction" href="#Introduction">Introduction</a>
 
 Not long ago, computer systems were like separate worlds, isolated from one another. The internet and related events have changed all that. A single system can be built of many different components, hardware and software, all needing to work together. Many different technologies have been important in bridging the gaps; in the internationalization arena, Unicode has provided a lingua franca for communicating textual data. However, there remain differences in the locale data used by different systems.
 
@@ -207,7 +207,7 @@ For more information, see the Common Locale Data Repository project page [[Local
 
 As LDML is an interchange format, it was designed for ease of maintenance and simplicity of transformation into other formats, above efficiency of run-time lookup and use. Implementations should consider converting LDML data into a more compact format prior to use.
 
-### <a name="Conformance" href="#Conformance">1.1 Conformance</a>
+### 1.1 <a name="Conformance" href="#Conformance">Conformance</a>
 
 There are many ways to use the Unicode LDML format and the data in CLDR, and the Unicode Consortium does not restrict the ways in which the format or data are used. However, an implementation may also claim conformance to LDML or to CLDR, as follows:
 
@@ -231,7 +231,7 @@ External specifications may also reference particular components of Unicode loca
 
 
 
-## <a name="Locale" href="#Locale">2 What is a Locale?</a>
+## 2 <a name="Locale" href="#Locale">What is a Locale?</a>
 
 Before diving into the XML structure, it is helpful to describe the model behind the structure. People do not have to subscribe to this model to use data in LDML, but they do need to understand it so that the data can be correctly translated into whatever model their implementation uses.
 
@@ -247,7 +247,7 @@ We will speak of data as being "in locale X". That does not imply that a locale 
 
 
 <a name="Identifiers"></a>
-## <a name="Unicode_Language_and_Locale_Identifiers" href="#Unicode_Language_and_Locale_Identifiers">3 Unicode Language and Locale Identifiers</a>
+## 3 <a name="Unicode_Language_and_Locale_Identifiers" href="#Unicode_Language_and_Locale_Identifiers">Unicode Language and Locale Identifiers</a>
 
 Unicode LDML uses stable identifiers based on [[BCP47](#BCP47)] for distinguishing among languages, locales, regions, currencies, time zones, transforms, and so on. There are many systems for identifiers for these entities. The Unicode LDML identifiers may not match the identifiers used on a particular target system. If so, some process of identifier translation may be required when using LDML data.
 
@@ -340,7 +340,7 @@ The identifiers can vary in case and in the separator characters. The "-" and "\
 
 All identifier field values are case-insensitive. Although case distinctions do not carry any special meaning, an implementation of LDML should use the casing recommendations in [[BCP47](#BCP47)], especially when a Unicode locale identifier is used for locale data exchange in software protocols.
 
-#### <a name="Canonical_Unicode_Locale_Identifiers" href="#Canonical_Unicode_Locale_Identifiers">3.2.1 Canonical Unicode Locale Identifiers</a>
+#### 3.2.1 <a name="Canonical_Unicode_Locale_Identifiers" href="#Canonical_Unicode_Locale_Identifiers">Canonical Unicode Locale Identifiers</a>
 
 A [`unicode_locale_id`](#unicode_locale_id) has _canonical syntax_ when:
 
@@ -388,7 +388,7 @@ Two [`unicode_locale_ids`](#unicode_locale_id) are _equivalent_ when their maxim
 The equivalence relationship may change over time, such as when subtags are deprecated or likely subtag mappings change. For example, if two countries were to merge, then various subtags would become deprecated. These kinds of changes are generally very infrequent.
 
 
-### <a name="BCP_47_Conformance" href="#BCP_47_Conformance">3.3 BCP 47 Conformance</a>
+### 3.3 <a name="BCP_47_Conformance" href="#BCP_47_Conformance">BCP 47 Conformance</a>
 
 Unicode language and locale identifiers inherit the design and the repertoire of subtags from [[BCP47](#BCP47)] Language Tags. There are some extensions and restrictions made for the use of the Unicode locale identifier in CLDR:
 
@@ -409,17 +409,15 @@ There are thus two subtypes of Unicode locale identifiers:
 * the term _Unicode CLDR locale identifier_ applies where the backwards compatibility syntax is used.
 * the term _Unicode BCP 47 locale identifier_ applies otherwise. A _Unicode BCP 47 locale identifier_ is also a valid BCP 47 language tag.
 
-#### <a name="BCP_47_Language_Tag_Conversion" href="#BCP_47_Language_Tag_Conversion">3.3.1 BCP 47 Language Tag Conversion</a>
+#### 3.3.1 <a name="BCP_47_Language_Tag_Conversion" href="#BCP_47_Language_Tag_Conversion">BCP 47 Language Tag Conversion</a>
 
 The different identifiers can be converted to one another as described in this section.
-
-###### <a name="Language_Tag_to_Locale_Identifier" href="#Language_Tag_to_Locale_Identifier">BCP 47 Language Tag to Unicode BCP 47 Locale Identifier</a>
 
 A valid [[BCP47](#BCP47)] language tag can be converted to a valid Unicode BCP 47 locale identifier according to [Annex C. LocaleId Canonicalization](#LocaleId_Canonicalization).
 
 The result is a Unicode BCP 47 locale identifier, in canonical form. It is both a BCP 47 language tag and a Unicode locale identifier. Because the process maps from all BCP 47 language tags into a subset of BCP 47 language tags, the format changes are not reversible, much as a lowercase transformation of the string “McGowan” is not reversible.
 
-_Examples_
+###### Table: <a name="Language_Tag_to_Locale_Identifier" href="#Language_Tag_to_Locale_Identifier">BCP 47 Language Tag to Unicode BCP 47 Locale Identifier</a> Examples
 
 | BCP 47 language tag | Unicode BCP 47 locale identifier | Comments |
 | ------------------- | -------------------------------- | -------- |
@@ -475,7 +473,7 @@ To allow for use of extensions, CLDR extends that minimum to 255 for Unicode loc
 Theoretically, a language tag could be far longer, due to the possibility of a large number of variants and extensions.
 In practice, the typical size of a locale or language identifier will be much smaller, so implementations can optimize for smaller sizes, as long as there is an escape mechanism allowing for up to 255.
 
-### <a name="Field_Definitions" href="#Field_Definitions">3.4 Language Identifier Field Definitions</a>
+### 3.4 <a name="Field_Definitions" href="#Field_Definitions">Language Identifier Field Definitions</a>
 
 Unicode language and locale identifier field values are provided in the following table. Note that some private-use BCP 47 field values are given specific meanings in CLDR. While field values are based on [[BCP47](#BCP47)] subtag values, their validity status in CLDR is specified by means of machine-readable files in the [common/validity/](https://github.com/unicode-org/cldr-staging/tree/main/production/common/validity) subdirectory, such as language.xml. For the format of those files and more information, see _[Section 3.11 Validity Data](#Validity_Data)_.
 
@@ -608,9 +606,9 @@ _Deprecated_ codes—such as QU above—are valid, but strongly discouraged.
 
 A locale that only has a language subtag (and optionally a script subtag) is called a _language locale_; one with both language and territory subtag is called a _territory locale_ (or _country locale_).
 
-### <a name="Special_Codes" href="#Special_Codes">3.5 Special Codes</a>
+### 3.5 <a name="Special_Codes" href="#Special_Codes">Special Codes</a>
 
-#### <a name="Unknown_or_Invalid_Identifiers" href="#Unknown_or_Invalid_Identifiers">3.5.1 Unknown or Invalid Identifiers</a>
+#### 3.5.1 <a name="Unknown_or_Invalid_Identifiers" href="#Unknown_or_Invalid_Identifiers">Unknown or Invalid Identifiers</a>
 
 The following identifiers are used to indicate an unknown or invalid code in Unicode language and locale identifiers. For Unicode identifiers, the region code uses a private use ISO 3166 code, and Time Zone code uses an additional code; the others are defined by the relevant standards. When these codes are used in APIs connected with Unicode identifiers, the meaning is that either there was no identifier available, or that at some point an input identifier value was determined to be invalid or ill-formed.
 
@@ -625,7 +623,7 @@ The following identifiers are used to indicate an unknown or invalid code in Uni
 
 When only the script or region are known, then a locale ID will use "und" as the language subtag portion. Thus the locale tag "und_Grek" represents the Greek script; "und_US" represents the US territory.
 
-#### <a name="Numeric_Codes" href="#Numeric_Codes">3.5.2 Numeric Codes</a>
+#### 3.5.2 <a name="Numeric_Codes" href="#Numeric_Codes">Numeric Codes</a>
 
 For region codes, ISO and the UN establish a mapping to three-letter codes and numeric codes. However, this does not extend to the private use codes, which are the codes 900-999 (total: 100), and AAA, QMA-QZZ, XAA-XZZ, and ZZZ (total: 1092). Unicode identifiers supply a standard mapping to these: for the numeric codes, it uses the top of the numeric private use range; for the 3-letter codes it doubles the final letter. These are the resulting mappings for all of the private use region codes:
 
@@ -650,7 +648,7 @@ Private use codes fall into three groups.
 *   **reserved:** those that may be given particular semantics in future versions of CLDR
 *   **excluded:** those that will never be given particular CLDR semantics in the future, and thus can normally be used by applications without worrying about collisions. However, CLDR may follow widespread industry practice in the use of some of these codes, such as for XA, XB, and XK.
 
-###### <a name="Private_Use_CLDR" href="#Private_Use_CLDR">Private Use Codes in CLDR</a>
+###### Table: <a name="Private_Use_CLDR" href="#Private_Use_CLDR">Private Use Codes in CLDR</a>
 
 | category      | status   | codes |
 | ------------- | -------- | ----- |
@@ -670,7 +668,7 @@ Private use codes fall into three groups.
 See also _Section 3.5.1 [Unknown or Invalid Identifiers](#Unknown_or_Invalid_Identifiers)_.
 
 <a name="Locale_Extension_Key_and_Type_Data"></a>
-### <a name="u_Extension" href="#u_Extension">3.6 Unicode BCP 47 U Extension</a>
+### 3.6 <a name="u_Extension" href="#u_Extension">Unicode BCP 47 U Extension</a>
 
 [[BCP47](#BCP47)] Language Tags provides a mechanism for extending language tags for use in various applications by extension subtags. Each extension subtag is identified by a single alphanumeric character subtag assigned by IANA.
 
@@ -684,7 +682,7 @@ A 'u' extension may contain multiple `attribute` s or `keyword` s as defined in 
 
 _See also [Unicode Extensions for BCP 47](http://cldr.unicode.org/index/bcp47-extension) on the CLDR site._
 
-#### <a name="Key_And_Type_Definitions_" href="#Key_And_Type_Definitions_">3.6.1 Key And Type Definitions</a>
+#### 3.6.1 <a name="Key_And_Type_Definitions_" href="#Key_And_Type_Definitions_">Key And Type Definitions</a>
 
 The following chart contains a set of U extension key values that are currently available, with a description or sampling of the U extension type values. Each category is associated with an XML file in the bcp47 directory.
 
@@ -699,7 +697,7 @@ Note that canonicalization does not change invalid locales to valid locales. For
 
 The BCP 47 form for keys and types is the canonical form, and recommended. Other aliases are included for backwards compatibility.
 
-###### <a name="Key_Type_Definitions" href="#Key_Type_Definitions">Key/Type Definitions</a>
+###### Table: <a name="Key_Type_Definitions" href="#Key_Type_Definitions">Key/Type Definitions</a>
 
 <!-- HTML: rowspan, colspan -->
 <table><tbody>
@@ -885,7 +883,7 @@ For more information on the allowed keys and types, see the specific elements be
 
 Additional keys or types might be added in future versions. Implementations of LDML should be robust to handle any syntactically valid key or type values.
 
-#### <a name="Numbering%20System%20Data" href="#Numbering%20System%20Data">3.6.2 Numbering System Data</a>
+#### 3.6.2 <a name="Numbering%20System%20Data" href="#Numbering%20System%20Data">Numbering System Data</a>
 
 LDML supports multiple numbering systems. The identifiers for those numbering systems are defined in the file **bcp47/number.xml**. For example, for the latest version of the data see [bcp47/number.xml](https://github.com/unicode-org/cldr/tree/main/common/bcp47/number.xml).
 
@@ -898,7 +896,7 @@ LDML makes certain stability guarantees on this data:
     1.  It is a decimal, positional numbering system with an attribute `digits=X`, where `X` is a string with the 10 digits in order used by the numbering system.
     2.  The values of the type and digits will never change.
 
-#### <a name="Time_Zone_Identifiers" href="#Time_Zone_Identifiers">3.6.3 Time Zone Identifiers</a>
+#### 3.6.3 <a name="Time_Zone_Identifiers" href="#Time_Zone_Identifiers">Time Zone Identifiers</a>
 
 LDML inherits time zone IDs from the tz database [[Olson](#Olson)]. Because these IDs from the tz database do not satisfy the BCP 47 language subtag syntax requirements, CLDR defines short identifiers for the use in the Unicode locale extension. The short identifiers are defined in the file **common/bcp47/timezone.xml**.
 
@@ -935,7 +933,7 @@ CLDR doesn't alias across country boundaries because countries are useful for ti
 Even if, for example, Serbia and Croatia share the same rules, CLDR maintains the difference so that the user can either pick "Serbia time" or "Croatia time".
 The Croat is not forced to pick "Serbia time" (Europe/Belgrade) nor the Serb forced to pick “Croatia time” (Europe/Zagreb).
 
-#### <a name="Unicode_Locale_Extension_Data_Files" href="#Unicode_Locale_Extension_Data_Files">3.6.4 U Extension Data Files</a>
+#### 3.6.4 <a name="Unicode_Locale_Extension_Data_Files" href="#Unicode_Locale_Extension_Data_Files">U Extension Data Files</a>
 
 The 'u' extension data is stored in multiple XML files located under common/bcp47 directory in CLDR. Each file contains the locale extension key/type values and their backward compatibility mappings appropriate for a particular domain. [common/bcp47/collation.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/collation.xml) contains key/type values for collation, including optional collation parameters and valid type values for each key.
 
@@ -1093,7 +1091,7 @@ The data above indicates:
 
 It is strongly recommended that all API methods accept all possible aliases for keywords and types, but generate the canonical form. For example, "ar-u-ca-islamicc" would be equivalent to "ar-u-ca-islamic-civil" on input, but the latter should be output. The one exception is where an alias would only be well-formed with the old syntax, such as "gregorian" (for "gregory").
 
-#### <a name="Unicode_Subdivision_Codes" href="#Unicode_Subdivision_Codes">3.6.5 Subdivision Codes</a>
+#### 3.6.5 <a name="Unicode_Subdivision_Codes" href="#Unicode_Subdivision_Codes">Subdivision Codes</a>
 
 The subdivision codes designate a subdivision of a country or region. They are called various names, such as a _state_ in the United States, or a _province_ in Canada. The codes in CLDR are based on ISO 3166-2 subdivision codes. The ISO codes have a region code followed by a hyphen, then a suffix consisting of 1..3 ASCII letters or digits.
 
@@ -1106,7 +1104,7 @@ CLDR has additional subdivision codes. These may start with a 3-digit region cod
 
 Like BCP 47, CLDR requires stable codes, which are not guaranteed for ISO 3166-2 (nor have the ISO 3166-2 codes been stable in the past). If an ISO 3166-2 code is removed, it remains valid (though marked as deprecated) in CLDR. If an ICU 3166-2 code is reused (for the same region), then CLDR will define a new equivalent code using these as 4-character suffixes.
 
-##### <a name="Validity" href="#Validity">3.6.5.1 Validity</a>
+##### 3.6.5.1 <a name="Validity" href="#Validity">Validity</a>
 
 A [unicode_subdivision_id](#unicode_subdivision_id) is only valid when it is present in the subdivision.xml file as described in _Section 3.11 [Validity Data](#Validity_Data)_. The data is in a compressed form, and thus needs to be expanded before such a test is made.
 
@@ -1129,7 +1127,7 @@ Examples:
 In version 28.0, the subdivisions in the validity files used the ISO format, uppercase with a hyphen separating two components, instead of the BCP 47 format.
 
 <a name="t_Extension"></a>
-### <a name="BCP47_T_Extension" href="#BCP47_T_Extension">3.7 Unicode BCP 47 T Extension</a>
+### 3.7 <a name="BCP47_T_Extension" href="#BCP47_T_Extension">Unicode BCP 47 T Extension</a>
 
 The Unicode Consortium has registered and is the maintaining authority for two BCP 47 language tag extensions: the extension 'u' for Unicode locale extension [[RFC6067](#RFC6067)] and extension 't' for transformed content [[RFC6497](#RFC6497)]. The Unicode BCP 47 extension data defines the complete list of valid subtags. While the title of the RFC is “Transformed Content”, the abstract makes it clear that the scope is broader than the term "transformed" might indicate to a casual reader: “including content that has been transliterated, transcribed, or translated, or _in some other way influenced by the source. It also provides for additional information used for identification._”
 
@@ -1149,7 +1147,7 @@ The following keys are defined for the -t- extension:
 | h0     | **Hybrid Locale Identifiers:** h0 with the value 'hybrid' indicates that the -t- value is a language that is mixed into the main language tag to form a hybrid. For more information, and examples, see _Section 3.10.2 [Hybrid Locale Identifiers](#Hybrid_Locale)._ | [​transform_hybrid.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_hybrid.xml) |
 | x0     | **Private use transform** | [​transform_private_use.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform_private_use.xml) |
 
-#### <a name="Transformed_Content_Data_File" href="#Transformed_Content_Data_File">3.7.1 T Extension Data Files</a>
+#### 3.7.1 <a name="Transformed_Content_Data_File" href="#Transformed_Content_Data_File">T Extension Data Files</a>
 
 The overall structure of the data files is the similar to the U Extension, with the following exceptions.
 
@@ -1187,11 +1185,11 @@ The attributes are:
 
 For information about the registration process, meaning, and usage of the 't' extension, see [[RFC6497](#RFC6497)].
 
-### <a name="Compatibility_with_Older_Identifiers" href="#Compatibility_with_Older_Identifiers">3.8 Compatibility with Older Identifiers</a>
+### 3.8 <a name="Compatibility_with_Older_Identifiers" href="#Compatibility_with_Older_Identifiers">Compatibility with Older Identifiers</a>
 
 LDML version before 1.7.2 used slightly different syntax for variant subtags and locale extensions. Implementations of LDML may provide backward compatible identifier support as described in following sections.
 
-#### <a name="Old_Locale_Extension_Syntax" href="#Old_Locale_Extension_Syntax">3.8.1 Old Locale Extension Syntax</a>
+#### 3.8.1 <a name="Old_Locale_Extension_Syntax" href="#Old_Locale_Extension_Syntax">Old Locale Extension Syntax</a>
 
 LDML 1.7 or older specification used different syntax for representing Unicode locale extensions. The previous definition of Unicode locale extensions had the following structure:
 
@@ -1205,7 +1203,7 @@ The new specification introduced a new field `attribute` in addition to key/type
 
 The chart below shows some example mappings between the new syntax and the old syntax.
 
-###### <a name="Locale_Extension_Mappings" href="#Locale_Extension_Mappings">Locale Extension Mappings</a>
+###### Table: <a name="Locale_Extension_Mappings" href="#Locale_Extension_Mappings">Locale Extension Mappings</a>
 
 | Old (LDML 1.7 or older)                    | New                          |
 | ------------------------------------------ | ---------------------------- |
@@ -1225,11 +1223,11 @@ Where the old API is supplied the bcp47 language code, or vice versa, the recomm
    2. **valid** - well-formed and only uses registered language subtags, extensions, keywords, types...
    3. **canonical** - valid and no deprecated codes or structure.
 
-#### <a name="Legacy_Variants" href="#Legacy_Variants">3.8.2 Legacy Variants</a>
+#### 3.8.2 <a name="Legacy_Variants" href="#Legacy_Variants">Legacy Variants</a>
 
 Old LDML specification allowed codes other than registered [[BCP47](#BCP47)] variant subtags used in Unicode language and locale identifiers for representing variations of locale data. Unicode locale identifiers including such variant codes can be converted to the new [[BCP47](#BCP47)] compatible identifiers by following the descriptions below:
 
-###### <a name="Legacy_Variant_Mappings" href="#Legacy_Variant_Mappings">Legacy Variant Mappings</a>
+###### Table: <a name="Legacy_Variant_Mappings" href="#Legacy_Variant_Mappings">Legacy Variant Mappings</a>
 
 | Variant Code | Description |
 | ------------ | ----------- |
@@ -1251,7 +1249,7 @@ Examples:
 
 > :point_right: Note that the mapping between `en_US_POSIX` and `en-US-u-va-posix` is a conversion process, not a canonicalization process.
 
-#### <a name="Relation_to_OpenI18n" href="#Relation_to_OpenI18n">3.8.3 Relation to OpenI18n</a>
+#### 3.8.3 <a name="Relation_to_OpenI18n" href="#Relation_to_OpenI18n">Relation to OpenI18n</a>
 
 The locale id format generally follows the description in the _OpenI18N Locale Naming Guideline_ [[NamingGuideline](#NamingGuideline)], with some enhancements. The main differences from those guidelines are that the locale id:
 
@@ -1260,7 +1258,7 @@ The locale id format generally follows the description in the _OpenI18N Locale N
 3. adds the ability to discriminate the written language by script (or script variant).
 4. is a superset of [[BCP47](#BCP47)] codes.
 
-### <a name="Transmitting_Locale_Information" href="#Transmitting_Locale_Information">3.9 Transmitting Locale Information</a>
+### 3.9 <a name="Transmitting_Locale_Information" href="#Transmitting_Locale_Information">Transmitting Locale Information</a>
 
 In a world of on-demand software components, with arbitrary connections between those components, it is important to get a sense of where localization should be done, and how to transmit enough information so that it can be done at that appropriate place. End-users need to get messages localized to their languages, messages that not only contain a translation of text, but also contain variables such as date, time, number formats, and currencies formatted according to the users' conventions. The strategy for doing the so-called _JIT localization_ is made up of two parts:
 
@@ -1278,7 +1276,7 @@ Moreover, the closer we are to end-user, the more we know about that user's pref
 
 Even though localization should be done as close to the end-user as possible, there will be cases where different components need to be aware of whatever settings are appropriate for doing the localization. Thus information such as a locale code or time zone needs to be communicated between different components.
 
-#### <a name="Message_Formatting_and_Exceptions" href="#Message_Formatting_and_Exceptions">3.9.1 Message Formatting and Exceptions</a>
+#### 3.9.1 <a name="Message_Formatting_and_Exceptions" href="#Message_Formatting_and_Exceptions">Message Formatting and Exceptions</a>
 
 Windows ([FormatMessage](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage), [String.Format](https://docs.microsoft.com/en-us/dotnet/api/system.string.format)), Java ([MessageFormat](https://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html)) and ICU ([MessageFormat](http://www.icu-project.org/apiref/icu4c/classMessageFormat.html), [umsg](http://www.icu-project.org/apiref/icu4c/umsg_8h.html)) all provide methods of formatting variables (dates, times, etc) and inserting them at arbitrary positions in a string. This avoids the manual string concatenation that causes severe problems for localization. The question is, where to do this? It is especially important since the original code site that originates a particular message may be far down in the bowels of a component, and passed up to the top of the component with an exception. So we will take that case as representative of this class of issues.
 
@@ -1288,7 +1286,7 @@ More often, the exact messages that could originate from within the component ar
 
 In addition, exceptions are often caught at a higher level; they do not end up being displayed to any end-user at all. By avoiding the localization at the throw site, it the cost of doing formatting, when that formatting is not really necessary. In fact, in many running programs most of the exceptions that are thrown at a low level never end up being presented to an end-user, so this can have considerable performance benefits.
 
-### <a name="Language_and_Locale_IDs" href="#Language_and_Locale_IDs">3.10 Unicode Language and Locale IDs</a>
+### 3.10 <a name="Language_and_Locale_IDs" href="#Language_and_Locale_IDs">Unicode Language and Locale IDs</a>
 
 People have very slippery notions of what distinguishes a language code versus a locale code. The problem is that both are somewhat nebulous concepts.
 
@@ -1302,7 +1300,7 @@ As far as we are concerned — _as a completely practical matter_ — two langua
 
 Notice also that _currency codes_ are different than _currency localizations_. The currency localizations should largely be in the language-based resource bundles, not in the territory-based resource bundles. Thus, the resource bundle _en_ contains the localized mappings in English for a range of different currency codes: USD → US$, RUR → Rub, AUD → $A and so on. Of course, some currency symbols are used for more than one currency, and in such cases specializations appear in the territory-based bundles. Continuing the example, _en_US_ would have USD → $, while _en_AU_ would have AUD → $. (In protocols, the currency codes should always accompany any currency amounts; otherwise the data is ambiguous, and software is forced to use the user's territory to guess at the currency. For some informal discussion of this, see [JIT Localization](http://source.icu-project.org/repos/icu/icuhtml/trunk/design/jit_localization.html).)
 
-#### <a name="Written_Language" href="#Written_Language">3.10.1 Written Language</a>
+#### 3.10.1 <a name="Written_Language" href="#Written_Language">Written Language</a>
 
 Criteria for what makes a written language should be purely pragmatic; _what would copy-editors say?_ If one gave them text like the following, they would respond that is far from acceptable English for publication, and ask for it to be redone:
 
@@ -1317,7 +1315,7 @@ Clearly there are many acceptable variations on this text. For example, copy edi
 
 Note that the language of locale data may differ from the language of localized software or web sites, when those latter are not localized into the user's preferred language. In such cases, the kind of incongruous juxtapositions described above may well appear, but this situation is usually preferable to forcing unfamiliar date or number formats on the user as well.
 
-#### <a name="Hybrid_Locale" href="#Hybrid_Locale">3.10.2 Hybrid Locale Identifiers</a>
+#### 3.10.2 <a name="Hybrid_Locale" href="#Hybrid_Locale">Hybrid Locale Identifiers</a>
 
 Hybrid locales have intermixed content from 2 (or more) languages, often with one language's grammatical structure applied to words in another. These are commonly referred to with portmanteau words such as _Franglais, [​Spanglish](https://en.oxforddictionaries.com/definition/spanglish)_ or _Denglish_. Hybrid locales do not _not_ reference text simply containing two languages: a book of parallel text containing English and French, such as the following, is not Franglais:
 
@@ -1364,7 +1362,7 @@ The value of -t- is a full _[unicode_language_id](#unicode_language_id)_, and ca
 
 Should there ever be strong need for hybrids of more than two languages or for other purposes such as hybrid languages as the source of translated content, additional structure could be added.
 
-### <a name="Validity_Data" href="#Validity_Data">3.11 Validity Data</a>
+### 3.11 <a name="Validity_Data" href="#Validity_Data">Validity Data</a>
 
 ```xml
 <!ELEMENT idValidity (id*) >
@@ -1393,7 +1391,7 @@ In version 28.0, the subdivisions in the validity files used the ISO format, upp
 
 
 
-## <a name="Locale_Inheritance" href="#Locale_Inheritance">4 Locale Inheritance and Matching</a>
+## 4 <a name="Locale_Inheritance" href="#Locale_Inheritance">Locale Inheritance and Matching</a>
 
 The XML format relies on an inheritance model, whereby the resources are collected into _bundles_, and the bundles organized into a tree. Data for the many Spanish locales does not need to be duplicated across all of the countries having Spanish as a national language. Instead, common data is collected in the Spanish language locale, and territory locales only need to supply differences. The parent of all of the language locales is a generic locale known as _root_. Wherever possible, the resources in the root are language & territory neutral. For example, the collation (sorting) order in the root is based on the [[DUCET](#DUCET)] (see _[Root Collation](tr35-collation.md#Root_Collation)_). Since English language collation has the same ordering as the root locale, the 'en' locale data does not need to supply any collation data, nor do the 'en_US', 'en_GB' or the any of the various other locales that use English.
 
@@ -1441,7 +1439,7 @@ Certain data items depend only on the region specified in a locale id (by a [uni
 
 For the relationship between Inheritance, DefaultContent, LikelySubtags, and LocaleMatching, see Section 4.2.6 [Inheritance vs Related Information](tr35.md#Inheritance_vs_Related).
 
-### <a name="Lookup" href="#Lookup">4.1 Lookup</a>
+### 4.1 <a name="Lookup" href="#Lookup">Lookup</a>
 
 If a language has more than one script in customary modern use, then the CLDR file structure in common/main follows the following model:
 
@@ -1452,7 +1450,7 @@ lang_script_region
 lang_region (aliases to lang_script_region)
 ```
 
-#### <a name="Bundle_vs_Item_Lookup" href="#Bundle_vs_Item_Lookup">4.1.1 Bundle vs Item Lookup</a>
+#### 4.1.1 <a name="Bundle_vs_Item_Lookup" href="#Bundle_vs_Item_Lookup">Bundle vs Item Lookup</a>
 
 There are actually two different kinds of inheritance fallback: _resource bundle lookup_ and _resource item lookup_. For the former, a process is looking to find the first, best resource bundle it can; for the later, it is fallback within bundles on individual items, like the translated name for the region "CN" in Breton.
 
@@ -1464,7 +1462,7 @@ If the naïve resource bundle lookup is used, the desired locale needs to be can
 
 For the purposes of CLDR, everything with the `<ldml>` dtd is treated logically as if it is one resource bundle, even if the implementation separates data into separate physical resource bundles. For example, suppose that there is a main XML file for Nama (naq), but there are no `<unit>` elements for it because the units are all inherited from root. If the `<unit>` elements are separated into a separate data tree for modularity in the implementation, the Nama `<unit>` resource bundle would be empty. However, for purposes of resource-bundle lookup the resource bundle lookup still stops at naq.xml.
 
-###### <a name="Lookup-Differences" href="#Lookup-Differences">Lookup Differences</a>
+###### Table: <a name="Lookup-Differences" href="#Lookup-Differences">Lookup Differences</a>
 
 
 <!-- HTML: readability -->
@@ -1549,7 +1547,7 @@ The locale data does not contain general character properties that are derived f
 ```
 
 <a name="Multiple_Inheritance"></a>
-#### <a name="Lateral_Inheritance" href="#Lateral_Inheritance">4.1.2 Lateral Inheritance</a>
+#### 4.1.2 <a name="Lateral_Inheritance" href="#Lateral_Inheritance">Lateral Inheritance</a>
 
 __Lateral Inheritance__ is where resources are inherited from within the same locale, _before inheriting from the parent_. This is used for the following element@attribute instances:
 
@@ -1619,7 +1617,7 @@ A path may have multiple attributes with lateral inheritance. In such a case, al
 
 _Examples:_
 
-###### <a name="Count_Fallback_normal" href="#Count_Fallback_normal">Count Fallback: normal</a>
+###### Table: <a name="Count_Fallback_normal" href="#Count_Fallback_normal">Count Fallback: normal</a>
 
 | Locale | Path |
 | ------ | ---- |
@@ -1638,7 +1636,7 @@ _Examples:_
 </unitLength>
 ```
 
-###### <a name="Count_Fallback_currency" href="#Count_Fallback_currency">Count Fallback: currency</a>
+###### Table: <a name="Count_Fallback_currency" href="#Count_Fallback_currency">Count Fallback: currency</a>
 
 | Locale | Path |
 | ------ | ---- |
@@ -1653,7 +1651,7 @@ _Examples:_
 | root  | `//ldml/numbers/currencies/currency[@type="CAD"]/displayName`                 |
 
 
-#### <a name="Parent_Locales" href="#Parent_Locales">4.1.3 Parent Locales</a>
+#### 4.1.3 <a name="Parent_Locales" href="#Parent_Locales">Parent Locales</a>
 
 ```xml
 <!ELEMENT parentLocales ( parentLocale* ) >
@@ -1691,11 +1689,11 @@ When a `parentLocale` element is used to override normal inheritance, the follow
 2.  If X is the parentLocale of Y, Y must not be a base language locale. For example, the parent of "en" cannot be "en_XX".
 3.  There can never be cycles, such as: X parent of Y ... parent of X.
 
-### <a name="Inheritance_and_Validity" href="#Inheritance_and_Validity">4.2 Inheritance and Validity</a>
+### 4.2 <a name="Inheritance_and_Validity" href="#Inheritance_and_Validity">Inheritance and Validity</a>
 
 The following describes in more detail how to determine the exact inheritance of elements, and the validity of a given element in LDML.
 
-#### <a name="Definitions" href="#Definitions">4.2.1 Definitions</a>
+#### 4.2.1 <a name="Definitions" href="#Definitions">Definitions</a>
 
 _Blocking_ elements are those whose subelements do not inherit from parent locales. For example, a `<collation>` element is a blocking element: everything in a `<collation>` element is treated as a single lump of data, as far as inheritance is concerned. For more information, see [Section 5.5 Valid Attribute Values](#Valid_Attribute_Values).
 
@@ -1758,7 +1756,7 @@ For any locale ID, a _locale chain_ is an ordered list starting with the root an
 
 > <root, de, de_DE, de_DE_xxx>
 
-#### <a name="Resolved_Data_File" href="#Resolved_Data_File">4.2.2 Resolved Data File</a>
+#### 4.2.2 <a name="Resolved_Data_File" href="#Resolved_Data_File">Resolved Data File</a>
 
 To produce fully resolved locale data file from CLDR for a locale ID L, you start with L, and successively add unique items from the parent locales until you get up to root. More formally, this can be expressed as the following procedure.
 
@@ -1777,7 +1775,7 @@ To produce fully resolved locale data file from CLDR for a locale ID L, you star
 * The identity element and its children are unaffected by resolution.
 * The LDML data must be constructed so as to avoid circularity in step 2.2.
 
-#### <a name="Valid_Data" href="#Valid_Data">4.2.3 Valid Data</a>
+#### 4.2.3 <a name="Valid_Data" href="#Valid_Data">Valid Data</a>
 
 The attribute `draft="x"` in LDML means that the data has not been approved by the subcommittee. (For more information, see [Process](http://cldr.unicode.org/index/process)). However, some data that is not explicitly marked as `draft` may be implicitly `draft`, either because it inherits it from a parent, or from an enclosing element.
 
@@ -1814,7 +1812,7 @@ However, normally the draft attributes should be canonicalized, which means they
 
 More formally, here is how to determine whether data for an element chain E is implicitly or explicitly draft, given a locale L. Sections 1, 2, and 4 are simply formalizations of what is in LDML already. Item 3 adds the new element.
 
-#### <a name="Checking_for_Draft_Status" href="#Checking_for_Draft_Status">4.2.4 Checking for Draft Status</a>
+#### 4.2.4 <a name="Checking_for_Draft_Status" href="#Checking_for_Draft_Status">Checking for Draft Status</a>
 
 1. **Parent Locale Inheritance**
    1. Walk through the locale chain until you find a locale ID L' with a data file D. (L' may equal L).
@@ -1836,7 +1834,7 @@ More formally, here is how to determine whether data for an element chain E is i
 
 The `validSubLocales` in the most specific (farthest from root file) locale file "wins" through the full resolution step (data from more specific files replacing data from less specific ones).
 
-#### <a name="Keyword_and_Default_Resolution" href="#Keyword_and_Default_Resolution">4.2.5 Keyword and Default Resolution</a>
+#### 4.2.5 <a name="Keyword_and_Default_Resolution" href="#Keyword_and_Default_Resolution">Keyword and Default Resolution</a>
 
 When accessing data based on keywords, the following process is used. Consider the following example:
 
@@ -1913,7 +1911,7 @@ Examples of lookup for Chinese collation types. Note:
 
 For identifiers, such as language codes, script codes, region codes, variant codes, types, keywords, currency symbols or currency display names, the default value is the identifier itself whenever no value is found in the root. Thus if there is no display name for the region code 'QA' in root, then the display name is simply 'QA'.
 
-#### <a name="Inheritance_vs_Related" href="#Inheritance_vs_Related">4.2.6 Inheritance vs Related Information</a>
+#### 4.2.6 <a name="Inheritance_vs_Related" href="#Inheritance_vs_Related">Inheritance vs Related Information</a>
 
 There are related types of data and processing that are easy to confuse:
 
@@ -1959,7 +1957,7 @@ There are related types of data and processing that are easy to confuse:
 
 </tbody></table>
 
-### <a name="Likely_Subtags" href="#Likely_Subtags">4.3 Likely Subtags</a>
+### 4.3 <a name="Likely_Subtags" href="#Likely_Subtags">Likely Subtags</a>
 
 ```xml
 <!ELEMENT likelySubtag EMPTY >
@@ -2058,7 +2056,7 @@ Example:
 
 A variant of this favors the script over the region, thus using {language, language_script, language_region} in the above. If that variant is used, then the result in this example would be zh_Hant instead of zh_TW.
 
-### <a name="LanguageMatching" href="#LanguageMatching">4.4 Language Matching</a>
+### 4.4 <a name="LanguageMatching" href="#LanguageMatching">Language Matching</a>
 
 ```xml
 <!ELEMENT languageMatching ( languageMatches* ) >
@@ -2200,7 +2198,7 @@ The "\*" acts as a wild card, as shown in the following example:
 
 When the language+region is not matched, and there is otherwise no reason to pick among the supported regions for that language, then some measure of geographic "closeness" can be used. The results may be more understandable by users. Looking for en-SK, for example, should fall back to something within Europe (eg en-GB) in preference to something far away and unrelated (eg en-SG). Such a closeness metric does not need to be exact; a small amount of data can be used to give an approximate distance between any two regions. However, any such data must be used carefully; although Hong Kong is closer to India than to the UK, it is unlikely that en-IN would be a better match to en-HK than en-GB would.
 
-#### <a name="EnhancedLanguageMatching" href="#EnhancedLanguageMatching">4.4.1 Enhanced Language Matching</a>
+#### 4.4.1 <a name="EnhancedLanguageMatching" href="#EnhancedLanguageMatching">Enhanced Language Matching</a>
 
 The enhanced format for language matching adds structure to enable better matching of languages. It is distinguished by having a suffix "\_new" on the type, as in the example below. The extended structure allows matching to take into account broad similarities that would give better results. For example, for English the regions that are or inherit from US (AS|GU|MH|MP|PR|UM|VI|US) form a “cluster”. Each region in that cluster should be closer to each other than to any other region. And a region outside the cluster should be closer to another region outside that cluster than to one inside. We get this issue with the “world languages” like English, Spanish, Portuguese, Arabic, etc.
 
@@ -2236,7 +2234,7 @@ The **paradigmLocales** also allow matching to macroregions. For example, desire
 
 
 
-## <a name="XML_Format" href="#XML_Format">5 XML Format</a>
+## 5 <a name="XML_Format" href="#XML_Format">XML Format</a>
 
 There are two kinds of data that can be expressed in LDML: language-dependent data and supplementary data. In either case, data can be split across multiple files, which can be in multiple directory trees.
 
@@ -2320,11 +2318,11 @@ Lists, such as singleCountries are space-delimited. That means that they are sep
 * preferenceOrdering
 * references
 
-### <a name="Common_Elements" href="#Common_Elements">5.1 Common Elements</a>
+### 5.1 <a name="Common_Elements" href="#Common_Elements">Common Elements</a>
 
 At any level in any element, two special elements are allowed.
 
-#### <a name="special" href="#special">5.1.1 Element special</a>
+#### 5.1.1 <a name="special" href="#special">Element special</a>
 
 This element is designed to allow for arbitrary additional annotation and data that is product-specific. It has one required attribute `xmlns`, which specifies the XML [namespace](https://www.w3.org/TR/REC-xml-names/) of the special data. For example, the following used the version 1.0 POSIX special element.
 
@@ -2347,7 +2345,7 @@ This element is designed to allow for arbitrary additional annotation and data t
 </ldml>
 ```
 
-##### <a name="Sample_Special_Elements" href="#Sample_Special_Elements">5.1.1.1 Sample Special Elements</a>
+##### 5.1.1.1 <a name="Sample_Special_Elements" href="#Sample_Special_Elements">Sample Special Elements</a>
 
 The elements in this section are _**not**_ part of the Locale Data Markup Language 1.0 specification. Instead, they are special elements used for application-specific data to be stored in the Common Locale Repository. They may change or be removed in future versions of this document, and are present here more as examples of how to extend the format. (Some of these items may move into a future version of the Locale Data Markup Language specification.)
 
@@ -2392,7 +2390,7 @@ A number of the elements above can have extra information for <a name="OpenOffic
 </special>
 ```
 
-#### <a name="Alias_Elements" href="#Alias_Elements">5.1.2 Element alias</a>
+#### 5.1.2 <a name="Alias_Elements" href="#Alias_Elements">Element alias</a>
 
 ```xml
 <!ELEMENT alias (special*) >
@@ -2429,7 +2427,7 @@ The default value if the path is not present is the same position in the tree. A
 
 There is a special value for the source attribute, the constant `source="locale"`. This special value is equivalent to the locale being resolved. For example, consider the following example, where locale data for 'de' is being resolved:
 
-###### <a name="Inheritance_with_source_locale_" href="#Inheritance_with_source_locale_">Inheritance with `source="locale"`</a>
+###### Table: <a name="Inheritance_with_source_locale_" href="#Inheritance_with_source_locale_">Inheritance with `source="locale"`</a>
 
 <!-- HTML: multiline, readability -->
 <table><thead>
@@ -2525,7 +2523,7 @@ Aliases must be resolved recursively. An alias may point to another path that re
 
 It is an error to have a circular chain of aliases. That is, a collection of LDML XML documents must not have situations where a sequence of alias lookups (including inheritance and lateral inheritance) can be followed indefinitely without terminating.
 
-#### <a name="Element_displayName" href="#Element_displayName">5.1.3 Element displayName</a>
+#### 5.1.3 <a name="Element_displayName" href="#Element_displayName">Element displayName</a>
 
 Many elements can have a display name. This is a translated name that can be presented to users when discussing the particular service. For example, a number format, used to format numbers using the conventions of that locale, can have translated name for presentation in GUIs.
 
@@ -2538,15 +2536,15 @@ Many elements can have a display name. This is a translated name that can be pre
 
 Where present, the display names must be unique; that is, two distinct codes would not get the same display name.  (There is one exception to this: in time zones, where parsing results would give the same GMT offset, the standard and daylight display names can be the same across different time zone IDs.) Any translations should follow customary practice for the locale in question. For more information, see [[Data Formats](#DataFormats)].
 
-#### <a name="Escaping_Characters" href="#Escaping_Characters">5.1.4 Escaping Characters</a>
+#### 5.1.4 <a name="Escaping_Characters" href="#Escaping_Characters">Escaping Characters</a>
 
 Unfortunately, XML does not have the capability to contain all Unicode code points. Due to this, in certain instances extra syntax is required to represent those code points that cannot be otherwise represented in element content. The escaping syntax is only defined on a few types of elements, such as in collation or exemplar sets, and uses the appropriate syntax for that type.
 
 The element `<cp>`, which was formerly used for this purpose, has been deprecated.
 
-### <a name="Common_Attributes" href="#Common_Attributes">5.2 Common Attributes</a>
+### 5.2 <a name="Common_Attributes" href="#Common_Attributes">Common Attributes</a>
 
-#### <a name="Attribute_type" href="#Attribute_type">5.2.1 Attribute type</a>
+#### 5.2.1 <a name="Attribute_type" href="#Attribute_type">Attribute type</a>
 
 The attribute `type` is also used to indicate an alternate resource that can be selected with a matching `type=option` in the locale id modifiers, or be referenced by a default element. For example:
 
@@ -2560,7 +2558,7 @@ The attribute `type` is also used to indicate an alternate resource that can be 
 </ldml>
 ```
 
-#### <a name="Attribute_draft" href="#Attribute_draft">5.2.2 Attribute draft</a>
+#### 5.2.2 <a name="Attribute_draft" href="#Attribute_draft">Attribute draft</a>
 
 If this attribute is present, it indicates the status of all the data in this element and any subelements (unless they have a contrary `draft` value), as per the following:
 
@@ -2573,7 +2571,7 @@ For more information on precisely how these values are computed for any given re
 
 The `draft` attribute should only occur on "leaf" elements, and is deprecated elsewhere. For a more formal description of how elements are inherited, and what their draft status is, see _[Section 4.2 Inheritance and Validity](#Inheritance_and_Validity)_.
 
-#### <a name="alt_attribute" href="#alt_attribute">5.2.3 Attribute alt</a>
+#### 5.2.3 <a name="alt_attribute" href="#alt_attribute">Attribute alt</a>
 
 This attribute labels an alternative value for an element. The value is a _descriptor_ that indicates what kind of alternative it is, and takes one of the following
 
@@ -2602,7 +2600,7 @@ The values for _variantname_ at this time include "variant", "list", "email", "w
 
 For a more complete description of how draft applies to data, see _[Section 4.2 Inheritance and Validity](#Inheritance_and_Validity)_.
 
-#### <a name="references_attribute" href="#references_attribute">5.2.4 Attribute references</a>
+#### 5.2.4 <a name="references_attribute" href="#references_attribute">Attribute references</a>
 
 The value of this attribute is a token representing a reference for the information in the element, including standards that it may conform to. `<references>`. (In older versions of CLDR, the value of the attribute was freeform text. That format is deprecated.)
 
@@ -2620,9 +2618,9 @@ The `reference` element may be inherited. Thus, for example, R222 may be used in
 
 This attribute was originally intended for use in marking display names whose capitalization differed from what was indicated by the now-deprecated `<inText>` element (perhaps, for example, because the names included a proper noun). It was never supported in the dtd and is not needed for use with the new `<contextTransforms>` element.
 
-### <a name="Common_Structures" href="#Common_Structures">5.3 Common Structures</a>
+### 5.3 <a name="Common_Structures" href="#Common_Structures">Common Structures</a>
 
-#### <a name="Date_Ranges" href="#Date_Ranges">5.3.1 Date and Date Ranges</a>
+#### 5.3.1 <a name="Date_Ranges" href="#Date_Ranges">Date and Date Ranges</a>
 
 When attribute specify date ranges, it is usually done with attributes `from` and `to`. The `from` attribute specifies the starting point, and the `to` attribute specifies the end point. The deprecated `time` attribute was formerly used to specify time with the deprecated `weekEndStart` and `weekEndEnd` elements, which were themselves inherently `from` or `to`.
 
@@ -2645,7 +2643,7 @@ If the `from` element is missing, it is assumed to be as far backwards in time a
 
 The dates and times are specified in local time, unless otherwise noted. (In particular, the metazone values are in UTC (also known as GMT).
 
-#### <a name="Text_Directionality" href="#Text_Directionality">5.3.2 Text Directionality</a>
+#### 5.3.2 <a name="Text_Directionality" href="#Text_Directionality">Text Directionality</a>
 
 The content of certain elements, such as date or number formats, may consist of several sub-elements with an inherent order (for example, the year, month, and day for dates). In some cases, the order of these sub-elements may be changed depending on the bidirectional context in which the element is embedded.
 
@@ -2653,7 +2651,7 @@ For example, short date formats in languages such as Arabic may contain neutral 
 
 Element content whose display may be affected in this way should include an explicit direction mark, such as U+200E LEFT-TO-RIGHT MARK or U+200F RIGHT-TO-LEFT MARK, at the beginning or end of the element content, or both.
 
-#### <a name="Unicode_Sets" href="#Unicode_Sets">5.3.3 Unicode Sets</a>
+#### 5.3.3 <a name="Unicode_Sets" href="#Unicode_Sets">Unicode Sets</a>
 
 Some attribute values or element contents use _UnicodeSet_ notation. A UnicodeSet represents a finite set of Unicode code points and strings, and is defined by lists of code points and strings, Unicode property sets, and set operators, all bounded by square brackets. In this context, a code point means a string consisting of exactly one code point.
 
@@ -2699,7 +2697,7 @@ The syntax characters are listed in the table below:
 |      | U+0020 U+0009..U+000D U+0085<br/>U+200E U+200F<br/>U+2028 U+2029 | ASCII whitespace,<br/>LRM, RLM,<br/>LINE/PARAGRAPH SEPARATOR | Ignored except when escaped |
 
 
-##### <a name="Lists_of_Code_Points" href="#Lists_of_Code_Points">5.3.3.1 Lists of Code Points</a>
+##### 5.3.3.1 <a name="Lists_of_Code_Points" href="#Lists_of_Code_Points">Lists of Code Points</a>
 
 Lists are a sequence of strings that may include ranges, which are indicated by a '-' between two code points, as in "a-z". The sequence _start-end_ specifies the range of all code points from the start to end, inclusive, in Unicode order. For example, **[a c d-f m]** is equivalent to **[a c d e f m]**. Whitespace can be freely used for clarity, as **[a c d-f m]** means the same as **[acd-fm]**.
 
@@ -2733,7 +2731,7 @@ Any code point formed as the result of a backslash escape loses any special mean
 
 Unicode property sets are defined as described in _UTS #18: Unicode Regular Expressions_ [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)], Level 1 and RL2.5, including the syntax where given. For an example of a concrete implementation of this, see [[ICUUnicodeSet](#ICUUnicodeSet)].
 
-##### <a name="Unicode_Properties" href="#Unicode_Properties">5.3.3.2 Unicode Properties</a>
+##### 5.3.3.2 <a name="Unicode_Properties" href="#Unicode_Properties">Unicode Properties</a>
 
 Briefly, Unicode property sets are specified by any Unicode property and a value of that property, such as **[:General_Category=Letter:]** for Unicode letters or **\\p\{uppercase}** for the set of upper case letters in Unicode. The property names are defined by the PropertyAliases.txt file and the property values by the PropertyValueAliases.txt file. For more information, see [[UAX44](https://unicode.org/reports/tr41/#UAX44)]. The syntax for specifying the property sets is an extension of either POSIX or Perl syntax, by the addition of `"=<value>"`. For example, you can match letters by using the POSIX-style syntax:
 
@@ -2752,7 +2750,7 @@ The table below shows the two kinds of syntax: POSIX and Perl style. Also, the t
 | POSIX-style Syntax | [:type=value:]   | [:^type=value:]   |
 | Perl-style Syntax  | \\p\{type=value} | \\P\{type=value}  |
 
-##### <a name="Boolean_Operations" href="#Boolean_Operations">5.3.3.3 Boolean Operations</a>
+##### 5.3.3.3 <a name="Boolean_Operations" href="#Boolean_Operations">Boolean Operations</a>
 
 The low-level lists or properties then can be freely combined with the normal set operations (union, inverse, difference, and intersection):
 
@@ -2766,7 +2764,7 @@ The binary operators '&', '-', and the implicit union have equal precedence and 
 
 **One caution:** the '&' and '-' operators operate between sets. That is, they must be immediately preceded and immediately followed by a set. For example, the pattern **[[:Lu:]-A]** is illegal, since it is interpreted as the set **[:Lu:]** followed by the incomplete range **-A**. To specify the set of upper case letters except for 'A', enclose the 'A' in brackets: **[[:Lu:]-[A]]**.
 
-##### <a name="UnicodeSet_Examples" href="#UnicodeSet_Examples">5.3.3.4 UnicodeSet Examples</a>
+##### 5.3.3.4 <a name="UnicodeSet_Examples" href="#UnicodeSet_Examples">UnicodeSet Examples</a>
 
 The following table summarizes the syntax that can be used.
 
@@ -2784,7 +2782,7 @@ The following table summarizes the syntax that can be used.
 | [:Lu:]               | The set of code points with a given property value, as defined by PropertyValueAliases.txt. In this case, these are the Unicode upper case letters. The long form for this is **[:General_Category=Uppercase_Letter:]**. |
 | [:L:]                | The set of code points belonging to all Unicode categories starting with 'L', that is, **[[:Lu:][:Ll:][:Lt:][:Lm:][:Lo:]]**. The long form for this is **[:General_Category=Letter:]**. |
 
-#### <a name="String_Range" href="#String_Range">5.3.4 String Range</a>
+#### 5.3.4 <a name="String_Range" href="#String_Range">String Range</a>
 
 A String Range is a compact format for specifying a list of strings.
 
@@ -2821,7 +2819,7 @@ The separator and the format of strings X, Y may vary depending on the domain. F
 <tr><td>👦🏻-🏿</td><td>→</td><td>👦🏻 👦🏼 👦🏽 👦🏾 👦🏿</td></tr>
 </tbody></table>
 
-### <a name="Identity_Elements" href="#Identity_Elements">5.4 Identity Elements</a>
+### 5.4 <a name="Identity_Elements" href="#Identity_Elements">Identity Elements</a>
 
 ```xml
 <!ELEMENT identity (alias | (version, generation?, language, script?, territory?, variant?, special*) ) >
@@ -2873,11 +2871,11 @@ The variant code is the tertiary part of the specification of the locale id, wit
 
 When combined according to the rules described in _[Section 3, Unicode Language and Locale Identifiers](#Unicode_Language_and_Locale_Identifiers)_, the `language` element, along with any of the optional `script`, `territory`, and `variant` elements, must identify a known, stable locale identifier. Otherwise, it is an error.
 
-### <a name="Valid_Attribute_Values" href="#Valid_Attribute_Values">5.5 Valid Attribute Values</a>
+### 5.5 <a name="Valid_Attribute_Values" href="#Valid_Attribute_Values">Valid Attribute Values</a>
 
 The [DTD Annotations](#DTD_Annotations) in Section 5.7 are used to determine whether elements, attributes, or attribute values are valid (or deprecated).
 
-### <a name="Canonical_Form" href="#Canonical_Form">5.6 Canonical Form</a>
+### 5.6 <a name="Canonical_Form" href="#Canonical_Form">Canonical Form</a>
 
 The following are restrictions on the format of LDML files to allow for easier parsing and comparison of files.
 
@@ -2907,7 +2905,7 @@ Note that there was one case that had to be corrected in order to make this true
 
 [XML](https://www.w3.org/TR/REC-xml/) files can have a wide variation in textual form, while representing precisely the same data. By putting the LDML files in the repository into a canonical form, this allows us to use the simple diff tools used widely (and in CVS) to detect differences when vetting changes, without those tools being confused. This is not a requirement on other uses of LDML; just simply a way to manage repository data more easily.
 
-#### <a name="Content" href="#Content">5.6.1 Content</a>
+#### 5.6.1 <a name="Content" href="#Content">Content</a>
 
 1.  All start elements are on their own line, indented by _depth_ tabs.
 2.  All end elements (except for leaf nodes) are on their own line, indented by _depth_ tabs.
@@ -2951,7 +2949,7 @@ _Example:_
 </ldml>
 ```
 
-#### <a name="Ordering" href="#Ordering">5.6.2 Ordering</a>
+#### 5.6.2 <a name="Ordering" href="#Ordering">Ordering</a>
 
 An element is ordered first by the element name, and then if the element names are identical, by the sorted set of attribute-value pairs. For the latter, compare the first pair in each (in sorted order by attribute pair). If not identical, go to the second pair, and so on.
 
@@ -2959,7 +2957,7 @@ Elements and attributes are ordered according to their order in the respective D
 
 Any future additions to the DTD must be structured so as to allow compatibility with this ordering. See also [Section 5.5 Valid Attribute Values.](#Valid_Attribute_Values)
 
-#### <a name="Comments" href="#Comments">5.6.3 Comments</a>
+#### 5.6.3 <a name="Comments" href="#Comments">Comments</a>
 
 1. Comments are of the form `<!-- stuff -->`.
 2. They are logically attached to a node. There are 4 kinds:
@@ -2984,7 +2982,7 @@ Any future additions to the DTD must be structured so as to allow compatibility 
     <zone type="Asia/Jerusalem">
 ```
 
-### <a name="DTD_Annotations" href="#DTD_Annotations">5.7 DTD Annotations</a>
+### 5.7 <a name="DTD_Annotations" href="#DTD_Annotations">DTD Annotations</a>
 
 The information in a standard DTD is insufficient for use in CLDR. To make up for that, DTD annotations are added. These are of the form
 
@@ -3035,25 +3033,25 @@ The following are constraints on the attribute values. Note: in future versions,
 
 
 
-## <a name="Property_Data" href="#Property_Data">6 Property Data</a>
+## 6 <a name="Property_Data" href="#Property_Data">Property Data</a>
 
 Some data in CLDR does not use an XML format, but rather a semicolon-delimited format derived from that of the Unicode Character Database. That is because the data is more likely to be parsed by implementations that already parse UCD data. Those files are present in the common/properties directory.
 
 Each file has a header that explains the format and usage of the data.
 
-### <a name="Script_Metadata" href="#Script_Metadata">6.1 Script Metadata</a>
+### 6.1 <a name="Script_Metadata" href="#Script_Metadata">Script Metadata</a>
 
 `scriptMetadata.txt`
 
 This file provides general information about scripts that may be useful to implementations processing text. The information is the best currently available, and may change between versions of CLDR. The format is similar to Unicode Character Database property file, and is documented in the header of the data file.
 
-### <a name="Extended_Pictographic" href="#Extended_Pictographic">6.2 Extended Pictographic</a>
+### 6.2 <a name="Extended_Pictographic" href="#Extended_Pictographic">Extended Pictographic</a>
 
 `ExtendedPictographic.txt`
 
 This file was used to define the ExtendedPictographic data used for “future-proofing” emoji behavior, especially in segmentation. As of Emoji version 11.0, the set of Extended_Pictographic is incorporated into the emoji data files found at [unicode.org/Public/emoji/](https://unicode.org/Public/emoji/).
 
-### <a name="Labels.txt" href="#Labels.txt">6.3 Labels.txt</a>
+### 6.3 <a name="Labels.txt" href="#Labels.txt">Labels.txt</a>
 
 `labels.txt`
 
@@ -3061,23 +3059,23 @@ This file provides general information about associations of labels to character
 
 Initially, the contents are focused on emoji, but may be expanded in the future to other types of characters. Note that a character may have multiple labels.
 
-### <a name="Segmentation_Tests" href="#Segmentation_Tests">6.4 Segmentation Tests</a>
+### 6.4 <a name="Segmentation_Tests" href="#Segmentation_Tests">Segmentation Tests</a>
 
 CLDR provides a tailoring to the [Grapheme Cluster Break (gcb)](https://unicode.org/reports/tr29/) algorithm to avoid splitting Indic aksaras. The corresponding test files for that are located in common/properties/segments/, along with a readme.txt that provides more details. There are also specific test files for the supported Indic scripts in the unittest directory.
 
 
 
-## <a name="Format_Parse_Issues" href="#Format_Parse_Issues">7 Issues in Formatting and Parsing</a>
+## 7 <a name="Format_Parse_Issues" href="#Format_Parse_Issues">Issues in Formatting and Parsing</a>
 
-### <a name="Lenient_Parsing" href="#Lenient_Parsing">7.1 Lenient Parsing</a>
+### 7.1 <a name="Lenient_Parsing" href="#Lenient_Parsing">Lenient Parsing</a>
 
-#### <a name="Motivation" href="#Motivation">7.1.1 Motivation</a>
+#### 7.1.1 <a name="Motivation" href="#Motivation">Motivation</a>
 
 User input is frequently messy. Attempting to parse it by matching it exactly against a pattern is likely to be unsuccessful, even when the meaning of the input is clear to a human being. For example, for a date pattern of "MM/dd/yy", the input "June 1, 2006" will fail.
 
 The goal of lenient parsing is to accept user input whenever it is possible to decipher what the user intended. Doing so requires using patterns as data to guide the parsing process, rather than an exact template that must be matched. This informative section suggests some heuristics that may be useful for lenient parsing of dates, times, and numbers.
 
-#### <a name="Loose_Matching" href="#Loose_Matching">7.1.2 Loose Matching</a>
+#### 7.1.2 <a name="Loose_Matching" href="#Loose_Matching">Loose Matching</a>
 
 Loose matching ignores attributes of the strings being compared that are not important to matching. It involves the following steps:
 
@@ -3097,7 +3095,7 @@ Loose matching ignores attributes of the strings being compared that are not imp
 
 Loose matching involves (logically) applying the above transform to both the input text and to each of the field elements used in matching, before applying the specific heuristics below. For example, if the input number text is " - NA f. 1,000.00", then it is mapped to "-naf1,000.00" before processing. The currency signs are also transformed, so "NA f." is converted to "naf" for purposes of matching. As with other Unicode algorithms, this is a logical statement of the process; actual implementations can optimize, such as by applying the transform incrementally during matching.
 
-### <a name="Invalid_Patterns" href="#Invalid_Patterns">7.2 Handling Invalid Patterns</a>
+### 7.2 <a name="Invalid_Patterns" href="#Invalid_Patterns">Handling Invalid Patterns</a>
 
 Processes sometimes encounter invalid number or date patterns, such as a number pattern with “¤¤¤¤¤” (valid pattern character but invalid length in current CLDR), a date pattern with “nn” (invalid pattern character in current CLDR), or a date pattern with “MMMMMM” (invalid length in current CLDR). The recommended behavior for handling such an invalid pattern field is:
 
@@ -3224,7 +3222,7 @@ The LDML specification is split into several [parts](#Parts) by topic, with one 
 
 Part 1 Links: Core (this document): No redirects needed.
 
-###### <a name="Part_2_Links" href="#Part_2_Links">Part 2 Links</a>: [General](tr35-general.md) (display names & transforms, etc.)
+###### Table: <a name="Part_2_Links" href="#Part_2_Links">Part 2 Links</a>: [General](tr35-general.md) (display names & transforms, etc.)
 
 | Old section                                                                                                 | Section in new part |
 | ----------------------------------------------------------------------------------------------------------- | ------------------- |
@@ -3251,7 +3249,7 @@ Part 1 Links: Core (this document): No redirects needed.
 | C.20 <a name="List_Gender" href="#List_Gender">Gender of Lists</a>                                          | 11.1 [Gender of Lists](tr35-general.md#List_Gender) |
 | 5.19 <a name="Context_Transform_Elements" href="#Context_Transform_Elements">ContextTransform Elements</a>  | 12 [ContextTransform Elements](tr35-general.md#Context_Transform_Elements) |
 
-###### <a name="Part_3_Links" href="#Part_3_Links">Part 3 Links</a>: [Numbers](tr35-numbers.md) (number & currency formatting)
+###### Table: <a name="Part_3_Links" href="#Part_3_Links">Part 3 Links</a>: [Numbers](tr35-numbers.md) (number & currency formatting)
 
 | Old section                                                                                                       | Section in new part |
 | ----------------------------------------------------------------------------------------------------------------- | ------------------- |
@@ -3264,7 +3262,7 @@ Part 1 Links: Core (this document): No redirects needed.
 | C.11 <a name="Language_Plural_Rules" href="#Language_Plural_Rules">Language Plural Rules</a>                      | 5 [Language Plural Rules](tr35-numbers.md#Language_Plural_Rules) |
 | 5.17 <a name="Rule-Based_Number_Formatting" href="#Rule-Based_Number_Formatting">Rule-Based Number Formatting</a> | 6 [Rule-Based Number Formatting](tr35-numbers.md#Rule-Based_Number_Formatting) |
 
-###### <a name="Part_4_Links" href="#Part_4_Links">Part 4 Links</a>: [Dates](tr35-dates.md) (date, time, time zone formatting)
+###### Table: <a name="Part_4_Links" href="#Part_4_Links">Part 4 Links</a>: [Dates](tr35-dates.md) (date, time, time zone formatting)
 
 | Old section                                                                                                                   | Section in new part |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------- |
@@ -3289,7 +3287,7 @@ Part 1 Links: Core (this document): No redirects needed.
 | <a name="fallbackFormat" href="#fallbackFormat">**fallbackFormat**:</a>                                                       | [**fallbackFormat**:](tr35-dates.md#fallbackFormat) |
 | O.4 Parsing Dates and Times                                                                                                   | 9 [Parsing Dates and Times](tr35-dates.md#Parsing_Dates_Times) |
 
-###### <a name="Part_5_Links" href="#Part_5_Links">Part 5 Links</a>: [Collation](tr35-collation.md) (sorting, searching, grouping)
+###### Table: <a name="Part_5_Links" href="#Part_5_Links">Part 5 Links</a>: [Collation](tr35-collation.md) (sorting, searching, grouping)
 
 | Old section                                                                                                                     | Section in new part |
 | ------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
@@ -3313,7 +3311,7 @@ Part 1 Links: Core (this document): No redirects needed.
 | Definition: <a name="UpperExceptions" href="#UpperExceptions">UpperExceptions</a>                                               | removed: see 3.13 [Case Parameters](tr35-collation.md#Case_Parameters) |
 | 5.14.14 <a name="Visibility" href="#Visibility">Visibility</a>                                                                  | 3.14 [Visibility](tr35-collation.md#Visibility) |
 
-###### <a name="Part_6_Links" href="#Part_6_Links">Part 6 Links</a>: [Supplemental](tr35-info.md) (supplemental data)
+###### Table: <a name="Part_6_Links" href="#Part_6_Links">Part 6 Links</a>: [Supplemental](tr35-info.md) (supplemental data)
 
 | Old section                                                                                                                              | Section in new part |
 | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
@@ -3332,7 +3330,7 @@ Part 1 Links: Core (this document): No redirects needed.
 | P.2 [Supplemental Deprecated Information](tr35-info.md#Supplemental_Deprecated_Information)                                              | 9.2 [Supplemental Deprecated Information](tr35-info.md#Supplemental_Deprecated_Information)
 | P.3 [Default Content](tr35-info.md#Default_Content)                                                                                      | 9.3 [Default Content](tr35-info.md#Default_Content) |
 
-###### <a name="Part_7_Links" href="#Part_7_Links">Part 7 Links</a>: [Keyboards](tr35-keyboards.md) (keyboard mappings)
+###### Table: <a name="Part_7_Links" href="#Part_7_Links">Part 7 Links</a>: [Keyboards](tr35-keyboards.md) (keyboard mappings)
 
 | Old section                                                                                                                | Section in new part |
 | -------------------------------------------------------------------------------------------------------------------------- | ------------------- |


### PR DESCRIPTION
- Update all anchors starting with section numbers (1.2.3.4) so the number
is outside of the anchor.

- CLDR-14611: Update all h6 (######) to have the text 'Table: '
outside of the anchor.

- Update archiver to move h6-followed-by-table into a <caption>
inside the table, iff the h6 starts with 'Table:'

- demoted a few non-caption h6

- Regenerate ToC

CLDR-15206

- [X] This PR completes the ticket.