### PR TITLE
CLDR-15561 read git hash directly for data

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
@@ -43,6 +43,7 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1573,28 +1574,101 @@ public class CldrUtility {
      * @return the hash, like "9786e05e95a2e4f02687fa3b84126782f9f698a3"
      */
     public final static String getGitHashForDir(String dir) {
-        final String GIT_HASH_COMMANDS[] = { "git",  "rev-parse", "HEAD" };
+        // Try #1
+        String hash = getGitHashDirectlyForDir(dir);
+        if (hash == null) {
+            // Try #2
+            hash = getGitHashByRevParseForDir(dir);
+        }
+        if (hash == null) {
+            // return 'unknown'
+            hash = CLDRURLS.UNKNOWN_REVISION;
+        }
+        return hash;
+    }
+
+    /**
+     * Attempt to retrieve git hash by digging through .git/HEAD and related files
+     * @param dir
+     * @return the hash, like "9786e05e95a2e4f02687fa3b84126782f9f698a3"
+     */
+    private static String getGitHashDirectlyForDir(String dir) {
+        // First, try just reading .git/HEAD
+        final File gitDir = new File(dir, ".git");
+        final File headfile = new File(gitDir, "HEAD");
+        if (headfile.canRead()) {
+            // Try this first, fallback to git commands
+            try {
+                String s = Files.readString(headfile.toPath());
+                if (s != null && !s.isBlank()) {
+                    s = s.trim();
+                    if (s.startsWith("ref: ")) {
+                        s = s.substring(5); // refs/heads/main
+                        final Path refPath = gitDir.toPath().resolve(s);
+                        if (refPath.startsWith(gitDir.toPath())) {
+                            s = Files.readString(refPath);
+                            if (s != null && !s.isBlank()) {
+                                return s.trim();
+                            }
+                        } else { // ignore something like refs: ../../../yourfiles
+                            System.err.println("Ignoring strange git refPath " + refPath);
+                        }
+                    } // else, maybe detached head
+                    return s.trim();
+                }
+            } catch (IOException e) {
+                System.err.println(e + ": readString failed for " + headfile);
+                e.printStackTrace();
+            }
+
+        }
+        return null; // not found;
+    }
+
+    /**
+     * Attempt to retrieve git hash by calling 'git rev-parse HEAD'
+     * @param dir
+     * @return the hash, like "9786e05e95a2e4f02687fa3b84126782f9f698a3"
+     */
+    private static String getGitHashByRevParseForDir(String dir) {
+        final String GIT_HASH_COMMANDS[] = { "git", "rev-parse", "HEAD" };
         try {
             if (dir == null) {
-                return CLDRURLS.UNKNOWN_REVISION; // no dir
+                return null; // no dir
             }
             File f = new File(dir);
             if (!f.isDirectory()) {
-                return CLDRURLS.UNKNOWN_REVISION; // does not exist
+                return null; // does not exist
             }
             Process p = Runtime.getRuntime().exec(GIT_HASH_COMMANDS, null, f);
+            if (!p.waitFor(15, TimeUnit.SECONDS)) {
+                System.err.println("Git query " + String.join(" ", GIT_HASH_COMMANDS) + " timed out");
+                p.destroyForcibly();
+                return null;
+            }
+            if (p.exitValue() != 0) {
+                System.err.println("Error return : " + p.exitValue() + " from " + String.join(" ", GIT_HASH_COMMANDS));
+                try (BufferedReader is = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+                    String str = is.readLine();
+                    if (str.length() == 0) {
+                        throw new Exception("git returned empty");
+                    }
+                    System.err.println("git: " + str);
+                }
+                return null;
+            }
             try (BufferedReader is = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
                 String str = is.readLine();
-                if (str.length() == 0) {
+                if (str == null || str.length() == 0) {
                     throw new Exception("git returned empty");
                 }
                 return str;
             }
-        } catch(Throwable t) {
+        } catch (Throwable t) {
             // We do not expect this to be called frequently.
             System.err.println("While trying to get 'git' hash for " + dir + " : " + t.getMessage());
             t.printStackTrace();
-            return CLDRURLS.UNKNOWN_REVISION;
+            return null;
         }
     }
 }


### PR DESCRIPTION
- if possible, read directly from .git/HEAD and related files
- due to a recent git update, 'git rev-parse HEAD' may refuse to operate,
details at https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory
- if we do use git rev-parse HEAD, be clearer when there is an error

CLDR-15561

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
