### PR TITLE
CLDR-15405 nameOrder→nameOrderLocales, mv sorting from usage→order, sampleNames in root / ∅∅∅ in en

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3164,16 +3164,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST annotation draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 
-<!ELEMENT personNames ( alias | ( nameOrder*, initialPattern*, personName+, sampleName*, special* ) ) >
+<!ELEMENT personNames ( alias | ( nameOrderLocales*, initialPattern*, personName+, sampleName*, special* ) ) >
 
-<!ELEMENT nameOrder EMPTY >
-<!ATTLIST nameOrder nameLocales NMTOKENS #REQUIRED >
-    <!--@MATCH:set/validity/locale-->
-<!ATTLIST nameOrder order (surnameFirst | givenFirst) #REQUIRED >
-    <!--@VALUE-->
-<!ATTLIST nameOrder draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+<!ELEMENT nameOrderLocales ( #PCDATA ) >
+<!ATTLIST nameOrderLocales order (givenFirst | surnameFirst) #REQUIRED >
+<!ATTLIST nameOrderLocales alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST nameOrderLocales draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
-<!ATTLIST nameOrder references CDATA #IMPLIED >
+<!ATTLIST nameOrderLocales references CDATA #IMPLIED >
     <!--@METADATA-->
 
 <!ELEMENT initialPattern ( #PCDATA ) >
@@ -3189,11 +3188,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST personName length NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/long, medium, short, monogram, monogramNarrow-->
 <!ATTLIST personName usage NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/addressing, referring, sorting-->
+    <!--@MATCH:set/literal/addressing, referring-->
 <!ATTLIST personName style NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/formal, informal-->
 <!ATTLIST personName order NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/surnameFirst, givenFirst-->
+    <!--@MATCH:set/literal/sorting, givenFirst, surnameFirst-->
 
 <!ELEMENT namePattern ( #PCDATA ) >
 <!ATTLIST namePattern alt (1|2) #IMPLIED >
@@ -3203,11 +3202,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT sampleName ( alias | ( nameField+, special* ) ) >
-<!ATTLIST sampleName item (minimal|simple|full|multiword) #REQUIRED >
+<!ATTLIST sampleName item NMTOKENS #REQUIRED >
+    <!--@MATCH:literal/givenSurname, given2Surname, givenSurname2, informal, full, multiword-->
 
 <!ELEMENT nameField ( #PCDATA ) >
 <!ATTLIST nameField type CDATA #REQUIRED >
-    <!--@MATCH:any--> <!--until we have a better sense, or maybe validity data, for all of the combinations here-->
+    <!--@MATCH:literal/prefix, given, given-informal, given2, surname, surname2, suffix-->
 <!ATTLIST nameField alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST nameField draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9129,145 +9129,212 @@ annotations.
 		<featureName type="zero">slashed zero</featureName>
 	</typographicNames>
 	<personNames>
+		<nameOrderLocales order="givenFirst">und</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ja zh ko</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<personName>
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
-		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
-			<namePattern>{prefix} {surname}</namePattern>
+		<personName length="long" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="addressing" style="formal" order="givenFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
-		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
-			<namePattern>{given-informal}</namePattern>
+		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="givenFirst">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
-		<personName length="long" usage="referring" style="formal" order="surnameFirst">
+		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="formal" order="sorting">
 			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
 		</personName>
-		<personName length="long" usage="referring" style="informal" order="surnameFirst">
+		<personName length="long" usage="referring" style="formal" order="surnameFirst">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName length="long" usage="referring" style="informal" order="sorting">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="givenFirst">
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
-		<personName length="long" usage="sorting" style="formal">
-			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
-		</personName>
-		<personName length="long" usage="sorting" style="informal">
+		<personName length="long" usage="referring" style="informal" order="surnameFirst">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
-			<namePattern>{prefix} {surname}</namePattern>
+		<personName length="medium" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
-			<namePattern>{given-informal}</namePattern>
+		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
-		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
-			<namePattern>{surname}, {given} {given2-initial}. {suffix}</namePattern>
+		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
-			<namePattern>{given} {given2-initial}. {surname} {suffix}</namePattern>
+			<namePattern>{given} {given2-initial} {surname} {suffix}</namePattern>
 		</personName>
-		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
+		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="referring" style="informal" order="sorting">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="givenFirst">
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
-		<personName length="medium" usage="sorting" style="formal">
-			<namePattern>{surname}, {given} {given2-initial}. {suffix}</namePattern>
-		</personName>
-		<personName length="medium" usage="sorting" style="informal">
+		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
-		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
-			<namePattern>{prefix} {surname}</namePattern>
+		<personName length="short" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="givenFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
-		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
-			<namePattern>{given-informal}</namePattern>
+		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="givenFirst">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
-		<personName length="short" usage="referring" style="formal" order="surnameFirst">
-			<namePattern>{surname}, {given-initial}. {given2-initial}.</namePattern>
+		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="formal" order="sorting">
+			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
-			<namePattern>{given-initial}. {given2-initial}. {surname}</namePattern>
+			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
 		</personName>
-		<personName length="short" usage="referring" style="informal" order="surnameFirst">
-			<namePattern>{surname}, {given-initial}.</namePattern>
+		<personName length="short" usage="referring" style="formal" order="surnameFirst">
+			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
 		</personName>
-		<personName length="short" usage="referring" style="informal" order="givenFirst">
-			<namePattern>{given-informal} {surname-initial}.</namePattern>
-		</personName>
-		<personName length="short" usage="sorting" style="formal">
-			<namePattern>{surname}, {given-initial}. {given2-initial}.</namePattern>
-		</personName>
-		<personName length="short" usage="sorting" style="informal">
+		<personName length="short" usage="referring" style="informal" order="sorting">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
-		<personName length="monogram" style="formal" order="surnameFirst">
-			<namePattern>{surname-initial}{given-initial}{given2-initial}</namePattern>
+		<personName length="short" usage="referring" style="informal" order="givenFirst">
+			<namePattern>{given-informal} {surname-initial}</namePattern>
+		</personName>
+		<personName length="short" usage="referring" style="informal" order="surnameFirst">
+			<namePattern>{surname}, {given-initial}</namePattern>
+		</personName>
+		<!-- for length="monogram" or "monogramNarrow", ignore usage -->
+		<personName length="monogram" style="formal" order="sorting">
+			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
 		</personName>
 		<personName length="monogram" style="formal" order="givenFirst">
-			<namePattern>{given-initial}{given2-initial}{surname-initial}</namePattern>
+			<namePattern>{given-initial-allCaps}{given2-initial-allCaps}{surname-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogram" style="informal" order="surnameFirst">
-			<namePattern>{surname-initial}{given-informal-initial}</namePattern>
+		<personName length="monogram" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="monogram" style="informal" order="sorting">
+			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
 		</personName>
 		<personName length="monogram" style="informal" order="givenFirst">
-			<namePattern>{given-informal-initial}{surname-initial}</namePattern>
+			<namePattern>{given-informal-initial-allCaps}{surname-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="formal" order="surnameFirst">
-			<namePattern>{surname-initial}</namePattern>
+		<personName length="monogram" style="informal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="monogramNarrow" style="formal" order="sorting">
+			<namePattern>{surname-initial-allCaps}</namePattern>
 		</personName>
 		<personName length="monogramNarrow" style="formal" order="givenFirst">
-			<namePattern>{surname-initial}</namePattern>
+			<namePattern>{surname-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="informal" order="surnameFirst">
-			<namePattern>{given-informal-initial}</namePattern>
+		<personName length="monogramNarrow" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="monogramNarrow" style="informal" order="sorting">
+			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
 		<personName length="monogramNarrow" style="informal" order="givenFirst">
-			<namePattern>{given-informal-initial}</namePattern>
+			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
-		<sampleName item="minimal">
+		<personName length="monogramNarrow" style="informal" order="surnameFirst">
+			<namePattern>{given-informal-initial-allCaps}</namePattern>
+		</personName>
+		<!-- The following samples are temporary, to be filled out with something better -->
+		<sampleName item="givenSurname">
+			<nameField type="prefix">∅∅∅</nameField>
 			<nameField type="given">Katherine</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
+			<nameField type="given2">∅∅∅</nameField>
 			<nameField type="surname">Johnson</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
-		<sampleName item="simple">
+		<sampleName item="given2Surname">
+			<nameField type="prefix">∅∅∅</nameField>
 			<nameField type="given">Alberto</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
 			<nameField type="given2">Pedro</nameField>
 			<nameField type="surname">Calderón</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="suffix">∅∅∅</nameField>
+		</sampleName>
+		<sampleName item="givenSurname2">
+			<nameField type="prefix">∅∅∅</nameField>
+			<nameField type="given">John</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
+			<nameField type="given2">∅∅∅</nameField>
+			<nameField type="surname">Blue</nameField>
+			<nameField type="surname2">Green</nameField>
+			<nameField type="suffix">∅∅∅</nameField>
+		</sampleName>
+		<sampleName item="informal">
+			<nameField type="prefix">∅∅∅</nameField>
+			<nameField type="given">John</nameField>
+			<nameField type="given-informal">Jack</nameField>
+			<nameField type="given2">William</nameField>
+			<nameField type="surname">Brown</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
 		<sampleName item="full">
 			<nameField type="prefix">Dr.</nameField>
 			<nameField type="given">Dorothy</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
 			<nameField type="given2">Lavinia</nameField>
 			<nameField type="surname">Brown</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
 			<nameField type="suffix">M.D.</nameField>
 		</sampleName>
 		<sampleName item="multiword">
+			<nameField type="prefix">∅∅∅</nameField>
 			<nameField type="given">Erich Oswald</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
 			<nameField type="given2">Hans Carl Maria</nameField>
 			<nameField type="surname">von Stroheim</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5368,130 +5368,212 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="zero">slashed zero</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrder nameLocales="und" order="surnameFirst"/>
+		<nameOrderLocales order="givenFirst">und</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ja zh ko hu</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<!-- fallback/any pattern -->
 		<personName>
 			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>
 		</personName>
-		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+		<personName length="long" usage="addressing" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="long" usage="addressing" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="long" usage="referring" style="formal" order="surnameFirst">
+		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="referring" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="long" usage="referring" style="informal" order="surnameFirst">
+		<personName length="long" usage="referring" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="long" usage="referring" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<!-- for usage="sorting", ignore order -->
-		<personName length="long" usage="sorting" style="formal">
+		<personName length="long" usage="referring" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="long" usage="sorting" style="informal">
-			<alias source="locale" path="../personName"/>
-		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+		<personName length="medium" usage="addressing" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
+		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="referring" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
+		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="medium" usage="referring" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<!-- for usage="sorting", ignore order -->
-		<personName length="medium" usage="sorting" style="formal">
+		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="medium" usage="sorting" style="informal">
-			<alias source="locale" path="../personName"/>
-		</personName>
-		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+		<personName length="short" usage="addressing" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="short" usage="referring" style="formal" order="surnameFirst">
+		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="referring" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="short" usage="referring" style="informal" order="surnameFirst">
+		<personName length="short" usage="referring" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="short" usage="referring" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<!-- for usage="sorting", ignore order -->
-		<personName length="short" usage="sorting" style="formal">
-			<alias source="locale" path="../personName"/>
-		</personName>
-		<personName length="short" usage="sorting" style="informal">
+		<personName length="short" usage="referring" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<!-- for length="monogram" or "monogramNarrow", ignore usage -->
-		<personName length="monogram" style="formal" order="surnameFirst">
+		<personName length="monogram" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="monogram" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="monogram" style="informal" order="surnameFirst">
+		<personName length="monogram" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogram" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="monogram" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="monogramNarrow" style="formal" order="surnameFirst">
+		<personName length="monogram" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogramNarrow" style="formal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="monogramNarrow" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
-		<personName length="monogramNarrow" style="informal" order="surnameFirst">
+		<personName length="monogramNarrow" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<personName length="monogramNarrow" style="informal" order="sorting">
 			<alias source="locale" path="../personName"/>
 		</personName>
 		<personName length="monogramNarrow" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName"/>
 		</personName>
+		<personName length="monogramNarrow" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName"/>
+		</personName>
+		<sampleName item="givenSurname">
+			<nameField type="prefix">Prefix</nameField>
+			<nameField type="given">Given</nameField>
+			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given2">Given2</nameField>
+			<nameField type="surname">Surname</nameField>
+			<nameField type="surname2">Surname2</nameField>
+			<nameField type="suffix">Suffix</nameField>
+		</sampleName>
+		<sampleName item="given2Surname">
+			<nameField type="prefix">Prefix</nameField>
+			<nameField type="given">Given</nameField>
+			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given2">Given2</nameField>
+			<nameField type="surname">Surname</nameField>
+			<nameField type="surname2">Surname2</nameField>
+			<nameField type="suffix">Suffix</nameField>
+		</sampleName>
+		<sampleName item="givenSurname2">
+			<nameField type="prefix">Prefix</nameField>
+			<nameField type="given">Given</nameField>
+			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given2">Given2</nameField>
+			<nameField type="surname">Surname</nameField>
+			<nameField type="surname2">Surname2</nameField>
+			<nameField type="suffix">Suffix</nameField>
+		</sampleName>
+		<sampleName item="informal">
+			<nameField type="prefix">Prefix</nameField>
+			<nameField type="given">Given</nameField>
+			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given2">Given2</nameField>
+			<nameField type="surname">Surname</nameField>
+			<nameField type="surname2">Surname2</nameField>
+			<nameField type="suffix">Suffix</nameField>
+		</sampleName>
+		<sampleName item="full">
+			<nameField type="prefix">Prefix</nameField>
+			<nameField type="given">Given</nameField>
+			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given2">Given2</nameField>
+			<nameField type="surname">Surname</nameField>
+			<nameField type="surname2">Surname2</nameField>
+			<nameField type="suffix">Suffix</nameField>
+		</sampleName>
+		<sampleName item="multiword">
+			<nameField type="prefix">Prefix</nameField>
+			<nameField type="given">Given</nameField>
+			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given2">Given2</nameField>
+			<nameField type="surname">Surname</nameField>
+			<nameField type="surname2">Surname2</nameField>
+			<nameField type="suffix">Suffix</nameField>
+		</sampleName>
 	</personNames>
 </ldml>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -137,7 +137,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%numberingSystem80" value="(arab(ext)?|armn(low)?|beng|deva|ethi|fullwide|geor|grek(low)?|gujr|guru|hanidec|han[st](fin)?|hebr|jpan(fin)?|khmr|knda|laoo|mlym|mymr|orya|roman(low)?|taml(dec)?|telu|thai|tibt)"/>
 		<coverageVariable key="%numberingSystem100" value="(finance|native|traditional|bali|brah|cakm|cham|diak|gong|gonm|hanidays|hmnp|java|jpanyear|kali|lana(tham)?|lepc|limb|mong|mtei|mymrshan|nkoo|olck|osma|rohg|saur|shrd|sora|sund|takr|talu|tnsa|vaii|wcho)"/>
 		<coverageVariable key="%persianCalendarTerritories" value="(AF|IR)"/>
-		<coverageVariable key="%personNameLanguages" value="(ar|de|en|es|hu|id|is|ja|ko|nl|uk)"/>
+		<coverageVariable key="%personNameLanguages" value="(ar|de|en|es|fr|hu|id|is|ja|ko|nl|ru|uk|zh)"/>
 		<coverageVariable key="%personNameNonMonograms" value="(long|medium|short)"/>
 		<coverageVariable key="%personNameMonograms" value="(monogram|monogramNarrow)"/>
 		<coverageVariable key="%phonebookCollationLanguages" value="(de|fi)"/>
@@ -906,15 +906,12 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="typographicNames/styleName[@type='%anyAttribute'][@subtype='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="typographicNames/featureName[@type='%anyAttribute']"/>
 
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrder[@nameLocales='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/initialPattern[@type='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/initialPattern[@type='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='addressing'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='addressing'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='referring'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='referring'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='sorting'][@style='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='sorting'][@style='%anyAttribute']/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern[@alt='%anyAttribute']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -11,7 +11,7 @@ import org.unicode.cldr.util.XPathParts;
 public class CheckPlaceHolders extends CheckCLDR {
 
     private static final Pattern PLACEHOLDER_PATTERN = PatternCache.get("([0-9]|[1-9][0-9]+)");
-    private static final Pattern PLACEHOLDER_PATTERN_PERS_NAMES = PatternCache.get("([a-z][a-z23-]+?)"); // CLDR-15384 need alpha, -
+    private static final Pattern PLACEHOLDER_PATTERN_PERS_NAMES = PatternCache.get("([a-z][a-zA-Z23-]+?)"); // CLDR-15384 need alpha, -
     private static final Pattern SKIP_PATH_LIST = Pattern
         .compile("//ldml/characters/(exemplarCharacters|parseLenient).*");
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -477,7 +477,7 @@ public class ExampleGenerator {
         //ldml/personNames/personName[@length="long"][@usage="addressing"][@style="formal"][@order="givenFirst"]/namePattern => {prefix} {surname}
         FormatParameters formatParameters = FormatParameters.from(parts);
 
-        if (parts.contains("nameOrder") || parts.contains("initialPattern") || parts.contains("sampleName")) {
+        if (parts.contains("nameOrderLocales") || parts.contains("initialPattern") || parts.contains("sampleName")) {
             return null; // TODO: we do not handle these yet
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -378,9 +378,9 @@ public class PathDescription {
         + "Minimal pairs for genders. For more information, please see "
         + CLDRURLS.GRAMMATICAL_INFLECTION + ".\n"
 
-        + "^//ldml/personNames/nameOrder\\[@nameLocales=\"([^\"]*)\"]"
+        + "^//ldml/personNames/nameOrderLocales\\[@order=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
-        + "Person name order for languages. For more information, please see "
+        + "Person name order for locales. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/initialPattern\\[@type=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
@@ -392,7 +392,7 @@ public class PathDescription {
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/sampleName"
         + RegexLookup.SEPARATOR
-        + "Sample names for person name forma examples. For more information, please see "
+        + "Sample names for person name forma examples (enter ∅∅∅ for unused fields). For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
 
         + "^//ldml/numbers/([a-z]*)Formats(\\[@numberSystem=\"([^\"]*)\"])?/\\1FormatLength/\\1Format\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]$"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1858,9 +1858,9 @@ public class PathHeader implements Comparable<PathHeader> {
                     // The various personName attribute values in desired sort order
                     final List<String> allValues = Arrays.asList(
                         "long", "medium", "short", "monogram", "monogramNarrow", // length values
-                        "addressing", "referring", "sorting", // usage values
+                        "addressing", "referring", // usage values
                         "formal", "informal", // style values
-                        "surnameFirst", "givenFirst"); //order values
+                        "sorting", "givenFirst", "surnameFirst"); //order values
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;
@@ -1878,25 +1878,19 @@ public class PathHeader implements Comparable<PathHeader> {
             functionMap.put("sampleNameOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
-                    final List<String> sampleItemValues = Arrays.asList("minimal", "simple", "full", "multiword");
-                    final List<String> fieldTypeValues = Arrays.asList("prefix", "given", "given2", "surname", "surname2", "suffix");
+                    final List<String> allValues = Arrays.asList(
+                        "givenSurname", "given2Surname", "givenSurname2", "informal", "full", "multiword", // values for sampleName item
+                        "prefix", "given", "given2", "surname", "surname2", "suffix", // values for nameField type
+                        "informal"); // modifiers for nameField type
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
-                    if (parts.size() >= 2) {
-                        order = 0;
-                        if (sampleItemValues.contains(parts.get(0))) {
-                            order += sampleItemValues.indexOf(parts.get(0)) * 16;
+                    order = 0;
+                    for (String part: parts) {
+                        if (allValues.contains(part)) {
+                            order += (1 << allValues.indexOf(part));
                         } else {
-                            order += sampleItemValues.size() * 16;
+                            order += (1 << allValues.size());
                         }
-                        if (fieldTypeValues.contains(parts.get(1))) {
-                            order += fieldTypeValues.indexOf(parts.get(1)) * 2;
-                        }
-                        if (parts.size() > 2) {
-                            order += 1;
-                        }
-                    } else {
-                        order = 128;
                     }
                     return source;
                 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -285,19 +285,18 @@
 //ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"%A\"]        ; Misc ; Minimal Pairs ; Case (for measurement units) ; &caseNumber($1) ; LTR_ALWAYS
 //ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"%A\"]        ; Misc ; Minimal Pairs ; Gender (for measurement units) ; &genderNumber($1) ; LTR_ALWAYS
 
-//ldml/personNames/nameOrder[@nameLocales=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Languages ; $1
+//ldml/personNames/nameOrderLocales[@order=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Locales ; $1-$2
+//ldml/personNames/nameOrderLocales[@order=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Locales ; $1
 //ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; Initial Patterns ; $1-$2
 //ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; Initial Patterns ; $1
 //ldml/personNames/personName/namePattern[@alt=\"%A\"]      ; Misc ; Person Name Formats ; Fallback Name Pattern ; any-$1
 //ldml/personNames/personName/namePattern           ; Misc ; Person Name Formats ; Fallback Name Pattern ; any
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4-$5)
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3)
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length $1 ; &personNameOrder($1-$2-$3)
-//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item $1 ; &sampleNameOrder($1-$2-$3)
-//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item $1 ; &sampleNameOrder($1-$2)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3-$4-$5)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item &sampleNameOrder($1) ; &sampleNameOrder($1-$2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item &sampleNameOrder($1) ; &sampleNameOrder($1-$2)
 
 
 #Emoji, etc.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
@@ -88,8 +88,8 @@ class LdmlConvertRulesTest {
         //Keep these as not-a-set for compatibility
         jsonSplittableAttrs.add(Pair.of("paradigmLocales", "locales"));
 
-        //Temporary skip while in development CLDR-15384
-        dtdSplittableAttrs.remove(Pair.of("nameOrder", "nameLocales"));
+        // TODO Temporary skip while in development CLDR-15384
+        dtdSplittableAttrs.remove(Pair.of("nameOrderLocales", "order"));
         dtdSplittableAttrs.remove(Pair.of("initialPattern", "type"));
         dtdSplittableAttrs.remove(Pair.of("personName", "length"));
         dtdSplittableAttrs.remove(Pair.of("personName", "order"));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -469,7 +469,7 @@ public class TestDtdData extends TestFmwk {
                 || (elementName.equals("compoundUnitPattern1") && (attribute.equals("case") || attribute.equals("gender")))
                 || (elementName.equals("genderMinimalPairs") && attribute.equals("gender"))
                 || (elementName.equals("caseMinimalPairs") && attribute.equals("case"))
-                || (elementName.equals("nameOrder") && attribute.equals("nameLocales"))
+                || (elementName.equals("nameOrderLocales") && attribute.equals("order"))
                 || (elementName.equals("initialPattern") && attribute.equals("type"))
                 || (elementName.equals("personName") && (attribute.equals("length") || attribute.equals("usage") ||
                                                          attribute.equals("style") || attribute.equals("order")))

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -188,17 +188,12 @@ public class TestExampleGenerator extends TestFmwk {
 
         "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard", // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
 
-        "//ldml/personNames/nameOrder[@nameLocales=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/nameOrderLocales[@order=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName/namePattern", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"]/namePattern", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern", // CLDR-15384
         "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"]" // CLDR-15384
 
@@ -245,7 +240,10 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard",
         "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/generic",
         "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/standard",
-        "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/daylight");
+        "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/daylight",
+        "//ldml/personNames/personName/namePattern",
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern",
+        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern"); // CLDR-15384
     // Add to above if the background SHOULD appear, but we don't have them yet. TODO Add later
 
     public void TestAllPaths() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -121,7 +121,7 @@ public class TestPersonNameFormatter extends TestFmwk{
             logln(personNameFormatter.toString());
         }
 
-        check(personNameFormatter, sampleNameObject1, "length=short; usage=sorting", "Smith, J. B.");
+        check(personNameFormatter, sampleNameObject1, "length=short; order=sorting", "Smith, J. B.");
         check(personNameFormatter, sampleNameObject1, "length=long; usage=referring; style=formal", "John Bob Smith Jr.");
 
         // TODO: we are getting the wrong answer for the second one obove.
@@ -197,13 +197,13 @@ public class TestPersonNameFormatter extends TestFmwk{
             assertTrue("label test\t"+ item + "\t" + label + "\t", added);
         }
 
-        FormatParameters testFormatParameters = new FormatParameters(Length.short_name, Style.formal, Usage.sorting, Order.givenFirst);
-        assertEquals("label test", "short-sorting-formal-givenFirst",
+        FormatParameters testFormatParameters = new FormatParameters(Length.short_name, Style.formal, Usage.referring, Order.givenFirst);
+        assertEquals("label test", "short-referring-formal-givenFirst",
             testFormatParameters.toLabel());
 
         // test just one example for ParameterMatcher, since there are too many combinations
         ParameterMatcher test = new ParameterMatcher(removeFirst(Length.ALL), removeFirst(Style.ALL), removeFirst(Usage.ALL), removeFirst(Order.ALL));
-        assertEquals("label test", "medium-short-monogram-monogramNarrow-addressing-sorting-informal-givenFirst",
+        assertEquals("label test", "medium-short-monogram-monogramNarrow-addressing-informal-givenFirst-surnameFirst",
             test.toLabel());
     }
 
@@ -274,13 +274,13 @@ public class TestPersonNameFormatter extends TestFmwk{
 
     public void TestExampleGenerator() {
         ExampleGenerator exampleGenerator = new ExampleGenerator(ENGLISH, ENGLISH, "");
-        String[][] tests = {
+        String[][] tests = { // TODO revise these when we have the real English examples
             {
                 "//ldml/personNames/personName[@length=\"long\"][@usage=\"referring\"][@style=\"formal\"][@order=\"givenFirst\"]/namePattern",
-                "〖Katherine Johnson〗〖Alberto Pedro Calderón〗〖Dorothy Lavinia Brown M.D.〗〖Erich Oswald Hans Carl Maria von Stroheim〗"
+                "〖Katherine Johnson〗〖Alberto Pedro Calderón〗〖John Blue〗〖John William Brown〗〖Dorothy Lavinia Brown M.D.〗〖Erich Oswald Hans Carl Maria von Stroheim〗"
             },{
                 "//ldml/personNames/personName[@length=\"monogram\"][@style=\"informal\"][@order=\"surnameFirst\"]/namePattern",
-                "〖JK〗〖CA〗〖BD〗〖vE〗"
+                "〖JK〗〖CA〗〖BJ〗〖BJ〗〖BD〗〖VE〗"
             }
         };
         for (String[] test : tests) {


### PR DESCRIPTION

CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Various items to unblock other work:
1. Change nameOrder to nameOrderLocales, make order attribute distinguishing, move locale list from attribute to value. Use root/en data suggested by Mark.
2. Move sorting from usage to order. Rearrange root/en data to match.
3. For sampleName, expanded & renamed items types, included givenInformal. Added root data with all nameFields for each item; adjusted the en data with ∅∅∅ for unused fields (add PathDescriotion note for that). The en sampleName data needs better values, current ones are just to have something for testing 
4. Misc en updates. remove . in mononym patterns since it is in initialPattern; use -initial-allCaps for all mononym patterns. 
5. Use PathHeader ordering functions for personName/sampleName section heads too.

Still to do (another PR): 
6. PlaceHolderDescriptions for non-{0},{1}-type placeholders
7. Better en sampleName data
