### PR TITLE
CLDR-15468 Locales.txt - steps towards support for focussed orgs

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -1196,7 +1196,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!-- # Coverage levels -->
 
-<!ELEMENT coverageLevels ( approvalRequirements, coverageVariable*, coverageLevel* ) >
+<!ELEMENT coverageLevels ( approvalRequirements, coverageVariable*, coverageLevel*, pathMatch* ) >
     <!--@METADATA-->
 
 <!ELEMENT approvalRequirements ( approvalRequirement* ) >
@@ -1230,6 +1230,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:literal/basic, core, minimal, moderate, modern, posix-->
     <!--@VALUE-->
 <!ATTLIST coverageLevel match CDATA #REQUIRED >
+    <!--@MATCH:any-->
+
+<!ELEMENT pathMatch EMPTY >
+<!ATTLIST pathMatch id NMTOKENS #IMPLIED >
+    <!--@MATCH:any-->
+
+<!ATTLIST pathMatch match CDATA #REQUIRED >
+    <!--@VALUE-->
     <!--@MATCH:any-->
 
 <!ELEMENT idValidity ( id* ) >

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -198,25 +198,25 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%teluNativeLanguages" value="(te)"/>
 		<coverageVariable key="%tibtDefaultLanguages" value="(dz)"/>
 		<coverageVariable key="%tibtNativeLanguages" value="(bo)"/>
-		
+
 		<!-- Additional variables for the restructuring -->
-		
+
 		<coverageVariable key="%basicDateSkeletons" value="(yMMMMEd|yMMMMd|yMMMd|yMd|Hmsv|hmsv|Hms|hms|Hm|hm)"/>
-		
+
 		<!-- -->
 		<!-- Coverage levels begin here -->
 		<!-- -->
 		<coverageLevel value="core" match="characters/exemplarCharacters"/>
 		<coverageLevel value="core" match="characters/exemplarCharacters[@type='%coreExemplarTypes']"/>
-		
+
 		<coverageLevel value="moderate" match="characters/exemplarCharacters[@type='%anyAlphaNum']"/>
 
 		<!-- *********************
-		Modified Basic rules (v41) 
+		Modified Basic rules (v41)
 		These contain a mixture of basic and moderate.
 		The only hard requirement is that each basic rule comes after any moderate rule *that could match the same path*.
 		********************* -->
-		
+
 		<coverageLevel	value="basic"	 	match="delimiters/alternateQuotationEnd"/>
 		<coverageLevel	value="basic"	 	match="delimiters/alternateQuotationStart"/>
 		<coverageLevel	value="basic"	 	match="delimiters/quotationEnd"/>
