### PR TITLE
CLDR-15632 prefix & core modifiers for sampleName

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3215,7 +3215,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT nameField ( #PCDATA ) >
 <!ATTLIST nameField type CDATA #REQUIRED >
-    <!--@MATCH:literal/prefix, given, given-informal, given2, surname, surname2, suffix-->
+    <!--@MATCH:literal/prefix, given, given-informal, given2, surname, surname-prefix, surname-core, surname2, suffix-->
 <!ATTLIST nameField alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST nameField draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9443,6 +9443,8 @@ annotations.
 			<nameField type="given-informal">Neele</nameField>
 			<nameField type="given2">Eva Sophia</nameField>
 			<nameField type="surname">Meyer Wolf</nameField>
+			<nameField type="surname-prefix">van den</nameField>
+			<nameField type="surname-core">Wolf</nameField>
 			<nameField type="surname2">Becker Schmidt</nameField>
 			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5594,6 +5594,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="given-informal">∅∅∅</nameField>
 			<nameField type="given2">∅∅∅</nameField>
 			<nameField type="surname">∅∅∅</nameField>
+			<nameField type="surname-prefix">∅∅∅</nameField>
+			<nameField type="surname-core">∅∅∅</nameField>
 			<nameField type="surname2">∅∅∅</nameField>
 			<nameField type="suffix">∅∅∅</nameField>
 		</sampleName>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -26,8 +26,8 @@ public class CheckPersonNames extends CheckCLDR {
      * @internal, public for testing
      */
     public static final ImmutableMultimap<SampleType, String> REQUIRED_EMPTY = ImmutableMultimap.<SampleType, String> builder()
-        .putAll(SampleType.givenOnly, "prefix", "given-informal", "given2", "surname", "surname2", "suffix")
-        .putAll(SampleType.givenSurnameOnly, "prefix", "given2", "surname2", "suffix")
+        .putAll(SampleType.givenOnly, "prefix", "given-informal", "given2", "surname", "surname-prefix", "surname-core", "surname2", "suffix")
+        .putAll(SampleType.givenSurnameOnly, "prefix", "given2", "surname-prefix", "surname-core", "surname2", "suffix")
         .build();
 
     boolean isRoot = false;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -135,6 +135,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                                 .setSubtype(Subtype.invalidPlaceHolder)
                                 .setMessage("Names must have a value for the ‘surname’ field if they have a ‘surname2’ field."));
                         }
+                        // Todo: check to be sure we don't have surname-prefix unless we also have surname-core or surname
                         break;
                     default:
                         break;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1922,7 +1922,7 @@ public class PathHeader implements Comparable<PathHeader> {
                     // sort order, but groups from least important to most
                     final List<String> attrValues = Arrays.asList(
                         "informal", // modifiers for nameField type
-                        "prefix", "given", "given2", "surname", "surname2", "suffix"); // values for nameField type
+                        "prefix", "given", "given2", "surname", "surname-prefix", "surname-core", "surname2", "suffix"); // values for nameField type
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;


### PR DESCRIPTION
CLDR-15632

- [x] This PR completes the ticket.

Add surname-prefix and surname-core options for personNames/sampleName

* Updates allowed nameField values
* Adds surname-prefix and surname-core test values to root.xml and en.xml

This PR blocks PR #1970 , add nl and nl_BE personNames
