### PR TITLE
CLDR-15588 add nl and nl_BE PersonNames

### DIFF
--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -19875,4 +19875,155 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="tnum">tabelvormige cijfers</featureName>
 		<featureName type="zero">nul met schuine streep</featureName>
 	</typographicNames>
+	<personNames>
+		<initialPattern type="initial">{0}.</initialPattern>
+		<initialPattern type="initialSequence">{0}{1}</initialPattern>
+		<!-- 
+			Addressee on formal business letter: https://taaladvies.net/opmaak-van-een-zakelijke-brief-in-nederland-algemeen/
+			Formal addresee: 	Mevrouw I.F. van den Berg	{prefix} {given-initial}{given2-initial} {surname}
+															{prefix} {given-initial}{given2-initial} {surname-prefix} {surname-core}
+			Salutation: 		Mevrouw Van den Berg  		{prefix} {surname-initialCap}
+															{prefix} {surname-prefix-initialCap} {surname-core}
+			Signed:				Ingrid van den Berg			{given} {surname}
+
+			inherit from root.xml:
+				* nameOrderLocales for givenFirst (default), surnameFirst
+				* surnameFirst namePaterns
+
+			To do in the future:
+				* [ ] Double-Barreled names: https://onzetaal.nl/taaladvies/geachte-mevrouw-jansen-de-jong-jansen
+						Use only first surname in usage=addressing
+						"mevrouw Jansen-de Jong" -> "Dear mevrouw Jansen"
+		-->
+		<personName order="givenFirst" length="long" usage="referring" formality="formal">
+			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
+			<namePattern>{prefix} {given-initial-allCaps}{given2-initial-allCaps} {surname-prefix} {surname-core}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-prefix-monogram}{surname-core-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="referring" formality="informal">
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
+			<namePattern>{prefix} {surname-prefix-initialCap} {surname-core-initialCap}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}{surname-prefix-monogram}{surname-core-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
+			<namePattern>{given} {given2-initial} {surname} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
+			<namePattern>{prefix} {surname-prefix-initialCap} {surname-core-initialCap}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
+			<namePattern>{given-monogram-allCaps}{surname-prefix-monogram}{surname-core-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="referring" formality="formal">
+			<namePattern>{given-initial}{given2-initial} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
+			<namePattern>{prefix} {surname-prefix-initialCap} {surname-core-initialCap}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
+			<namePattern>{surname-prefix-monogram}{surname-core-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="referring" formality="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="formal">
+			<namePattern>{surname-core}, {prefix} {given} {given2} {surname-prefix}, {suffix}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="addressing" formality="formal">
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix} {suffix}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="monogram" formality="formal">
+			<namePattern>{surname-core-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}{surname-prefix-monogram}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="informal">
+			<namePattern>{surname-core}, {given-informal} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="addressing" formality="informal">
+			<namePattern>{surname-core}, {given-informal} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="monogram" formality="informal">
+			<namePattern>{surname-core-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="formal">
+			<namePattern>{surname-core}, {given} {given2-initial} {surname-prefix} {suffix}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="addressing" formality="formal">
+			<namePattern>{surname-core}, {given} {given2-initial} {surname-prefix} {suffix}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="monogram" formality="formal">
+			<namePattern>{surname-core-monogram-allCaps}{given-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="informal">
+			<namePattern>{surname-core}, {given-informal} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="addressing" formality="informal">
+			<namePattern>{surname-core}, {given-informal} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="referring" formality="formal">
+			<namePattern>{surname-core}, {given-initial}{given2-initial} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="addressing" formality="formal">
+			<namePattern>{surname-core}, {given-initial}{given2-initial} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="monogram" formality="formal">
+			<namePattern>{surname-core-monogram-allCaps}{surname-prefix-monogram}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="referring" formality="informal">
+			<namePattern>{surname-core}, {given-informal} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="addressing" formality="informal">
+			<namePattern>{surname-core}, {given-informal} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<sampleName item="givenOnly">
+			<nameField type="given">Johannes</nameField>
+		</sampleName>
+		<sampleName item="givenSurnameOnly">
+			<nameField type="given">Johannes</nameField>
+			<nameField type="surname">van den Berg</nameField>
+		</sampleName>
+		<sampleName item="given12Surname">
+			<nameField type="given">Johannes</nameField>
+			<nameField type="given2">Lidewijn Mees</nameField>
+			<nameField type="surname">van den Berg</nameField>
+		</sampleName>
+		<sampleName item="full">
+			<nameField type="prefix">mevrouw</nameField>
+			<nameField type="given">Ingrid</nameField>
+			<nameField type="given-informal">Ingy</nameField>
+			<nameField type="given2">Francina Zoë</nameField>
+			<nameField type="surname">van den Berg</nameField>
+			<nameField type="surname-prefix">van den</nameField>
+			<nameField type="surname-core">Berg</nameField>
+			<nameField type="suffix">PhD</nameField>
+		</sampleName>
+	</personNames>
 </ldml>

--- a/common/main/nl_BE.xml
+++ b/common/main/nl_BE.xml
@@ -115,4 +115,149 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 		</currencyFormats>
 	</numbers>
+	<personNames>
+		<!--
+			Minor variations from nl-NL
+			https://onzetaal.nl/taaladvies/hoofdletters-namen-nederland
+			"Belgian surnames are immutable: they are written as they are recorded in the 
+			population register. If the surname is registered as Van der Meeren , 
+			that is always the correct spelling in Belgium"
+
+			https://onzetaal.nl/taaladvies/hoofdletters-namen-belgie
+			"In practice, Belgian names are almost always capitalized: Margot De Ridder, 
+			Patsy Van der Meeren, Marie De Ruyter-Van Goethem."
+
+			Therfore, no need for -prefix and -core modifiers in nl-BE
+
+			inherit initialPattern, initialSequence, and order='surnameFirst' from nl.xml
+		-->
+		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
+			<namePattern>{prefix} {given-initial-allCaps}{given2-initial-allCaps} {surname}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="addressing" formality="formal">
+			<namePattern>{surname}, {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
+			<namePattern>{prefix} {surname-core-initialCap}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="addressing" formality="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="referring" formality="formal">
+			<namePattern>{given} {given2} {surname} {suffix}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="formal">
+			<namePattern>{surname}, {prefix} {given} {given2}, {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="referring" formality="informal">
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="monogram" formality="formal">
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="monogram" formality="informal">
+			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
+			<namePattern>{prefix} {surname-initialCap}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="addressing" formality="formal">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="addressing" formality="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
+			<namePattern>{given} {given2-initial} {surname} {suffix}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="formal">
+			<namePattern>{surname}, {given} {given2-initial} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
+			<namePattern>{given-informal} {surname}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
+			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="monogram" formality="formal">
+			<namePattern>{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
+			<namePattern>{prefix} {surname-initialCap}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="addressing" formality="formal">
+			<namePattern>{surname}, {given-initial}{given2-initial}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="addressing" formality="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="referring" formality="formal">
+			<namePattern>{given-initial}{given2-initial} {surname}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="referring" formality="formal">
+			<namePattern>{surname}, {given-initial}{given2-initial}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="referring" formality="informal">
+			<namePattern>{given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="referring" formality="informal">
+			<namePattern>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
+			<namePattern>{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="monogram" formality="formal">
+			<namePattern>{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="monogram" formality="informal">
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<sampleName item="givenOnly">
+			<nameField type="given">Liam</nameField>
+		</sampleName>
+		<sampleName item="givenSurnameOnly">
+			<nameField type="given">Liam</nameField>
+			<nameField type="surname">Van den Berg</nameField>
+		</sampleName>
+		<sampleName item="given12Surname">
+			<nameField type="given">Liam</nameField>
+			<nameField type="given2">Hugo Mees</nameField>
+			<nameField type="surname">Van den Berg</nameField>
+		</sampleName>
+		<sampleName item="full">
+			<nameField type="prefix">mevrouw</nameField>
+			<nameField type="given">Juliette</nameField>
+			<nameField type="given-informal">Juli</nameField>
+			<nameField type="given2">Francina Zoë</nameField>
+			<nameField type="surname">Van den Berg</nameField>
+			<nameField type="suffix">PhD</nameField>
+		</sampleName>
+	</personNames>
 </ldml>


### PR DESCRIPTION
CLDR-15588

- [x] This PR completes the ticket.

Add nl and nl_BE personName patterns and sample names.

Note that nl uses surname-prefix and surname-core to handle tussenvoegsels, but -prefix and -core are not used in Belgium

Double-Barreled names are not handled.  See: https://onzetaal.nl/taaladvies/geachte-mevrouw-jansen-de-jong-jansen
In double-barreled surnames, e.g. maiden plus married, defacto usage it to only use the first surname in `usage="addressing"`

  "mevrouw Jansen-de Jong" -> "Dear mevrouw Jansen" (mevrouw = "Ms.")

Test data are in the "nl" and "nl-BE" tabs of the [PersonName Test Data Google Sheet ](https://docs.google.com/spreadsheets/d/1YwWVSgaMNx13O0yf3f86MQjpMqy8VS1gfqGrT38fQ8g/edit?usp=sharing)

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