@@ -228,7 +228,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/localeDisplayPattern/localePattern"/>
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/localeDisplayPattern/localeSeparator"/>
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/codePatterns/codePattern[@type='(language|script|territory)']"/>
-					
+
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/languages/language[@type='${Target-Language}']"/>
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/languages/language[@type='${Target-Language}'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/languages/language[@type='en']"/>
@@ -237,24 +237,24 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/languages/language[@type='%language30'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/languages/language[@type='%language40']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/languages/language[@type='%language40'][@alt='%anyAttribute']"/>
-					
+
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/scripts/script[@type='${Target-Scripts}']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/scripts/script[@type='%script30']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/scripts/script[@type='%script30'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/scripts/script[@type='%script40']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/scripts/script[@type='%script40'][@alt='%anyAttribute']"/>
-					
+
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/territories/territory[@type='${Target-Territories}']"/>
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/territories/territory[@type='${Target-Territories}'][@alt='(%anyAttribute)']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory30']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory30'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory40']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory40'][@alt='%anyAttribute']"/>
-					
+
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/measurementSystemNames/measurementSystemName[@type='(metric|UK|US)']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/annotationPatterns/annotationPattern[@type='(flag|keycap|emoji|combined)']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/localeDisplayPattern/localeKeyTypePattern"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/types/type[@key='calendar'][@type='${Calendar-List}']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/types/type[@key='calendar'][@type='gregorian']"/>
@@ -293,7 +293,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inScript="Thai"	match="localeDisplayNames/types/type[@key='numbers'][@type='thai']"/>
 		<coverageLevel	value="moderate"	inScript="Tibt"	match="localeDisplayNames/types/type[@key='numbers'][@type='tibt']"/>
 		<coverageLevel	value="moderate"	inLanguage="vai"	match="localeDisplayNames/types/type[@key='numbers'][@type='vaii']"/>
-					
+
 		<coverageLevel	value="basic"		match="dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='format']/monthWidth[@type='wide']/month[@type='%monthTypes']"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='format']/monthWidth[@type='%wideAbbr']/month[@type='%monthTypes']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/months/monthContext[@type='stand-alone']/monthWidth[@type='%allWidths']/month[@type='%monthTypes']"/>
@@ -307,14 +307,14 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inTerritory="IN"	match="dates/calendars/calendar[@type='indian']/months/monthContext[@type='%contextTypes']/monthWidth[@type='%allWidths']/month[@type='%monthTypes']"/>
 		<coverageLevel	value="moderate"	inTerritory="%islamicCalendarTerritories"	match="dates/calendars/calendar[@type='islamic']/months/monthContext[@type='%contextTypes']/monthWidth[@type='%allWidths']/month[@type='%monthTypes']"/>
 		<coverageLevel	value="moderate"	inTerritory="%persianCalendarTerritories"	match="dates/calendars/calendar[@type='persian']/months/monthContext[@type='%contextTypes']/monthWidth[@type='%allWidths']/month[@type='%monthTypes']"/>
-					
+
 		<coverageLevel	value="basic"		match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='format']/dayWidth[@type='wide']/day[@type='%dayTypes']"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='format']/dayWidth[@type='%wideAbbr']/day[@type='%dayTypes']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='format']/dayWidth[@type='narrow']/day[@type='%dayTypes']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='stand-alone']/dayWidth[@type='%allWidths']/day[@type='%dayTypes']"/>
-					
+
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dayPeriods/dayPeriodContext[@type='format']/dayPeriodWidth[@type='wide']/dayPeriod[@type='(am|pm)']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='generic']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
@@ -322,11 +322,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inTerritory="%chineseCalendarTerritories"	match="dates/calendars/calendar[@type='chinese']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inTerritory="KR"	match="dates/calendars/calendar[@type='dangi']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="yi" inTerritory="IL"	match="dates/calendars/calendar[@type='hebrew']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
-					
+
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/timeFormats/timeFormatLength[@type='%medLong']/timeFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/timeFormats/timeFormatLength[@type='%fullShort']/timeFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="units/durationUnit[@type='(hm|ms|hms)']/durationUnitPattern"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%atTimePattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%stdPattern"/>
@@ -334,15 +334,15 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
-					
+
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)'][@alt='variant']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/quarters/quarterContext[@type='%contextTypes']/quarterWidth[@type='%allWidths']/quarter[@type='%quarterTypes']"/>
-					
+
 		<coverageLevel	value="moderate"	inTerritory="TH"	match="dates/calendars/calendar[@type='buddhist']/eras/eraAbbr/era[@type='0']"/>
 		<coverageLevel	value="moderate"	inLanguage="yi" inTerritory="IL"	match="dates/calendars/calendar[@type='hebrew']/eras/eraAbbr/era[@type='0']"/>
 		<coverageLevel	value="moderate"	inTerritory="IN"	match="dates/calendars/calendar[@type='indian']/eras/eraAbbr/era[@type='0']"/>
@@ -351,10 +351,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inTerritory="JP"	match="dates/calendars/calendar[@type='japanese']/eras/eraNarrow/era[@type='%japaneseEras']"/>
 		<coverageLevel	value="moderate"	inTerritory="%persianCalendarTerritories"	match="dates/calendars/calendar[@type='persian']/eras/eraAbbr/era[@type='0']"/>
 		<coverageLevel	value="moderate"	inTerritory="TW"	match="dates/calendars/calendar[@type='roc']/eras/eraAbbr/era[@type='(0|1)']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="dates/fields/field[@type='day(-short|-narrow)?']/relative[@type='(-1|0|1)']"/>
 		<coverageLevel	value="moderate"	 	match="dates/fields/field[@type='%dayFieldTypes']/displayName"/>
