### PR TITLE
CLDR-15405 Add foreignSpaceReplacement with \u0020 for root and ・ for ja

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3164,7 +3164,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST annotation draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 
-<!ELEMENT personNames ( alias | ( nameOrderLocales*, initialPattern*, personName+, sampleName*, special* ) ) >
+<!ELEMENT personNames ( alias | ( nameOrderLocales*, foreignSpaceReplacement*, initialPattern*, personName*, sampleName*, special* ) ) >
 
 <!ELEMENT nameOrderLocales ( #PCDATA ) >
 <!ATTLIST nameOrderLocales order (givenFirst | surnameFirst) #REQUIRED >
@@ -3173,6 +3173,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST nameOrderLocales draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST nameOrderLocales references CDATA #IMPLIED >
+    <!--@METADATA-->
+
+<!ELEMENT foreignSpaceReplacement ( #PCDATA ) >
+<!ATTLIST foreignSpaceReplacement alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST foreignSpaceReplacement draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+<!ATTLIST foreignSpaceReplacement references CDATA #IMPLIED >
     <!--@METADATA-->
 
 <!ELEMENT initialPattern ( #PCDATA ) >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9224,7 +9224,7 @@ annotations.
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">ja zh ko</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ja ko zh</nameOrderLocales>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -11718,4 +11718,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="tnum">表形式数字</featureName>
 		<featureName type="zero">スラッシュゼロ</featureName>
 	</typographicNames>
+	<personNames>
+		<foreignSpaceReplacement>・</foreignSpaceReplacement>
+	</personNames>
 </ldml>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5370,9 +5370,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<personNames>
 		<nameOrderLocales order="givenFirst">und</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">hu ja ko vi yue zh</nameOrderLocales>
+		<foreignSpaceReplacement> </foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
-
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{prefix} {given} {given2} {surname} {surname2} {suffix}</namePattern>
 		</personName>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -907,6 +907,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute']"/>
+		<coverageLevel value="modern" match="personNames/foreignSpaceReplacement[@alt='%anyAttribute']"/>
+		<coverageLevel value="modern" match="personNames/foreignSpaceReplacement"/>
 		<coverageLevel value="modern" match="personNames/initialPattern[@type='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="personNames/initialPattern[@type='%anyAttribute']"/>
 		<coverageLevel value="modern" match="personNames/personName[@order='%anyAttribute'][@length='%anyAttribute'][@usage='%anyAttribute'][@formality='%anyAttribute']/namePattern[@alt='%anyAttribute']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -453,7 +453,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
 
         // check for spaces
 
-        if (!value.equals(value.trim())) {
+        if (!value.equals(value.trim())  && !path.contains("/foreignSpaceReplacement")) { // foreignSpaceReplacement value can be just space
             if (!leadOrTrailWhitespaceOk.reset(path).find()) {
                 result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.errorType)
                     .setSubtype(Subtype.mustNotStartOrEndWithSpace)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -382,9 +382,17 @@ public class PathDescription {
         + RegexLookup.SEPARATOR
         + "Person name order for locales. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
-        + "^//ldml/personNames/initialPattern\\[@type=\"([^\"]*)\"]"
+        + "^//ldml/personNames/foreignSpaceReplacement"
         + RegexLookup.SEPARATOR
-        + "Initials patterns for person name formats. For more information, please see "
+        + "For foreign personal names displayed in your locale, any special character that replaces a space (defaults to regular space). For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/initialPattern\\[@type=\"initial\"]"
+        + RegexLookup.SEPARATOR
+        + "The pattern used for a single initial in person name formats. For more information, please see "
+        + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
+        + "^//ldml/personNames/initialPattern\\[@type=\"initialSequence\"]"
+        + RegexLookup.SEPARATOR
+        + "The pattern used to compose sequences of initials in person name formats. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/personName\\[@order=\"([^\"]*)\"]\\[@length=\"([^\"]*)\"]\\[@usage=\"referring\"]\\[@formality=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1867,7 +1867,7 @@ public class PathHeader implements Comparable<PathHeader> {
                         order = 0;
                         return "NameOrder for Locales";
                     }
-                    if (source.equals("InitialPatterns")) {
+                    if (source.equals("AuxiliaryItems")) {
                         order = 10;
                         return source;
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -1351,6 +1351,9 @@ public class PersonNameFormatter {
                         _localeToOrder.put(new ULocale(locale), Order.surnameFirst);
                     }
                     break;
+                case "foreignSpaceReplacement":
+                    // TODO use this data
+                    break;
                 case "sampleName":
                     // skip
                     break;

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -287,8 +287,10 @@
 
 //ldml/personNames/nameOrderLocales[@order=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1-$2
 //ldml/personNames/nameOrderLocales[@order=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1
-//ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(InitialPatterns) ; $1-$2
-//ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(InitialPatterns) ; $1
+//ldml/personNames/foreignSpaceReplacement[@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; foreignSpaceReplacement-$1
+//ldml/personNames/foreignSpaceReplacement   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; foreignSpaceReplacement
+//ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; pattern-$1-$2
+//ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; pattern-$1
 //ldml/personNames/personName[@order=\"%A\"][@length=\"%A\"][@usage=\"%A\"][@formality=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$2) ; &personNameOrder($3-$4-$5)
 //ldml/personNames/personName[@order=\"%A\"][@length=\"%A\"][@usage=\"%A\"][@formality=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$2) ; &personNameOrder($3-$4)
 //ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(SampleName:$1) ; &sampleNameOrder($2-$3)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -361,6 +361,9 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         if (value.equals(input)) {
             return null;
         }
+        if (path.contains("/foreignSpaceReplacement")) {
+            return null; // CLDR-15384 typically inherited; no DAIP processing desired
+        }
         if (path.contains("/exemplarCharacters") || path.contains("/parseLenient")) {
             try {
                 UnicodeSet s1 = new UnicodeSet(value);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -189,6 +189,8 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard", // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
 
         "//ldml/personNames/nameOrderLocales[@order=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/foreignSpaceReplacement[@alt=\"([^\"]*+)\"]", // CLDR-15384
+        "//ldml/personNames/foreignSpaceReplacement", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"]", // CLDR-15384
         "//ldml/personNames/personName[@order=\"([^\"]*+)\"][@length=\"([^\"]*+)\"][@usage=\"([^\"]*+)\"][@formality=\"([^\"]*+)\"]/namePattern[@alt=\"([^\"]*+)\"]", // CLDR-15384

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -371,7 +371,7 @@ public class TestPersonNameFormatter extends TestFmwk{
                 "〖und = «any other»〗"
             },{
                 "//ldml/personNames/nameOrderLocales[@order=\"surnameFirst\"]",
-                "〖ja = Japanese〗〖zh = Chinese〗〖ko = Korean〗"
+                "〖ja = Japanese〗〖ko = Korean〗〖zh = Chinese〗"
             }
         };
         for (String[] test : tests) {


### PR DESCRIPTION
CLDR-15405

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
 Per e-mail discussion, add foreignSpaceReplacement element with regular space for root value, and ・ \u30BF for Japanese, along with coverage and PathHeader stuff, etc. Having a value of space required some exceptions in tests for DAIP and exemplars.