### PR TITLE
CLDR-15405 add mononym sample, more code-like root dummy names, fix ST section & path ordering

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3203,7 +3203,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT sampleName ( alias | ( nameField+, special* ) ) >
 <!ATTLIST sampleName item NMTOKENS #REQUIRED >
-    <!--@MATCH:literal/givenSurname, given2Surname, givenSurname2, informal, full, multiword-->
+    <!--@MATCH:literal/givenSurname, given2Surname, givenSurname2, informal, full, multiword, mononym-->
 
 <!ELEMENT nameField ( #PCDATA ) >
 <!ATTLIST nameField type CDATA #REQUIRED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9333,5 +9333,14 @@ annotations.
 			<nameField type="surname2">∅∅∅</nameField>
 			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
+		<sampleName item="mononym">
+			<nameField type="prefix">∅∅∅</nameField>
+			<nameField type="given">Sinbad</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
+			<nameField type="given2">∅∅∅</nameField>
+			<nameField type="surname">∅∅∅</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="suffix">∅∅∅</nameField>
+		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5518,58 +5518,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<sampleName item="givenSurname">
-			<nameField type="prefix">Prefix</nameField>
-			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">givenInformal</nameField>
-			<nameField type="given2">Given2</nameField>
-			<nameField type="surname">Surname</nameField>
-			<nameField type="surname2">Surname2</nameField>
-			<nameField type="suffix">Suffix</nameField>
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
 		</sampleName>
 		<sampleName item="given2Surname">
-			<nameField type="prefix">Prefix</nameField>
-			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">givenInformal</nameField>
-			<nameField type="given2">Given2</nameField>
-			<nameField type="surname">Surname</nameField>
-			<nameField type="surname2">Surname2</nameField>
-			<nameField type="suffix">Suffix</nameField>
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
 		</sampleName>
 		<sampleName item="givenSurname2">
-			<nameField type="prefix">Prefix</nameField>
-			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">givenInformal</nameField>
-			<nameField type="given2">Given2</nameField>
-			<nameField type="surname">Surname</nameField>
-			<nameField type="surname2">Surname2</nameField>
-			<nameField type="suffix">Suffix</nameField>
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
 		</sampleName>
 		<sampleName item="informal">
-			<nameField type="prefix">Prefix</nameField>
-			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">givenInformal</nameField>
-			<nameField type="given2">Given2</nameField>
-			<nameField type="surname">Surname</nameField>
-			<nameField type="surname2">Surname2</nameField>
-			<nameField type="suffix">Suffix</nameField>
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
 		</sampleName>
 		<sampleName item="full">
-			<nameField type="prefix">Prefix</nameField>
-			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">givenInformal</nameField>
-			<nameField type="given2">Given2</nameField>
-			<nameField type="surname">Surname</nameField>
-			<nameField type="surname2">Surname2</nameField>
-			<nameField type="suffix">Suffix</nameField>
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
 		</sampleName>
 		<sampleName item="multiword">
-			<nameField type="prefix">Prefix</nameField>
-			<nameField type="given">Given</nameField>
-			<nameField type="given-informal">givenInformal</nameField>
-			<nameField type="given2">Given2</nameField>
-			<nameField type="surname">Surname</nameField>
-			<nameField type="surname2">Surname2</nameField>
-			<nameField type="suffix">Suffix</nameField>
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
+		</sampleName>
+		<sampleName item="mononym">
+			<nameField type="prefix">PreX</nameField>
+			<nameField type="given">GivX</nameField>
+			<nameField type="given-informal">GivIX</nameField>
+			<nameField type="given2">Giv2X</nameField>
+			<nameField type="surname">SurX</nameField>
+			<nameField type="surname2">Sur2X</nameField>
+			<nameField type="suffix">SufX</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1857,7 +1857,7 @@ public class PathHeader implements Comparable<PathHeader> {
                 public String transform(String source) {
                     // value for personName length and sampleName item in desired sort order
                     final List<String> lengthValues = Arrays.asList("long", "medium", "short", "monogram", "monogramNarrow");
-                    final List<String> itemValues = Arrays.asList("givenSurname", "given2Surname", "givenSurname2", "informal", "full", "multiword");
+                    final List<String> itemValues = Arrays.asList("givenSurname", "given2Surname", "givenSurname2", "informal", "full", "multiword", "mononym");
 
                     if (source.equals("NameOrder")) {
                         order = 0;
@@ -1867,17 +1867,17 @@ public class PathHeader implements Comparable<PathHeader> {
                         order = 10;
                         return source;
                     }
-                    String lengthPrefix = "PersonName:";
-                    if (source.startsWith(lengthPrefix)) {
-                        String lengthValue = source.substring(lengthPrefix.length());
-                        order = 20 + lengthValues.indexOf(lengthValue);
-                        return "PersonName Patterns for Length: " + lengthValue;
-                    }
                     String itemPrefix = "SampleName:";
                     if (source.startsWith(itemPrefix)) {
                         String itemValue = source.substring(itemPrefix.length());
-                        order = 30 + itemValues.indexOf(itemValue);
+                        order = 20 + itemValues.indexOf(itemValue);
                         return "SampleName Fields for Item: " + itemValue;
+                    }
+                    String lengthPrefix = "PersonName:";
+                    if (source.startsWith(lengthPrefix)) {
+                        String lengthValue = source.substring(lengthPrefix.length());
+                        order = 30 + lengthValues.indexOf(lengthValue);
+                        return "PersonName Patterns for Length: " + lengthValue;
                     }
                     order = 40;
                     return source;
@@ -1887,19 +1887,20 @@ public class PathHeader implements Comparable<PathHeader> {
             functionMap.put("personNameOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
-                    // The various personName attribute values in desired sort order
+                    // The various personName attribute values: each group in desired
+                    // sort order, but groups from least important to most
                     final List<String> allValues = Arrays.asList(
-                        // length values already handled in &personNameSection
-                        "addressing", "referring", // usage values
+                        "sorting", "givenFirst", "surnameFirst", //order values
                         "formal", "informal", // style values
-                        "sorting", "givenFirst", "surnameFirst"); //order values
+                        "addressing", "referring"); // usage values
+                        // length values already handled in &personNameSection
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;
                     for (String part: parts) {
                         if (allValues.contains(part)) {
                             order += (1 << allValues.indexOf(part));
-                        }
+                        } // anything else like alt="variant" is at order 0
                     }
                     return source;
                 }
@@ -1908,17 +1909,18 @@ public class PathHeader implements Comparable<PathHeader> {
             functionMap.put("sampleNameOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
-                    // The various nameField attribute values in desired sort order
+                    // The various nameField attribute values: each group in desired
+                    // sort order, but groups from least important to most
                     final List<String> allValues = Arrays.asList(
-                        "prefix", "given", "given2", "surname", "surname2", "suffix", // values for nameField type
-                        "informal"); // modifiers for nameField type
+                        "informal", // modifiers for nameField type
+                        "prefix", "given", "given2", "surname", "surname2", "suffix"); // values for nameField type
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;
                     for (String part: parts) {
                         if (allValues.contains(part)) {
                             order += (1 << allValues.indexOf(part));
-                        }
+                        } // anything else like alt="variant" is at order 0
                     }
                     return source;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -167,6 +167,7 @@ public class PersonNameFormatter {
         informal,
         full,
         multiword,
+        mononym,
     }
 
     public static final Splitter SPLIT_SPACE = Splitter.on(' ').trimResults();

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -293,8 +293,8 @@
 //ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4)
 //ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4)
 //ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3)
-//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(SampleName:$1) ; &sampleNameOrder($1-$2-$3)
-//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ;  &personNameSection(SampleName:$1) ; &sampleNameOrder($1-$2)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(SampleName:$1) ; &sampleNameOrder($2-$3)
+//ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ;  &personNameSection(SampleName:$1) ; &sampleNameOrder($2)
 
 
 #Emoji, etc.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -288,10 +288,10 @@ public class TestPersonNameFormatter extends TestFmwk{
         String[][] tests = {
             {
                 "//ldml/personNames/personName[@length=\"long\"][@usage=\"referring\"][@style=\"formal\"][@order=\"givenFirst\"]/namePattern",
-                "〖Katherine Johnson〗〖Alberto Pedro Calderón〗〖John Blue〗〖John William Brown〗〖Dorothy Lavinia Brown M.D.〗〖Erich Oswald Hans Carl Maria von Stroheim〗"
+                "〖Katherine Johnson〗〖Alberto Pedro Calderón〗〖John Blue〗〖John William Brown〗〖Dorothy Lavinia Brown M.D.〗〖Erich Oswald Hans Carl Maria von Stroheim〗〖Sinbad〗"
             },{
                 "//ldml/personNames/personName[@length=\"monogram\"][@style=\"informal\"][@order=\"surnameFirst\"]/namePattern",
-                "〖JK〗〖CA〗〖BJ〗〖BJ〗〖BD〗〖VE〗"
+                "〖JK〗〖CA〗〖BJ〗〖BJ〗〖BD〗〖VE〗〖S〗"
             }
         };
         for (String[] test : tests) {


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

1. Add mononym example to sampleNames (for English I used Sinbad, Popeye has IP encumbrance in the US)
2. For the sampleName dummy name fields in root, used more code-like values
3. For the ST PathHeader section ordering and item ordering:
    - Moved the SampleName sections before the PersonName sections
    - Fixed the item ordering within those sections
    - For the SampleName sections, drop the item type as part of the key in the left column
    