### PR TITLE
CLDR-15449 add wod_nko for the nqo langauge

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Organization.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Organization.java
@@ -54,7 +54,9 @@ public enum Organization {
     surveytool("Survey Tool"),
     welsh_lc("Welsh LC"),
     wikimedia("Wikimedia Foundation"),
+    wod_nko("WOD N’ko", "World Organization for the Development of N’ko", "WODN"),
     yahoo("Yahoo"),
+
     // To be removed.
     ;
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -966,5 +966,9 @@ wikimedia ; yi ; moderate ;
 wikimedia ; zh ; moderate ;
 wikimedia ; * ; moderate ;
 
+# World Organization for the Development of N’ko (WODN)
+wod_nko ; nqo ; modern ; N’Ko
+wod_nko ; bm_Nkoo ; modern ; Bambara (N’ko)
+
 yahoo ; mul ; modern ;
 # ^no votes in 30…40 for this org


### PR DESCRIPTION
- World Organization for the Development of N’ko (WODN)

CLDR-15449

- [X] This PR completes the ticket.