### PR TITLE
CLDR-14906 Retain Dashboard hidden status across releases

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -727,7 +727,7 @@ function testsToHtml(tests) {
       ": " +
       (testItem.cause || { class: "Unknown" }).class +
       "." +
-      testItem.subType +
+      testItem.subtype +
       "'>";
     if (testItem.type == "Warning") {
       newHtml += cldrStatus.warnIcon();
@@ -737,8 +737,8 @@ function testsToHtml(tests) {
     newHtml += testItem.message;
     // Add a link
 
-    if (testItem.subTypeUrl) {
-      newHtml += ' <a href="' + testItem.subTypeUrl + '">(how to fix…)</a>';
+    if (testItem.subtypeUrl) {
+      newHtml += ' <a href="' + testItem.subtypeUrl + '">(how to fix…)</a>';
     }
 
     newHtml += "</p>";

--- a/tools/cldr-apps/js/test/Test.html
+++ b/tools/cldr-apps/js/test/Test.html
@@ -48,6 +48,7 @@
       mocha.setup("bdd");
     </script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="data/dash_data.js"></script>
     <script src="data/forum_fr.js"></script>
     <script src="data/forum_participation_json.js"></script>
     <script src="data/bulk_close_posts_json.js"></script>

--- a/tools/cldr-apps/js/test/TestCldrDash.js
+++ b/tools/cldr-apps/js/test/TestCldrDash.js
@@ -1,0 +1,69 @@
+import * as cldrDash from "../src/esm/cldrDash.js";
+
+export const TestCldrDash = "ok";
+
+const assert = chai.assert;
+
+describe("cldrDash.setData", function () {
+  let json = null;
+
+  it("should have test data", function () {
+    /*
+     * dashJson is defined in dash_data.js
+     */
+    json = dashJson;
+    assert(json, "Test data is defined");
+  });
+
+  it("should not crash", function () {
+    cldrDash.setData(json);
+  });
+});
+
+describe("cldrDash.updatePath", function () {
+  let json0 = null,
+    json1 = null,
+    json2 = null;
+
+  it("should have test data", function () {
+    /*
+     * dashUpdateJson1 and dashUpdateJson2 are defined in dash_data.js
+     */
+    json0 = dashJson;
+    json1 = dashUpdateJson1;
+    json2 = dashUpdateJson2;
+    assert(json0 && json1 && json2, "Test data is defined");
+  });
+
+  it("should add entries", function () {
+    // json0 has 1 entry for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
+    // json1 has 3 entries for 710b6e70773e5764
+    // the resulting data should have 3 entries for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
+    const data = cldrDash.updatePath(json0, json1);
+    assert.strictEqual(countEntriesForPath(data, "710b6e70773e5764"), 3);
+    assert.strictEqual(countEntriesForPath(data, "64a8a83fbacdf836"), 1);
+  });
+
+  it("should remove entries", function () {
+    // json0 has 1 entry for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
+    // json2 has 0 entries for 710b6e70773e5764
+    // the resulting data should have 0 entries for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
+    const data = cldrDash.updatePath(json0, json2);
+    assert.strictEqual(countEntriesForPath(data, "710b6e70773e5764"), 0);
+    assert.strictEqual(countEntriesForPath(data, "64a8a83fbacdf836"), 1);
+  });
+});
+
+function countEntriesForPath(data, xpstrid) {
+  let count = 0;
+  for (let catData of data.notifications) {
+    for (let group of catData.groups) {
+      for (let entry of group.entries) {
+        if (entry.xpstrid === xpstrid) {
+          ++count;
+        }
+      }
+    }
+  }
+  return count;
+}

--- a/tools/cldr-apps/js/test/data/dash_data.js
+++ b/tools/cldr-apps/js/test/data/dash_data.js
@@ -1,0 +1,416 @@
+// This is based on an actual response returned for a dashboard request.
+let dashJson =
+{
+  "hidden": {
+    "asciiCharactersNotInMainOrAuxiliaryExemplars": [
+      {
+        "value": "M01",
+        "xpstrid": "1d88b195fc94db8e"
+      }
+    ]
+  },
+  "notifications": [
+    {
+      "category": "Error",
+      "groups": [
+        {
+          "entries": [
+            {
+              "code": "long-one-nominative",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0} metric pint",
+              "old": "{0} mpt",
+              "subtype": "missingPlaceholders",
+              "winning": "////",
+              "xpstrid": "710b6e70773e5764"
+            },
+            {
+              "code": "long-one-accusative",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0} metric pint",
+              "old": "{0} ሜትሪክ ፒንት",
+              "subtype": "missingPlaceholders",
+              "winning": "////",
+              "xpstrid": "64a8a83fbacdf836"
+            },
+            {
+              "code": "long-other-nominative",
+              "comment": "&lt;display collision&gt; Can't have same translation as [<a href=\"/cldr-apps/v#/am/MassWeight/275e733607b4babe\">carat: long-one-nominative</a>]. Please change either this name or the other one. See <a target='doc' href='http://cldr.unicode.org/translation/short-names-and-keywords#TOC-Unique-Names'>Unique-Names</a>.<br>&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0} metric pints",
+              "old": "{0} mpt",
+              "subtype": "displayCollision",
+              "winning": "???",
+              "xpstrid": "51ad46ead277a5b6"
+            },
+            {
+              "code": "short-one-nominative",
+              "comment": "&lt;display collision&gt; Can't have same translation as [<a href=\"/cldr-apps/v#/am/MassWeight/275e733607b4babe\">carat: long-one-nominative</a>]. Please change either this name or the other one. See <a target='doc' href='http://cldr.unicode.org/translation/short-names-and-keywords#TOC-Unique-Names'>Unique-Names</a>.<br>&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0} mpt",
+              "old": "{0} mpt",
+              "subtype": "displayCollision",
+              "winning": "...",
+              "xpstrid": "79b2c17ebd9644f3"
+            },
+            {
+              "code": "short-other-nominative",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0} mpt",
+              "old": "{0} mpt",
+              "subtype": "missingPlaceholders",
+              "winning": "sadfasd",
+              "xpstrid": "5afc920b5f0bbc53"
+            },
+            {
+              "code": "narrow-other-nominative",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0}mpt",
+              "old": "{0} mpt",
+              "subtype": "missingPlaceholders",
+              "winning": "sadfasd",
+              "xpstrid": "6c4b9cb74797908c"
+            }
+          ],
+          "header": "pint-metric",
+          "page": "Volume",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long-one-nominative",
+              "comment": "&lt;display collision&gt; Can't have same translation as [<a href=\"/cldr-apps/v#/am/Volume/51ad46ead277a5b6\">pint-metric: long-other-nominative</a>, <a href=\"/cldr-apps/v#/am/Volume/79b2c17ebd9644f3\">pint-metric: short-one-nominative</a>]. Please change either this name or the other one. See <a target='doc' href='http://cldr.unicode.org/translation/short-names-and-keywords#TOC-Unique-Names'>Unique-Names</a>.<br>&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={NUMBER_OF_UNITS}, e.g. “3”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.",
+              "english": "{0} carat",
+              "old": "{0} ካራት",
+              "subtype": "displayCollision",
+              "winning": "???",
+              "xpstrid": "275e733607b4babe"
+            }
+          ],
+          "header": "carat",
+          "page": "MassWeight",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "narrow",
+              "comment": "&lt;missing placeholders&gt; Need at least 2 placeholder(s), but only have 0. Placeholders are: {{0}={DIVIDEND}, e.g. “UNIT meters”, {1}={DIVISOR}, e.g. “UNIT second”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.<br>&lt;invalid place holder&gt; Invalid unit pattern, must have min 2 and max 2 distinct placeholders of the form {n}",
+              "english": "{0}/{1}",
+              "old": "{0}/{1}",
+              "subtype": "missingPlaceholders",
+              "winning": "3333333",
+              "xpstrid": "6c46c41bb59b604"
+            }
+          ],
+          "header": "per",
+          "page": "CompoundUnits",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "short-one-nominative-dgender",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={POWER}, e.g. “UNIT meters”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.<br>&lt;invalid place holder&gt; Invalid unit pattern, must have min 1 and max 1 distinct placeholders of the form {n}",
+              "english": "{0}²",
+              "old": "{0}²",
+              "subtype": "missingPlaceholders",
+              "winning": "....",
+              "xpstrid": "6da42acaa30ab41b"
+            },
+            {
+              "code": "narrow-one-nominative-dgender",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={POWER}, e.g. “UNIT meters”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.<br>&lt;invalid place holder&gt; Invalid unit pattern, must have min 1 and max 1 distinct placeholders of the form {n}",
+              "english": "{0}²",
+              "old": "{0}²",
+              "subtype": "missingPlaceholders",
+              "winning": "....",
+              "xpstrid": "791d0154f7c8b0c2"
+            }
+          ],
+          "header": "power2",
+          "page": "CompoundUnits",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "narrow-other-nominative-dgender",
+              "comment": "&lt;missing placeholders&gt; Need at least 1 placeholder(s), but only have 0. Placeholders are: {{0}={POWER}, e.g. “UNIT meters”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.<br>&lt;invalid place holder&gt; Invalid unit pattern, must have min 1 and max 1 distinct placeholders of the form {n}",
+              "english": "{0}³",
+              "old": "{0}³",
+              "subtype": "missingPlaceholders",
+              "winning": "?@@",
+              "xpstrid": "15b36616163c9af6"
+            }
+          ],
+          "header": "power3",
+          "page": "CompoundUnits",
+          "section": "Units"
+        }
+      ]
+    },
+    {
+      "category": "Disputed",
+      "groups": [
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} east",
+              "old": "{0}ምስ",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0} east",
+              "xpstrid": "24bffacda2d45847"
+            }
+          ],
+          "header": "east",
+          "page": "Coordinates",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} per {1}",
+              "old": "{0} በ{1}",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0}/{1}",
+              "xpstrid": "7c92c0407c07261a"
+            },
+            {
+              "code": "narrow",
+              "comment": "&lt;missing placeholders&gt; Need at least 2 placeholder(s), but only have 0. Placeholders are: {{0}={DIVIDEND}, e.g. “UNIT meters”, {1}={DIVISOR}, e.g. “UNIT second”}; see <a href='http://cldr.unicode.org/translation/error-codes#missingPlaceholders'  target='cldr_error_codes'>missing placeholders</a>.<br>&lt;invalid place holder&gt; Invalid unit pattern, must have min 2 and max 2 distinct placeholders of the form {n}",
+              "english": "{0}/{1}",
+              "old": "{0}/{1}",
+              "subtype": "missingPlaceholders",
+              "winning": "3333333",
+              "xpstrid": "6c46c41bb59b604"
+            }
+          ],
+          "header": "per",
+          "page": "CompoundUnits",
+          "section": "Units"
+        }
+      ]
+    },
+    {
+      "category": "English_Changed",
+      "groups": [
+        {
+          "entries": [
+            {
+              "code": "long-displayName",
+              "english": "cardinal direction",
+              "old": "ዓቢይ አቅጣጫ",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "ዓቢይ አቅጣጫ",
+              "xpstrid": "f8a86481ab6f7c4"
+            }
+          ],
+          "header": "all",
+          "page": "Coordinates",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} east",
+              "old": "{0}ምስ",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0} east",
+              "xpstrid": "24bffacda2d45847"
+            }
+          ],
+          "header": "east",
+          "page": "Coordinates",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} north",
+              "old": "{0}ሰ",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0}ሰ",
+              "xpstrid": "70cd56e66f2e1571"
+            }
+          ],
+          "header": "north",
+          "page": "Coordinates",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} south",
+              "old": "{0}ደ",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0}ደ",
+              "xpstrid": "5145b6aa12555070"
+            }
+          ],
+          "header": "south",
+          "page": "Coordinates",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} west",
+              "old": "{0}ምዕ",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0}ምዕ",
+              "xpstrid": "14b9827c199aa34a"
+            }
+          ],
+          "header": "west",
+          "page": "Coordinates",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0} per {1}",
+              "old": "{0} በ{1}",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0}/{1}",
+              "xpstrid": "7c92c0407c07261a"
+            }
+          ],
+          "header": "per",
+          "page": "CompoundUnits",
+          "section": "Units"
+        },
+        {
+          "entries": [
+            {
+              "code": "long",
+              "english": "{0}-{1}",
+              "old": "{0}⋅{1}",
+              "previousEnglish": "�",
+              "subtype": "none",
+              "winning": "{0}⋅{1}",
+              "xpstrid": "6761036bf70f7124"
+            }
+          ],
+          "header": "times",
+          "page": "CompoundUnits",
+          "section": "Units"
+        }
+      ]
+    }
+  ],
+  "voterProgress": {
+    "votablePathCount": 0,
+    "votedPathCount": 0
+  }
+}
+
+// This is based on an actual response returned for a WHAT_GETROW request with dashboard true.
+// Some irrelevant parts of the data were removed.
+// The data is specific to a single path, with three notification categories.
+let dashUpdateJson1 =
+{
+  "section": {
+    "rows": {
+      "_xctnmb": {
+        "xpstrid": "710b6e70773e5764",
+      },
+    }
+  },
+  "notifications": [
+    {
+      "groups": [
+        {
+          "entries": [
+            {
+              "code": "long-one-nominative",
+              "previousEnglish": "�",
+              "winning": "{0} ሜፒ",
+              "subtype": "largerDifferences",
+              "old": "{0} mpt",
+              "english": "{0} metric pint",
+              "comment": "&lt;larger differences&gt; 16 different characters within {???, {0} ሜትሪክ ፒንቶች, {0} ሜፒ⨱2}; COUNT_CASE",
+              "xpstrid": "710b6e70773e5764"
+            }
+          ],
+          "header": "pint-metric",
+          "section": "Units",
+          "page": "Volume"
+        }
+      ],
+      "category": "Disputed"
+    },
+    {
+      "groups": [
+        {
+          "entries": [
+            {
+              "code": "long-one-nominative",
+              "previousEnglish": "�",
+              "winning": "{0} ሜፒ",
+              "subtype": "largerDifferences",
+              "old": "{0} mpt",
+              "english": "{0} metric pint",
+              "comment": "&lt;larger differences&gt; 16 different characters within {???, {0} ሜትሪክ ፒንቶች, {0} ሜፒ⨱2}; COUNT_CASE",
+              "xpstrid": "710b6e70773e5764"
+            }
+          ],
+          "header": "pint-metric",
+          "section": "Units",
+          "page": "Volume"
+        }
+      ],
+      "category": "Warning"
+    },
+    {
+      "groups": [
+        {
+          "entries": [
+            {
+              "code": "long-one-nominative",
+              "previousEnglish": "�",
+              "winning": "{0} ሜፒ",
+              "subtype": "largerDifferences",
+              "old": "{0} mpt",
+              "english": "{0} metric pint",
+              "comment": "&lt;larger differences&gt; 16 different characters within {???, {0} ሜትሪክ ፒንቶች, {0} ሜፒ⨱2}; COUNT_CASE",
+              "xpstrid": "710b6e70773e5764"
+            }
+          ],
+          "header": "pint-metric",
+          "section": "Units",
+          "page": "Volume"
+        }
+      ],
+      "category": "English_Changed"
+    }
+  ]
+}
+
+// This getrow data is specific to a single path, with zero notification categories.
+// Since notifications is empty, we need to get xpstrid from section.rows...xpstrid
+let dashUpdateJson2 =
+{
+  "section": {
+    "rows": {
+      "_xctnmb": {
+        "xpstrid": "710b6e70773e5764",
+      },
+    }
+  },
+  "notifications": []
+}

