### PR TITLE
CLDR-15405 replace "any" entry with 3 root fallbacks by order; add/use &personNameSection

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9133,9 +9133,6 @@ annotations.
 		<nameOrderLocales order="surnameFirst">ja zh ko</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-		<personName>
-			<namePattern>{given-informal} {surname}</namePattern>
-		</personName>
 		<personName length="long" usage="addressing" style="formal" order="sorting">
 			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
 		</personName>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5372,159 +5372,155 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<nameOrderLocales order="surnameFirst">ja zh ko hu</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-		<!-- fallback/any pattern -->
-		<personName>
-			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>
-		</personName>
 		<personName length="long" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<namePattern>{prefix} {given} {given2} {surname} {surname2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<namePattern>{surname} {surname2} {prefix} {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<!-- for length="monogram" or "monogramNarrow", ignore usage -->
 		<personName length="monogram" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="monogram" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="monogram" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="monogram" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="monogram" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="monogram" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="monogramNarrow" style="formal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="monogramNarrow" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="monogramNarrow" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="monogramNarrow" style="informal" order="sorting">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="monogramNarrow" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="monogramNarrow" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName"/>
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<sampleName item="givenSurname">
 			<nameField type="prefix">Prefix</nameField>
 			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given-informal">givenInformal</nameField>
 			<nameField type="given2">Given2</nameField>
 			<nameField type="surname">Surname</nameField>
 			<nameField type="surname2">Surname2</nameField>
@@ -5533,7 +5529,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<sampleName item="given2Surname">
 			<nameField type="prefix">Prefix</nameField>
 			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given-informal">givenInformal</nameField>
 			<nameField type="given2">Given2</nameField>
 			<nameField type="surname">Surname</nameField>
 			<nameField type="surname2">Surname2</nameField>
@@ -5542,7 +5538,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<sampleName item="givenSurname2">
 			<nameField type="prefix">Prefix</nameField>
 			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given-informal">givenInformal</nameField>
 			<nameField type="given2">Given2</nameField>
 			<nameField type="surname">Surname</nameField>
 			<nameField type="surname2">Surname2</nameField>
@@ -5551,7 +5547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<sampleName item="informal">
 			<nameField type="prefix">Prefix</nameField>
 			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given-informal">givenInformal</nameField>
 			<nameField type="given2">Given2</nameField>
 			<nameField type="surname">Surname</nameField>
 			<nameField type="surname2">Surname2</nameField>
@@ -5560,7 +5556,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<sampleName item="full">
 			<nameField type="prefix">Prefix</nameField>
 			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given-informal">givenInformal</nameField>
 			<nameField type="given2">Given2</nameField>
 			<nameField type="surname">Surname</nameField>
 			<nameField type="surname2">Surname2</nameField>
@@ -5569,7 +5565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<sampleName item="multiword">
 			<nameField type="prefix">Prefix</nameField>
 			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">given-informal</nameField>
+			<nameField type="given-informal">givenInformal</nameField>
 			<nameField type="given2">Given2</nameField>
 			<nameField type="surname">Surname</nameField>
 			<nameField type="surname2">Surname2</nameField>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -914,8 +914,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/sampleName[@item='%anyAttribute']/nameField[@type='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/sampleName[@item='%anyAttribute']/nameField[@type='%anyAttribute']"/>
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -148,10 +148,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                 // check that we don't have a difference in the order AND there is a surname or surname2
                 // that is, it is ok to coalesce patterns of different orders where the order doesn't make a difference
 
-                // TODO Mark We should get rid of the empty matcher; that should be handled by compactor. Then remove this condition
-
-                final boolean parameterMatcherIsMatchAll = parameterMatcher.equals(ParameterMatcher.MATCH_ALL);
-                if (!parameterMatcherIsMatchAll) {
+                if (true) { // TODO: clean up to avoid block
 
                     if(order.contains(Order.givenFirst)
                         && order.contains(Order.surnameFirst)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -491,8 +491,7 @@ public class ExampleGenerator {
         //TODO Peter extract from sampleName data once that is in en.xml
         // eventually, this will cycle through the types of sample names, and extract from CLDRFile
         for (NameObject sampleNameObject1 : sampleNames.values()) {
-            // TODO Remove initial periods from en.xml
-            NamePattern namePattern = NamePattern.from(0, value.replace(".", ""));
+            NamePattern namePattern = NamePattern.from(0, value);
             ULocale locale = new ULocale(getCldrFile().getLocaleID());
             String result = namePattern.format(sampleNameObject1, formatParameters, personNameFormatter.getFallbackInfo());
             examples.add(result);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -392,7 +392,7 @@ public class PathDescription {
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/sampleName"
         + RegexLookup.SEPARATOR
-        + "Sample names for person name forma examples (enter ∅∅∅ for unused fields). For more information, please see "
+        + "Sample names for person name format examples (enter ∅∅∅ for unused fields). For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
 
         + "^//ldml/numbers/([a-z]*)Formats(\\[@numberSystem=\"([^\"]*)\"])?/\\1FormatLength/\\1Format\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]$"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1852,12 +1852,44 @@ public class PathHeader implements Comparable<PathHeader> {
                 }
             });
 
+            functionMap.put("personNameSection", new Transform<String, String>() {
+                @Override
+                public String transform(String source) {
+                    // value for personName length and sampleName item in desired sort order
+                    final List<String> lengthValues = Arrays.asList("long", "medium", "short", "monogram", "monogramNarrow");
+                    final List<String> itemValues = Arrays.asList("givenSurname", "given2Surname", "givenSurname2", "informal", "full", "multiword");
+
+                    if (source.equals("NameOrder")) {
+                        order = 0;
+                        return "NameOrder for Locales";
+                    }
+                    if (source.equals("InitialPatterns")) {
+                        order = 10;
+                        return source;
+                    }
+                    String lengthPrefix = "PersonName:";
+                    if (source.startsWith(lengthPrefix)) {
+                        String lengthValue = source.substring(lengthPrefix.length());
+                        order = 20 + lengthValues.indexOf(lengthValue);
+                        return "PersonName Patterns for Length: " + lengthValue;
+                    }
+                    String itemPrefix = "SampleName:";
+                    if (source.startsWith(itemPrefix)) {
+                        String itemValue = source.substring(itemPrefix.length());
+                        order = 30 + itemValues.indexOf(itemValue);
+                        return "SampleName Fields for Item: " + itemValue;
+                    }
+                    order = 40;
+                    return source;
+                }
+            });
+
             functionMap.put("personNameOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
                     // The various personName attribute values in desired sort order
                     final List<String> allValues = Arrays.asList(
-                        "long", "medium", "short", "monogram", "monogramNarrow", // length values
+                        // length values already handled in &personNameSection
                         "addressing", "referring", // usage values
                         "formal", "informal", // style values
                         "sorting", "givenFirst", "surnameFirst"); //order values
@@ -1867,8 +1899,6 @@ public class PathHeader implements Comparable<PathHeader> {
                     for (String part: parts) {
                         if (allValues.contains(part)) {
                             order += (1 << allValues.indexOf(part));
-                        } else {
-                            order += (1 << allValues.size());
                         }
                     }
                     return source;
@@ -1878,8 +1908,8 @@ public class PathHeader implements Comparable<PathHeader> {
             functionMap.put("sampleNameOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
+                    // The various nameField attribute values in desired sort order
                     final List<String> allValues = Arrays.asList(
-                        "givenSurname", "given2Surname", "givenSurname2", "informal", "full", "multiword", // values for sampleName item
                         "prefix", "given", "given2", "surname", "surname2", "suffix", // values for nameField type
                         "informal"); // modifiers for nameField type
 
@@ -1888,8 +1918,6 @@ public class PathHeader implements Comparable<PathHeader> {
                     for (String part: parts) {
                         if (allValues.contains(part)) {
                             order += (1 << allValues.indexOf(part));
-                        } else {
-                            order += (1 << allValues.size());
                         }
                     }
                     return source;

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -285,18 +285,16 @@
 //ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"%A\"]        ; Misc ; Minimal Pairs ; Case (for measurement units) ; &caseNumber($1) ; LTR_ALWAYS
 //ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"%A\"]        ; Misc ; Minimal Pairs ; Gender (for measurement units) ; &genderNumber($1) ; LTR_ALWAYS
 
-//ldml/personNames/nameOrderLocales[@order=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Locales ; $1-$2
-//ldml/personNames/nameOrderLocales[@order=\"%A\"]   ; Misc ; Person Name Formats ; Name Order For Locales ; $1
-//ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; Initial Patterns ; $1-$2
-//ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; Initial Patterns ; $1
-//ldml/personNames/personName/namePattern[@alt=\"%A\"]      ; Misc ; Person Name Formats ; Fallback Name Pattern ; any-$1
-//ldml/personNames/personName/namePattern           ; Misc ; Person Name Formats ; Fallback Name Pattern ; any
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3-$4-$5)
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; Name Patterns for Length &personNameOrder($1) ; &personNameOrder($1-$2-$3)
-//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item &sampleNameOrder($1) ; &sampleNameOrder($1-$2-$3)
-//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ; Sample Name Fields for Item &sampleNameOrder($1) ; &sampleNameOrder($1-$2)
+//ldml/personNames/nameOrderLocales[@order=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1-$2
+//ldml/personNames/nameOrderLocales[@order=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1
+//ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(InitialPatterns) ; $1-$2
+//ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(InitialPatterns) ; $1
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4-$5)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4)
+//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(SampleName:$1) ; &sampleNameOrder($1-$2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ;  &personNameSection(SampleName:$1) ; &sampleNameOrder($1-$2)
 
 
 #Emoji, etc.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFactory.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFactory.java
@@ -172,11 +172,7 @@ public class TestCldrFactory extends TestFmwkPlus {
             System.out.println(temp);
         }
         CLDRFile enDoubleWithoutAnnotations = cldrFileFromString(temp);
-        String differentPath = differentPathValue(enMain, enDoubleWithoutAnnotations);
-        if (differentPath == null || !differentPath.startsWith("//ldml/personNames/") ||
-                !logKnownIssue("CLDR-15406", "TestCldrFactory.testWrite issue with personNames")) {
-             assertEquals("enMain == enDoubleWithoutAnnotations", null, differentPathValue(enMain, enDoubleWithoutAnnotations));
-        }
+        assertEquals("enMain == enDoubleWithoutAnnotations", null, differentPathValue(enMain, enDoubleWithoutAnnotations));
 
         temp = cldrFileToString(enDouble, keepAnnotations);
         if (DEBUG) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -191,7 +191,6 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/personNames/nameOrderLocales[@order=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
@@ -241,7 +240,6 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/generic",
         "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/standard",
         "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/daylight",
-        "//ldml/personNames/personName/namePattern",
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern",
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern"); // CLDR-15384
     // Add to above if the background SHOULD appear, but we don't have them yet. TODO Add later

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -75,7 +75,9 @@ public class TestPersonNameFormatter extends TestFmwk{
             "length=short medium; style=formal; usage=addressing", "{given} {given2-initial} {surname}",
             "length=short medium; style=formal; usage=addressing", "{given} {surname}",
             "length=monogram; style=formal; usage=addressing", "{given-initial}{surname-initial}",
-            "", "{prefix} {given} {given2} {surname} {surname2} {suffix}");
+            "order=givenFirst", "{prefix} {given} {given2} {surname} {surname2} {suffix}",
+            "order=surnameFirst", "{surname} {surname2} {prefix} {given} {given2} {suffix}",
+            "order=sorting", "{surname} {surname2}, {prefix} {given} {given2} {suffix}");
 
         PersonNameFormatter personNameFormatter = new PersonNameFormatter(namePatternData, FALLBACK_FORMATTER);
 
@@ -221,7 +223,7 @@ public class TestPersonNameFormatter extends TestFmwk{
 
         NamePatternData namePatternData = new NamePatternData(
             localeToOrder,
-            "", "1{prefix}1 2{given}2 3{given2}3 4{surname}4 5{surname2}5 6{suffix}6");
+            "order=givenFirst", "1{prefix}1 2{given}2 3{given2}3 4{surname}4 5{surname2}5 6{suffix}6");
 
         PersonNameFormatter personNameFormatter = new PersonNameFormatter(namePatternData, FALLBACK_FORMATTER);
 


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

- Remove the fallback "any" personName entry in root & en. Instead, in root provide explicit patterns for the 3 different orders (with length="long" usage="referring" style="formal" ) and have other personName entries fall back to the appropriate one of those.
- As a result, remove ParameterMatcher.MATCH_ALL and adjust code accordingly. Update tests that passed an empty string of attribute values to now pass one or more fallback strings with order attribute set.
- Add PathHeader function personNameSection and use it in PathHeader.txt
- Remove the logKnownIssue skip around a test in TestCldrFactory.testWrite, the original test now works fine.
-  Other minor fixes