### PR TITLE
CLDR-15405 add supplemental nameOrderLocalesDefault; rearrange usage order to be referring, addressing…

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3188,7 +3188,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST personName length NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/long, medium, short-->
 <!ATTLIST personName usage NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/addressing, referring, monogram-->
+    <!--@MATCH:set/literal/referring, addressing, monogram-->
 <!ATTLIST personName style NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/formal, informal-->
 <!ATTLIST personName order NMTOKENS #IMPLIED >

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 
-<!ELEMENT supplementalData ( version, generation?, cldrVersion?, currencyData?, territoryContainment?, subdivisionContainment?, languageData?, territoryInfo?, postalCodeData?, calendarData?, calendarPreferenceData?, weekData?, timeData?, measurementData?, unitConstants*, unitQuantities*, convertUnits*, unitPreferenceData?, timezoneData?, characters?, transforms?, metadata?, codeMappings?, parentLocales?, likelySubtags?, metazoneInfo?, plurals?, telephoneCodeData?, numberingSystems?, bcp47KeywordMappings?, gender?, references?, languageMatching?, dayPeriodRuleSet*, metaZones?, primaryZones?, windowsZones?, coverageLevels?, idValidity?, rgScope?, languageGroups?, grammaticalData? ) >
+<!ELEMENT supplementalData ( version, generation?, cldrVersion?, currencyData?, territoryContainment?, subdivisionContainment?, languageData?, territoryInfo?, postalCodeData?, calendarData?, calendarPreferenceData?, weekData?, timeData?, measurementData?, unitConstants*, unitQuantities*, convertUnits*, unitPreferenceData?, timezoneData?, characters?, transforms?, metadata?, codeMappings?, parentLocales?, personNamesDefaults?, likelySubtags?, metazoneInfo?, plurals?, telephoneCodeData?, numberingSystems?, bcp47KeywordMappings?, gender?, references?, languageMatching?, dayPeriodRuleSet*, metaZones?, primaryZones?, windowsZones?, coverageLevels?, idValidity?, rgScope?, languageGroups?, grammaticalData? ) >
 
 <!ELEMENT version EMPTY >
     <!--@METADATA-->
@@ -898,6 +898,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST parentLocale locales NMTOKENS #REQUIRED >
     <!--@MATCH:set/validity/locale-->
     <!--@VALUE-->
+
+<!ELEMENT personNamesDefaults ( alias | ( nameOrderLocalesDefault* ) ) >
+
+<!ELEMENT nameOrderLocalesDefault ( #PCDATA ) >
+<!ATTLIST nameOrderLocalesDefault order (givenFirst | surnameFirst) #REQUIRED >
+<!ATTLIST nameOrderLocalesDefault references CDATA #IMPLIED >
+    <!--@METADATA-->
 
 <!ELEMENT likelySubtags ( likelySubtag* ) >
 

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9138,24 +9138,6 @@ annotations.
 		<nameOrderLocales order="surnameFirst">ja zh ko</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-		<personName length="long" usage="addressing" style="formal" order="givenFirst">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName length="long" usage="addressing" style="formal" order="sorting">
-			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
-		</personName>
-		<personName length="long" usage="addressing" style="informal" order="givenFirst">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName length="long" usage="addressing" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
-		</personName>
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
 		</personName>
@@ -9172,6 +9154,24 @@ annotations.
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="givenFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="givenFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="sorting">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="long" usage="monogram" style="formal" order="givenFirst">
@@ -9192,25 +9192,6 @@ annotations.
 		<personName length="long" usage="monogram" style="informal" order="sorting">
 			<namePattern>{surname-initial-allCaps}{given-informal-initial-allCaps}</namePattern>
 		</personName>
-
-		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="sorting">
-			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
-		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
-		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given} {given2-initial} {surname} {suffix}</namePattern>
 		</personName>
@@ -9227,6 +9208,24 @@ annotations.
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="sorting">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="medium" usage="monogram" style="formal" order="givenFirst">
@@ -9247,24 +9246,6 @@ annotations.
 		<personName length="medium" usage="monogram" style="informal" order="sorting">
 			<namePattern>{given-informal-initial-allCaps}</namePattern>
 		</personName>
-		<personName length="short" usage="addressing" style="formal" order="givenFirst">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
-			<namePattern>{prefix} {surname}</namePattern>
-		</personName>
-		<personName length="short" usage="addressing" style="formal" order="sorting">
-			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
-		</personName>
-		<personName length="short" usage="addressing" style="informal" order="givenFirst">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
-			<namePattern>{given-informal}</namePattern>
-		</personName>
-		<personName length="short" usage="addressing" style="informal" order="sorting">
-			<namePattern>{surname}, {given-informal}</namePattern>
-		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
 		</personName>
@@ -9281,6 +9262,24 @@ annotations.
 			<namePattern>{surname} {given-initial}</namePattern>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="sorting">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="givenFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+			<namePattern>{prefix} {surname}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="sorting">
+			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="givenFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="sorting">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName length="short" usage="monogram" style="formal" order="givenFirst">

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5372,24 +5372,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<nameOrderLocales order="surnameFirst">ja zh ko hu</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-		<personName length="long" usage="addressing" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="long" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
-		<personName length="long" usage="addressing" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="long" usage="addressing" style="informal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
+
 		<personName length="long" usage="referring" style="formal" order="givenFirst">
 			<namePattern>{prefix} {given} {given2} {surname} {surname2} {suffix}</namePattern>
 		</personName>
