### PR TITLE
CLDR-15411 Add high coverage locales to Locales.txt

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -565,6 +565,22 @@ Cldr    ; sa ; basic ; Sanskrit
 Cldr    ; doi ; basic ; Dogri
 #Cldr    ; nv ; basic ; Navajo
 
+#Cldr other (high coverage locales)
+Cldr  ; hsb ; modern ; Upper Sorbian
+Cldr  ; dsb ; modern  ; Lower Sorbian
+Cldr  ; gd  ; modern  ; Scottish Gaelic
+Cldr  ; chr ; modern  ; Cherokee
+Cldr  ; yue_Hans  ; modern  ; Cantonese (Simplified)
+
+Cldr  ; fo  ; moderate  ; Faroese
+Cldr  ; qu  ; moderate  ; Quechua
+Cldr  ; br  ; moderate  ; Breton
+Cldr  ; sc  ; moderate  ; Sardinian
+Cldr  ; kgp ; moderate  ; Kaingang
+Cldr  ; yrl ; moderate  ; Nheetgatu
+Cldr  ; ast ; moderate  ; Asturian
+Cldr  ; ff_Adlm ; moderate ; Fulah (Adlam)
+
 Bangor_Univ ;   cy   ;    modern  ; Welsh
 
 Bhutan ;   dz   ;    modern  ; Dzongkha

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
@@ -15,7 +15,7 @@ public class TestStandardCodes {
         "doi,BASIC",  // CLDR locale
         "nn,MODERN",  // CLDR locale
         "hnj,MODERN", // Maximum coverage (hmong)
-        "br,MODERN",  // Maximum (Breton)
+        "br,MODERATE",  // Maximum (Breton)
         "zxx,BASIC",  // "all others: BASIC"
     })
     void testTargetCoverageLevel(final String locale, final String level) {


### PR DESCRIPTION
CLDR-15411

Add high coverage locales to Locales.txt so that they show up in the priority view.

I will file a separate ticket about updating the docs.

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
