### PR TITLE
CLDR-15630 Fix DTD attribute ordering for personName, other cleanups

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1740,19 +1740,19 @@ annotations.
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
-						<dateTimeFormat type="atTime">
-							<pattern>{1} 'at' {0}</pattern>
-						</dateTimeFormat>
 						<dateTimeFormat>
 							<pattern>{1}, {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern>{1} 'at' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
-						<dateTimeFormat type="atTime">
-							<pattern>{1} 'at' {0}</pattern>
-						</dateTimeFormat>
 						<dateTimeFormat>
 							<pattern>{1}, {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern>{1} 'at' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1952,19 +1952,19 @@ annotations.
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
-						<dateTimeFormat type="atTime">
-							<pattern>{1} 'at' {0}</pattern>
-						</dateTimeFormat>
 						<dateTimeFormat>
 							<pattern>{1}, {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern>{1} 'at' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
-						<dateTimeFormat type="atTime">
-							<pattern>{1} 'at' {0}</pattern>
-						</dateTimeFormat>
 						<dateTimeFormat>
 							<pattern>{1}, {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern>{1} 'at' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2425,19 +2425,19 @@ annotations.
 				</timeFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
-						<dateTimeFormat type="atTime">
-							<pattern>{1} 'at' {0}</pattern>
-						</dateTimeFormat>
 						<dateTimeFormat>
 							<pattern>{1}, {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern>{1} 'at' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
-						<dateTimeFormat type="atTime">
-							<pattern>{1} 'at' {0}</pattern>
-						</dateTimeFormat>
 						<dateTimeFormat>
 							<pattern>{1}, {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern>{1} 'at' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/util/SandboxLocalesTest.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/util/SandboxLocalesTest.java
@@ -46,14 +46,9 @@ class SandboxLocalesTest {
         // our factory includes common/main, so limit here.
         for(final CLDRLocale l : SpecialLocales.getByType(SpecialLocales.Type.scratch)) {
             System.out.println("Testing " + l);
-            // As part of CLDR-14336 I had to change the minimalDraftStatus parameter below from null to unconfirmed.
-            // Without that an NPE exception was thrown below the following. The Factory.make call ends up in
-            // SimpleFactory.handleMake; the first call there for "mul" with resolved=true calls makeResolvingSource
-            // which recursively calls SimpleFactory.handleMake, eventually ending up with a call for "root" with
-            // resolved=false that calls new CLDRFile. That ends up in XMLNormalizingLoader.getFrozenInstance. With
-            // the null DraftStatus, the NPE occurred inside the call there to cache.getUnchecked(key) which is
-            // Google library code.
-            CLDRFile f = factory.make(l.getBaseName(), true, DraftStatus.unconfirmed);
+            // A noted in CLDR-14336, factory.make needs at least DraftStatus.unconfirmed. That is the default
+            // for the 2-argument form without an explicit minimalDraftStatus param.
+            CLDRFile f = factory.make(l.getBaseName(), true);
             List<CheckCLDR.CheckStatus> errs = new LinkedList<>();
             check.setCldrFileToCheck(f, options, errs);
             for(final CheckCLDR.CheckStatus err : errs) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1277,6 +1277,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         "morning1", "morning2", "afternoon1", "afternoon2", "evening1", "evening2", "night1", "night2",
         // The ones on the following line are no longer used actively. Can be removed later?
         "earlyMorning", "morning", "midDay", "afternoon", "evening", "night", "weeHours").freeze();
+    static MapComparator<String> dateTimeFormatOrder = new MapComparator<String>().add(
+        "standard", "atTime").freeze();
     static MapComparator<String> listPatternOrder = new MapComparator<String>().add(
         "start", "middle", "end", "2", "3").freeze();
     static MapComparator<String> widthOrder = new MapComparator<String>().add(
@@ -1306,6 +1308,19 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         "minute", "minute-short", "minute-narrow",
         "second", "second-short", "second-narrow",
         "zone", "zone-short", "zone-narrow").freeze();
+    static MapComparator<String> nameFieldOrder = new MapComparator<String>().add(
+        "prefix", "given", "given-informal", "given2",
+        "surname", "surname-prefix", "surname-core", "surname2", "suffix").freeze();
+    static MapComparator<String> orderValueOrder = new MapComparator<String>().add(
+        "givenFirst", "surnameFirst", "sorting").freeze();
+    static MapComparator<String> lengthValueOrder = new MapComparator<String>().add(
+        "long", "medium", "short").freeze();
+    static MapComparator<String> usageValueOrder = new MapComparator<String>().add(
+        "referring", "addressing", "monogram").freeze();
+    static MapComparator<String> formalityValueOrder = new MapComparator<String>().add(
+        "formal", "informal").freeze();
+    static MapComparator<String> sampleNameItemOrder = new MapComparator<String>().add(
+        "givenOnly", "givenSurnameOnly", "given12Surname", "full").freeze();
 
     /* TODO: change this to be data-file driven. Can do with new Unit preferences info; also put them in a more meaningful order (metric vs other; size) */
 
@@ -1474,7 +1489,21 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                 comp = unitOrder;
             } else if (element.equals("dayPeriod")) {
                 comp = dayPeriodOrder;
+            } else if (element.equals("dateTimeFormat")) {
+                comp = dateTimeFormatOrder;
+            } else if (element.equals("nameField")) {
+                comp = nameFieldOrder;
             }
+        } else if (attribute.equals("order") && element.equals("personName")) {
+            comp = orderValueOrder;
+        } else if (attribute.equals("length") && element.equals("personName")) {
+            comp = lengthValueOrder;
+        } else if (attribute.equals("usage")) {
+            comp = usageValueOrder;
+        } else if (attribute.equals("formality")) {
+            comp = formalityValueOrder;
+        } else if (attribute.equals("item") && element.equals("sampleName")) {
+            comp = sampleNameItemOrder;
         } else if (attribute.equals("count") && !element.equals("minDays")) {
             comp = countValueOrder;
         } else if (attribute.equals("cp") && element.equals("annotation")) {


### PR DESCRIPTION
CLDR-15630

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix DtdAttribute attribute ordering for personName attributes. Also some other cleanup:
- Fix DtdAttribute attribute ordering for dateTimeFormat type attribute
- In SandboxLocalesTest.java call to Factory.make, delete third parameter to use default minimalDraftStatus (unconfirmed).
Regenerate en.xml with updated attribute ordering.