### PR TITLE
CLDR-15405 move monogram from length→usage, reduce/rename sampleName items, rearrange order

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3186,13 +3186,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT personName ( alias | ( namePattern+, special* ) ) >
 <!ATTLIST personName length NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/long, medium, short, monogram, monogramNarrow-->
+    <!--@MATCH:set/literal/long, medium, short-->
 <!ATTLIST personName usage NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/addressing, referring-->
+    <!--@MATCH:set/literal/addressing, referring, monogram-->
 <!ATTLIST personName style NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/formal, informal-->
 <!ATTLIST personName order NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/sorting, givenFirst, surnameFirst-->
+    <!--@MATCH:set/literal/givenFirst, surnameFirst, sorting-->
 
 <!ELEMENT namePattern ( #PCDATA ) >
 <!ATTLIST namePattern alt (1|2) #IMPLIED >
@@ -3203,7 +3203,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT sampleName ( alias | ( nameField+, special* ) ) >
 <!ATTLIST sampleName item NMTOKENS #REQUIRED >
-    <!--@MATCH:literal/givenSurname, given2Surname, givenSurname2, informal, full, multiword, mononym-->
+    <!--@MATCH:literal/givenOnly, givenSurnameOnly, given12Surname, full-->
 
 <!ELEMENT nameField ( #PCDATA ) >
 <!ATTLIST nameField type CDATA #REQUIRED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9138,17 +9138,14 @@ annotations.
 		<nameOrderLocales order="surnameFirst">ja zh ko</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-		<personName length="long" usage="addressing" style="formal" order="sorting">
-			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
-		</personName>
 		<personName length="long" usage="addressing" style="formal" order="givenFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
 		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
-		<personName length="long" usage="addressing" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
+		<personName length="long" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="givenFirst">
 			<namePattern>{given-informal}</namePattern>
@@ -9156,8 +9153,8 @@ annotations.
 		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
-		<personName length="long" usage="referring" style="formal" order="sorting">
-			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		<personName length="long" usage="addressing" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
@@ -9165,8 +9162,8 @@ annotations.
 		<personName length="long" usage="referring" style="formal" order="surnameFirst">
 			<namePattern>{surname} {given} {given2} {suffix}</namePattern>
 		</personName>
-		<personName length="long" usage="referring" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
+		<personName length="long" usage="referring" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="givenFirst">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -9174,17 +9171,36 @@ annotations.
 		<personName length="long" usage="referring" style="informal" order="surnameFirst">
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="sorting">
-			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
+		<personName length="long" usage="referring" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
+		<personName length="long" usage="monogram" style="formal" order="givenFirst">
+			<namePattern>{given-initial-allCaps}{given2-initial-allCaps}{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="formal" order="sorting">
+			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="informal" order="givenFirst">
+			<namePattern>{given-informal-initial-allCaps}{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="informal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="informal" order="sorting">
+			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
+		</personName>
+
 		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
+		<personName length="medium" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
 			<namePattern>{given-informal}</namePattern>
@@ -9192,8 +9208,8 @@ annotations.
 		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
-		<personName length="medium" usage="referring" style="formal" order="sorting">
-			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
+		<personName length="medium" usage="addressing" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given} {given2-initial} {surname} {suffix}</namePattern>
@@ -9201,8 +9217,8 @@ annotations.
 		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
 			<namePattern>{surname} {given} {given2-initial} {suffix}</namePattern>
 		</personName>
-		<personName length="medium" usage="referring" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
+		<personName length="medium" usage="referring" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="givenFirst">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -9210,8 +9226,26 @@ annotations.
 		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
-		<personName length="short" usage="addressing" style="formal" order="sorting">
-			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
+		<personName length="medium" usage="referring" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="monogram" style="formal" order="givenFirst">
+			<namePattern>{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="medium" usage="monogram" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="medium" usage="monogram" style="formal" order="sorting">
+			<namePattern>{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="medium" usage="monogram" style="informal" order="givenFirst">
+			<namePattern>{given-informal-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="medium" usage="monogram" style="informal" order="surnameFirst">
+			<namePattern>{given-informal-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="medium" usage="monogram" style="informal" order="sorting">
+			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="givenFirst">
 			<namePattern>{prefix} {surname}</namePattern>
@@ -9219,8 +9253,8 @@ annotations.
 		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
 			<namePattern>{prefix} {surname}</namePattern>
 		</personName>
-		<personName length="short" usage="addressing" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
+		<personName length="short" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="givenFirst">
 			<namePattern>{given-informal}</namePattern>
@@ -9228,8 +9262,8 @@ annotations.
 		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
-		<personName length="short" usage="referring" style="formal" order="sorting">
-			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
+		<personName length="short" usage="addressing" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -9237,8 +9271,8 @@ annotations.
 		<personName length="short" usage="referring" style="formal" order="surnameFirst">
 			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
 		</personName>
-		<personName length="short" usage="referring" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
+		<personName length="short" usage="referring" style="formal" order="sorting">
+			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="givenFirst">
 			<namePattern>{given-informal} {surname-initial}</namePattern>
@@ -9246,106 +9280,48 @@ annotations.
 		<personName length="short" usage="referring" style="informal" order="surnameFirst">
 			<namePattern>{surname} {given-initial}</namePattern>
 		</personName>
-		<!-- for length="monogram" or "monogramNarrow", ignore usage -->
-		<personName length="monogram" style="formal" order="sorting">
-			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
+		<personName length="short" usage="referring" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
-		<personName length="monogram" style="formal" order="givenFirst">
-			<namePattern>{given-initial-allCaps}{given2-initial-allCaps}{surname-initial-allCaps}</namePattern>
-		</personName>
-		<personName length="monogram" style="formal" order="surnameFirst">
-			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
-		</personName>
-		<personName length="monogram" style="informal" order="sorting">
-			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
-		</personName>
-		<personName length="monogram" style="informal" order="givenFirst">
-			<namePattern>{given-informal-initial-allCaps}{surname-initial-allCaps}</namePattern>
-		</personName>
-		<personName length="monogram" style="informal" order="surnameFirst">
-			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
-		</personName>
-		<personName length="monogramNarrow" style="formal" order="sorting">
+		<personName length="short" usage="monogram" style="formal" order="givenFirst">
 			<namePattern>{surname-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="formal" order="givenFirst">
+		<personName length="short" usage="monogram" style="formal" order="surnameFirst">
 			<namePattern>{surname-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="formal" order="surnameFirst">
+		<personName length="short" usage="monogram" style="formal" order="sorting">
 			<namePattern>{surname-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="informal" order="sorting">
+		<personName length="short" usage="monogram" style="informal" order="givenFirst">
 			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="informal" order="givenFirst">
+		<personName length="short" usage="monogram" style="informal" order="surnameFirst">
 			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="monogramNarrow" style="informal" order="surnameFirst">
+		<personName length="short" usage="monogram" style="informal" order="sorting">
 			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
 		<!-- The following samples are temporary, to be filled out with something better -->
-		<sampleName item="givenSurname">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">Katherine</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">Johnson</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
+		<sampleName item="givenOnly">
+			<nameField type="given">Sinbad</nameField>
 		</sampleName>
-		<sampleName item="given2Surname">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">Alberto</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">Pedro</nameField>
-			<nameField type="surname">Calderón</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
+		<sampleName item="givenSurnameOnly">
+			<nameField type="given">Irene</nameField>
+			<nameField type="surname">Adler</nameField>
 		</sampleName>
-		<sampleName item="givenSurname2">
-			<nameField type="prefix">∅∅∅</nameField>
+		<sampleName item="given12Surname">
 			<nameField type="given">John</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">Blue</nameField>
-			<nameField type="surname2">Green</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
-		</sampleName>
-		<sampleName item="informal">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">John</nameField>
-			<nameField type="given-informal">Jack</nameField>
-			<nameField type="given2">William</nameField>
-			<nameField type="surname">Brown</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
+			<nameField type="given2">Hamish</nameField>
+			<nameField type="surname">Watson</nameField>
 		</sampleName>
 		<sampleName item="full">
-			<nameField type="prefix">Dr.</nameField>
-			<nameField type="given">Dorothy</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">Lavinia</nameField>
-			<nameField type="surname">Brown</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">M.D.</nameField>
-		</sampleName>
-		<sampleName item="multiword">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">Erich Oswald</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">Hans Carl Maria</nameField>
-			<nameField type="surname">von Stroheim</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
-		</sampleName>
-		<sampleName item="mononym">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">Sinbad</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
+			<nameField type="prefix">Prof. Dr.</nameField>
+			<nameField type="given">Ada Cornelia</nameField>
+			<nameField type="given-informal">Neele</nameField>
+			<nameField type="given2">Eva Sophia</nameField>
+			<nameField type="surname">Meyer Wolf</nameField>
+			<nameField type="surname2">Becker Schmidt</nameField>
+			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5372,16 +5372,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<nameOrderLocales order="surnameFirst">ja zh ko hu</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-		<personName length="long" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
 		<personName length="long" usage="addressing" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="long" usage="addressing" style="informal" order="sorting">
+		<personName length="long" usage="addressing" style="formal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="long" usage="addressing" style="informal" order="givenFirst">
@@ -5390,8 +5387,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="long" usage="referring" style="formal" order="sorting">
-			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>
+		<personName length="long" usage="addressing" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{prefix} {given} {given2} {surname} {surname2} {suffix}</namePattern>
@@ -5399,8 +5396,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="long" usage="referring" style="formal" order="surnameFirst">
 			<namePattern>{surname} {surname2} {prefix} {given} {given2} {suffix}</namePattern>
 		</personName>
-		<personName length="long" usage="referring" style="informal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		<personName length="long" usage="referring" style="formal" order="sorting">
+			<namePattern>{surname} {surname2}, {prefix} {given} {given2} {suffix}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="givenFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
@@ -5408,8 +5405,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="long" usage="referring" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="sorting">
+		<personName length="long" usage="referring" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="long" usage="monogram" style="formal" order="givenFirst">
+			<namePattern>{given-initial-allCaps}{given2-initial-allCaps}{surname-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="formal" order="surnameFirst">
+			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="formal" order="sorting">
+			<namePattern>{surname-initial-allCaps}{given-initial-allCaps}{given2-initial-allCaps}</namePattern>
+		</personName>
+		<personName length="long" usage="monogram" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="long" usage="monogram" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="long" usage="monogram" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
@@ -5417,7 +5432,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="sorting">
+		<personName length="medium" usage="addressing" style="formal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
@@ -5426,7 +5441,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="medium" usage="referring" style="formal" order="sorting">
+		<personName length="medium" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
@@ -5435,7 +5450,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="medium" usage="referring" style="formal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="medium" usage="referring" style="informal" order="sorting">
+		<personName length="medium" usage="referring" style="formal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="givenFirst">
@@ -5444,8 +5459,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="medium" usage="referring" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="short" usage="addressing" style="formal" order="sorting">
+		<personName length="medium" usage="referring" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="medium" usage="monogram" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="medium" usage="monogram" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="medium" usage="monogram" style="formal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="medium" usage="monogram" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="medium" usage="monogram" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="medium" usage="monogram" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
@@ -5453,7 +5486,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="short" usage="addressing" style="informal" order="sorting">
+		<personName length="short" usage="addressing" style="formal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="addressing" style="informal" order="givenFirst">
@@ -5462,7 +5495,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="short" usage="referring" style="formal" order="sorting">
+		<personName length="short" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
@@ -5471,7 +5504,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="short" usage="referring" style="formal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="short" usage="referring" style="informal" order="sorting">
+		<personName length="short" usage="referring" style="formal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="givenFirst">
@@ -5480,98 +5513,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="short" usage="referring" style="informal" order="surnameFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<!-- for length="monogram" or "monogramNarrow", ignore usage -->
-		<personName length="monogram" style="formal" order="sorting">
+		<personName length="short" usage="referring" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
-		<personName length="monogram" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		<personName length="short" usage="monogram" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='givenFirst']"/>
 		</personName>
-		<personName length="monogram" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		<personName length="short" usage="monogram" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="monogram" style="informal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		<personName length="short" usage="monogram" style="formal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
 		</personName>
-		<personName length="monogram" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		<personName length="short" usage="monogram" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='givenFirst']"/>
 		</personName>
-		<personName length="monogram" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		<personName length="short" usage="monogram" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
-		<personName length="monogramNarrow" style="formal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		<personName length="short" usage="monogram" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
 		</personName>
-		<personName length="monogramNarrow" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="monogramNarrow" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="monogramNarrow" style="informal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
-		<personName length="monogramNarrow" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="monogramNarrow" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<sampleName item="givenSurname">
-			<nameField type="prefix">∅∅∅</nameField>
+		<sampleName item="givenOnly">
 			<nameField type="given">∅∅∅</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
-		<sampleName item="given2Surname">
-			<nameField type="prefix">∅∅∅</nameField>
+		<sampleName item="givenSurnameOnly">
 			<nameField type="given">∅∅∅</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
 			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
-		<sampleName item="givenSurname2">
-			<nameField type="prefix">∅∅∅</nameField>
+		<sampleName item="given12Surname">
 			<nameField type="given">∅∅∅</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
 			<nameField type="given2">∅∅∅</nameField>
 			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
-		</sampleName>
-		<sampleName item="informal">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">∅∅∅</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>
 		<sampleName item="full">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">∅∅∅</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
-		</sampleName>
-		<sampleName item="multiword">
-			<nameField type="prefix">∅∅∅</nameField>
-			<nameField type="given">∅∅∅</nameField>
-			<nameField type="given-informal">∅∅∅</nameField>
-			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">∅∅∅</nameField>
-			<nameField type="surname2">∅∅∅</nameField>
-			<nameField type="suffix">∅∅∅</nameField>
-		</sampleName>
-		<sampleName item="mononym">
 			<nameField type="prefix">∅∅∅</nameField>
 			<nameField type="given">∅∅∅</nameField>
 			<nameField type="given-informal">∅∅∅</nameField>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -138,8 +138,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%numberingSystem100" value="(finance|native|traditional|bali|brah|cakm|cham|diak|gong|gonm|hanidays|hmnp|java|jpanyear|kali|lana(tham)?|lepc|limb|mong|mtei|mymrshan|nkoo|olck|osma|rohg|saur|shrd|sora|sund|takr|talu|tnsa|vaii|wcho)"/>
 		<coverageVariable key="%persianCalendarTerritories" value="(AF|IR)"/>
 		<coverageVariable key="%personNameLanguages" value="(ar|de|en|es|fr|hu|id|is|ja|ko|nl|ru|uk|zh)"/>
-		<coverageVariable key="%personNameNonMonograms" value="(long|medium|short)"/>
-		<coverageVariable key="%personNameMonograms" value="(monogram|monogramNarrow)"/>
 		<coverageVariable key="%phonebookCollationLanguages" value="(de|fi)"/>
 		<coverageVariable key="%ptVariants" value="(ABL1943|AO1990|COLB1945)"/>
 		<coverageVariable key="%quarterTypes" value="([1-4])"/>
@@ -910,10 +908,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/initialPattern[@type='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/initialPattern[@type='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameNonMonograms'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%personNameMonograms'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/personName[@length='%anyAttribute'][@usage='%anyAttribute'][@style='%anyAttribute'][@order='%anyAttribute']/namePattern"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/sampleName[@item='%anyAttribute']/nameField[@type='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel inLanguage="%personNameLanguages" value="modern" match="personNames/sampleName[@item='%anyAttribute']/nameField[@type='%anyAttribute']"/>
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -17,20 +17,17 @@ public class CheckPersonNames extends CheckCLDR {
      * @internal, public for testing
      */
     public static final ImmutableMultimap<SampleType, String> REQUIRED = ImmutableMultimap.<SampleType, String> builder()
-        .putAll(SampleType.mononym, "given")
-        .putAll(SampleType.givenSurname, "given", "surname")
-        .putAll(SampleType.given2Surname, "given", "given2", "surname")
-        .putAll(SampleType.givenSurname2, "given", "surname", "surname2")
-        .putAll(SampleType.informal, "given", "given-informal") // todo, combine with full
-        .putAll(SampleType.full, "prefix", "given", "given2", "surname", "suffix") // TODO add "given-informal", "surname2"
-        .putAll(SampleType.multiword, "given", "given2", "surname") // todo, combine with full
+        .putAll(SampleType.givenOnly, "given")
+        .putAll(SampleType.givenSurnameOnly, "given", "surname")
+        .putAll(SampleType.given12Surname, "given", "given2", "surname")
+        .putAll(SampleType.full, "prefix", "given", "given-informal", "given2", "surname", "surname2", "suffix")
         .build();
     /**
      * @internal, public for testing
      */
     public static final ImmutableMultimap<SampleType, String> REQUIRED_EMPTY = ImmutableMultimap.<SampleType, String> builder()
-        .putAll(SampleType.mononym, "prefix", "given-informal", "given2", "surname", "surname2", "suffix")
-        .putAll(SampleType.givenSurname, "prefix", "given2", "surname2", "suffix")
+        .putAll(SampleType.givenOnly, "prefix", "given-informal", "given2", "surname", "surname2", "suffix")
+        .putAll(SampleType.givenSurnameOnly, "prefix", "given2", "surname2", "suffix")
         .build();
 
     boolean isRoot = false;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -103,7 +103,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                         // can't have surname2 unless we have surname
                         String modPath = parts.cloneAsThawed().setAttribute(-1, "type", Field.surname2.toString()).toString();
                         String surname2Value = getCldrFileToCheck().getStringValue(modPath);
-                        if (!surname2Value.equals("∅∅∅")) {
+                        if (surname2Value != null && !surname2Value.equals("∅∅∅")) {
                             result.add(new CheckStatus().setCause(this)
                                 .setMainType(CheckStatus.errorType)
                                 .setSubtype(Subtype.invalidPlaceHolder)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -386,9 +386,17 @@ public class PathDescription {
         + RegexLookup.SEPARATOR
         + "Initials patterns for person name formats. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
-        + "^//ldml/personNames/personName"
+        + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"addressing\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
-        + "Person name formats by length, usage, style, order. For more information, please see "
+        + "Person name format for addressing a person (with a given length, style, order). For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"referring\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "Person name formats for referring to a person (with a given length, style, order). For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"monogram\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "Person name formats for monograms (with a given length, style, order). For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/sampleName"
         + RegexLookup.SEPARATOR

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1855,9 +1855,13 @@ public class PathHeader implements Comparable<PathHeader> {
             functionMap.put("personNameSection", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
-                    // value for personName length and sampleName item in desired sort order
-                    final List<String> lengthValues = Arrays.asList("long", "medium", "short", "monogram", "monogramNarrow");
-                    final List<String> itemValues = Arrays.asList("givenSurname", "given2Surname", "givenSurname2", "informal", "full", "multiword", "mononym");
+                    // sampleName item values in desired sort order
+                    final List<String> itemValues = Arrays.asList("givenOnly", "givenSurnameOnly", "given12Surname", "full");
+                    // personName attribute values: each group in desired
+                    // sort order, but groups from least important to most
+                    final List<String> pnAttrValues = Arrays.asList(
+                        "addressing", "referring", "monogram", // usage values
+                        "long", "medium", "short"); // length values
 
                     if (source.equals("NameOrder")) {
                         order = 0;
@@ -1873,11 +1877,17 @@ public class PathHeader implements Comparable<PathHeader> {
                         order = 20 + itemValues.indexOf(itemValue);
                         return "SampleName Fields for Item: " + itemValue;
                     }
-                    String lengthPrefix = "PersonName:";
-                    if (source.startsWith(lengthPrefix)) {
-                        String lengthValue = source.substring(lengthPrefix.length());
-                        order = 30 + lengthValues.indexOf(lengthValue);
-                        return "PersonName Patterns for Length: " + lengthValue;
+                    String pnPrefix = "PersonName:";
+                    if (source.startsWith(pnPrefix)) {
+                        String lengthUsageValue = source.substring(pnPrefix.length());
+                        List<String> parts = HYPHEN_SPLITTER.splitToList(lengthUsageValue);
+                        order = 30;
+                        for (String part: parts) {
+                         if (pnAttrValues.contains(part)) {
+                                order += (1 << pnAttrValues.indexOf(part));
+                            }
+                        }
+                        return "PersonName Patterns for Length-Usage: " + lengthUsageValue;
                     }
                     order = 40;
                     return source;
@@ -1887,19 +1897,18 @@ public class PathHeader implements Comparable<PathHeader> {
             functionMap.put("personNameOrder", new Transform<String, String>() {
                 @Override
                 public String transform(String source) {
-                    // The various personName attribute values: each group in desired
+                    // personName attribute values: each group in desired
                     // sort order, but groups from least important to most
-                    final List<String> allValues = Arrays.asList(
-                        "sorting", "givenFirst", "surnameFirst", //order values
-                        "formal", "informal", // style values
-                        "addressing", "referring"); // usage values
-                        // length values already handled in &personNameSection
+                    final List<String> attrValues = Arrays.asList(
+                        "givenFirst", "surnameFirst", "sorting", //order values
+                        "formal", "informal"); // style values
+                        // length & usage values handled in &personNameSection
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;
                     for (String part: parts) {
-                        if (allValues.contains(part)) {
-                            order += (1 << allValues.indexOf(part));
+                        if (attrValues.contains(part)) {
+                            order += (1 << attrValues.indexOf(part));
                         } // anything else like alt="variant" is at order 0
                     }
                     return source;
@@ -1911,15 +1920,15 @@ public class PathHeader implements Comparable<PathHeader> {
                 public String transform(String source) {
                     // The various nameField attribute values: each group in desired
                     // sort order, but groups from least important to most
-                    final List<String> allValues = Arrays.asList(
+                    final List<String> attrValues = Arrays.asList(
                         "informal", // modifiers for nameField type
                         "prefix", "given", "given2", "surname", "surname2", "suffix"); // values for nameField type
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;
                     for (String part: parts) {
-                        if (allValues.contains(part)) {
-                            order += (1 << allValues.indexOf(part));
+                        if (attrValues.contains(part)) {
+                            order += (1 << attrValues.indexOf(part));
                         } // anything else like alt="variant" is at order 0
                     }
                     return source;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -69,9 +69,7 @@ public class PersonNameFormatter {
         // There is a slight complication because 'long' collides with a keyword.
         long_name,
         medium,
-        short_name,
-        monogram,
-        monogramNarrow;
+        short_name;
 
         private static ImmutableBiMap<String,Length> exceptionNames = ImmutableBiMap.of(
             "long", long_name,
@@ -112,7 +110,8 @@ public class PersonNameFormatter {
 
     public enum Usage {
         referring,
-        addressing;
+        addressing,
+        monogram;
         public static final Comparator<Iterable<Usage>> ITERABLE_COMPARE = Comparators.lexicographical(Comparator.<Usage>naturalOrder());
         public static final Set<Usage> ALL = ImmutableSet.copyOf(Usage.values());
         /**
@@ -124,9 +123,9 @@ public class PersonNameFormatter {
     }
 
     public enum Order {
-        sorting,
         givenFirst,
-        surnameFirst;
+        surnameFirst,
+        sorting;
         public static final Comparator<Iterable<Order>> ITERABLE_COMPARE = Comparators.lexicographical(Comparator.<Order>naturalOrder());
         public static final Set<Order> ALL = ImmutableSet.copyOf(Order.values());
         /**
@@ -161,13 +160,10 @@ public class PersonNameFormatter {
     }
 
     public enum SampleType {
-        givenSurname,
-        given2Surname,
-        givenSurname2,
-        informal,
-        full,
-        multiword,
-        mononym;
+        givenOnly,
+        givenSurnameOnly,
+        given12Surname,
+        full;
         public static final Set<SampleType> ALL = ImmutableSet.copyOf(SampleType.values());
     }
 
@@ -334,26 +330,17 @@ public class PersonNameFormatter {
         }
 
         public String formatInitial(String bestValue, FormatParameters nameFormatParameters) {
-            switch(nameFormatParameters.getLength()) {
-            case monogram:
-            case monogramNarrow:
-                bestValue = getFirstGrapheme(bestValue);
-                break;
-            default:
-                String result = null;
-                for(String part : SPLIT_SPACE.split(bestValue)) {
-                    String partFirst = getFirstGrapheme(part);
-                    bestValue = initialFormatter.format(new String[] {partFirst});
-                    if (result == null) {
-                        result = bestValue;
-                    } else {
-                        result = initialSequenceFormatter.format(new String[] {result, bestValue});
-                    }
+            String result = null;
+            for(String part : SPLIT_SPACE.split(bestValue)) {
+                String partFirst = getFirstGrapheme(part);
+                bestValue = initialFormatter.format(new String[] {partFirst});
+                if (result == null) {
+                    result = bestValue;
+                } else {
+                    result = initialSequenceFormatter.format(new String[] {result, bestValue});
                 }
-                bestValue = result;
-                break;
             }
-            return bestValue;
+            return result;
         }
 
         private String getFirstGrapheme(String bestValue) {
@@ -1368,7 +1355,7 @@ public class PersonNameFormatter {
         final String altValue = parts.getAttributeValue(-1, "alt");
         int rank = altValue == null ? 0 : Integer.parseInt(altValue);
         ParameterMatcher pm = new ParameterMatcher(
-            hackFix(parts.getAttributeValue(-2, "length")),
+            parts.getAttributeValue(-2, "length"),
             parts.getAttributeValue(-2, "style"),
             parts.getAttributeValue(-2, "usage"),
             parts.getAttributeValue(-2, "order")
@@ -1404,20 +1391,6 @@ public class PersonNameFormatter {
             result.put(entry.getKey(), name);
         }
         return ImmutableMap.copyOf(result);
-    }
-
-    /**
-     * Remove once the DTD and en.xml are fixed
-     * @param attributeValue
-     * @return
-     */
-    private static String hackFix(String attributeValue) {
-        if (attributeValue == null) {
-            return null;
-        }
-        else {
-            return attributeValue.replace("monogram-narrow", "monogramNarrow");
-        }
     }
 
     /**

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -289,10 +289,8 @@
 //ldml/personNames/nameOrderLocales[@order=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1
 //ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(InitialPatterns) ; $1-$2
 //ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(InitialPatterns) ; $1
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4-$5)
-//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3-$4)
-//ldml/personNames/personName[@length=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern         ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1) ; &personNameOrder($1-$2-$3)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$2) ; &personNameOrder($3-$4-$5)
+//ldml/personNames/personName[@length=\"%A\"][@usage=\"%A\"][@style=\"%A\"][@order=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$2) ; &personNameOrder($3-$4)
 //ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(SampleName:$1) ; &sampleNameOrder($2-$3)
 //ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ;  &personNameSection(SampleName:$1) ; &sampleNameOrder($2)
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestExampleGenerator.java
@@ -18,8 +18,8 @@ public class TestExampleGenerator {
     @Test
     public void testPersonNamesGwen() {
         final String loc = "es";
-        final String X_GIVEN = "//ldml/personNames/sampleName[@item=\"givenSurname\"]/nameField[@type=\"given\"]";
-        final String X_SURNAME = "//ldml/personNames/sampleName[@item=\"givenSurname\"]/nameField[@type=\"surname\"]";
+        final String X_GIVEN = "//ldml/personNames/sampleName[@item=\"givenSurnameOnly\"]/nameField[@type=\"given\"]";
+        final String X_SURNAME = "//ldml/personNames/sampleName[@item=\"givenSurnameOnly\"]/nameField[@type=\"surname\"]";
         final String X_PATTERN = "//ldml/personNames/personName[@length=\"long\"][@usage=\"addressing\"][@style=\"formal\"][@order=\"sorting\"]/namePattern";
 
         final CLDRFile english = CLDRConfig.getInstance().getEnglish();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -192,7 +192,6 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
-        "//ldml/personNames/personName[@length=\"([^\"]*+)\"][@style=\"([^\"]*+)\"][@order=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/sampleName[@item=\"([^\"]*+)\"]/nameField[@type=\"([^\"]*+)\"]" // CLDR-15384
 


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

- move monograms from length to usage attribute
- reorder the values for the order attribute to be givenFirst, surnameFirst, sorting
- sampleNames:
    - change items to be just givenOnly, givenSurnameOnly, given12Surname, full
    - update the English values to be all fictional characters (e.g. from Sherlock Holmes, no IP issues) or made-up names
    - remove the fields from root that are not supposed to be supplied for a given sampleName
- add a little more path description
- for SurveyTool, group personName entries by both length and usage

Note: There may be a problem with initials, a couple of the results in TestPersonNameFormatter looked odd (flagged with TODO and noted below). Rather than fully investigating and debugging these (if they are indeed errors), I thought it best to get this PR merged to unblock other work first, since it has multiple changes.