### PR TITLE
CLDR-15404 Enhance error checking

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.test;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -10,24 +11,38 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.MatchValue.LocaleMatchValue;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Field;
+import org.unicode.cldr.util.personname.PersonNameFormatter.ModifiedField;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Modifier;
 import org.unicode.cldr.util.personname.PersonNameFormatter.NamePattern;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Order;
 import org.unicode.cldr.util.personname.PersonNameFormatter.ParameterMatcher;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 public class CheckPlaceHolders extends CheckCLDR {
 
     private static final Pattern PLACEHOLDER_PATTERN = PatternCache.get("([0-9]|[1-9][0-9]+)");
+    private static final Splitter SPLIT_SPACE = Splitter.on(' ').trimResults();
+    private static final Joiner JOIN_SPACE = Joiner.on(' ');
+
     private static final Pattern SKIP_PATH_LIST = Pattern
         .compile("//ldml/characters/(exemplarCharacters|parseLenient).*");
+
+    private static final LocaleMatchValue LOCALE_MATCH_VALUE = new LocaleMatchValue(ImmutableSet.of(
+        Validity.Status.regular,
+        Validity.Status.special,
+        Validity.Status.unknown)
+        );
 
     @Override
     public CheckCLDR handleCheck(String path, String fullPath, String value, Options options,
@@ -38,146 +53,198 @@ public class CheckPlaceHolders extends CheckCLDR {
             return this;
         }
 
-        if (path.contains("/personNames/personName")) {
-
-            // TODO Mark (maybe not here); validate the nameOrderLocales values and the initialPattern
-
-            // check that the name pattern is valid
-
+        if (path.contains("/personNames")) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
-            Pair<ParameterMatcher, NamePattern> pair = null;
-            try {
-                pair = PersonNameFormatter.fromPathValue(parts, value);
-            } catch (Exception e) {
-                result.add(new CheckStatus().setCause(this)
-                    .setMainType(CheckStatus.errorType)
-                    .setSubtype(Subtype.invalidPlaceHolder)
-                    .setMessage("Invalid placeholder in value: \"" + value + "\""));
-                return this; // fatal error, don't bother with others
-            }
+            switch(parts.getElement(2)) {
+            //ldml/personNames/initialPattern[@type="initial"]
+            default:
+                // skip to rest of handleCheck
+                break;
 
-            final ParameterMatcher parameterMatcher = pair.getFirst();
-            final NamePattern namePattern = pair.getSecond();
-
-            // now check that the namePattern is reasonable
-
-            // gather information about the fields
-            int firstSurname = Integer.MAX_VALUE;
-            int firstGiven = Integer.MAX_VALUE;
-
-            Multimap<Field, Integer> fieldToPositions = namePattern.getFieldPositions();
-
-            // TODO ALL check for combinations we should enforce; eg, only have given2 if there is a given; only have surname2 if there is a surname; others?
-
-            for (Entry<Field, Collection<Integer>> entry : fieldToPositions.asMap().entrySet()) {
-
-                // If a field occurs twice, probably an error. Could relax this upon feedback
-
-                Collection<Integer> positions = entry.getValue();
-                if (positions.size() > 1) {
-
-                    // However, do allow prefix&core together
-
-                    boolean skip = false;
-                    if (entry.getKey() == Field.surname) {
-                        Iterator<Integer> it = positions.iterator();
-                        Set<Modifier> m1 = namePattern.getModifiedField(it.next()).getModifiers();
-                        Set<Modifier> m2 = namePattern.getModifiedField(it.next()).getModifiers();
-                        skip = m1.contains(Modifier.core) && m2.contains(Modifier.prefix)
-                            || m1.contains(Modifier.prefix) && m2.contains(Modifier.core);
+            case "nameOrderLocales":
+                //ldml/personNames/nameOrderLocales[@order="givenFirst"]
+                Set<String> orderErrors = null;
+                for (String item : SPLIT_SPACE.split(value)) {
+                    boolean mv = LOCALE_MATCH_VALUE.is(item);
+                    if (!mv) {
+                        if (orderErrors == null) {
+                            orderErrors = new LinkedHashSet<>();
+                        }
+                        orderErrors.add(item);
                     }
+                }
+                if (orderErrors != null) {
+                    result.add(new CheckStatus().setCause(this)
+                        .setMainType(CheckStatus.errorType)
+                        .setSubtype(Subtype.invalidPlaceHolder)
+                        .setMessage("Invalid locales: \"" + JOIN_SPACE.join(orderErrors) + "\""));
+                }
+                return this;
 
-                    if (!skip) {
-                        result.add(new CheckStatus().setCause(this)
-                            .setMainType(CheckStatus.errorType)
-                            .setSubtype(Subtype.invalidPlaceHolder)
-                            .setMessage("Duplicate fields: " + entry));
+            case "sampleName":
+                //ldml/personNames/sampleName[@item="informal"]/nameField[@type="surname"]
+                if (value.equals("∅∅∅")) {
+                    // check for required values
+
+                    ModifiedField fieldType = ModifiedField.from(parts.getAttributeValue(-1, "type"));
+                    Field field = fieldType.getField();
+
+                    switch(field) {
+                    case given:
+                        // we must have a given
+                        if (fieldType.getModifiers().isEmpty()) {
+                            result.add(new CheckStatus().setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.invalidPlaceHolder)
+                                .setMessage("Names must have a value for the ‘given‘ field. Mononyms (like ‘Lady Gaga’) use given, not surname"));
+                        }
+                        break;
+                    case surname:
+                        // can't have surname2 unless we have surname
+                        String modPath = parts.cloneAsThawed().setAttribute(-1, "type", Field.surname2.toString()).toString();
+                        String surname2Value = getCldrFileToCheck().getStringValue(modPath);
+                        if (!surname2Value.equals("∅∅∅")) {
+                            result.add(new CheckStatus().setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.invalidPlaceHolder)
+                                .setMessage("Names must have a value for the ‘surname’ field if they have a ‘surname2’ field."));
+                        }
+                        break;
+                    default:
+                        break;
                     }
                 }
 
-                // gather some info for later
+                return this;
+            case "personName":
+                //ldml/personNames/personName[@length="long"][@usage="addressing"][@style="formal"][@order="sorting"]/namePattern
 
-                Integer leastPosition = positions.iterator().next();
-                switch (entry.getKey()) {
-                case given: case given2:
-                    firstGiven = Math.min(leastPosition, firstGiven);
-                    break;
-                case surname: case surname2:
-                    firstSurname = Math.min(leastPosition, firstSurname);
-                    break;
-                default: // ignore
-                }
-            }
+                // check that the name pattern is valid
 
-            // we must have at least a given* and a surname*
-
-            if (firstGiven == Integer.MAX_VALUE && firstSurname == Integer.MAX_VALUE) {
-                result.add(new CheckStatus().setCause(this)
-                    .setMainType(CheckStatus.errorType)
-                    .setSubtype(Subtype.invalidPlaceHolder)
-                    .setMessage("Must have given, given2, surname, or surname2"));
-                return this; // fatal error, don't bother with others
-            }
-
-            // the rest of the tests are of the pattern, and only apply when we have both given and surname
-
-            if (firstGiven < Integer.MAX_VALUE && firstSurname < Integer.MAX_VALUE) {
-
-                Set<Order> order = parameterMatcher.getOrder();
-
-
-                // Handle 'sorting' value. Will usually be compatible with surnameFirst in foundOrder, except for known exceptions
-
-                ImmutableSet<Object> givenFirstSortingLocales = ImmutableSet.of("is"); // will be static
-                if (order.contains(Order.sorting)) {
-                    EnumSet<Order> temp = EnumSet.noneOf(Order.class);
-                    temp.addAll(order);
-                    temp.remove(Order.sorting);
-                    if (givenFirstSortingLocales.contains(getCldrFileToCheck().getLocaleID())) { // TODO Mark cover contains-by-inheritance also
-                        temp.add(Order.givenFirst);
-                    } else {
-                        temp.add(Order.surnameFirst);
-                    }
-                    order = temp;
+                Pair<ParameterMatcher, NamePattern> pair = null;
+                try {
+                    pair = PersonNameFormatter.fromPathValue(parts, value);
+                } catch (Exception e) {
+                    result.add(new CheckStatus().setCause(this)
+                        .setMainType(CheckStatus.errorType)
+                        .setSubtype(Subtype.invalidPlaceHolder)
+                        .setMessage("Invalid placeholder in value: \"" + value + "\""));
+                    return this; // fatal error, don't bother with others
                 }
 
-                if (order.isEmpty()) {
-                    order = Order.ALL;
-                }
+                final ParameterMatcher parameterMatcher = pair.getFirst();
+                final NamePattern namePattern = pair.getSecond();
 
-                // check that we don't have a difference in the order AND there is a surname or surname2
-                // that is, it is ok to coalesce patterns of different orders where the order doesn't make a difference
+                // now check that the namePattern is reasonable
 
-                if (true) { // TODO: clean up to avoid block
+                Multimap<Field, Integer> fieldToPositions = namePattern.getFieldPositions();
 
-                    if(order.contains(Order.givenFirst)
-                        && order.contains(Order.surnameFirst)
-                        ) {
-                        result.add(new CheckStatus().setCause(this)
-                            .setMainType(CheckStatus.errorType)
-                            .setSubtype(Subtype.invalidPlaceHolder)
-                            .setMessage("Conflicting Order values: " + order));
-                    }
+                // gather information about the fields
+                int firstSurname = Integer.MAX_VALUE;
+                int firstGiven = Integer.MAX_VALUE;
 
-                    // now check order in pattern is consistent with Order
+                // TODO ALL check for combinations we should enforce; eg, only have given2 if there is a given; only have surname2 if there is a surname; others?
 
-                    Order foundOrder = firstGiven < firstSurname ? Order.givenFirst : Order.surnameFirst;
-                    final Order first = order.iterator().next();
+                for (Entry<Field, Collection<Integer>> entry : fieldToPositions.asMap().entrySet()) {
 
-                    if (first != foundOrder) {
+                    // If a field occurs twice, probably an error. Could relax this upon feedback
 
-                        if (first == Order.givenFirst && !"en".equals(getCldrFileToCheck().getLocaleID())) { // TODO Mark Drop HACK once root is ok
-                            return this;
+                    Collection<Integer> positions = entry.getValue();
+                    if (positions.size() > 1) {
+
+                        // However, do allow prefix&core together
+
+                        boolean skip = false;
+                        if (entry.getKey() == Field.surname) {
+                            Iterator<Integer> it = positions.iterator();
+                            Set<Modifier> m1 = namePattern.getModifiedField(it.next()).getModifiers();
+                            Set<Modifier> m2 = namePattern.getModifiedField(it.next()).getModifiers();
+                            skip = m1.contains(Modifier.core) && m2.contains(Modifier.prefix)
+                                || m1.contains(Modifier.prefix) && m2.contains(Modifier.core);
                         }
 
-                        result.add(new CheckStatus().setCause(this)
-                            .setMainType(CheckStatus.errorType)
-                            .setSubtype(Subtype.invalidPlaceHolder)
-                            .setMessage("Pattern order {0} is inconsistent with code order {1}", foundOrder, first));
+                        if (!skip) {
+                            result.add(new CheckStatus().setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.invalidPlaceHolder)
+                                .setMessage("Duplicate fields: " + entry));
+                        }
+                    }
+
+                    // gather some info for later
+
+                    Integer leastPosition = positions.iterator().next();
+                    switch (entry.getKey()) {
+                    case given: case given2:
+                        firstGiven = Math.min(leastPosition, firstGiven);
+                        break;
+                    case surname: case surname2:
+                        firstSurname = Math.min(leastPosition, firstSurname);
+                        break;
+                    default: // ignore
                     }
                 }
+
+                // the rest of the tests are of the pattern, and only apply when we have both given and surname
+
+                if (firstGiven < Integer.MAX_VALUE && firstSurname < Integer.MAX_VALUE) {
+
+                    Set<Order> order = parameterMatcher.getOrder();
+
+
+                    // Handle 'sorting' value. Will usually be compatible with surnameFirst in foundOrder, except for known exceptions
+
+                    ImmutableSet<Object> givenFirstSortingLocales = ImmutableSet.of("is"); // will be static
+                    if (order.contains(Order.sorting)) {
+                        EnumSet<Order> temp = EnumSet.noneOf(Order.class);
+                        temp.addAll(order);
+                        temp.remove(Order.sorting);
+                        if (givenFirstSortingLocales.contains(getCldrFileToCheck().getLocaleID())) { // TODO Mark cover contains-by-inheritance also
+                            temp.add(Order.givenFirst);
+                        } else {
+                            temp.add(Order.surnameFirst);
+                        }
+                        order = temp;
+                    }
+
+                    if (order.isEmpty()) {
+                        order = Order.ALL;
+                    }
+
+                    // check that we don't have a difference in the order AND there is a surname or surname2
+                    // that is, it is ok to coalesce patterns of different orders where the order doesn't make a difference
+
+                    if (true) { // TODO: clean up to avoid block
+
+                        if(order.contains(Order.givenFirst)
+                            && order.contains(Order.surnameFirst)
+                            ) {
+                            result.add(new CheckStatus().setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.invalidPlaceHolder)
+                                .setMessage("Conflicting Order values: " + order));
+                        }
+
+                        // now check order in pattern is consistent with Order
+
+                        Order foundOrder = firstGiven < firstSurname ? Order.givenFirst : Order.surnameFirst;
+                        final Order first = order.iterator().next();
+
+                        if (first != foundOrder) {
+
+                            if (first == Order.givenFirst && !"en".equals(getCldrFileToCheck().getLocaleID())) { // TODO Mark Drop HACK once root is ok
+                                return this;
+                            }
+
+                            result.add(new CheckStatus().setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.invalidPlaceHolder)
+                                .setMessage("Pattern order {0} is inconsistent with code order {1}", foundOrder, first));
+                        }
+                    }
+                }
+                return this;
             }
-            return this;
             // done with person names
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
@@ -107,11 +107,22 @@ public abstract class MatchValue implements Predicate<String> {
         }
     }
 
-    static class LocaleMatchValue extends MatchValue {
-        private final Predicate<String> lang = new ValidityMatchValue(LstrType.language);
-        private final Predicate<String> script = new ValidityMatchValue(LstrType.script);
-        private final Predicate<String> region = new ValidityMatchValue(LstrType.region);
-        private final Predicate<String> variant = new ValidityMatchValue(LstrType.variant);
+    public static class LocaleMatchValue extends MatchValue {
+        private final Predicate<String> lang;
+        private final Predicate<String> script;
+        private final Predicate<String> region;
+        private final Predicate<String> variant;
+
+        public LocaleMatchValue() {
+            this(null);
+        }
+
+        public LocaleMatchValue(Set<Status> statuses) {
+            lang = new ValidityMatchValue(LstrType.language, statuses, false);
+            script = new ValidityMatchValue(LstrType.script, statuses, false);
+            region = new ValidityMatchValue(LstrType.region, statuses, false);
+            variant = new ValidityMatchValue(LstrType.variant, statuses, false);
+        }
 
         @Override
         public String getName() {
@@ -631,7 +642,7 @@ public abstract class MatchValue implements Predicate<String> {
         @Override
         public  boolean is(String items) {
             List<String> splitItems = SPACE_SPLITTER.splitToList(items);
-            if( (new HashSet<String>(splitItems)).size() != splitItems.size() ) {
+            if( (new HashSet<>(splitItems)).size() != splitItems.size() ) {
                 throw new IllegalArgumentException("Set contains duplicates: " + items);
             }
             return and(subtest, splitItems);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -93,20 +93,20 @@ public class TestPersonNameFormatter extends TestFmwk{
     String HACK_INITIAL_FORMATTER = "{0}॰"; // use "unusual" period to mark when we are using fallbacks
 
     public void TestNamePatternParserThrowsWhenInvalidPatterns() {
-        final String[] invalidPatterns = new String[] {
-            "{",
-            "}",
-            "{}",
-            "\\",
-            "blah {given", "blah given}",
-            "blah {given\\}",                           /* blah {given\} */
-            "blah {given} yadda {}",
-            "blah \\n"                                  /* blah \n */
+        final String[][] invalidPatterns = {
+            {"{", "Unmatched {: «{❌»"},
+            {"}", "Unexpected }: «❌}»"},
+            {"{}", "Empty field '{}' is not allowed : «{❌}»"},
+            {"\\", "Invalid character: : «❌\\»"},
+            {"blah {given", "Unmatched {: «blah {given❌»"},
+            {"blah {given\\}", "Unmatched {: «blah {given\\}❌»"},                           /* blah {given\} */
+            {"blah {given} yadda {}", "Empty field '{}' is not allowed : «blah {given} yadda {❌}»"},
+            {"blah \\n", "Escaping character 'n' is not supported: «blah ❌\\n»"}                                  /* blah \n */
         };
-        for (final String pattern : invalidPatterns) {
-            assertThrows(String.format("Pattern '%s'", pattern), () -> {
-                NamePattern.from(0, pattern);
-            });
+        for (final String[] pattern : invalidPatterns) {
+            assertThrows(String.format("Pattern '%s'", pattern[0]), () -> {
+                NamePattern.from(0, pattern[0]);
+            }, pattern[1]);
         }
     }
 
@@ -271,13 +271,13 @@ public class TestPersonNameFormatter extends TestFmwk{
         return result;
     }
 
-    private void assertThrows(String subject, Runnable code) {
+    private void assertThrows(String subject, Runnable code, String expectedMessage) {
         try {
             code.run();
             fail(String.format("%s was supposed to throw an exception.", subject));
         }
         catch (Exception e) {
-            assertTrue(subject + " threw exception as expected", true);
+            assertEquals(subject + " threw exception as expected", expectedMessage, e.getMessage());
         }
     }
 
@@ -333,12 +333,12 @@ public class TestPersonNameFormatter extends TestFmwk{
     }
 
     public void TestInvalidNameObjectThrows() {
-        final String[] invalidPatterns = new String[] {
-            "given2-initial=B",
+        final String[][] invalidPatterns = {
+            {"given2-initial=B","Every field must have a completely modified value given2={[initial]=B}"}
         };
-        for (final String pattern : invalidPatterns) {
-            assertThrows("Invalid Name object " + pattern,
-                () -> SimpleNameObject.from(pattern));
+        for (final String[] pattern : invalidPatterns) {
+            assertThrows("Invalid Name object: " + pattern,
+                () -> SimpleNameObject.from(pattern[0]), pattern[1]);
         }
     }
 
@@ -371,7 +371,7 @@ public class TestPersonNameFormatter extends TestFmwk{
             if (!assertEquals("Comma right?\t" + parameterMatcher + " ➡︎ " + namePattern + "\t", commaRequired, hasComma)) {
                 if (!messageShown) {
                     System.out.println("\t\tNOTE: In English, comma is required IFF the pattern has both given and surname, "
-                + "and order has sorting, and length has neither monogram nor monogramNarrow,");
+                        + "and order has sorting, and length has neither monogram nor monogramNarrow,");
                     messageShown = true;
                 }
             }


### PR DESCRIPTION
CLDR-15404

- Add checks for nameOrderLocales and sampleName
- Make LocaleMatchValue public, for ease of checking validity of locales
- Add information to exceptions thrown by NamePattern.parse
- Fix the TestPersonNameFormatter to account for the more detailed messages

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
