### PR TITLE
CLDR-15464 spec: fix gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '16'
       - name: Run TR archiver
         # Note: will update ToC if out of date
-        run: 'cd tools/scripts/tr-archive/ && bash make-tr-archive.sh'
+        run: 'cd tools/scripts/tr-archive/ && npm ci && npm run build'
       - name: Lint Markdown
         # Warn, don't fail yet
         run: npx markdownlint-cli *.md {specs,docs}/*.md $(find .github -name '*.md') || (echo Warning, please fix these ; true)


### PR DESCRIPTION
With a recent change (below), we need to do an extra step in the gh-pages build.
make-tr-archive.sh does not fetch remote resources (css/gif) by default.
Run 'npm build' to fix.

Regression was in CLDR-15088 / #1881 / db15bae6b0ba6be54b50072c220e77a2dc14047f

CLDR-15464

- [ ] This PR completes the ticket.

-----

Review note: https://srl295.github.io/cldr/ldml/tr35.html was built using this commit.