### PR TITLE
CLDR-13335 Errors in Survey Tool, names same as codes, Modhi

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -608,23 +608,8 @@ public class CLDRTest extends TestFmwk {
         checkTranslatedCode(cldrfile, codes, "variant", "//ldml/localeDisplayNames/variants/variant", "");
     }
 
-    /**
-     * @param codes
-     * @param type
-     * @param prefix
-     * @param postfix
-     *            TODO
-     */
     private void checkTranslatedCode(CLDRFile cldrfile, StandardCodes codes, String type, String prefix, String postfix) {
-
-        // TODO, expand to other languages
-        Map<String, Set<String>> completionExceptions = new HashMap<>();
-        Set<String> scriptExceptions = new HashSet<>();
-        scriptExceptions.add("Cham");
-        scriptExceptions.add("Thai");
-        scriptExceptions.add("Toto");
-        completionExceptions.put("script", scriptExceptions);
-
+        Map<String, Set<String>> completionExceptions = getCompletionExceptions();
         Set<String> codeItems = codes.getGoodAvailableCodes(type);
         int count = 0;
         Set<String> exceptions = completionExceptions.get(type);
@@ -647,6 +632,21 @@ public class CLDRTest extends TestFmwk {
             }
         }
         logln("Total " + type + ":\t" + count);
+    }
+
+    private Map<String, Set<String>> theCompletionExceptions = null;
+
+    private Map<String, Set<String>> getCompletionExceptions() {
+        if (theCompletionExceptions == null) {
+            theCompletionExceptions = new HashMap<>();
+            final Set<String> scriptExceptions = new HashSet<>();
+            scriptExceptions.add("Cham");
+            scriptExceptions.add("Modi");
+            scriptExceptions.add("Thai");
+            scriptExceptions.add("Toto");
+            theCompletionExceptions.put("script", scriptExceptions);
+        }
+        return theCompletionExceptions;
     }
 
     // <territoryContainment><group type="001" contains="002 009 019 142 150"/>


### PR DESCRIPTION
-Add Modhi to the exception list

-Move that code into a subroutine and cache the constant result

CLDR-13335

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
