### PR TITLE
CLDR-15472 dbUtils is null in SurveyMain.doStartupDB

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DBUtils.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DBUtils.java
@@ -884,7 +884,7 @@ public class DBUtils {
     }
 
     public void validateDatasourceExists(SurveyMain sm, CLDRProgressIndicator.CLDRProgressTask progress) {
-        logger.info("StartupDB: datasource=" + datasource);
+        logger.info("validateDatasourceExists: datasource=" + datasource);
         if (datasource == null) {
             throw new RuntimeException(" - JNDI required:  " + getDbBrokenMessage());
         }


### PR DESCRIPTION
-Ensure dbUtils is initialized before calling doStartupDB

-Exit doStartup early if dbUtils is null (this can happen with liberty:dev)

-Wait until the end of doStartupDB to call Summary.scheduleAutomaticSnapshots

-Rename startUpDatabase to getDbInstance, reducing confusion with doStartupDB

-Throw exception from getDbInstance instead of boolean return, for consistency/brevity

-Revise logger.info in validateDatasourceExists to use actual method name

-Comments

CLDR-15472

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
