### PR TITLE
CLDR-13263 Merge getConstructedBaileyValue and getBaileyValue

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
@@ -904,7 +904,7 @@ public class DataSection implements JSONString {
              */
             Output<String> inheritancePathWhereFound = new Output<>(); // may become pathWhereFound
             Output<String> localeWhereFound = new Output<>(); // may be used to construct inheritedLocale
-            inheritedValue = ourSrc.getConstructedBaileyValue(xpath, inheritancePathWhereFound, localeWhereFound);
+            inheritedValue = ourSrc.getBaileyValue(xpath, inheritancePathWhereFound, localeWhereFound);
 
             if (TRACE_TIME) {
                 System.err.println("@@1:" + (System.currentTimeMillis() - lastTime));
@@ -921,7 +921,7 @@ public class DataSection implements JSONString {
                  * xpath = //ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMMMEEEEd"]
                  * ourValueIsInherited = false; ourValue = "EEEE, d/MM/y"; isExtraPath = false
                  *
-                 * TODO: what are the implications when ourSrc.getConstructedBaileyValue has returned null?
+                 * TODO: what are the implications when ourSrc.getBaileyValue has returned null?
                  * Unless we're at root, shouldn't there always be a non-null inheritedValue here?
                  * See https://unicode.org/cldr/trac/ticket/11299
                  */

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
@@ -691,7 +691,7 @@ public class DataSection implements JSONString {
          *
          * Sequential order in which addItem may be called (as of 2019-04-19) for a given DataRow:
          *
-         * (1) For INHERITANCE_MARKER (if inheritedValue = ourSrc.getConstructedBaileyValue not null):
+         * (1) For INHERITANCE_MARKER (if inheritedValue = ourSrc.getBaileyValue not null):
          *     in updateInheritedValue (called by populateFromThisXpath):
          *         inheritedItem = addItem(CldrUtility.INHERITANCE_MARKER, "inherited");
          *

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -934,7 +934,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             }
 
             CLDRFile cf = make(locale, true);
-            r.setBaileyValue(cf.getConstructedBaileyValue(path, null, null));
+            r.setBaileyValue(cf.getBaileyValue(path, null, null));
 
             // add each vote
             if (perXPathData != null && !perXPathData.isEmpty()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -312,18 +312,7 @@ public class VoteAPIHelper {
         if (val != null) {
             try (SurveyMain.UserLocaleStuff uf = sm.getUserFile(mySession, locale);) {
                 final CLDRFile file = uf.cldrfile;
-                final String checkval = val;
-                if (CldrUtility.INHERITANCE_MARKER.equals(val)) {
-                    final Output<String> localeWhereFound = new Output<>();
-                    /*
-                     * TODO: this looks dubious, see https://unicode.org/cldr/trac/ticket/11299
-                     * temporarily for debugging, don't change checkval, but do call
-                     * getBaileyValue in order to get localeWhereFound
-                     */
-                    // checkval = file.getBaileyValue(xp, null, localeWhereFound);
-                    file.getBaileyValue(xp, null, localeWhereFound);
-                }
-                cc.check(xp, result, checkval);
+                cc.check(xp, result, val);
                 r.dataEmpty = file.isEmpty();
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -402,9 +402,13 @@ public class Ldml2JsonConverter {
             final String path = it.next();
             String fullPath = file.getFullXPath(path);
             String value = file.getWinningValue(path);
+            /*
+             * TODO: check whether this next block is superfluous, and remove it if so
+             * Reference: https://unicode-org.atlassian.net/browse/CLDR-13263
+             */
             if (path.startsWith("//ldml/localeDisplayNames/languages") &&
                 file.getSourceLocaleID(path, null).equals("code-fallback")) {
-                value = file.getConstructedBaileyValue(path, null, null);
+                value = file.getBaileyValue(path, null, null);
             }
 
             if (fullPath == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -1115,7 +1115,7 @@ abstract public class CheckCLDR {
         // If we're being asked to run tests for an inheritance marker, then we need to change it
         // to the "real" value first before running tests. Testing the value CldrUtility.INHERITANCE_MARKER ("↑↑↑") doesn't make sense.
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-            value = cldrFileToCheck.getConstructedBaileyValue(path, null, null);
+            value = cldrFileToCheck.getBaileyValue(path, null, null);
             // If it hasn't changed, then don't run any tests.
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
                 return this;
@@ -1212,7 +1212,7 @@ abstract public class CheckCLDR {
             // If we're being asked to run tests for an inheritance marker, then we need to change it
             // to the "real" value first before running tests. Testing the value CldrUtility.INHERITANCE_MARKER ("↑↑↑") doesn't make sense.
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-                value = getCldrFileToCheck().getConstructedBaileyValue(path, null, null);
+                value = getCldrFileToCheck().getBaileyValue(path, null, null);
             }
             for (Iterator<CheckCLDR> it = filteredCheckList.iterator(); it.hasNext();) {
                 CheckCLDR item = it.next();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -115,13 +115,12 @@ public class CheckForCopy extends FactoryCheckCLDR {
          * otherwise nothing prevents voting to inherit the code value.
          *
          * TODO: clarify the purpose of using topStringValue and getConstructedValue here;
-         * cf. getConstructedBaileyValue. This code is confusing and warrants explanation.
-         * The meaning of "explicit" here seems to be the opposite of its meaning elsewhere.
+         * This code is confusing and warrants explanation.
          */
         String topStringValue = unresolvedFile.getStringValue(path);
-        final boolean isExplicitBailey = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
+        final boolean topValueIsInheritanceMarker = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
         String loc = cldrFile.getSourceLocaleID(path, status);
-        if (!contextIsVoteSubmission && !isExplicitBailey) {
+        if (!contextIsVoteSubmission && !topValueIsInheritanceMarker) {
             if (!cldrFile.getLocaleID().equals(loc)
                 || !path.equals(status.pathWhereFound)) {
                 return Failure.ok;
@@ -156,7 +155,12 @@ public class CheckForCopy extends FactoryCheckCLDR {
             return Failure.ok;
         }
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-            value = cldrFile.getConstructedBaileyValue(path, null, null);
+            /*
+             * DANGER: the value of the "value" parameter is changed here -- potentially problematic
+             * for code understandability and maintainability, especially in the middle of a function
+             * that's too long to fit on the screen
+             */
+            value = cldrFile.getBaileyValue(path, null, null);
             if (value == null) {
                 return Failure.ok;
             }
@@ -165,7 +169,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
             return Failure.ok;
         }
         String value2 = value;
-        if (isExplicitBailey) {
+        if (topValueIsInheritanceMarker) {
             value2 = cldrFile.getConstructedValue(path);
             if (value2 == null) { // no special constructed value
                 value2 = value;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -363,7 +363,7 @@ public class ExampleGenerator {
         String result = null;
         try {
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-                value = cldrFile.getConstructedBaileyValue(xpath, null, null);
+                value = cldrFile.getBaileyValue(xpath, null, null);
                 if (value == null) {
                     /*
                      * This can happen for some paths, such as
@@ -2005,7 +2005,7 @@ public class ExampleGenerator {
                 if (value != null && !value.equals(type)) {
                     result = value;
                 } else {
-                    result = cldrFile.getConstructedBaileyValue(xpath, null, null);
+                    result = cldrFile.getBaileyValue(xpath, null, null);
                 }
             } else {
                 value = setBackground(value);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -442,11 +442,11 @@ public class ChartDelta extends Chart {
 
                                 currentValue = current.getStringValue(path);
                                 if (CldrUtility.INHERITANCE_MARKER.equals(currentValue)) {
-                                    currentValue = current.getConstructedBaileyValue(path, null, null);
+                                    currentValue = current.getBaileyValue(path, null, null);
                                 }
                                 oldValue = hasReformattedValue.value ? reformattedValue.value : old.getStringValue(path);
                                 if (CldrUtility.INHERITANCE_MARKER.equals(oldValue)) {
-                                    oldValue = old.getConstructedBaileyValue(path, null, null);
+                                    oldValue = old.getBaileyValue(path, null, null);
                                 }
                             }
                             if (highLevelOnly && new SuspiciousChange(oldValue, currentValue, path, locale).isDisruptive() == false) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindFlipFlops.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindFlipFlops.java
@@ -266,7 +266,7 @@ public class FindFlipFlops {
     private static String getProcessedStringValue(String xpath, CLDRFile file, DisplayAndInputProcessor processor) {
         String value = file.getStringValue(xpath);
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-            value = file.getConstructedBaileyValue(xpath, null, null);
+            value = file.getBaileyValue(xpath, null, null);
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
                 System.out.println("Warning: INHERITANCE_MARKER not resolved in FindFlipFlops: " + xpath);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -225,7 +225,7 @@ public class GenerateDerivedAnnotations {
 
                 // remove items that are the same as their bailey values. This also catches Inheritance Marker
 
-                String bailey = cldrFileResolved.getConstructedBaileyValue(xpath, null, null);
+                String bailey = cldrFileResolved.getBaileyValue(xpath, null, null);
                 if (value.equals(bailey)) {
                     toRemove.add(xpath);
                     continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -330,7 +330,7 @@ public class GenerateProductionData {
 
                 // remove items that are the same as their bailey values. This also catches Inheritance Marker
 
-                String bailey = cldrFileResolved.getConstructedBaileyValue(xpath, pathWhereFound, localeWhereFound);
+                String bailey = cldrFileResolved.getBaileyValue(xpath, pathWhereFound, localeWhereFound);
                 if (value.equals(bailey)
                     && (!ADD_SIDEWAYS
                         || pathEqualsOrIsAltVariantOf(xpath, pathWhereFound.value))

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -295,7 +295,7 @@ public class GetChanges {
 //                    continue;
 //                }
                 // skip inherited
-                String baileyValue = snapshot.getConstructedBaileyValue(xpath, pathWhereFound, localeWhereFound);
+                String baileyValue = snapshot.getBaileyValue(xpath, pathWhereFound, localeWhereFound);
                 if (!"root".equals(localeWhereFound.value)
                     && !"code-fallback".equals(localeWhereFound.value)
                     && CldrUtility.equals(valueSnapshot, baileyValue)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -614,7 +614,18 @@ public class VettingViewer<T> {
             if (ph == null || ph.shouldHide()) {
                 return;
             }
-            String value = sourceFile.getWinningValueForVettingViewer(path);
+            final String value = sourceFile.getWinningValueForVettingViewer(path);
+            final String otherValue = sourceFile.getWinningValue(path);
+            if (value == null) {
+                if (otherValue != null) {
+                    System.out.println("🏄‍♀️ handleOnePath: value is null but otherValue is not, for path " + path);
+                    System.out.println("otherValue: " + otherValue);
+                }
+            } else if (!value.equals(otherValue)) {
+                System.out.println("🏄‍♀️ handleOnePath: difference found for path " + path);
+                System.out.println("value: " + value);
+                System.out.println("otherValue: " + otherValue);
+            }
             statusMessage.setLength(0);
             subtypes.clear();
             ErrorChecker.Status errorStatus = errorChecker.getErrorStatus(path, value, statusMessage, subtypes);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -92,7 +92,7 @@ public class TestAlt extends TestFmwk {
         assertEquals("Regular, pathWhereFound", plain, pathWhereFound.value);
         assertEquals("Regular, localeWhereFound", "fr_CA", localeWhereFound.value);
 
-        String actualBailey = testCldrFile.getConstructedBaileyValue(plain+altMedium, pathWhereFound, localeWhereFound);
+        String actualBailey = testCldrFile.getBaileyValue(plain+altMedium, pathWhereFound, localeWhereFound);
         assertEquals("Bailey, " + plain+altMedium, expected, actualBailey);
         
         assertEquals("Bailey, pathWhereFound", plain, pathWhereFound.value);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -20,30 +20,14 @@ import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.LikelySubtags;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRFile.Status;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.PatternPlaceholders;
 import org.unicode.cldr.util.PatternPlaceholders.PlaceholderStatus;
-import org.unicode.cldr.util.SimpleFactory;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
@@ -642,25 +626,20 @@ public class TestCLDRFile extends TestFmwk {
         }
     }
 
-    public void TestConstructedBailey() {
+    public void TestConstructedValue() {
         CLDRFile eng = CLDRConfig.getInstance().getEnglish();
 
         String prefix = "//ldml/localeDisplayNames/languages/language[@type=\"";
-        String display = eng.getConstructedBaileyValue(prefix + "zh_Hans"
-            + "\"]", null, null);
-        assertEquals("contructed bailey", "Chinese (Simplified)", display);
-        display = eng.getConstructedBaileyValue(prefix + "es_US" + "\"]", null,
-            null);
-        assertEquals("contructed bailey", "Spanish (United States)", display);
-        display = eng.getConstructedBaileyValue(prefix + "es_US"
-            + "\"][@alt=\"short\"]", null, null);
-        assertEquals("contructed bailey", "Spanish (US)", display);
-        display = eng.getConstructedBaileyValue(prefix + "es" + "\"]", null,
-            null);
-        assertEquals("contructed bailey", "es", display);
-        display = eng.getConstructedBaileyValue(prefix + "missing" + "\"]",
-            null, null);
-        assertEquals("contructed bailey", null, display);
+        String display = eng.getConstructedValue(prefix + "zh_Hans" + "\"]");
+        assertEquals("contructed value", "Chinese (Simplified)", display);
+        display = eng.getConstructedValue(prefix + "es_US" + "\"]");
+        assertEquals("contructed value", "Spanish (United States)", display);
+        display = eng.getConstructedValue(prefix + "es_US" + "\"][@alt=\"short\"]");
+        assertEquals("contructed value", "Spanish (US)", display);
+        display = eng.getConstructedValue(prefix + "es" + "\"]");
+        assertEquals("contructed value", null, display);
+        display = eng.getConstructedValue(prefix + "missing" + "\"]");
+        assertEquals("contructed value", null, display);
     }
 
     public void TestFileLocations() {


### PR DESCRIPTION
-Remove getConstructedBaileyValue, call getBaileyValue instead

-In getBaileyValue, call getConstructed value if null or code fallback

-Add temporary debugging code in VettingViewer to compare getWinningValue and getWinningValueForVettingViewer

-Delete dead code in VoteAPIHelper

-Rename isExplicitBailey to topValueIsInheritanceMarker for clarity

-Comments

CLDR-13263

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