@@ -5406,6 +5389,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="long" usage="referring" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="long" usage="addressing" style="formal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="long" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="long" usage="monogram" style="formal" order="givenFirst">
@@ -5426,24 +5427,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="long" usage="monogram" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
 		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="medium" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="medium" usage="addressing" style="informal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
 		<personName length="medium" usage="referring" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
@@ -5460,6 +5443,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="medium" usage="referring" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="formal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="medium" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="medium" usage="monogram" style="formal" order="givenFirst">
@@ -5480,24 +5481,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<personName length="medium" usage="monogram" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='monogram'][@style='formal'][@order='sorting']"/>
 		</personName>
-		<personName length="short" usage="addressing" style="formal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="short" usage="addressing" style="formal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
-		<personName length="short" usage="addressing" style="informal" order="givenFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
-		</personName>
-		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
-		</personName>
-		<personName length="short" usage="addressing" style="informal" order="sorting">
-			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
-		</personName>
 		<personName length="short" usage="referring" style="formal" order="givenFirst">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
 		</personName>
@@ -5514,6 +5497,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
 		</personName>
 		<personName length="short" usage="referring" style="informal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="short" usage="addressing" style="formal" order="sorting">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="givenFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='givenFirst']"/>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="surnameFirst">
+			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='surnameFirst']"/>
+		</personName>
+		<personName length="short" usage="addressing" style="informal" order="sorting">
 			<alias source="locale" path="../personName[@length='long'][@usage='referring'][@style='formal'][@order='sorting']"/>
 		</personName>
 		<personName length="short" usage="monogram" style="formal" order="givenFirst">

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -5378,6 +5378,11 @@ XXX Code for transations where no currency is involved
 		<parentLocale parent="zh_Hant_HK" locales="zh_Hant_MO"/>
 	</parentLocales>
 
+	<personNamesDefaults>
+		<nameOrderLocalesDefault order="givenFirst">en und</nameOrderLocalesDefault>
+		<nameOrderLocalesDefault order="surnameFirst">ja zh ko hu</nameOrderLocalesDefault>
+	</personNamesDefaults>
+
 	<references>
 		<reference type="R1000" uri="https://www.cia.gov/cia/publications/factbook/geos/aa.html">Dutch official</reference>
 		<reference type="R1001" uri="http://www.migrationinformation.org/Feature/display.cfm?ID=72">At most 6% are not fluent in English</reference>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -386,13 +386,13 @@ public class PathDescription {
         + RegexLookup.SEPARATOR
         + "Initials patterns for person name formats. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
-        + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"addressing\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
-        + RegexLookup.SEPARATOR
-        + "Person name format for addressing a person (with a given length, style, order). For more information, please see "
-        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"referring\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
         + "Person name formats for referring to a person (with a given length, style, order). For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"addressing\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "Person name format for addressing a person (with a given length, style, order). For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/personName\\[@length=\"([^\"]*)\"]\\[@usage=\"monogram\"]\\[@style=\"([^\"]*)\"]\\[@order=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1860,7 +1860,7 @@ public class PathHeader implements Comparable<PathHeader> {
                     // personName attribute values: each group in desired
                     // sort order, but groups from least important to most
                     final List<String> pnAttrValues = Arrays.asList(
-                        "addressing", "referring", "monogram", // usage values
+                        "referring", "addressing", "monogram", // usage values
                         "long", "medium", "short"); // length values
 
                     if (source.equals("NameOrder")) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -468,6 +468,8 @@
 
 //supplementalData/timeData/hours[@allowed="%A"][@preferred="%A"]/_%E			; Supplemental ; WeekData ; hours-$2-$3 ; $1 ; HIDE
 
+//supplementalData/personNamesDefaults/nameOrderLocalesDefault[@order="%A"]			; Supplemental ; Person Name Formats ; NameOrder ; $1 ; HIDE
+
 //supplementalData/measurementData/measurementSystem[@type="%A"]/_territories			; Supplemental ; Measurement ; default ; $1 ; HIDE
 //supplementalData/measurementData/measurementSystem[@type="%A"][@category="%A"]/_territories			; Supplemental ; Measurement ; $2 ; $1 ; HIDE
 //supplementalData/measurementData/paperSize[@type="%A"]/_territories			; Supplemental ; Measurement ; Paper ; $1 ; HIDE

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -596,6 +596,7 @@ public class TestDtdData extends TestFmwk {
                 || elementName.equals("deriveComponent") && (attribute.equals("feature") || attribute.equals("structure"))
                 || elementName.equals("grammaticalDerivations") && attribute.equals("locales")
                 || elementName.equals("deriveCompound") && (attribute.equals("feature")|| attribute.equals("structure"))
+                || (elementName.equals("nameOrderLocalesDefault") && attribute.equals("order"))
                 ;
 
         case keyboard:


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
 
1. This adds supplemental personNamesDefaults/nameOrderLocalesDefault with som e initial data (will flesh out by adding more explicit locales as we gather data)
2. It rearranges the usage attribute ordering in dtd, data, and SurveyTool to be referring, addressing, monogram, to math the ordering in PersonNameFormatter.Usage.