### PR TITLE
CLDR-15567 fixes for old DTDs

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDtdDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDtdDelta.java
@@ -109,6 +109,7 @@ public class ChartDtdDelta extends Chart {
             for (DtdType type : TYPES) {
                 String firstVersion = type.firstVersion; // FIRST_VERSION.get(type);
                 if (firstVersion != null && current != null && current.compareTo(firstVersion) < 0) {
+                    // skip if current is too old to have “type”
                     continue;
                 }
                 DtdData dtdCurrent = null;
@@ -126,14 +127,9 @@ public class ChartDtdDelta extends Chart {
                     continue;
                 }
                 DtdData dtdLast = null;
-                if (last != null) {
-                    try {
-                        dtdLast = DtdData.getInstance(type, last);
-                    } catch (Exception e) {
-                        if (!(e.getCause() instanceof FileNotFoundException)) {
-                            throw e;
-                        }
-                    }
+                if (last != null && (firstVersion == null || last.compareTo(firstVersion) >= 0)) {
+                    // only read if last isn’t too old to have “type”
+                    dtdLast = DtdData.getInstance(type, last);
                 }
                 diff(currentName, dtdLast, dtdCurrent);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
@@ -29,10 +29,13 @@ public class ToolConstants {
 
     // TODO change this to CldrVersion, add add in the ShowLocaleCoverage years.
     public static final List<String> CLDR_VERSIONS = ImmutableList.of(
+        "1.1",
         "1.1.1",
         "1.2",
         "1.3",
+        "1.4",
         "1.4.1",
+        "1.5.0.1",
         "1.5.1",
         "1.6.1",
         "1.7.2",
@@ -62,7 +65,8 @@ public class ToolConstants {
         "38.0",
         "38.1",
         "39.0",
-        "40.0"
+        "40.0",
+        "41.0"
         // add to this once the release is final!
         );
     public static final Set<VersionInfo> CLDR_VERSIONS_VI = ImmutableSet.copyOf(CLDR_VERSIONS.stream()

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -691,6 +691,13 @@ public class DtdData extends XMLFileReader.SimpleHandler {
      * Special form using version, used only by tests, etc.
      */
     public static DtdData getInstance(DtdType type, String version) {
+        // Map out versions that had no DTD
+        switch (version) {
+            case "1.1.1": version="1.1"; break;
+            case "1.4.1": version="1.4"; break;
+            case "1.5.1": version="1.5.0.1"; break;
+            default:
+        }
         File directory = version == null ? CLDRConfig.getInstance().getCldrBaseDirectory()
             : new File(CLDRPaths.ARCHIVE_DIRECTORY + "/cldr-" + version);
 


### PR DESCRIPTION
CLDR-15567 fixes for DTD and chart generation

- ToolConstants: add 1.1, 1.4, 1.5.0.1, 41 versions
( [1.1](https://github.com/unicode-org/cldr/releases/tag/release-1-1) is newly remanufactured)

- DtdData: map 1.1.1, 1.4.1, 1.5.1 to prior DTDs (those versions did
not have a shipped DTD.)
