### PR TITLE
CLDR-15572 liberty: enable monitoring and metrics

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyLog.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyLog.java
@@ -74,6 +74,16 @@ public class SurveyLog {
 
     public static void logException(Logger logger, final Throwable exception, String what, WebContext ctx) {
         logger.log(Level.SEVERE, what, exception);
+        countException(exception);
+    }
+
+    /**
+     * Count an exception in the SurveyMetrics
+     */
+    public static void countException(final Throwable exception) {
+        if (CookieSession.sm != null && CookieSession.sm.surveyMetrics != null) {
+            CookieSession.sm.surveyMetrics.countException(exception);
+        }
     }
 
     /**
@@ -104,6 +114,7 @@ public class SurveyLog {
 
     public static void logException(Logger logger, Throwable t, String string) {
         logger.log(Level.SEVERE, string, t);
+        countException(t);
     }
 
     public static void logException(Logger logger, Throwable t, WebContext ctx) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -54,6 +54,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.JspWriter;
 
+import javax.inject.Inject;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -105,6 +107,12 @@ import com.ibm.icu.util.ULocale;
  * The main servlet class of Survey Tool
  */
 public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Externalizable {
+    /**
+     * This needs a global place to access for non-jaxrs callers
+     */
+    @Inject
+    public SurveyMetrics surveyMetrics;
+
     private static final String CLDR_OLDVERSION = "CLDR_OLDVERSION";
     private static final String CLDR_NEWVERSION = "CLDR_NEWVERSION";
     private static final String CLDR_LASTVOTEVERSION = "CLDR_LASTVOTEVERSION";

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMetrics.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMetrics.java
@@ -1,0 +1,40 @@
+package org.unicode.cldr.web;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+
+/**
+ * Metrics availble from the /metrics endpoint
+ */
+@ApplicationScoped
+public class SurveyMetrics {
+    @Inject
+    @Metric(
+        name = "exceptions",
+        description = "Number of SurveyTool Exceptions that happened")
+    Counter surveyExceptions;
+
+    /**
+     * Count an exception. Right now there is only one bucket.
+     */
+    public void countException(Throwable exception) {
+        surveyExceptions.inc();
+    }
+
+    @Gauge(
+        name = "users",
+        description = "Number of active users",
+        unit = MetricUnits.NONE)
+    public int getUsers() {
+        return CookieSession.getUserCount();
+    }
+
+    public SurveyMetrics() {
+
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.ws.rs.Consumes;
@@ -21,6 +22,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -37,6 +40,7 @@ import org.unicode.cldr.web.*;
 import org.unicode.cldr.web.Dashboard.ReviewOutput;
 import org.unicode.cldr.web.VettingViewerQueue.LoadingPolicy;
 
+@ApplicationScoped
 @Path("/summary")
 @Tag(name = "voting", description = "APIs for voting")
 public class Summary {
@@ -364,6 +368,8 @@ public class Summary {
     @Operation(
         summary = "Fetch the Dashboard for a locale",
         description = "Given a locale, get the summary information, aka Dashboard")
+    @Counted(name = "getDashboardCount", absolute = true, description = "Number of dashboards computed")
+    @Timed(absolute = true, name = "getDashboard", description = "Time to fetch the Dashboard")
     @APIResponses(
         value = {
             @APIResponse(

--- a/tools/cldr-apps/src/main/liberty/config/server.xml
+++ b/tools/cldr-apps/src/main/liberty/config/server.xml
@@ -10,6 +10,8 @@
 		<feature>mpConfig-1.4</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>concurrent-1.0</feature>
+		<feature>mpMetrics-2.0</feature>
+		<feature>monitor-1.0</feature>
 	</featureManager>
 	<!-- end::featureManager[] -->
 
@@ -63,4 +65,8 @@
 
 	<!-- Needed to enable JSPs to be at source level 1.8 (at least) -->
 	<jspEngine jdkSourceLevel="18" />
+
+	<!-- We will be proxying access to the metrics server, so not an issue here -->
+	<mpMetrics authentication="false" />
+
 </server>


### PR DESCRIPTION
CLDR-15572

add the `/metrics` endpoint to the server for prometheus monitoring
