### PR TITLE
CLDR-15404 fix the internal caching in example generator, part 1

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
@@ -261,5 +261,11 @@ public class ExampleDependencies {
     .put("//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]", "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]")
     .put("//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]", "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern")
     .put("//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]", "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]")
+    .putAll("//ldml/personNames/sampleName[@item=\"*\"]/nameField[@type=\"*\"]",
+        "//ldml/personNames/personName[@length=\"*\"][@usage=\"*\"][@style=\"*\"][@order=\"*\"]/namePattern",
+        "//ldml/personNames/personName[@length=\"*\"][@style=\"*\"][@order=\"*\"]/namePattern")
+    .putAll("//ldml/personNames/initialPattern[@type=\"*\"]",
+        "//ldml/personNames/personName[@length=\"*\"][@usage=\"*\"][@style=\"*\"][@order=\"*\"]/namePattern",
+        "//ldml/personNames/personName[@length=\"*\"][@style=\"*\"][@order=\"*\"]/namePattern")
     .build();
 }


### PR DESCRIPTION
CLDR-15404

There were problems where a change in a sample name wasn't reflected in the examples for patterns. That doesn't work for two reasons:

1. The examples are cached per path, so wouldn't get automatically refreshed. 
2. For *generating* those examples, two objects are used that relatively expensive to create, and were being cached across invocations.  

For the first problem, I added paths to ExampleDependencies. There is a call that uses that in ExampleGenerator to clear examples that are dependent on given paths.

For the second problem, there was no built-in mechanism for that. You could clear examples, but not arbitrary other constructs. So I extended the cache mechanism a bit so that I could clear out other items when a path changed.

The synchronization is a bit heavy handed, because I wanted to get the functionality working. There might be a bit of contention when the same locale is being worked on by 2 people.

In a subsequent PR I want to get some advice on better synchronization to decrease possible contention, but want at least to get the functionality correct on smoketest.

tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleCache.java
tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
Adds the ability to add other kinds of objects to be handled if a path changes.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
Adds a test that the examples for a path change when a path it depends on gets a different value.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
3. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
4. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
