### PR TITLE
CLDR-15653 LocaleCompletion: cache, concurrency, metrics

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -406,7 +406,7 @@ public class Summary {
         summary = "Fetch the Dashboard for a locale",
         description = "Given a locale, get the summary information, aka Dashboard")
     @Counted(name = "getDashboardCount", absolute = true, description = "Number of dashboards computed")
-    @Timed(absolute = true, name = "getDashboard", description = "Time to fetch the Dashboard")
+    @Timed(absolute = true, name = "getDashboardTime", description = "Time to fetch the Dashboard")
     @APIResponses(
         value = {
             @APIResponse(

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/api/TestLocaleCompletion.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/api/TestLocaleCompletion.java
@@ -98,7 +98,7 @@ public class TestLocaleCompletion {
         assertFalse(CheckCLDR.LIMITED_SUBMISSION, "This test becomes invalid if LIMITED_SUBMISSION (or SubmissionLocales) changes.");
 
         {
-            LocaleCompletionResponse completion = LocaleCompletion.getLocaleCompletion(locale, stf);
+            LocaleCompletionResponse completion = LocaleCompletion.handleGetLocaleCompletion(locale, stf);
 
             assertNotNull(completion);
             assertAll("tests on completion - not quite 100%",
@@ -149,7 +149,7 @@ public class TestLocaleCompletion {
         tc.invalidateAllCached();
 
         {
-            LocaleCompletionResponse completion = LocaleCompletion.getLocaleCompletion(locale, stf);
+            LocaleCompletionResponse completion = LocaleCompletion.handleGetLocaleCompletion(locale, stf);
 
             assertNotNull(completion);
             assertAll("tests on completio - 100%",


### PR DESCRIPTION
- update Summary (dashboard) for metric names
- add metrics to LocaleCompletion
- add a Cache to LocaleCompletion, that gets invalidated if any votes change

CLDR-15653

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
