### PR TITLE
CLDR-15460 build: restructure workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,6 +1,14 @@
 name: Ansible Lint
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'tools/scripts/ansible/**'
+      - '.github/workflows/ansible-lint.yml'
+  pull_request:
+    paths:
+      - 'tools/scripts/ansible/**'
+      - '.github/workflows/ansible-lint.yml'
 
 jobs:
   lint:
@@ -16,26 +24,7 @@ jobs:
         targets: tools/scripts/ansible/*-playbook.yml
         override-deps: |
           rich>=9.5.1,<11.0.0
-    - name: Cache lint npm repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-lint-${{ hashFiles('.github/workflows/ansible-lint.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-lint-
-          lint-
-    - name: Lint Markdown
-      # Warn, don't fail yet
-      run: npx markdownlint-cli *.md {specs,docs}/*.md $(find .github -name '*.md') || (echo Warning, please fix these ; true)
-    - name: Lint GitHub Actions
-      run: npx yaml-lint .github/workflows/*.yml
-    - name: Prepare JS tests
-      run: (cd tools/cldr-apps/js && npm ci)
-    - name: Run JS tests
-      # stopgap: fail this if it takes too long
-      timeout-minutes: 10
-      run: (cd tools/cldr-apps/js && npm t)
-  build:
+  testprovision:
     runs-on: macos-10.15  # see https://github.com/actions/virtual-environments/issues/4060
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    # Only run if docs change.
+    paths:
+      - "tools/scripts/tr-archive/**"
+      - "docs/**"
+      - '.github/workflows/gh-pages.yml'
 
 jobs:
   build:
@@ -20,6 +25,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nodetr-
             nodetr-
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Run TR archiver
+        # Note: will update ToC if out of date
+        run: 'cd tools/scripts/tr-archive/ && bash make-tr-archive.sh'
+      - name: Lint Markdown
+        # Warn, don't fail yet
+        run: npx markdownlint-cli *.md {specs,docs}/*.md $(find .github -name '*.md') || (echo Warning, please fix these ; true)
+      - name: Note any changes
+        run: git status ; git diff
       - name: Ruby cache
         uses: actions/cache@v2
         with:
@@ -34,11 +50,6 @@ jobs:
         run: |
           gem install bundler github-pages kramdown-parser-gfm  # should pull in jekyll, etc.
           jekyll build -s docs -d _site
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-      - name: Run TR archiver
-        run: 'cd tools/scripts/tr-archive/ && bash make-tr-archive.sh'
       - name: Rearrange stuff
         run: 'cp -vr tools/scripts/tr-archive/dist/* ./_site/ldml/ && cp tools/scripts/tr-archive/reports-v2.css ./_site/'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,0 +1,35 @@
+name: JavaScript Tests
+
+on:
+  push:
+    paths:
+      - 'tools/cldr-apps/js/**'
+      - '.github/workflows/js.yml'
+  pull_request:
+    paths:
+      - 'tools/cldr-apps/js/**'
+      - '.github/workflows/js.yml'
+
+jobs:
+  fetest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: false # not needed for this job, as we don’t currently do a Java build
+    - name: Cache npm repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-lint-${{ hashFiles('.github/workflows/js.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-lint-
+          lint-
+    - name: Prepare JS tests
+      run: (cd tools/cldr-apps/js && npm ci)
+    - name: Run JS tests
+      # stopgap: fail this if it takes too long
+      timeout-minutes: 10
+      run: (cd tools/cldr-apps/js && npm t)
+    - name: Run Webpack build
+      run: (cd tools/cldr-apps/js && npm run build)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,11 +2,7 @@ name: cldr-mvn
 
 on:
   push:
-    branches:
-    - '*'
   pull_request:
-    branches:
-    - '*'
   workflow_dispatch:
     inputs:
       git-ref:
@@ -47,6 +43,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
             node-
+      - name: Lint GitHub Actions
+        run: npx yaml-lint .github/workflows/*.yml
       - name: Build with Maven
         run: >
           mvn -s .github/workflows/mvn-settings.xml -B compile install package --file tools/pom.xml


### PR DESCRIPTION
- run ansible/vagrant only if ansible changes
- run js test only if js changes
- move yaml lint of the workflows into maven

CLDR-15460

Includes fix from: CLDR-15467 update maven.yml to improve builds (#1824) 2ea074bfc0716359c24e47b757b6027bc78eb69f

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
