### PR TITLE
CLDR-15651 fixup incorrect calls into ICU4J PluralRules

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralList.java
@@ -16,10 +16,12 @@ import java.util.TreeSet;
 
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.Builder;
+import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.FileReaders;
+import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 
 import com.ibm.icu.text.DecimalFormat;
@@ -98,7 +100,8 @@ public class GeneratePluralList {
     }
 
     private void getExamples(String locale) {
-        rules = PluralRules.forLocale(new ULocale(locale));
+        SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+        rules = sdi.getPluralRules(new ULocale(locale), PluralRules.PluralType.CARDINAL);
         // Setup.
         Count[] digits = new Count[1000];
         // 0 is always considered a plural type even if the plural rules say otherwise.
@@ -220,7 +223,8 @@ public class GeneratePluralList {
     static String[] units = { "second", "minute", "hour", "day", "month", "year" };
 
     private void getForms(CLDRFile file) {
-        rules = PluralRules.forLocale(new ULocale(file.getLocaleID()));
+        SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+        rules = sdi.getPluralRules(new ULocale(file.getLocaleID()), PluralRules.PluralType.CARDINAL);
         System.out.println(file.getLocaleID());
         for (String plural : rules.getKeywords()) {
             out.print(file.getLocaleID() + '\t' + plural + '\t' +

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -3612,8 +3612,8 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                 try {
                     int item = Integer.parseInt(actualCount);
                     String locale = getLocaleID();
-                    // TODO get data from SupplementalDataInfo...
-                    PluralRules rules = PluralRules.forLocale(new ULocale(locale));
+                    SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+                    PluralRules rules = sdi.getPluralRules(new ULocale(locale), PluralRules.PluralType.CARDINAL);
                     String keyword = rules.select(item);
                     Count itemCount = Count.valueOf(keyword);
                     result = getCountPathWithFallback2(parts, xpath, itemCount, winning);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -3969,6 +3969,26 @@ public class SupplementalDataInfo {
         return null;
     }
 
+    /**
+     * CLDR equivalent of com.ibm.icu.text.PluralRules.forLocale()
+     * @param loc
+     * @param type
+     * @return an ICU PluralRules, from CLDR data
+     */
+    public PluralRules getPluralRules(ULocale loc, PluralRules.PluralType type) {
+        return getPluralRules(loc.getBaseName(), type);
+    }
+
+    /**
+     * CLDR equivalent of com.ibm.icu.text.PluralRules.forLocale()
+     * @param loc
+     * @param type
+     * @return an ICU PluralRules, from CLDR data
+     */
+    public PluralRules getPluralRules(String loc, PluralRules.PluralType type) {
+        return getPlurals(PluralType.fromStandardType(type), loc).getPluralRules();
+    }
+
     public DayPeriodInfo getDayPeriods(DayPeriodInfo.Type type, String locale) {
         Map<String, DayPeriodInfo> map1 = typeToLocaleToDayPeriodInfo.get(type);
         while (locale != null) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
@@ -250,8 +250,9 @@ public class TestPluralRuleGeneration extends TestFmwkPlus {
             + ops
             + "\tpluralCat"
             );
+        SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
         for (ULocale locale : locales) {
-            PluralRules pr = PluralRules.forLocale(locale);
+            PluralRules pr = sdi.getPluralRules(locale, PluralRules.PluralType.CARDINAL);
 
             for (String test : tests) {
                 final FixedDecimal source = new FixedDecimal(test);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
@@ -2,6 +2,10 @@ package org.unicode.cldr.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ibm.icu.text.PluralRules;
+import com.ibm.icu.util.ULocale;
 
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.SupplementalDataInfo.ApprovalRequirementMatcher;
@@ -29,5 +33,14 @@ public class TestSupplementalDataInfo {
             assertNotNull(arm);
             assertEquals(3, arm.getRequiredVotes());
         }
+    }
+
+    @Test
+    void TestArabicPlurals() {
+        final SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+        PluralRules arrules = sdi.getPluralRules(ULocale.forLanguageTag("ar"), PluralRules.PluralType.CARDINAL);
+        assertNotNull(arrules, "ar rules");
+        assertTrue(arrules.getKeywords().contains("two"), "ar did not have two");
+        assertEquals(2.0, arrules.getUniqueKeywordValue("two"), "ar unique value for 'two'");
     }
 }


### PR DESCRIPTION
- add a convenience function SupplementalDataInfo.getPluralRules()
- fix call sites to use this function instead of ICU4J's PluralRules.forLocale()

CLDR-15651

- [ ] This PR completes the ticket.

blocks #1709

Note, I did not change PluralRulesFactory call sites. It seems to explicitly use ICU4J plurals, need more feedback.