### PR TITLE
CLDR-15290 BRS v41: fix broken links in spec

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1902,7 +1902,7 @@ Here is a list of the data sources used to generate the initial key map layouts:
 | Android  | Android 4.0 - Ice Cream Sandwich ([https://source.android.com/source/downloading.html](https://source.android.com/source/downloading.html)) | Parsed layout files located in packages/inputmethods/LatinIME/java/res |
 | ChromeOS | XKB ([https://www.x.org/wiki/XKB](https://www.x.org/wiki/XKB)) | The ChromeOS represents a very small subset of the keyboards available from XKB.
 | Mac OSX  | Ukelele bundled System Keyboards ([https://software.sil.org/ukelele/](https://software.sil.org/ukelele/)) | These layouts date from Mac OSX 10.4 and are therefore a bit outdated |
-| Windows  | Generated .klc files from the Microsoft Keyboard Layout Creator ([https://support.microsoft.com/en-us/help/823010/the-microsoft-keyboard-layout-creator](https://support.microsoft.com/en-us/help/823010/the-microsoft-keyboard-layout-creator)) |
+| Windows  | Generated .klc files from the Microsoft Keyboard Layout Creator ([https://support.microsoft.com/en-us/topic/906c31e4-d5ea-7988-cb39-7b688880d7cb](https://support.microsoft.com/en-us/topic/906c31e4-d5ea-7988-cb39-7b688880d7cb)) |
 
 * * *
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1528,7 +1528,7 @@ The default locale is not even always used in resource bundle inheritance. For t
 *   break iteration
 *   case mapping
 *   transliteration
-    *   The lookup for transliteration is yet more complicated because of the interplay of source and target locales: see _Part 2 General, Section 10.1 [Inheritance.](https://www.unicode.org/reports/tr35/tr35-general.md#Inheritance)_
+    *   The lookup for transliteration is yet more complicated because of the interplay of source and target locales: see _Part 2 General, Section 10.1 [Inheritance.](tr35-general.md#Inheritance)_
 
 Thus if there is no Akan locale, for example, asking for a collation for Akan should produce the root collation, _not the Swedish collation._
 
@@ -3604,7 +3604,7 @@ The above algorithm is a logical statement of the process, but would obviously n
 | [<a name="RBNF" href="#RBNF">RBNF</a>]                                  | Rule-Based Number Format<br/>[https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1RuleBasedNumberFormat.html](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1RuleBasedNumberFormat.html) |
 | [<a name="RBBI" href="#RBBI">RBBI</a>]                                  | Rule-Based Break Iterator<br/>[https://unicode-org.github.io/icu/userguide/boundaryanalysis](https://unicode-org.github.io/icu/userguide/boundaryanalysis) |
 | [<a name="UCAChart" href="#UCAChart">UCAChart</a>]                      | Collation Chart[<br/>https://unicode.org/charts/collation/](https://unicode.org/charts/collation/) |
-| [<a name="UTCInfo" href="#UTCInfo">UTCInfo</a>]                         | NIST Time and Frequency Division Home Page<br/>[https://tf.nist.gov/<br/>](https://tf.nist.gov/)U.S. Naval Observatory: What is Universal Time?<br/>[https://www.usno.navy.mil/USNO/time/master-clock/systems-of-time](https://www.usno.navy.mil/USNO/time/master-clock/systems-of-time) |
+| [<a name="UTCInfo" href="#UTCInfo">UTCInfo</a>]                         | NIST Time and Frequency Division Home Page<br/>[https://tf.nist.gov/<br/>](https://tf.nist.gov/)U.S. Naval Observatory: What is Universal Time?<br/>[https://www.cnmoc.usff.navy.mil/Organization/United-States-Naval-Observatory/Precise-Time-Department/The-USNO-Master-Clock/Definitions-of-Systems-of-Time/](https://www.cnmoc.usff.navy.mil/Organization/United-States-Naval-Observatory/Precise-Time-Department/The-USNO-Master-Clock/Definitions-of-Systems-of-Time/) |
 | [<a name="WindowsCulture" href="#WindowsCulture">WindowsCulture</a>]    | Windows Culture Info (with mappings from [[BCP47](#BCP47)]-style codes to LCIDs)<br/>[https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo) |
 
 


### PR DESCRIPTION
CLDR-15290

- [ ] This PR completes the ticket.

I checked and fixed all of the external (http / https) links in markdown, using `npx markdown-link-check *.md` 

-----

I couldn't figure out what to do with the following in `tr35-general.md`:

-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#AbessiveCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#AdessiveCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#AllativeCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#DelativeCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#ElativeCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#EssiveCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#IllativeCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#InessiveCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#SublativeCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#SuperessiveCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#TerminativeCase → Status: 404
-   [✖] http://acoli.cs.uni-frankfurt.de/resources/olia/olia.owl#TranslativeCase → Status: 404

Per https://github.com/acoli-repo/olia/issues/6#issuecomment-1087895314 there is some migration in place, but I'm not sure what the right links are. 