### PR TITLE
CLDR-15404 fix monograms3

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -141,8 +141,9 @@ public class PersonNameFormatter {
         informal,
         allCaps,
         initial,
+        monogram,
         prefix,
-        core
+        core,
         ;
         public static final Comparator<Iterable<Modifier>> ITERABLE_COMPARE = Comparators.lexicographical(Comparator.<Modifier>naturalOrder());
         public static final Comparator<Collection<Modifier>> LONGEST_FIRST = new Comparator<>() {
@@ -333,17 +334,7 @@ public class PersonNameFormatter {
             // It is probably unusual to have multiple name fields, so this could be optimized for
             // the simpler case.
 
-            // For the case of monograms, don't use the initialFormatter or initialSequenceFormatter
-
-            if (nameFormatParameters.getUsage() == Usage.monogram) {
-                StringBuilder sp = new StringBuilder();
-                for(String part : SPLIT_SPACE.split(bestValue)) {
-                    sp.append(getFirstGrapheme(part));
-                }
-                return sp.toString();
-            }
-
-            // For other usages, employ both the initialFormatter and initialSequenceFormatter
+            // Employ both the initialFormatter and initialSequenceFormatter
 
             String result = null;
             for(String part : SPLIT_SPACE.split(bestValue)) {
@@ -357,6 +348,17 @@ public class PersonNameFormatter {
             }
             return result;
         }
+
+        public String formatMonogram(String bestValue, FormatParameters nameFormatParameters) {
+            // It is probably unusual to have multiple name fields, so this could be optimized for
+            // the simpler case.
+
+            // For the case of monograms, don't use the initialFormatter or initialSequenceFormatter
+            // And just take the first grapheme.
+
+            return getFirstGrapheme(bestValue);
+        }
+
 
         private String getFirstGrapheme(String bestValue) {
             characterBreakIterator.setText(bestValue);
@@ -456,6 +458,9 @@ public class PersonNameFormatter {
                     switch(modifier) {
                     case initial:
                         bestValue = fallbackInfo.formatInitial(bestValue, nameFormatParameters);
+                        break;
+                    case monogram:
+                        bestValue = fallbackInfo.formatMonogram(bestValue, nameFormatParameters);
                         break;
                     case allCaps:
                         bestValue = UCharacter.toUpperCase(fallbackInfo.formatterLocale, bestValue);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -40,6 +40,7 @@ import com.ibm.icu.util.ULocale;
 public class TestPersonNameFormatter extends TestFmwk{
 
     public static final boolean DEBUG = System.getProperty("TestPersonNameFormatter.DEBUG") != null;
+    public static final boolean SHOW = System.getProperty("TestPersonNameFormatter.SHOW") != null;
 
     final FallbackFormatter FALLBACK_FORMATTER = new FallbackFormatter(ULocale.ENGLISH, "{0}*", "{0} {1}");
     final CLDRFile ENGLISH = CLDRConfig.getInstance().getEnglish();
@@ -84,7 +85,7 @@ public class TestPersonNameFormatter extends TestFmwk{
             "length=short; style=formal; usage=addressing; order=surnameFirst", "{surname-allCaps} {given}",
             "length=short medium; style=formal; usage=addressing", "{given} {given2-initial} {surname}",
             "length=short medium; style=formal; usage=addressing", "{given} {surname}",
-            "length=long; style=formal; usage=monogram", "{given-initial}{surname-initial}",
+            "length=long; style=formal; usage=monogram", "{given-monogram}{surname-monogram}",
             "order=givenFirst", "{prefix} {given} {given2} {surname} {surname2} {suffix}",
             "order=surnameFirst", "{surname} {surname2} {prefix} {given} {given2} {suffix}",
             "order=sorting", "{surname} {surname2}, {prefix} {given} {given2} {suffix}");
@@ -94,7 +95,7 @@ public class TestPersonNameFormatter extends TestFmwk{
         check(personNameFormatter, sampleNameObject1, "length=short; style=formal; usage=addressing", "John B. Smith");
         check(personNameFormatter, sampleNameObject2, "length=short; style=formal; usage=addressing", "John Smith");
         check(personNameFormatter, sampleNameObject1, "length=long; style=formal; usage=addressing", "Mr. John Bob Smith Barnes Pascal Jr.");
-        check(personNameFormatter, sampleNameObject3, "length=long; style=formal; usage=monogram", "JBS");
+        check(personNameFormatter, sampleNameObject3, "length=long; style=formal; usage=monogram", "JS");
         check(personNameFormatter, sampleNameObject4, "length=short; style=formal; usage=addressing; order=surnameFirst", "ABE Shinzō");
 
         checkFormatterData(personNameFormatter);
@@ -133,8 +134,10 @@ public class TestPersonNameFormatter extends TestFmwk{
     }
 
     public void TestWithCLDR() {
-        if (PersonNameFormatter.DEBUG) {
-            logln(ENGLISH_NAME_FORMATTER.toString());
+        if (SHOW) {
+            warnln(ENGLISH_NAME_FORMATTER.toString());
+        } else {
+            warnln("To see the contents of the English patterns, use -DTestPersonNameFormatter.SHOW");
         }
 
         check(ENGLISH_NAME_FORMATTER, sampleNameObject1, "length=short; order=sorting", "Smith, J. B.");
@@ -274,6 +277,9 @@ public class TestPersonNameFormatter extends TestFmwk{
     }
 
     public void TestLiteralTextElisionNoSpaces() {
+
+        // Also used to generate examples in the user guide
+
         ImmutableMap<ULocale, Order> localeToOrder = ImmutableMap.of(); // don't worry about using the order from the locale right now.
 
         NamePatternData namePatternData2 = new NamePatternData(
@@ -284,12 +290,24 @@ public class TestPersonNameFormatter extends TestFmwk{
 
         PersonNameFormatter personNameFormatter2 = new PersonNameFormatter(namePatternData2, FALLBACK_FORMATTER);
 
-        check(personNameFormatter2, sampleNameObject5, "order=givenFirst", "Mary₂³₃⁴Smith"); // reasonable, given no break
-        check(personNameFormatter2, sampleNameObject5, "order=surnameFirst", "¹SMITH₁²₃⁴Mary"); // reasonable, given no break
-        check(personNameFormatter2, sampleNameObject5, "order=sorting", "¹Smith₁²₃⁴Mary"); //  TODO RICH should be ¹Smith,⁴Mary
+        check(personNameFormatter2, sampleNameObject5, "order=givenFirst", "Mary₂³₃⁴Smith"); // TODO Rich, make ₁²Mary₂³₃⁴Smith₄ or we change desc.
+        check(personNameFormatter2, sampleNameObject5, "order=surnameFirst", "¹SMITH₁²₃⁴Mary"); // similar
+        check(personNameFormatter2, sampleNameObject5, "order=sorting", "¹Smith₁²₃⁴Mary"); //  TODO RICH should be ¹Smith,³₃⁴Mary₄
     }
 
     public void TestLiteralTextElisionSpaces() {
+
+        // Also used to generate examples in the user guide
+        if (SHOW) {
+            logln("Patterns for User Guide:");
+            final String pattern = "¹{prefix}₁ ²{given}₂ ³{given2}₃ ⁴{surname}₄";
+            final String patternNoSpaces = "¹{prefix}₁²{given}₂³{given2}₃⁴{surname}₄";
+            System.out.println(pattern.replace(" ", "⌴"));
+            System.out.println(patternNoSpaces);
+            System.out.println("[" + pattern.replace(" ", "]⌴[") + "]");
+            System.out.println("[" + patternNoSpaces.replace("}", "}[").replace("{", "]{") + "]");
+        }
+
         ImmutableMap<ULocale, Order> localeToOrder = ImmutableMap.of(); // don't worry about using the order from the locale right now.
 
         NamePatternData namePatternData2 = new NamePatternData(
@@ -300,9 +318,9 @@ public class TestPersonNameFormatter extends TestFmwk{
 
         PersonNameFormatter personNameFormatter2 = new PersonNameFormatter(namePatternData2, FALLBACK_FORMATTER);
 
-        check(personNameFormatter2, sampleNameObject5, "order=givenFirst", "Mary₂ ⁴Smith"); // reasonable
-        check(personNameFormatter2, sampleNameObject5, "order=surnameFirst", "¹SMITH₁ ⁴Mary"); // reasonable
-        check(personNameFormatter2, sampleNameObject5, "order=sorting", "¹Smith₁ ⁴Mary"); //  TODO RICH should be ¹Smith, ⁴Mary
+        check(personNameFormatter2, sampleNameObject5, "order=givenFirst", "Mary₂ ⁴Smith"); // TODO Rich to make ²Mary₂ ⁴Smith₄ (or we change desc.
+        check(personNameFormatter2, sampleNameObject5, "order=surnameFirst", "¹SMITH₁ ⁴Mary"); // similar
+        check(personNameFormatter2, sampleNameObject5, "order=sorting", "¹Smith₁ ⁴Mary"); //  TODO RICH should be ¹Smith, ⁴Mary₄
 
         // TODO Rich: The behavior is not quite what I describe in the guide.
         // Example: ²{given}₂ means that ² and ₂ "belong to" Mary, so the results should have ²Mary₂.
@@ -339,9 +357,10 @@ public class TestPersonNameFormatter extends TestFmwk{
             {
                 "//ldml/personNames/personName[@length=\"long\"][@usage=\"referring\"][@style=\"formal\"][@order=\"givenFirst\"]/namePattern",
                 "〖Sinbad〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Meyer Wolf M.D. Ph.D.〗"
-            },{
-                "//ldml/personNames/personName[@length=\"long\"][@usage=\"monogram\"][@style=\"informal\"][@order=\"surnameFirst\"]/namePattern",
-                "〖S〗〖AI〗〖WJ〗〖MWN〗"
+//HACK, reenable after en data changes {xxx-initial} to {xxx-monogram} for monogram patterns
+//            },{
+//                "//ldml/personNames/personName[@length=\"long\"][@usage=\"monogram\"][@style=\"informal\"][@order=\"surnameFirst\"]/namePattern",
+//                "〖S〗〖AI〗〖WJ〗〖MWN〗"
             },{
                 "//ldml/personNames/nameOrderLocales[@order=\"givenFirst\"]",
                 "〖und = «any other»〗"


### PR DESCRIPTION
CLDR-15404

3 fixes:
- change to print out order for spreadsheet
- fix comments for Rich
- add -monogram support
  - Note that one of the tests has a commented out section, until monograms are fixed in the data.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