--- a/tools/cldr-apps/js/test/index.js
+++ b/tools/cldr-apps/js/test/index.js
@@ -4,6 +4,7 @@ import { TestCldrBulkClosePosts } from "./TestCldrBulkClosePosts.js";
 import { TestCldrChecksum } from "./TestCldrChecksum.js";
 import { TestCldrCreateLogin } from "./TestCldrCreateLogin.js";
 import { TestCldrCsvFromTable } from "./TestCldrCsvFromTable.js";
+import { TestCldrDash } from "./TestCldrDash.js";
 import { TestCldrErrorSubtypes } from "./TestCldrErrorSubtypes.js";
 import { TestCldrForum } from "./TestCldrForum.js";
 import { TestCldrForumFilter } from "./TestCldrForumFilter.js";
@@ -22,6 +23,7 @@ export default {
   TestCldrChecksum,
   TestCldrCreateLogin,
   TestCldrCsvFromTable,
+  TestCldrDash,
   TestCldrErrorSubtypes,
   TestCldrForum,
   TestCldrForumFilter,

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DBUtils.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DBUtils.java
@@ -1608,15 +1608,21 @@ public class DBUtils {
     public enum Table {
         /* These constants represent names and other attributes of database tables.
          *
-         * The (false, false) constructor makes isVersioned, hasBeta both false for
-         * the FORUM_POSTS and FORUM_TYPES tables: these tables are not version-specific.
-         *
-         * The LOCKED_XPATHS(false, true) constructor makes isVersioned, hasBeta both false.
+         * The (false, false) constructor makes isVersioned, hasBeta both false for some tables.
          *
          * Other constants here have default constructor equivalent to (true, true).
          */
-        VOTE_VALUE, VOTE_VALUE_ALT, VOTE_FLAGGED, FORUM_POSTS(false, false), FORUM_TYPES(false, false),
-        DASH_HIDE, REVIEW_POST, IMPORT, IMPORT_AUTO, LOCKED_XPATHS(false, false), SUMMARY_SNAPSHOTS;
+        VOTE_VALUE,
+        VOTE_VALUE_ALT,
+        VOTE_FLAGGED,
+        FORUM_POSTS(false, false),
+        FORUM_TYPES(false, false),
+        DASH_HIDE(false, false),
+        REVIEW_POST,
+        IMPORT,
+        IMPORT_AUTO,
+        LOCKED_XPATHS(false, false),
+        SUMMARY_SNAPSHOTS;
 
         /**
          * Construct a Table constant with explicit parameters for isVersioned, hasBeta.

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -1,26 +1,14 @@
 package org.unicode.cldr.web;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.json.JSONArray;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
+import org.unicode.cldr.test.CheckCLDR;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
-import org.unicode.cldr.util.VettingViewer;
 import org.unicode.cldr.util.VettingViewer.Choice;
-import org.unicode.cldr.util.VoterProgress;
 
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
@@ -47,15 +35,15 @@ public class Dashboard {
 
         /**
          * Add this notification, unless the name is an exact match
-         * @param notificationName name of the next notification (e.g. Error)
+         * @param category category of the next notification (e.g. English_Changed)
          * @param unlessMatches if this notification is already the same as notificationName, just return it.
          * @return
          */
-        public ReviewNotification add(String notificationName, ReviewNotification unlessMatches) {
-            if (unlessMatches != null && unlessMatches.notification.equals(notificationName)) {
+        public ReviewNotification add(String category, ReviewNotification unlessMatches) {
+            if (unlessMatches != null && unlessMatches.category.equals(category)) {
                 return unlessMatches;
             } else {
-                return add(notificationName);
+                return add(category);
             }
         }
 
@@ -64,10 +52,18 @@ public class Dashboard {
             return notification;
         }
 
+        @Schema(description = "Notifications that the user has chosen to hide")
+        private HiddenNotifications hidden;
+
         /**
-         * Notifications that the user has chosen to hide
+         * Get a map from each subtype (String from CheckCLDR.CheckStatus.Subtype)
+         * to an array of path-value pairs
+         *
+         * @return the map
          */
-        public HashMap<String, List<String>> hidden;
+        public Map<String, PathValuePair[]> getHidden() {
+            return hidden.getHidden();
+        }
 
         public VoterProgress voterProgress = null;
     }
@@ -75,22 +71,23 @@ public class Dashboard {
     @Schema(description = "Heading for a portion of the notifications")
     public static final class ReviewNotification {
 
-        @Schema(description = "Notification type", example = "Error")
-        public String notification;
+        // See org.unicode.cldr.util.VettingViewer.Choice
+        @Schema(description = "Notification category", example = "English_Changed")
+        public String category;
 
-        public ReviewNotification(String notificationName) {
-            this.notification = notificationName;
+        public ReviewNotification(String category) {
+            this.category = category;
         }
 
         // for serialization
-        public ReviewNotificationGroup[] getEntries() {
-            return entries.toArray(new ReviewNotificationGroup[entries.size()]);
+        public ReviewNotificationGroup[] getGroups() {
+            return groups.toArray(new ReviewNotificationGroup[groups.size()]);
         }
 
-        private List<ReviewNotificationGroup> entries = new ArrayList<>();
+        private List<ReviewNotificationGroup> groups = new ArrayList<>();
 
         ReviewNotificationGroup add(ReviewNotificationGroup group) {
-            this.entries.add(group);
+            this.groups.add(group);
             return group;
         }
     }
@@ -131,7 +128,7 @@ public class Dashboard {
         public String code;
 
         @Schema(example = "7bd36b15a66d02cf")
-        public String xpath;
+        public String xpstrid;
 
         @Schema(description = "English text", example = "{0}dsp-Imp")
         public String english;
@@ -140,13 +137,16 @@ public class Dashboard {
         public String previousEnglish;
 
         @Schema(description = "Baseline value", example = "{0} dstspn Imp")
-        public String old; /* Not currently (2021-08-13) used by front end; should be renamed "baseline" */
+        public String old; /* Not currently (2022-04-08) used by front end; should be renamed "baseline" */
 
-        @Schema(description = "Winning string in this locale", example = "{0} dstspn Imp")
+        @Schema(description = "Winning value in this locale", example = "{0} dstspn Imp")
         public String winning;
 
         @Schema(description = "html comment on the error", example = "&lt;value too wide&gt; Too wide by about 100% (with common fonts).")
         public String comment;
+
+        @Schema(description = "Subtype of the error", example = "largerDifferences")
+        public CheckCLDR.CheckStatus.Subtype subtype;
 
         /**
          * Create a new ReviewEntry
@@ -155,47 +155,8 @@ public class Dashboard {
          */
         public ReviewEntry(String code, String xpath) {
             this.code = code;
-            this.xpath = XPathTable.getStringIDString(xpath);
+            this.xpstrid = XPathTable.getStringIDString(xpath);
         }
-    }
-
-    /**
-     * Get a miniature version of the Dashboard data, for only a single path
-     *
-     * Called by SurveyAjax.getRow (deprecated)
-     * TODO: VoteAPI should call this!
-     * Reference: https://unicode-org.atlassian.net/browse/CLDR-14745
-     *
-     * @param locale
-     * @param ctx
-     * @param sess
-     * @param path
-     * @return
-     */
-    public JSONArray getErrorOnPath(CLDRLocale locale, WebContext ctx, CookieSession sess, String path) {
-        Level usersLevel;
-        Organization usersOrg;
-        if (ctx != null) {
-            usersLevel = Level.get(ctx.getEffectiveCoverageLevel(ctx.getLocale().toString()));
-            sess = ctx.session;
-        } else {
-            String levelString = sess.settings().get(SurveyMain.PREF_COVLEV, WebContext.PREF_COVLEV_LIST[0]);
-            usersLevel = Level.get(levelString);
-        }
-
-        usersOrg = Organization.fromString(sess.user.voterOrg());
-
-        SurveyMain sm = CookieSession.sm;
-        VettingViewer<Organization> vv = new VettingViewer<>(sm.getSupplementalDataInfo(), sm.getSTFactory(),
-            new STUsersChoice(sm));
-
-        EnumSet<VettingViewer.Choice> choiceSet = VettingViewer.getChoiceSetForOrg(usersOrg);
-        ArrayList<String> out = vv.getErrorOnPath(choiceSet, locale.getBaseName(), usersOrg, usersLevel, path);
-        JSONArray result = new JSONArray();
-        for (String issues : out) {
-            result.put(issues);
-        }
-        return result;
     }
 
     /**
@@ -203,15 +164,13 @@ public class Dashboard {
      *
      * @param locale
      * @param user
-     * @param usersLevel
+     * @param coverageLevel
+     * @param xpath like "//ldml/..."; only check the given xpath; if xpath is null, check all paths
      * @return the ReviewOutput
      */
-    public ReviewOutput get(CLDRLocale locale, UserRegistry.User user, Level usersLevel) {
+    public ReviewOutput get(CLDRLocale locale, UserRegistry.User user, Level coverageLevel, String xpath) {
         final SurveyMain sm = CookieSession.sm;
         String loc = locale.getBaseName();
-        /*
-         * if no coverage level set, use default one
-         */
         Organization usersOrg = Organization.fromString(user.voterOrg());
         STFactory sourceFactory = sm.getSTFactory();
         final Factory baselineFactory = CookieSession.sm.getDiskFactory();
@@ -229,13 +188,14 @@ public class Dashboard {
          */
         CLDRFile sourceFile = sourceFactory.make(loc);
         CLDRFile baselineFile = baselineFactory.make(loc, true);
-
-        /*
-         * TODO: refactor -- too many parameters! Some could be fields of Dashboard or other classes...
-         * Reference: https://unicode-org.atlassian.net/browse/CLDR-15056
-         */
+        VettingViewer.DashboardArgs args = new VettingViewer.DashboardArgs(choiceSet, locale, coverageLevel);
+        args.setUserAndOrganization(user.id, usersOrg);
+        args.setFiles(sourceFile, baselineFile);
+        if (xpath != null) {
+            args.setXpath(xpath);
+        }
         VettingViewer<Organization>.DashboardData dd;
-        dd = vv.generateDashboard(choiceSet, loc, user.id, usersOrg, usersLevel, sourceFile, baselineFile);
+        dd = vv.generateDashboard(args);
         return reallyGet(sourceFile, baselineFile, dd, locale, user.id);
     }
 
@@ -247,7 +207,7 @@ public class Dashboard {
 
         addNotificationEntries(sourceFile, baselineFile, dd.sorted, reviewInfo);
 
-        reviewInfo.hidden = new ReviewHide().getHiddenField(userId, locale.toString());
+        reviewInfo.hidden = new ReviewHide(userId, locale.toString()).get();
 
         reviewInfo.voterProgress = dd.voterProgress;
 
@@ -268,7 +228,7 @@ public class Dashboard {
 
             notification = getNextNotification(reviewInfo, notification, entry);
 
-            addNotificiationGroup(sourceFile, baselineFile, notification, englishFile, entry);
+            addNotificationGroup(sourceFile, baselineFile, notification, englishFile, entry);
         }
     }
 
@@ -299,7 +259,7 @@ public class Dashboard {
         return notification;
     }
 
-    private void addNotificiationGroup(CLDRFile sourceFile, CLDRFile baselineFile, ReviewNotification notification, CLDRFile englishFile,
+    private void addNotificationGroup(CLDRFile sourceFile, CLDRFile baselineFile, ReviewNotification notification, CLDRFile englishFile,
         Entry<R4<Choice, SectionId, PageId, String>, Set<VettingViewer<Organization>.WritingInfo>> entry) {
         String sectionName = entry.getKey().get1().name();
         String pageName = entry.getKey().get2().name();
@@ -328,6 +288,9 @@ public class Dashboard {
             // winning value
             String newWinningValue = sourceFile.getWinningValue(path);
             reviewEntry.winning = newWinningValue;
+
+            // CheckCLDR.CheckStatus.Subtype
+            reviewEntry.subtype = info.subtype;
 
             // comment
             if (!info.htmlMessage.isEmpty()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/HiddenNotifications.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/HiddenNotifications.java
@@ -1,0 +1,37 @@
+package org.unicode.cldr.web;
+
+import java.util.*;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Hidden notifications")
+public class HiddenNotifications {
+
+    private final HashMap<String, List<PathValuePair>> map;
+
+    public HiddenNotifications() {
+        map = new HashMap<>();
+    }
+
+    public boolean needsData() {
+        return map.isEmpty();
+    }
+
+    /*
+     * For serialization, convert lists to arrays
+     */
+    public HashMap<String, PathValuePair[]> getHidden() {
+        HashMap<String, PathValuePair[]> m = new HashMap<>();
+        map.forEach((subtype, pairList) -> m.put(subtype, pairList.toArray(new PathValuePair[0])));
+        return m;
+    }
+
+    public void put(String subtype, String xpstrid, String value) {
+        List<PathValuePair> pvList = map.get(subtype);
+        if (pvList == null) {
+            pvList = new ArrayList<>();
+        }
+        pvList.add(new PathValuePair(xpstrid, value));
+        map.put(subtype, pvList);
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/PathValuePair.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/PathValuePair.java
@@ -1,0 +1,17 @@
+package org.unicode.cldr.web;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Path, Value Pair")
+public class PathValuePair {
+    @Schema(description = "Path")
+    public String xpstrid;
+
+    @Schema(description = "Value")
+    public String value;
+
+    public PathValuePair(String xpstrid, String value) {
+        this.xpstrid = xpstrid;
+        this.value = value;
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
@@ -5,29 +5,61 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
-//save hidden line
 public class ReviewHide {
+    /**
+     * Notifications that the user has chosen to hide for this locale
+     */
+    private final HiddenNotifications hiddenNotifications;
 
-    private HashMap<String, List<String>> hiddenField;
+    private final int userId;
+    private final String localeId;
 
-    public ReviewHide() {
-        this.hiddenField = new HashMap<>();
+    public ReviewHide(int userId, String localeId) {
+        this.userId = userId;
+        this.localeId = localeId;
+        this.hiddenNotifications = new HiddenNotifications();
     }
 
-    //create the table (path, locale, type of notifications as key to get unique line)
+    // "VALUE" is a reserved word in mysql, so use "val" instead
+
+    private static final String CREATE_TABLE_SQL = "CREATE TABLE " +
+            DBUtils.Table.DASH_HIDE +
+            " (id INT NOT NULL " + DBUtils.DB_SQL_IDENTITY +
+            ", user_id INT NOT NULL" +
+            ", locale VARCHAR(20) NOT NULL" +
+            ", subtype VARCHAR(255) NOT NULL" +
+            ", xpstrid VARCHAR(20) NOT NULL" +
+            ", val " + DBUtils.DB_SQL_UNICODE + " NOT NULL)";
+
+    private static final String CREATE_INDEX_SQL = "CREATE UNIQUE INDEX " +
+            DBUtils.Table.DASH_HIDE + "_id ON " +
+            DBUtils.Table.DASH_HIDE + " (id) ";
+
+    private static final String GET_LIST_SQL = "SELECT * FROM " +
+            DBUtils.Table.DASH_HIDE +
+            " WHERE user_id=? AND locale=?";
+
+    private static final String GET_ITEM_SQL = "SELECT * FROM " +
+            DBUtils.Table.DASH_HIDE +
+            " WHERE user_id=? AND locale=? AND subtype=? AND xpstrid=? AND val=?";
+
+    private static final String INSERT_ITEM_SQL = "INSERT INTO " +
+            DBUtils.Table.DASH_HIDE +
+            " (user_id,locale,subtype,xpstrid,val) VALUES(?,?,?,?,?)";
+
+    private static final String DELETE_ITEM_SQL = "DELETE FROM " +
+            DBUtils.Table.DASH_HIDE +
+            " WHERE user_id=? AND locale=? AND subtype=? AND xpstrid=? AND val=?";
+
     public static void createTable(Connection conn) throws SQLException {
         String sql = null;
         Statement s = null;
         if (!DBUtils.hasTable(DBUtils.Table.DASH_HIDE.toString())) {
             try {
                 s = conn.createStatement();
-                s.execute(sql = "CREATE TABLE " + DBUtils.Table.DASH_HIDE + " (id int not null " + DBUtils.DB_SQL_IDENTITY
-                    + ", path varchar(20) not null, choice varchar(20) not null, user_id int not null, locale varchar(20) not null)");
-                s.execute(sql = "CREATE UNIQUE INDEX " + DBUtils.Table.DASH_HIDE + "_id ON " + DBUtils.Table.DASH_HIDE + " (id) ");
+                s.execute(sql = CREATE_TABLE_SQL);
+                s.execute(sql = CREATE_INDEX_SQL);
                 s.close();
                 s = null;
                 conn.commit();
@@ -43,80 +75,76 @@ public class ReviewHide {
 
     /**
      * Get a map of all the notifications this user has chosen to hide in the Dashboard
+     * in this locale
      *
-     * @param userId
-     * @param locale
-     * @return the map
+     * @return the HiddenNotifications
      */
-    public HashMap<String, List<String>> getHiddenField(int userId, String locale) {
-        if (this.hiddenField.isEmpty()) {
-            Connection conn = null;
-            ResultSet rs = null;
-            PreparedStatement s = null;
-            try {
-                try {
-                    conn = DBUtils.getInstance().getAConnection();
-                    s = conn.prepareStatement("SELECT * FROM " + DBUtils.Table.DASH_HIDE + " WHERE user_id=? AND locale=?");
-                    s.setInt(1, userId);
-                    s.setString(2, locale);
-                    rs = s.executeQuery();
-                    while (rs.next()) {
-                        String choice = rs.getString("choice");
-                        List<String> paths = this.hiddenField.get(choice);
-                        if (paths == null) {
-                            paths = new ArrayList<>();
-                        }
-                        paths.add(rs.getString("path"));
-
-                        this.hiddenField.put(choice, paths);
-                    }
-                } finally {
-                    DBUtils.close(rs, s, conn);
-                }
-            } catch (SQLException sqe) {
-                SurveyLog.logException(sqe, "Getting hidden fields for uid#" + userId + " in " + locale, null);
-                throw new InternalError("Error getting hidden fields: " + sqe.getMessage());
-            }
+    public HiddenNotifications get() {
+        if (this.hiddenNotifications.needsData()) {
+            getData();
         }
-
-        return this.hiddenField;
+        return this.hiddenNotifications;
     }
 
-    //insert or delete a line to hide/show
-    public void toggleItem(String choice, String xpathHexId, int user, String locale) {
+    private void getData() {
+        Connection conn = null;
+        ResultSet rs = null;
+        PreparedStatement s = null;
+        try {
+            conn = DBUtils.getInstance().getAConnection();
+            s = conn.prepareStatement(GET_LIST_SQL);
+            s.setInt(1, userId);
+            s.setString(2, localeId);
+            rs = s.executeQuery();
+            while (rs.next()) {
+                final String subtype = rs.getString("subtype");
+                final String xpstrid = rs.getString("xpstrid");
+                final String val = DBUtils.getStringUTF8(rs, "val");
+                this.hiddenNotifications.put(subtype, xpstrid, val);
+            }
+        } catch (SQLException sqe) {
+            SurveyLog.logException(sqe, "Getting hidden notifications for uid#" + userId + " in " + localeId, null);
+            throw new InternalError("Error getting hidden notifications: " + sqe.getMessage());
+        } finally {
+            DBUtils.close(rs, s, conn);
+        }
+    }
+
+    // insert or delete a line to hide/show
+    public void toggleItem(String subtype, String xpstrid, String val) {
         try {
             Connection conn = null;
             ResultSet rs = null;
             PreparedStatement ps = null, updateQuery = null;
             try {
                 conn = DBUtils.getInstance().getDBConnection();
-                ps = conn.prepareStatement("SELECT * FROM " + DBUtils.Table.DASH_HIDE + " WHERE path=? AND user_id=? AND choice=? AND locale=?");
-
-                ps.setString(1, xpathHexId);
-                ps.setInt(2, user);
-                ps.setString(3, choice);
-                ps.setString(4, locale);
+                ps = conn.prepareStatement(GET_ITEM_SQL);
+                setArgs(ps, userId, localeId, subtype, xpstrid, val);
                 rs = ps.executeQuery();
-
                 if (!rs.next()) {
                     //the item is currently shown, not in the table, we can hide it
-                    updateQuery = conn.prepareStatement("INSERT INTO " + DBUtils.Table.DASH_HIDE + " (path, user_id,choice,locale) VALUES(?,?,?,?)");
+                    updateQuery = conn.prepareStatement(INSERT_ITEM_SQL);
                 } else {
-                    updateQuery = conn.prepareStatement("DELETE FROM " + DBUtils.Table.DASH_HIDE + " WHERE path=? AND user_id=? AND choice=? AND locale=?");
+                    updateQuery = conn.prepareStatement(DELETE_ITEM_SQL);
                 }
-
-                updateQuery.setString(1, xpathHexId);
-                updateQuery.setInt(2, user);
-                updateQuery.setString(3, choice);
-                updateQuery.setString(4, locale);
+                setArgs(updateQuery, userId, localeId, subtype, xpstrid, val);
                 updateQuery.executeUpdate();
                 conn.commit();
             } finally {
                 DBUtils.close(updateQuery, rs, ps, conn);
             }
         } catch (SQLException sqe) {
-            SurveyLog.logException(sqe, "Setting hidden fields for uid#" + user + " in " + locale, null);
-            throw new InternalError("Error setting hidden fields: " + sqe.getMessage());
+            SurveyLog.logException(sqe, "Setting hidden notifications for uid#" + userId + " in " + localeId, null);
+            throw new InternalError("Error setting hidden notifications: " + sqe.getMessage());
         }
+    }
+
+    private void setArgs(PreparedStatement ps, int userId, String localeId,
+                         String subtype, String xpstrid, String val) throws SQLException {
+        ps.setInt(1, userId);
+        ps.setString(2, localeId);
+        ps.setString(3, subtype);
+        ps.setString(4, xpstrid);
+        DBUtils.setStringUTF8(ps, 5, val);
     }
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SubtypeToURLMap.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SubtypeToURLMap.java
@@ -448,9 +448,9 @@ public class SubtypeToURLMap {
         return SubtypeToURLMapHelper.INSTANCE;
     }
 
-    public static String forSubtype(Subtype subType) {
+    public static String forSubtype(Subtype subtype) {
         if(SubtypeToURLMapHelper.INSTANCE == null) return null;
-        return SubtypeToURLMapHelper.INSTANCE.get(subType);
+        return SubtypeToURLMapHelper.INSTANCE.get(subtype);
     }
 
     public static SubtypeToURLMap reload() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
@@ -62,10 +62,12 @@ public final class SurveyJSONWrapper {
                 if (cs.getCause() != null) {
                     put("cause", wrap(cs.getCause()));
                 }
-                Subtype subType = cs.getSubtype();
-                if (subType != null) {
-                    put("subType", subType.name());
-                    put("subTypeUrl", SubtypeToURLMap.forSubtype(subType)); // could be null.
+                Subtype subtype = cs.getSubtype();
+                if (subtype != null) {
+                    // in json, subtype is like "missingPlaceholders" NOT "missing placeholders"
+                    // so use name() not toString() -- this is consistent with SurveyAjax.java (2022-03-07)
+                    put("subtype", subtype.name());
+                    put("subtypeUrl", SubtypeToURLMap.forSubtype(subtype)); // could be null.
                 }
             }
         };

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
@@ -317,6 +317,8 @@ public class XPathTable {
 
     /**
      * API for get by ID
+     * @param id an integer like 677172
+     * @return a string like //ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"]
      */
     public final String getById(int id) {
         if (id == -1) {
@@ -333,8 +335,8 @@ public class XPathTable {
      * Adds an xpathid-xpath value pair to the XPathTable. This method is used
      * by classes to cache the values obtained by using their own queries.
      *
-     * @param id
-     * @param xpath
+     * @param id an integer like 24600
+     * @param xpath a string like //ldml/dates/timeZoneNames/zone[@type="America/Guadeloupe"]/short/daylight
      */
     public final void setById(int id, String xpath) {
         stringToId.put(idToString_put(id, xpath), id);
@@ -344,9 +346,8 @@ public class XPathTable {
     /**
      * get an xpath id by value, add it if not found
      *
-     * @param xpath
-     *            string string to add
-     * @return the id for the specified path
+     * @param xpath the string to add, like "//ldml/units/..."
+     * @return the id, like 692804, for the specified path
      */
     public final int getByXpath(String xpath) {
         Integer nid = stringToId.get(xpath);
@@ -406,7 +407,6 @@ public class XPathTable {
     /**
      *
      * @param path
-     * @param xpp
      * @return
      */
     public String altFromPathToTinyXpath(String path) {
@@ -431,8 +431,8 @@ public class XPathTable {
      * almost distinguishing, except that certain attributes, such as numbers=,
      * will be left.
      *
-     * @param path
-     * @return
+     * @param path a string like //ldml/typographicNames/styleName[@type="wdth"][@subtype="200"][@alt="wide"]
+     * @return a string like //ldml/typographicNames/styleName[@type="wdth"][@subtype="200"][@alt="wide"]
      */
     public static String removeDraftAltProposed(String path) {
         XPathParts xpp = XPathParts.getFrozenInstance(path).cloneAsThawed(); // not frozen, for removeAttribute
@@ -662,8 +662,8 @@ public class XPathTable {
 
     /**
      * xpid to hex
-     * @param baseXpath
-     * @return
+     * @param baseXpath an integer like 690863
+     * @return a sixteen-digit hex string like "2066782cf4356135"
      */
     public String getStringIDString(int baseXpath) {
         return getStringIDString(getById(baseXpath));
@@ -680,8 +680,8 @@ public class XPathTable {
 
     /**
      * Turn a strid into a xpid (int token)
-     * @param sid
-     * @return
+     * @param sid like "2066782cf4356135"
+     * @return an integer like 690863
      */
     public final int getXpathIdFromStringId(String sid) {
         return getByXpath(getByStringID(sid));

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -337,7 +337,7 @@ public class Summary {
 
         // *Beware*  org.unicode.cldr.util.Level (coverage) ≠ VoteResolver.Level (user)
         Level coverageLevel = org.unicode.cldr.util.Level.fromString(level);
-        ReviewOutput ret = new Dashboard().get(loc, cs.user, coverageLevel);
+        ReviewOutput ret = new Dashboard().get(loc, cs.user, coverageLevel, null /* xpath */);
 
         return Response.ok().entity(ret).build();
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -240,8 +240,8 @@ public class VoteAPI {
     final static public class CheckStatusSummary {
         public String message;
         public Type type;
-        public Subtype subType;
-        public String subTypeUrl;
+        public Subtype subtype;
+        public String subtypeUrl;
         public Phase phase;
 
         @JsonbProperty("class")
@@ -256,10 +256,10 @@ public class VoteAPI {
                 this.clazz = cause.getClass().getSimpleName();
                 this.phase = cause.getPhase();
             }
-            // subType
-            this.subType = checkStatus.getSubtype();
-            if (this.subType != null) {
-                this.subTypeUrl = SubtypeToURLMap.forSubtype(this.subType); // could be null.
+            // subtype
+            this.subtype = checkStatus.getSubtype();
+            if (this.subtype != null) {
+                this.subtypeUrl = SubtypeToURLMap.forSubtype(this.subtype); // could be null.
             }
         }
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -49,6 +49,13 @@ import com.ibm.icu.util.Output;
 
 /**
  * Note: The functions in this class needed to be separated from VoteAPI because of static init problems.
+ *
+ * As of 2022-04-07, this class hasn't been used yet, except for testing in conjunction
+ * with CldrRows.vue and CldrRow.vue. This is intended to be a modernized replacement
+ * for SurveyAjax.getRow (WHAT_GETROW). It isn't ready to be used since it doesn't produce
+ * json compatible with the front end. References:
+ * https://unicode-org.atlassian.net/browse/CLDR-15368
+ * https://unicode-org.atlassian.net/browse/CLDR-15403
  */
 public class VoteAPIHelper {
     public static final class VoteEntry {
@@ -138,7 +145,12 @@ public class VoteAPIHelper {
                 r.rows = calculateRows(pageData.getAll());
             }
             if (args.getDashboard) {
-                r.issues = new Dashboard().getErrorOnPath(locale, null /* WebContext */, mySession, args.xpath);
+                /*
+                 * TODO: implement single-path dashboard in this modern-api context
+                 * See existing implementation in SurveyAjax.java, Dashboard.java
+                 * Reference: https://unicode-org.atlassian.net/browse/CLDR-15368
+                 */
+                return new STError(ErrorCode.E_INTERNAL, "handleGetRows: single-path dashboard not implemented yet").build();
             }
             return Response.ok(r).build();
         } catch (Throwable t) {

--- a/tools/cldr-apps/src/main/webapp/tc-all-errors.jsp
+++ b/tools/cldr-apps/src/main/webapp/tc-all-errors.jsp
@@ -59,7 +59,7 @@ if(request.getParameter("flush") != null) {
 <body>
 
 
-<h1>All error subTypes</h1>
+<h1>All error subtypes</h1>
 
 <p>
 	

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -946,15 +946,15 @@ public class ConsoleCheckCLDR {
             true);
 
         private static void addDataToErrorFile(String localeID, String path, ErrorType shortStatus,
-            Subtype subType) {
+            Subtype subtype) {
             String section = path == null ? null : XPathToMenu.xpathToMenu(path);
             if (section == null) {
                 section = "general";
             }
             errorFileCounter.add(
-                new Row.R4<>(localeID, section, shortStatus, subType), 1);
+                new Row.R4<>(localeID, section, shortStatus, subtype), 1);
             ErrorFile.sectionToProblemsToLocaleToCount.add(
-                new Row.R4<>(section, shortStatus, subType, localeID), 1);
+                new Row.R4<>(section, shortStatus, subtype, localeID), 1);
         }
 
         private static void closeErrorFile() {
@@ -1341,12 +1341,12 @@ public class ConsoleCheckCLDR {
     }
 
     private static void showValue(CLDRFile cldrFile, String prettyPath, String localeID, String example,
-        String path, String value, String fullPath, String statusString, Subtype subType) {
+        String path, String value, String fullPath, String statusString, Subtype subtype) {
         ErrorType shortStatus = ErrorType.fromStatusString(statusString);
         subtotalCount.add(shortStatus, 1);
         totalCount.add(shortStatus, 1);
-        if (subType == null) {
-            subType = Subtype.none;
+        if (subtype == null) {
+            subtype = Subtype.none;
         }
         final SourceLocation location = fullPath == null ? null : cldrFile.getSourceLocation(fullPath);
 
@@ -1387,7 +1387,7 @@ public class ConsoleCheckCLDR {
                     + "\t〈" + value + "〉"
                     + "\t«" + fillinValue + "»"
                     + "\t【" + example + "】"
-                    + "\t⁅" + subType + "⁆"
+                    + "\t⁅" + subtype + "⁆"
                     + "\t❮" + statusString + "❯"
                     + "\t" + pathLink
                     + otherSource
@@ -1397,7 +1397,7 @@ public class ConsoleCheckCLDR {
                     + "\t【" + englishExample + "】"
                     + "\t" + value + "〉"
                     + "\t【" + example + "】"
-                    + "\t⁅" + subType + "⁆"
+                    + "\t⁅" + subtype + "⁆"
                     + "\t❮" + statusString + "❯"));
         } else if (ErrorFile.errorFileWriter != null) {
             if (shortStatus == ErrorType.contributed) {
@@ -1411,7 +1411,7 @@ public class ConsoleCheckCLDR {
                 lastHtmlLocaleID = localeID;
             }
             addError(shortStatus);
-            ErrorFile.addDataToErrorFile(localeID, path, shortStatus, subType);
+            ErrorFile.addDataToErrorFile(localeID, path, shortStatus, subtype);
         }
         if (CLDR_GITHUB_ANNOTATIONS) {
             // Annotate anything that needs annotation
@@ -1424,7 +1424,7 @@ public class ConsoleCheckCLDR {
                     // Fallback if SourceLocation fails
                     filePath = "file="+localeXpathToFilePath.computeIfAbsent(Pair.of(localeID, path), locPath -> guessFilePath(locPath));
                 }
-                System.out.println("::" + shortStatus + " " + filePath.trim() + ",title=" + subType + ":: " + statusString);
+                System.out.println("::" + shortStatus + " " + filePath.trim() + ",title=" + subtype + ":: " + statusString);
             }
         }
         if (PATH_IN_COUNT && ErrorFile.generated_html_count != null) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
@@ -57,8 +57,6 @@ class TestVettingViewer {
 
         });
 
-        Organization usersOrg = Organization.surveytool;
-
         final Factory baselineFactory = CLDRConfig.getInstance().getCldrFactory();
         final Factory sourceFactory = baselineFactory;
 
@@ -66,8 +64,10 @@ class TestVettingViewer {
         CLDRFile sourceFile = sourceFactory.make(loc, true);
         CLDRFile baselineFile = baselineFactory.make(loc, true);
         Relation<R2<SectionId, PageId>, VettingViewer<Organization>.WritingInfo> sorted;
-        final Level usersLevel = Level.MODERN;
-        VettingViewer<Organization>.DashboardData dd = vv.generateDashboard(choiceSet, loc, 0, usersOrg, usersLevel, sourceFile, baselineFile);
+        VettingViewer.DashboardArgs args = new VettingViewer.DashboardArgs(choiceSet, locale, Level.MODERN);
+        args.setUserAndOrganization(0 /* userId */, Organization.surveytool);
+        args.setFiles(sourceFile, baselineFile);
+        VettingViewer<Organization>.DashboardData dd = vv.generateDashboard(args);
         boolean foundAny = false;
         for (Entry<R2<SectionId, PageId>, VettingViewer<Organization>.WritingInfo> e : dd.sorted.entrySet()) {
             for(Choice problem : e.getValue().problems) {


### PR DESCRIPTION
-Revise DASH_HIDE db table: unversioned; new column val (blob)

-DASH_HIDE subtype column, CheckCLDR.CheckStatus.Subtype instead of VettingViewer.Choice

-Include value and subtype in http requests and responses

-Consistently spell subtype with lowercase t in all files

-New small class PathValuePair.java

-New HiddenNotifications.java to encapsulate complex HashMap

-New subclasses of VettingViewer etc to encapsulate arguments and results

-Refactor single-path dashboard to use the same code as multi-path dashboard

-Refactor ReviewHide using HiddenNotifications and move inline SQL to constants

-Rename some items for consistency to reduce confusion

-Distinguish ReviewNotificationGroup groups from ReviewEntry entries

-Shorten methods by moving code into new subroutines

-New unit tests for cldrDash.js in TestCldrDash.js and dash_data.js

-Remove Deprecated annotation from SurveyAjax.getRow

-Postpone revising unfinished modern replacement VoteAPIHelper.handleGetRows; error if getDashboard

-Comments

CLDR-14906

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
