### PR TITLE
CLDR-13785 Fix PathHeader & PathDescription for fw, em, ...

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -103,6 +103,14 @@ public class PathDescription {
         + RegexLookup.SEPARATOR
         + "The name of “{1} calendar”. For more information, please see "
         + CLDRURLS.KEY_NAMES + ".\n"
+        + "^//ldml/localeDisplayNames/types/type\\[@key=\"em\"]\\[@type=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "The name of “emoji presentation style {1}”. For more information, please see "
+        + CLDRURLS.KEY_NAMES + ".\n"
+        + "^//ldml/localeDisplayNames/types/type\\[@key=\"fw\"]\\[@type=\"([^\"]*)\"]"
+        + RegexLookup.SEPARATOR
+        + "The name of “first day of the week is {1}”. For more information, please see "
+        + CLDRURLS.KEY_NAMES + ".\n"
         + "^//ldml/localeDisplayNames/types/type\\[@key=\"lb\"]\\[@type=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
         + "The name of “{1} line break style”. For more information, please see "

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1351,10 +1351,13 @@ public class PathHeader implements Comparable<PathHeader> {
             });
             functionMap.put("categoryFromKey", new Transform<String, String>() {
                 Map<String, String> fixNames = Builder.with(new HashMap<String, String>())
+                    .put("cf", "Currency Format")
+                    .put("em", "Emoji Presentation")
+                    .put("fw", "First Day of Week")
                     .put("lb", "Line Break")
                     .put("hc", "Hour Cycle")
                     .put("ms", "Measurement System")
-                    .put("cf", "Currency Format")
+                    .put("ss", "Sentence Break Suppressions")
                     .freeze();
 
                 @Override


### PR DESCRIPTION
CLDR-13785

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Looks like we do already have coverage & PathHeader.txt for fw (and a few other items apparently missing in coverage), but the PathHeader.java method categoryFromKey did not handle them. Also added PathDescription for fw and em.