### PR TITLE
CLDR-7813 Add islamic to calendarPreferenceData & coverage for more regions

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -93,7 +93,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%intervalFormatTimeItems" value="((h|H)m?v?)"/>
 		<coverageVariable key="%intervalFormatTimeItemsDayPer" value="(Bhm?v?)"/>
 		<coverageVariable key="%intervalFormatGDiff" value="([GyMdaBHhm])"/>
-		<coverageVariable key="%islamicCalendarTerritories" value="(AE|AF|AZ|BH|DJ|DZ|EG|EH|ER|ID|IL|IQ|IR|JO|KM|KW|LB|LY|MA|MR|OM|PK|PS|QA|SA|SD|SO|SY|TD|TJ|TN|TR|UZ|YE)"/>
+		<coverageVariable key="%islamicCalendarTerritories" value="(AE|AF|AL|AZ|BD|BH|DJ|DZ|EG|EH|ER|ID|IL|IQ|IR|JO|KM|KW|LB|LY|MA|MR|MV|MY|NE|OM|PK|PS|QA|SA|SD|SO|SY|TD|TJ|TM|TN|TR|UZ|XK|YE)"/>
 		<coverageVariable key="%japaneseEras" value="([0-9]{1,3})"/>
 		<coverageVariable key="%keys80" value="(calendar|cf|collation|currency|em|fw|hc|lb|lw|ms|rg|ss|numbers|d0|h0|i0|k0|m0|s0|t0|x0)"/>
 		<coverageVariable key="%keys100" value="(col(Alternate|Backwards|CaseFirst|CaseLevel|HiraganaQuaternary|Normalization|Numeric|Reorder|Strength)|kv|sd|timezone|va|variableTop|x)"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -4713,7 +4713,8 @@ XXX Code for transations where no currency is involved
 
     <calendarPreferenceData>
         <calendarPreference territories="001" ordering="gregorian"/>
-        <calendarPreference territories="DJ DZ EH ER IQ JO KM LB LY MA MR OM PS SD SY TD TN YE" ordering="gregorian islamic islamic-civil islamic-tbla"/>
+        <calendarPreference territories="BD DJ DZ EH ER ID IQ JO KM LB LY MA MR MY NE OM PK PS SD SY TD TN YE" ordering="gregorian islamic islamic-civil islamic-tbla"/>
+        <calendarPreference territories="AL AZ MV TJ TM TR UZ XK" ordering="gregorian islamic-civil islamic-tbla"/>
         <calendarPreference territories="AE BH KW QA" ordering="gregorian islamic-umalqura islamic islamic-civil islamic-tbla"/>
         <calendarPreference territories="AF IR" ordering="persian gregorian islamic islamic-civil islamic-tbla"/>
         <calendarPreference territories="CN CX HK MO SG" ordering="gregorian chinese"/>


### PR DESCRIPTION
CLDR-7813

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Add Islamic calendar to supplemental calendarPreferenceData and to coverage (if not already there) for more regions, but after Gregorian in preference.

In calendarPreferenceData the following prefer
- astronomical islamic: BD ID MY NE PK
- civil islamic: AL AZ MV TJ TM TR UZ XK