### PR TITLE
CLDR-15637 add checks on consistency of modifiers

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -163,7 +163,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                         // We need consistency among the 3 values if we have either prefix or core
 
                         String coreValue = hasCore ? value : modifiedFieldValue(parts, field, modifiers, Modifier.core);
-                        String prefixValue = hasCore ? value : modifiedFieldValue(parts, field, modifiers, Modifier.prefix);
+                        String prefixValue = hasPrefix ? value : modifiedFieldValue(parts, field, modifiers, Modifier.prefix);
                         String plainValue = modifiedFieldValue(parts, field, modifiers, null);
 
                         String errorMessage2 = Modifier.inconsistentPrefixCorePlainValues(prefixValue, coreValue, plainValue);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -150,7 +150,6 @@ public class CheckPlaceHolders extends CheckCLDR {
                                 .setSubtype(Subtype.invalidPlaceHolder)
                                 .setMessage("Names must have a value for the ‘surname’ field if they have a ‘surname2’ field."));
                         }
-
                         break;
                     default:
                         break;


### PR DESCRIPTION
Add checks on consistency of modifiers
Add checks on consistency of values for -core, -prefix, and plain

CLDR-15637

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
