### PR TITLE
CLDR-15292 rdf: fix LanguageMapper

### DIFF
--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/rdf/LanguageMapper.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/rdf/LanguageMapper.java
@@ -8,8 +8,6 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.sparql.lang.sparql_11.ParseException;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CoverageInfo;
 import org.unicode.cldr.util.XPathParts;
 
 /**
@@ -17,25 +15,23 @@ import org.unicode.cldr.util.XPathParts;
  * @author srl295
  */
 public class LanguageMapper implements XPathMapper {
-    
+
     static final String O_LANGUAGE = "?language";
     static final String DBO_639_3 = "dbo:iso6393Code";
     static final String DBO_639_2 = "dbo:iso6392Code";
     static final String DBO_639_1 = "dbo:iso6391Code";
     static final boolean DEBUG = false;
-    
+
     public LanguageMapper() {
     }
 
-    
+
     @Override
     public int addEntries(AbstractCache cache) throws ParseException {
     	int newAdd = 0;
-        final CLDRConfig config = CLDRConfig.getInstance();
-        CoverageInfo ci = config.getCoverageInfo();
         ResultSet rs = queryLanguageResources();
-        
-        
+
+
         XPathParts xpp = XPathParts.getFrozenInstance("//ldml/localeDisplayNames/languages/language").cloneAsThawed();
         while(rs.hasNext()) {
             final QuerySolution qs = rs.next();
@@ -44,13 +40,25 @@ public class LanguageMapper implements XPathMapper {
                 code = QueryClient.getLiteralOrNull(qs, "iso6392");
             }
             final String res = QueryClient.getResourceOrNull(qs, "language");
-//            final String abs = QueryClient.getStringOrNull(qs, "abstract");
+            if (code == null) {
+                // SPARQL should have filtered out this entry.
+                System.err.println("!!! SPARQL error: No code for " + res);
+                continue;
+            }
+            if (code.isEmpty()) {
+                if (DEBUG) {
+                    System.err.println("!!! Empty code for " + res);
+                }
+                // This happens for https://dbpedia.org/page/Grebo_language which has a junk extra entry
+                continue;
+            }
             if(code.length() != 3 && code.length() != 2) {
                 if(DEBUG) System.out.println("!!!" + rs.getRowNumber() + " - " + code + " " + res);
                 int spaceLoc = code.indexOf(' ');
                 if(!Character.isLowerCase(code.charAt(0))
                        || (spaceLoc != 2 && spaceLoc != 3)) {
-                    System.err.println("Rejecting: " + code + " for " + res);
+                    // Happens for Igbo
+                    System.err.println("Rejecting wrong-length " + code + " for " + res);
                     continue;
                 }
                 code = code.substring(0, spaceLoc);
@@ -58,7 +66,7 @@ public class LanguageMapper implements XPathMapper {
             } else {
             	if(DEBUG) System.out.println("== " + rs.getRowNumber() + " - " + code + " " + res);
             }
-            
+
             xpp.setAttribute(-1, "type", code);
             final String xpath = xpp.toString();
             if(DEBUG) System.out.println("\t"+res+"\t"+xpath);
@@ -84,12 +92,7 @@ public class LanguageMapper implements XPathMapper {
     			//                    .addOptional(resType, "dbo:iso6393Code", "?iso6393")  // Future: 639-3 code
 
 
-    			.addFilter("(?iso6391 || ?iso6392 "
-    					//                            + "|| ?iso6393"
-    					+ ") && "
-    					+ "(?iso6391 != 'none' && ?iso6392 != 'none' "
-    					//                            + "&& ?iso6393 != 'none'"
-    					+ ")")
+                .addFilter("(bound(?iso6391) || bound(?iso6392))") // At least 639-1 or 639-2, or both
     			;
     	System.out.println(builder.buildString());
     	Query q = builder.build();

--- a/tools/cldr-rdf/src/test/java/org/unicode/cldr/rdf/TestMapAll.java
+++ b/tools/cldr-rdf/src/test/java/org/unicode/cldr/rdf/TestMapAll.java
@@ -1,5 +1,6 @@
 package org.unicode.cldr.rdf;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -8,42 +9,42 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.annotation.Testable;
-
-import com.google.common.io.Files;
 
 @Testable
 public class TestMapAll {
 	private static final String TEST_XPATH = "//ldml";
 	private static final String TEST_URL = "http://cldr.unicode.org";
 	public static final boolean CLDR_TEST_ENABLE_NET = Boolean.parseBoolean(System.getProperty("CLDR_TEST_ENABLE_NET", "false"));
-	
+
 	@Test
-	void TestNoMappings() {
-		File root = Files.createTempDir();
+	void TestNoMappings() throws IOException {
+		File root = Files.createTempDirectory("rdf_TestMapAll_TestNoMappings").toFile();
 		AbstractCache tmpCache = new AbstractCache(root);
 		assertEquals(0,  tmpCache.size(), "Cache should be empty when created.");
 		assertNull(tmpCache.get("//cldr"));
 
 		assertFalse(tmpCache.add(TEST_XPATH, TEST_URL), "expected this value was not already there");
 		assertTrue(tmpCache.add(TEST_XPATH, TEST_URL), "expected this value was already there");
-		
+
 		assertEquals(TEST_URL, tmpCache.get(TEST_XPATH));
-		
+
 		{
 			AbstractCache cache2 = new AbstractCache(root);
 			assertEquals(0, cache2.size(), "Cache was not written yet");
 			assertNull(cache2.get("//cldr"));
 			assertNull(cache2.get(TEST_XPATH));
 		}
-		
+
 		tmpCache.store();
-		
+
 		assertEquals(TEST_URL, tmpCache.get(TEST_XPATH));
-		
+
 		{
 			AbstractCache cache3 = new AbstractCache(root);
 			assertEquals(1, cache3.size(), "Cache was written and was re-read");
@@ -51,24 +52,36 @@ public class TestMapAll {
 			assertEquals(TEST_URL, cache3.get(TEST_XPATH));
 		}
 	}
-	
-	
-	
+
+
+
 	@Test
-	void TestAllMappings() throws ParseException {
+	void TestAllMappings() throws ParseException, IOException {
 		assumeTrue(CLDR_TEST_ENABLE_NET, "CLDR_TEST_ENABLE_NET not true, not attempting network read");
-		
-		File root = Files.createTempDir();
+
+		File root = Files.createTempDirectory("rdf_TestMapAll_TestAllMappings").toFile();
 		AbstractCache tmpCache = new AbstractCache(root);
 
 		int count = new MapAll().addEntries(tmpCache);
 		assertNotEquals(0, count, "added count of net entries");
-		
-		// Spot check
-		
-		assertEquals("http://dbpedia.org/resource/French_language", tmpCache.get("//ldml/localeDisplayNames/languages/language[@type=\"fr\"]"));
-		
+
+		// write the cache here, for debugging.
 		tmpCache.store();
+
+		// Spot
+		assertAll("Spot Checks",
+				() -> assertLanguage(tmpCache, "fr", "http://dbpedia.org/resource/French_language"),
+				() -> assertLanguage(tmpCache, "co", "http://dbpedia.org/resource/Corsican_language"),
+				() -> assertLanguage(tmpCache, "ace", "http://dbpedia.org/resource/Acehnese_language"));
+	}
+
+	void assertLanguage(AbstractCache cache, String code, String url) {
+		assertUrl(cache, "//ldml/localeDisplayNames/languages/language[@type=\"" + code + "\"]", url);
+	}
+
+	void assertUrl(AbstractCache cache, String xpath, String url) {
+		assertEquals(url, cache.get(xpath),
+			() -> xpath.substring(xpath.lastIndexOf('/'))); // leaf element only
 	}
 
 }


### PR DESCRIPTION
- was not catching an error on https://dbpedia.org/page/Grebo_language so some entries were missing
- Filter was incorrect, so skipped some entries
- Added unit tests for 'ace' (Acehnese)
- Cleaned up test code, fixed use of deprecated API

CLDR-15292
