### PR TITLE
CLDR-15538 Expedite page refresh after user votes

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.js
+++ b/tools/cldr-apps/js/src/esm/cldrGui.js
@@ -542,7 +542,7 @@ function dashboardIsVisible() {
 
 function updateDashboardRow(json) {
   if (dashboardVisible) {
-    dashboardWidgetWrapper?.updateRow(json);
+    dashboardWidgetWrapper?.updatePath(json);
   }
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -76,10 +76,11 @@ const statusActionTable = {
 /**
  * How often to fetch updates. Default 15s.
  * Used only for delay in calling updateStatus.
- * May (theoretically, if it were visible) be changed by js written by SurveyMain.showOfflinePage, etc.
  * @property timerSpeed
  */
 let timerSpeed = 15000; // 15 seconds
+let fastTimerSpeed = 3000; // 3 seconds
+let statusTimeout = null;
 
 let overridedir = null;
 
@@ -452,6 +453,7 @@ function updateStatusBox(json) {
  * This is called periodically to fetch latest ST status
  */
 function updateStatus() {
+  statusTimeout = null;
   if (cldrStatus.isDisconnected()) {
     return;
   }
@@ -562,7 +564,7 @@ function updateStatusLoadHandler(json) {
   if (wasBusted == false && json.status.isSetup && loadOnOk != null) {
     window.location.replace(loadOnOk);
   } else {
-    setTimeout(updateStatus, timerSpeed);
+    statusTimeout = setTimeout(updateStatus, timerSpeed);
   }
 }
 
@@ -572,6 +574,13 @@ function updateStatusErrHandler(err) {
     err: err,
     disconnected: true,
   });
+}
+
+function expediteStatusUpdate() {
+  if (statusTimeout) {
+    clearTimeout(statusTimeout);
+  }
+  statusTimeout = setTimeout(updateStatus, fastTimerSpeed);
 }
 
 /**
@@ -929,6 +938,7 @@ export {
   cloneAnon,
   cloneLocalizeAnon,
   createGravatar,
+  expediteStatusUpdate,
   findItemByValue,
   getDidUnbust,
   getTagChildren,

--- a/tools/cldr-apps/js/src/esm/cldrVote.js
+++ b/tools/cldr-apps/js/src/esm/cldrVote.js
@@ -535,6 +535,9 @@ function oneLessPendingVote() {
   if (CLDR_VOTE_DEBUG) {
     console.log("oneLessPendingVote: --pendingVoteCount = " + pendingVoteCount);
   }
+  if (pendingVoteCount == 0) {
+    cldrSurvey.expediteStatusUpdate();
+  }
 }
 
 /**


### PR DESCRIPTION
-After user votes, when no more votes are pending responses, schedule update in 3 seconds

-New function cldrSurvey.expediteStatusUpdate

-New fastTimerSpeed = 3000 ms = 3 seconds

-Fix bug in updateDashboardRow, updateRow was renamed to updatePath

CLDR-15538

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
