### PR TITLE
CLDR-15598 Update Google coverage in Locales.txt

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -143,8 +143,7 @@ Google	;	gl	;	modern	;	T5	Galician
 # Google	; gn ; basic ; Guarani (Bengali script)
 Google	;	gsw	;	basic	;	Swiss German
 Google	;	gu	;	modern	;	T4	Gujarati
-#Google	;	ha	;	basic	;	Hausa
-Google	;	ha	;	moderate	;	Hausa
+Google	;	ha	;	modern	;	Hausa
 Google	;	he	;	modern	;	T2	Hebrew
 Google	;	hi	;	modern	;	T2	Hindi
 Google	;	hr	;	modern	;	T2	Croatian
@@ -153,8 +152,7 @@ Google	;	hu	;	modern	;	T2	Hungarian
 Google	;	hy	;	modern	;	T3.1	Armenian
 Google ; ia ; moderate ;
 Google	;	id	;	modern	;	T2	Indonesian
-#Google	;	ig	;	basic	;	Igbo
-Google	;	ig	;	moderate	;	Igbo
+Google	;	ig	;	modern	;	Igbo
 Google	;	is	;	modern	;	T3	Icelandic
 Google	;	it	;	modern	;	T1	Italian
 Google	;	ja	;	modern	;	T1	Japanese
@@ -192,14 +190,14 @@ Google	;	mt	;	basic	;	Maltese
 Google	;	my	;	modern	;	T3.1	Burmese (Myanmar)
 Google	;	ne	;	modern	;	T3.1	Nepali
 Google	;	nl	;	modern	;	T1	Dutch
-Google    ; nn ; Moderate ; Nynorsk
+Google	; nn	; Modern ; Nynorsk
 Google	;	no	;	modern	;	T2	Norwegian (Bokmål)
 Google ; nqo ; moderate ;
 #Google	;	nso	;	basic	;	NorthernSotho
 #Google    ; nv ; basic ; Navajo
 #Google	;	ny	;	basic	;	Nyanja
 #Google	;	nyn	;	basic	;	Nyankole
-Google ; oc ; moderate ;
+#Google ; oc ; moderate ;
 #Google	;	om	;	basic	;	Oromo
 Google	;	or	;	modern	;	T5	Odia
 Google	;	pa	;	modern	;	T4.1	Punjabi
@@ -249,8 +247,7 @@ Google	;	uz	;	modern		;	T4.1	Uzbek	(Latin)
 Google	;	vi	;	modern	;	T2	Vietnamese
 #Google	;	wo	;	basic	;	Wolof
 #Google	;	xh	;	basic	;	Xhosa
-#Google	;	yo	;	basic	;	Yoruba
-Google	;	yo	;	moderate	;	Yoruba
+Google	;	yo	;	modern	;	Yoruba
 Google	;	yue	;	modern	;	T5	Cantonese
 Google	;	zh	;	modern	;	T1	Simplified Chinese
 Google	;	zh_Hant	;	modern	;	T1	Traditional Chinese
@@ -544,9 +541,9 @@ Cldr	;	tk	;	modern	;	Turkmen
 Cldr	;	jv	;	modern	;	Javanese
 Cldr	;   so  ;   modern	;   Somali
 
-Cldr	;	ha	;	moderate	;	Hausa
-Cldr	;	ig	;	moderate	;	Igbo
-Cldr	;	yo	;	moderate	;	Yoruba
+Cldr	;	ha	;	modern	;	Hausa
+Cldr	;	ig	;	modern	;	Igbo
+Cldr	;	yo	;	modern	;	Yoruba
 Cldr	;	ceb	;	moderate	;	Cebuano
 
 Cldr	; mai ; basic ; Maithili (Devanagari script)


### PR DESCRIPTION
CLDR-15598 Update Google coverage in Locales.txt

Updated from moderate to modern: ha, ig, nn, yo in Google and Cldr items

Commented OC out for Google
Removed basic level versions of ha, ig, yo

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