-					
+
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/regionFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/regionFormat[@type='%regionFormatTypes']"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/fallbackFormat"/>
@@ -362,16 +362,16 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtZeroFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/hourFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/metazone[@type='GMT']/long/standard"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/long/standard"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/Unknown']/exemplarCity"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='${Target-TimeZones}']/exemplarCity"/>
-					
+
 		<coverageLevel	value="moderate"	inTerritory="IE"	match="dates/timeZoneNames/zone[@type='Europe/Dublin']/long/daylight"/>
 		<coverageLevel	value="moderate"	inTerritory="IE"	match="dates/timeZoneNames/zone[@type='Europe/Dublin']/short/daylight"/>
 		<coverageLevel	value="moderate"	inTerritory="GB"	match="dates/timeZoneNames/zone[@type='Europe/London']/long/daylight"/>
 		<coverageLevel	value="moderate"	inTerritory="GB"	match="dates/timeZoneNames/zone[@type='Europe/London']/short/daylight"/>
-					
+
 		<coverageLevel	value="moderate"	inTerritory="AR"	match="dates/timeZoneNames/metazone[@type='%metazone30_AR']/long/daylight"/>
 		<coverageLevel	value="moderate"	inTerritory="AR"	match="dates/timeZoneNames/metazone[@type='%metazone30_AR']/long/generic"/>
 		<coverageLevel	value="moderate"	inTerritory="AR"	match="dates/timeZoneNames/metazone[@type='%metazone30_AR']/long/standard"/>
@@ -403,13 +403,13 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/metazone[@type='%metazone40']/long/daylight"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/metazone[@type='%metazone40']/long/generic"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/metazone[@type='%metazone40']/long/standard"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="listPatterns/listPattern/listPatternPart[@type='(2|start|middle|end)']"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='${Target-Currencies}']/displayName"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='${Target-Currencies}']/displayName[@count='%allPlurals']"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='${Target-Currencies}']/symbol"/>
-					
+
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='%currency30']/displayName"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='%currency30']/displayName[@count='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='%currency30']/symbol[@alt='(narrow|variant)']"/>
@@ -417,13 +417,13 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='%currency40']/displayName[@count='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='%currency40']/symbol"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencies/currency[@type='%currency40']/symbol[@alt='(narrow|variant)']"/>
-					
+
 		<coverageLevel	value="basic"		match="numbers/symbols[@numberSystem='latn']/decimal"/>
 		<coverageLevel	value="basic"		match="numbers/symbols[@numberSystem='latn']/group"/>
 		<coverageLevel	value="basic"	 	match="numbers/symbols[@numberSystem='latn']/minusSign"/>
 		<coverageLevel	value="basic"	 	match="numbers/symbols[@numberSystem='latn']/percentSign"/>
 		<coverageLevel	value="basic"	 	match="numbers/symbols[@numberSystem='latn']/plusSign"/>
-					
+
 		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/decimal"/>
 		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/group"/>
 		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/minusSign"/>
@@ -454,14 +454,14 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/minusSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/percentSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/plusSign"/>
-					
-					
+
+
 		<coverageLevel	value="basic"	 	match="numbers/decimalFormats[@numberSystem='latn']/decimalFormatLength/decimalFormat%stdPattern"/>
 		<coverageLevel	value="basic"	 	match="numbers/percentFormats[@numberSystem='latn']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel	value="basic"	 	match="numbers/scientificFormats[@numberSystem='latn']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel	value="basic"	 	match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencyFormats[@numberSystem='latn']/unitPattern[@count='%anyAttribute']"/>
-					
+
 		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern"/>
@@ -492,9 +492,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='deva']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='mymr']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='tibt']/scientificFormatLength/scientificFormat%stdPattern"/>
-		
+
 		<!-- *********************
-		Modified Moderate rules (v41) 
+		Modified Moderate rules (v41)
 		********************* -->
 
 		<coverageLevel	value="moderate"	inTerritory="TH"	match="dates/calendars/calendar[@type='buddhist']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
@@ -927,5 +927,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="numbers/minimalPairs/caseMinimalPairs[@case='%anyAlphaNum']"/>
         <coverageLevel value="modern" match="numbers/minimalPairs/genderMinimalPairs[@gender='%anyAlphaNum']"/>
 
