### PR TITLE
CLDR-14992 SDI.getTargetTerritories/Scripts should include the ones for actual CLDR locales

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -41,6 +41,7 @@ import org.unicode.cldr.util.RegexLookup;
 import org.unicode.cldr.util.RegexLookup.Finder;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.SupplementalDataInfo.CoverageVariableInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.CurrencyDateInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
@@ -669,6 +670,72 @@ public class TestCoverageLevel extends TestFmwkPlus {
             }
 
             errln("Comprehensive & no exception for path =>\t" + path);
+        }
+    }
+
+    public static class TargetsAndSublocales  {
+        public final CoverageVariableInfo cvi;
+        public Set<String> scripts;
+        public Set<String> regions;
+
+        public TargetsAndSublocales(String localeLanguage) {
+            cvi = SDI.getCoverageVariableInfo(localeLanguage);
+            scripts = new TreeSet<>();
+            regions = new TreeSet<>();
+        }
+
+        public boolean addScript(String localeScript) {
+            return scripts.add(localeScript);
+        }
+        public boolean addRegion(String localeRegion) {
+            return regions.add(localeRegion);
+        }
+    }
+
+    public void TestCoverageVariableInfo() {
+        /**
+         * Compare the targetScripts and targetTerritories for a language to
+         * what we actually have in locales
+         */
+        Map<String, TargetsAndSublocales> langToTargetsAndSublocales = new TreeMap<>();
+        org.unicode.cldr.util.Factory factory = testInfo.getCldrFactory();
+        for (CLDRLocale locale : factory.getAvailableCLDRLocales()) {
+            String language = locale.getLanguage();
+            if (language.length() == 0 || language.equals("root")) {
+                continue;
+            }
+            TargetsAndSublocales targetsAndSublocales = langToTargetsAndSublocales.get(language);
+            if (targetsAndSublocales == null) {
+                targetsAndSublocales = new TargetsAndSublocales(language);
+                langToTargetsAndSublocales.put(language, targetsAndSublocales);
+            }
+            String script = locale.getScript();
+            if (script.length() > 0) {
+                targetsAndSublocales.addScript(script);
+            }
+            String region = locale.getCountry();
+            if (region.length() > 0 && region.length() < 3) { // do not want numeric codes like 001, 419
+                targetsAndSublocales.addRegion(region);
+            }
+        }
+
+        for (String language : langToTargetsAndSublocales.keySet()) {
+            TargetsAndSublocales targetsAndSublocales = langToTargetsAndSublocales.get(language);
+            if (targetsAndSublocales == null) {
+                continue;
+            }
+            Set<String> targetScripts = new TreeSet<>(targetsAndSublocales.cvi.targetScripts);
+            Set<String> localeScripts = targetsAndSublocales.scripts;
+            localeScripts.removeAll(targetScripts);
+            if (localeScripts.size() > 0) {
+                errln("Missing scripts for language: " + language + ", target scripts: " + targetScripts + ", but locales also have: " + localeScripts);
+            }
+            Set<String> targetRegions = new TreeSet<>(targetsAndSublocales.cvi.targetTerritories);
+            Set<String> localeRegions = targetsAndSublocales.regions;
+            localeRegions.removeAll(targetRegions);
+            if (localeRegions.size() > 0) {
+                errln("Missing regions for language: " + language + ", target regions: " + targetRegions + ", but locales also have: " + localeRegions);
+            }
         }
     }
 


### PR DESCRIPTION
CLDR-14992

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Per the ticket and TC discussion, the locales returned by SupplementalDataInfo getTargetScripts and getTargetTerritories for a given target language should include not just the primary script and region from languageData, but also the explicit scripts and regions from the locale IDs for all (common/main) CLDR locales for that language (except for regions that are 3-digit UN M.49 codes, which we decided in TC to exclude). See the scripts/regions that will be added in [Additions to Target-Scripts, Target-Regions](https://docs.google.com/document/d/1TqsXBswiOSCgHckeAJ--day9WR08EXSNBuJUeJz48Dk/)

This will help do things like ensure that there is Persian calendar coverage in ckb_IR, for example.