### PR TITLE
CLDR-15646 Priority Items: include Missing in org-neutral summaries

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1586,8 +1586,10 @@ public class VettingViewer<T> {
                 VettingViewer.Choice.error,
                 VettingViewer.Choice.warning,
                 VettingViewer.Choice.hasDispute,
-                VettingViewer.Choice.notApproved);
-                // skip missingCoverage, weLost, englishChanged, changedOldValue, abstained
+                VettingViewer.Choice.notApproved,
+                VettingViewer.Choice.missingCoverage
+            );
+            // skip weLost, englishChanged, changedOldValue, abstained
         }
         return choiceSet;
     }


### PR DESCRIPTION
-Missing (VettingViewer.Choice.missingCoverage) should not have been omitted from org-neutral summaries

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