+		<!-- pathMatch entries are used with focussed organizations in Locales.txt -->
+		<pathMatch id="characterLabel1" match="characterLabels/characterLabelPattern[@type='%anyAttribute']"/>
+		<pathMatch id="characterLabel2" match="characterLabels/characterLabelPattern[@type='%anyAttribute'][@count='%allPlurals']"/>
+		<pathMatch id="annotations1" match="annotations/annotation[@cp='%modernEmoji'][@type='%anyAttribute']"/>
+		<pathMatch id="annotations2" match="annotations/annotation[@cp='%modernEmoji']"/>
 	</coverageLevels>
 </supplementalData>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocalesTxtReader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocalesTxtReader.java
@@ -1,0 +1,205 @@
+package org.unicode.cldr.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.google.common.collect.ImmutableSet;
+import com.ibm.icu.impl.Relation;
+import com.ibm.icu.util.ICUUncheckedIOException;
+
+class LocalesTxtReader {
+    Map<Organization, Map<String, Level>> platform_locale_level = null;
+    Map<Organization, Relation<Level, String>> platform_level_locale = null;
+    Map<String, Map<String, String>> platform_locale_levelString = null;
+    Map<Organization, Map<String, Integer>> organization_locale_weight = null;
+    Map<Organization, Map<String, Set<String>>> organization_locale_match = null;
+
+    public static final String DEFAULT_NAME = "Locales.txt";
+
+    public LocalesTxtReader() {
+    }
+
+    /**
+     * Read from Locales.txt, from the default location
+     * @param lstreg stream to read from
+     */
+    public LocalesTxtReader read(StandardCodes sc) {
+        try (BufferedReader lstreg = CldrUtility.getUTF8Data(DEFAULT_NAME);) {
+            return read(sc, lstreg);
+        } catch (IOException e) {
+            throw new ICUUncheckedIOException("Internal Error reading Locales.txt", e);
+        }
+    }
+
+    /**
+     * Parse a Locales.txt file
+     * @param sc StandardCodes used for validation
+     * @param lstreg stream to read from
+     */
+    public LocalesTxtReader read(StandardCodes sc, BufferedReader lstreg) {
+        LocaleIDParser parser = new LocaleIDParser();
+        platform_locale_level = new EnumMap<>(Organization.class);
+        organization_locale_weight = new EnumMap<>(Organization.class);
+        organization_locale_match = new EnumMap<>(Organization.class);
+        SupplementalDataInfo sd = SupplementalDataInfo.getInstance();
+        Set<String> defaultContentLocales = sd.getDefaultContentLocales();
+        String line;
+        try {
+            while (true) {
+                Integer weight = null; // @weight
+                String pathMatch = null; // @pathMatch
+                line = lstreg.readLine();
+                if (line == null)
+                    break;
+                int commentPos = line.indexOf('#');
+                if (commentPos >= 0) {
+                    line = line.substring(0, commentPos);
+                }
+                line = line.trim();
+                if (line.length() == 0)
+                    continue;
+                List<String> stuff = CldrUtility.splitList(line, ';', true);
+                Organization organization;
+
+                // verify that the organization is valid
+                try {
+                    organization = Organization.fromString(stuff.get(0));
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Invalid organization in Locales.txt: " + line);
+                }
+
+                // verify that the locale is valid BCP47
+                String localePart = stuff.get(1).trim();
+                List<String> localeStuff = CldrUtility.splitList(localePart, ' ', true);
+                Set<String> locales = new TreeSet<>();
+
+                for (final String entry : localeStuff) {
+                    if (entry.startsWith("@")) {
+                        List<String> kwStuff = CldrUtility.splitList(entry, '=', true);
+                        if (kwStuff.size() > 2 || kwStuff.size() < 1) {
+                            throw new IllegalArgumentException("Invalid @-command " + entry + " in Locales.txt: " + line);
+                        }
+                        final String atCommand = kwStuff.get(0);
+                        switch(atCommand) {
+                            case "@weight":
+                                weight = Integer.parseInt(kwStuff.get(1));
+                                break;
+
+                            case "@pathMatch":
+                                pathMatch = kwStuff.get(1);
+                            break;
+                            default:
+                                throw new IllegalArgumentException("Unknown @-command " + atCommand + " in Locales.txt: " + line);
+                        }
+                    } else {
+                        locales.add(entry);
+                    }
+                }
+
+                if (locales.size() != 1) {
+                    // require there to be exactly one locale.
+                    // This would allow collapsing into fewer lines.
+                    throw new IllegalArgumentException("Expected one locale entry in Locales.txt but got " + locales.size() + ": " + line);
+                }
+
+                // extract the single locale, process as before
+                String locale = locales.iterator().next();
+
+                if (!locale.equals(StandardCodes.ALL_LOCALES)) {
+                    parser.set(locale);
+                    String valid = sc.validate(parser);
+                    if (valid.length() != 0) {
+                        throw new IllegalArgumentException("Invalid locale in Locales.txt: " + line);
+                    }
+                    locale = parser.toString(); // normalize
+
+                    // verify that the locale is not a default content locale
+                    if (defaultContentLocales.contains(locale)) {
+                        throw new IllegalArgumentException("Cannot have default content locale in Locales.txt: " + line);
+                    }
+                }
+
+                Level status = Level.get(stuff.get(2));
+                if (status == Level.UNDETERMINED) {
+                    System.out.println("Warning: Level unknown on: " + line);
+                }
+                Map<String, Level> locale_status = platform_locale_level.get(organization);
+                if (locale_status == null) {
+                    platform_locale_level.put(organization, locale_status = new TreeMap<>());
+                }
+                locale_status.put(locale, status);
+                if (!locale.equals(StandardCodes.ALL_LOCALES)) {
+                    String scriptLoc = parser.getLanguageScript();
+                    if (locale_status.get(scriptLoc) == null)
+                        locale_status.put(scriptLoc, status);
+                    String lang = parser.getLanguage();
+                    if (locale_status.get(lang) == null)
+                        locale_status.put(lang, status);
+                }
+
+                if (weight != null) {
+                    organization_locale_weight
+                        .computeIfAbsent(organization, ignored -> new TreeMap<String, Integer>())
+                        .put(locale, weight);
+                }
+                if (pathMatch != null) {
+                    organization_locale_match
+                        .computeIfAbsent(organization, ignored -> new TreeMap<String, Set<String>>())
+                        .put(locale, ImmutableSet.copyOf(pathMatch.split(",")));
+                }
+            }
+        } catch (IOException e) {
+            throw new ICUUncheckedIOException("Internal Error", e);
+        }
+
+        // now reset the parent to be the max of the children
+        for (Organization platform : platform_locale_level.keySet()) {
+            Map<String, Level> locale_level = platform_locale_level.get(platform);
+            for (String locale : locale_level.keySet()) {
+                parser.set(locale);
+                Level childLevel = locale_level.get(locale);
+
+                String language = parser.getLanguage();
+                if (!language.equals(locale)) {
+                    Level languageLevel = locale_level.get(language);
+                    if (languageLevel == null || languageLevel.compareTo(childLevel) < 0) {
+                        locale_level.put(language, childLevel);
+                    }
+                }
+                String oldLanguage = language;
+                language = parser.getLanguageScript();
+                if (!language.equals(oldLanguage)) {
+                    Level languageLevel = locale_level.get(language);
+                    if (languageLevel == null || languageLevel.compareTo(childLevel) < 0) {
+                        locale_level.put(language, childLevel);
+                    }
+                }
+            }
+        }
+        // backwards compat hack
+        platform_locale_levelString = new TreeMap<>();
+        platform_level_locale = new EnumMap<>(Organization.class);
+        for (Organization platform : platform_locale_level.keySet()) {
+            Map<String, String> locale_levelString = new TreeMap<>();
+            platform_locale_levelString.put(platform.toString(), locale_levelString);
+            Map<String, Level> locale_level = platform_locale_level.get(platform);
+            for (String locale : locale_level.keySet()) {
+                locale_levelString.put(locale, locale_level.get(locale).toString());
+            }
+            Relation level_locale = Relation.of(new EnumMap(Level.class), HashSet.class);
+            level_locale.addAllInverted(locale_level).freeze();
+            platform_level_locale.put(platform, level_locale);
+        }
+        CldrUtility.protectCollection(platform_level_locale);
+        platform_locale_level = CldrUtility.protectCollection(platform_locale_level);
+        platform_locale_levelString = CldrUtility.protectCollection(platform_locale_levelString);
+        return this;
+    }
+}

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -1,7 +1,46 @@
+# Locales.txt
+#
+# This file controls the coverage used by different organizations for their respective
+# locales, and also controls which locales an organization is allowed to contribute to.
+#
+# The homepage for this file is:
+#   https://cldr.unicode.org/index/survey-tool/coverage
+#
+# Format:
+#
+# Each line is either a comment or of this form:
+#
+#  <organization> ; <@-commands> <language_code> ; <coverage_level> ; <language name - optional>
+#
+# For example,
+#
+#  Oracle	;	ar	;	modern ; Arabic
+#  iaap ; @weight=4 @pathMatch=annotations,characterLabel * ; moderate ; All annotations
+#
+# Fields:
+# <organization>: this is the organization as defined by org.unicode.cldr.util.Organization
+#
+# <@-commands> may be used prior to the language code, as in this example:
+# @weight=4 indicates that the voting weight is restricted to a vote of 4.
+#  (See <https://cldr.unicode.org/index/process#h.mz5r3eqr6cxn> for details)
+# @pathMatch=annotations,characterLabel restricts the voting so that it
+# must match one or the other of the named pathMatches elements. All other
+# paths will show as readonly to these users.
+#
+# <language_code>: the code for each locale.
+# Note, do not list default content locales.  List 'fr', but not 'fr_FR'.
+# Instead of a language code, * can be used if 'all others' is meant.
+#
+# <coverage_level>: the level which will be presented to users for this
+# locale, see <https://cldr.unicode.org/index/cldr-spec/coverage-levels>
+#
+# <language name - optional>
+# This is an optional comment which can be used to give the name of the locale,
+# or any other organization-specific information such as tiers (T0, T1, …)
+
 
 # http://java.sun.com/j2se/1.5.0/docs/guide/intl/locale.doc.html
 # http://developers.sun.com/techtopics/global/index.html
