### PR TITLE
CLDR-15549 Remove duplicate attributes in `blockingItems`

### DIFF
--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -286,7 +286,7 @@
 			<attributeValues dtds='supplementalData' elements='attributes' attributes='element' type='choice'>collation currency dateFormat
 				dateTimeFormat decimalFormat ldml orientation pattern percentFormat scientificFormat timeFormat weekendEnd weekendStart</attributeValues>
 			<attributeValues dtds='supplementalData' elements='blockingItems' attributes='elements' type='list'>identity supplementalData cldrTest
-				collation transform identity supplementalData cldrTest collation transform</attributeValues>
+				collation transform</attributeValues>
 			<attributeValues dtds='supplementalData' elements='calendar' attributes='type' type='regex'>$_bcp47_calendar</attributeValues>
 			<attributeValues dtds='supplementalData' elements='calendarPreference' attributes='ordering' type='list'>$_bcp47_calendar</attributeValues>
 			<attributeValues dtds='supplementalData' elements='calendarPreference' attributes='territories' type='list'>$_region</attributeValues>


### PR DESCRIPTION
CLDR-15549

`blockingItems` has each of the items duplicated.
It is the only `type="list"` in `attributeValueValidity.xml` with duplicate values.

Duplicate values were introduced [here](https://github.com/unicode-org/cldr/commit/b9ae65dd897e584ff01e73815734de0d6f001ed4).

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