-
 Oracle	;	ar	;	modern
 # The following were added in response to this org's vetter assignment.
 Oracle	;	ja	;	modern
@@ -997,3 +1036,6 @@ wod_nko ; bm_Nkoo ; modern ; Bambara (N’ko)
 
 yahoo ; mul ; modern ;
 # ^no votes in 30…40 for this org
+
+#Example of using weight and pathMatch:
+#iaap ; @weight=4 @pathMatch=annotations1,anotations2,characterLabel1,characterLabel2 * ; moderate ;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -582,6 +582,8 @@ public class TestDtdData extends TestFmwk {
                 && (attribute.equals("inLanguage") || attribute.equals("inScript") || attribute.equals("inTerritory") || attribute.equals("match"))
                 || elementName.equals("languageMatch")
                 && (attribute.equals("desired") || attribute.equals("supported"))
+                || elementName.equals("pathMatch")
+                && (attribute.equals("id"))
                 || (elementName.equals("transform") && (attribute.equals("source") || attribute.equals("target") || attribute.equals("direction") || attribute
                     .equals("variant")))
                 || (elementName.equals("grammaticalFeatures") && (attribute.equals("locales") || attribute.equals("targets")))

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLocalesTxtReader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLocalesTxtReader.java
@@ -1,0 +1,79 @@
+package org.unicode.cldr.util;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.jupiter.api.Test;
+
+public class TestLocalesTxtReader {
+
+    @Test
+    void TestRegularLocalesTxt() {
+        LocalesTxtReader rdr = new LocalesTxtReader().read(StandardCodes.make());
+        assertNotNull(rdr);
+        assertAll("LocalesTxtReader assertions",
+            // These are not used yet
+            // () -> assertTrue(rdr.organization_locale_match.isEmpty(),
+            // () -> assertTrue(rdr.organization_locale_weight.isEmpty(),
+
+            () -> assertFalse(rdr.platform_level_locale.isEmpty()),
+            () -> assertFalse(rdr.platform_locale_level.isEmpty()),
+            () -> assertFalse(rdr.platform_locale_levelString.isEmpty()));
+    }
+
+    @Test
+    void TestCannedLocalesTxt() throws IOException {
+        try (BufferedReader r = FileReaders.openFile(TestLocalesTxtReader.class, "TestLocales.txt");) {
+            LocalesTxtReader rdr = new LocalesTxtReader().read(StandardCodes.make(), r);
+            assertNotNull(rdr);
+            assertAll("LocalesTxtReader basic assertions",
+                () -> assertFalse(rdr.organization_locale_match.isEmpty()),
+                () -> assertFalse(rdr.organization_locale_weight.isEmpty()),
+                () -> assertFalse(rdr.platform_level_locale.isEmpty()),
+                () -> assertFalse(rdr.platform_locale_level.isEmpty()),
+                () -> assertFalse(rdr.platform_locale_levelString.isEmpty()),
+                () -> assertTrue(rdr.organization_locale_match.containsKey(Organization.adlam)),
+                () -> assertTrue(rdr.organization_locale_weight.containsKey(Organization.adlam)),
+                () -> assertTrue(rdr.platform_locale_level.containsKey(Organization.adlam)),
+                () -> assertTrue(rdr.platform_locale_level.containsKey(Organization.wod_nko)),
+                () -> assertTrue(rdr.platform_locale_level.containsKey(Organization.wikimedia)));
+
+            Map<String, Integer> adlam_weight = rdr.organization_locale_weight.get(Organization.adlam);
+            Map<String, Set<String>> adlam_match = rdr.organization_locale_match.get(Organization.adlam);
+            Map<String, Level> nko_level = rdr.platform_locale_level.get(Organization.wod_nko);
+            Map<String, Level> adlam_level = rdr.platform_locale_level.get(Organization.adlam);
+            Map<String, Level> wikimedia_level = rdr.platform_locale_level.get(Organization.wikimedia);
+
+            assertAll("verify maps",
+                () -> assertNotNull(adlam_weight),
+                () -> assertFalse(adlam_weight.isEmpty()),
+                () -> assertNotNull(adlam_match),
+                () -> assertFalse(adlam_match.isEmpty()),
+                () -> assertNotNull(nko_level),
+                () -> assertFalse(nko_level.isEmpty()),
+                () -> assertNotNull(adlam_level),
+                () -> assertFalse(adlam_level.isEmpty()),
+                () -> assertNotNull(wikimedia_level),
+                () -> assertFalse(wikimedia_level.isEmpty()));
+
+            final Set<String> adlamPaths = adlam_match.get(StandardCodes.ALL_LOCALES);
+            assertAll("verify values",
+                () -> assertEquals(4, adlam_weight.get(StandardCodes.ALL_LOCALES)),
+                () -> assertEquals(ImmutableSet.of("annotations1","annotations2","characterLabel1","characterLabel2"), adlamPaths, "adlam: *"),
+                () -> assertEquals(Level.MODERATE, adlam_level.get(StandardCodes.ALL_LOCALES), "adlam: *"),
+                () -> assertEquals(Level.MODERN, nko_level.get("nqo"), "wod_nko: nqo"),
+                () -> assertEquals(Level.BASIC, wikimedia_level.get(StandardCodes.ALL_LOCALES), "wikimedia: *"));
+
+        }
+    }
+}

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/util/TestLocales.txt
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/util/TestLocales.txt
@@ -1,0 +1,6 @@
+# a test version of Locales.txt, for testing!
+# see the test: TestLocalesTxtReader
+adlam ; @weight=4 @pathMatch=annotations1,annotations2,characterLabel1,characterLabel2 * ; moderate ;
+wod_nko ; nqo ; modern ; N’Ko
+wod_nko ; bm_Nkoo ; modern ; Bambara (N’ko)
+wikimedia ; * ; basic ; All


### PR DESCRIPTION
CLDR-15468 Locales.txt: steps to support for focussed orgs

- new pathMatch element in coverageLevels.xml
- document Locales.txt format
- Split Locales.txt to a separate reader class
- parse @-commands
- tests for Locales.txt reader

Co-authored-by: Peter Edberg <42151464+pedberg-icu@users.noreply.github.com>

Note that this does NOT add IAAP, nor make any changes to Locales.txt content.
It also does not parse pathMatch.