### PR TITLE
CLDR-14064 Prevent submission of root annotation values/codes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
@@ -42,26 +42,13 @@ import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.PathValueInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.CoverageInfo;
-import org.unicode.cldr.util.LDMLUtilities;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SurveyToolStatus;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.PatternPlaceholders;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.VoteResolver.Status;
-import org.unicode.cldr.util.XMLSource;
-import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.web.DataSection.DataRow.CandidateItem;
 import org.unicode.cldr.web.UserRegistry.User;
 import org.unicode.cldr.web.api.VoteAPIHelper;
@@ -1303,7 +1290,7 @@ public class DataSection implements JSONString {
          * This is so that people can search for, e.g., "E12" to find rows for emoji that are new.
          */
         private void addAnnotationRootValue() {
-            if (xpath.startsWith("//ldml/annotations/annotation")) {
+            if (AnnotationUtil.pathIsAnnotation(xpath)) {
                 String rootValue = getRootFile().getStringValue(xpath);
                 if (rootValue != null && !rootValue.equals(inheritedValue)) {
                     /*

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -33,23 +33,11 @@ import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
-import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRConfig.Environment;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Emoji;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.LDMLUtilities;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.PathHeader;
-import org.unicode.cldr.util.SimpleXMLSource;
-import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.util.VoteResolver.Status;
-import org.unicode.cldr.util.XMLFileReader;
-import org.unicode.cldr.util.XMLSource;
-import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.XPathParts.Comments;
 import org.unicode.cldr.web.CLDRProgressIndicator.CLDRProgressTask;
 import org.unicode.cldr.web.SurveyException.ErrorCode;
@@ -918,7 +906,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
              * Note: this does not affect the occurrences of "new VoteResolver" in ConsoleCheckCLDR.java or TestUtilities.java;
              * if those tests ever involve annotation keywords, they could call setUsingKeywordAnnotationVoting as needed.
              */
-            r.setUsingKeywordAnnotationVoting(path.startsWith("//ldml/annotations/annotation") && !path.contains(Emoji.TYPE_TTS));
+            r.setUsingKeywordAnnotationVoting(AnnotationUtil.pathIsAnnotation(path) && !path.contains(Emoji.TYPE_TTS));
 
             final ValueChecker vc = ERRORS_ALLOWED_IN_VETTING ? null : new ValueChecker(path);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -5,15 +5,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.Status;
-import org.unicode.cldr.util.CLDRURLS;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.InternalCldrException;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.RegexLookup;
-import org.unicode.cldr.util.XPathParts;
 
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
@@ -171,18 +164,37 @@ public class CheckForCopy extends FactoryCheckCLDR {
                 value2 = value;
             }
         }
+        if (reallySameAsCode(path, value2)) {
+            return Failure.same_as_code;
+        }
+        return failure;
+    }
 
+    private static boolean reallySameAsCode(String path, String value) {
+        if (AnnotationUtil.pathIsAnnotation(path)) {
+            return AnnotationUtil.matchesCode(value);
+        } else {
+            return sameAsCodePerAttributes(path, value);
+        }
+    }
+
+    /**
+     * Does the given value match the "code" for the given path?
+     *
+     * @param path like //ldml/localeDisplayNames/languages/language[@type="ace"]
+     * @param value like "ace"
+     * @return true if value matches one of the attributes in path
+     */
+    private static boolean sameAsCodePerAttributes(String path, String value) {
         XPathParts parts = XPathParts.getFrozenInstance(path);
-
         int elementCount = parts.size();
         for (int i = 2; i < elementCount; ++i) {
             Map<String, String> attributes = parts.getAttributes(i);
             for (Entry<String, String> attributeEntry : attributes.entrySet()) {
                 final String attributeValue = attributeEntry.getValue();
                 try {
-                    if (value2.equals(attributeValue)) {
-                        failure = Failure.same_as_code;
-                        break;
+                    if (value.equals(attributeValue)) {
+                        return true;
                     }
                 } catch (NullPointerException e) {
                     throw new ICUException("Value: " + value + "\nattributeValue: " + attributeValue
@@ -190,7 +202,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
                 }
             }
         }
-        return failure;
+        return false;
     }
 
     private static boolean sameAsEnglishOK(String loc, String path, String value) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNew.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNew.java
@@ -2,11 +2,10 @@ package org.unicode.cldr.test;
 
 import java.util.Date;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.tool.CldrVersion;
+import org.unicode.cldr.util.AnnotationUtil;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.Factory;
 
@@ -31,20 +30,18 @@ public class CheckNew extends FactoryCheckCLDR {
         return this;
     }
 
-    static final Pattern BAD_EMOJI = Pattern.compile("E\\d+(\\.\\d+)?-\\d+");
-
     @Override
     public CheckCLDR handleCheck(String path, String fullPath, String value, Options options,
         List<CheckStatus> result) {
 
         CLDRFile cldrFileToCheck = getCldrFileToCheck();
+        // don't check inherited values
+        // first see if the value is inherited or not
         if (!isRoot
             && value != null
-            && path.startsWith("//ldml/annotations/annotation")
-            && cldrFileToCheck.getUnresolved().getStringValue(path) != null) { // don't check inherited values
-            // first see if the value is inherited or not
-            Matcher matcher = BAD_EMOJI.matcher(value);
-            if (matcher.matches()) {
+            && AnnotationUtil.pathIsAnnotation(path)
+            && cldrFileToCheck.getUnresolved().getStringValue(path) != null) {
+            if (AnnotationUtil.matchesCode(value)) {
                 result.add(new CheckStatus().setCause(this)
                     .setMainType(CheckStatus.errorType)
                     .setSubtype(Subtype.valueMustBeOverridden)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -14,20 +14,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CheckExemplars.ExemplarType;
-import org.unicode.cldr.util.Builder;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.DateTimeCanonicalizer;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
-import org.unicode.cldr.util.Emoji;
-import org.unicode.cldr.util.ICUServiceBuilder;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
-import org.unicode.cldr.util.With;
-import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -520,7 +508,7 @@ public class DisplayAndInputProcessor {
                 value = normalizeHyphens(value);
             }
 
-            if (path.startsWith("//ldml/annotations/annotation")) {
+            if (AnnotationUtil.pathIsAnnotation(path)) {
                 if (path.contains(Emoji.TYPE_TTS)) {
                     // The row has something like "🦓 -name" in the first column. Cf. namePath, getNamePaths.
                     // Normally the value is like "zebra" or "unicorn face", without "|".

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -21,37 +21,17 @@ import java.util.regex.Pattern;
 import org.unicode.cldr.tool.CLDRFileTransformer;
 import org.unicode.cldr.tool.CLDRFileTransformer.LocaleTransform;
 import org.unicode.cldr.tool.LikelySubtags;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.DayPeriodInfo;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
-import org.unicode.cldr.util.EmojiConstants;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
-import org.unicode.cldr.util.ICUServiceBuilder;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.PathDescription;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.PluralSamples;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
-import org.unicode.cldr.util.TransliteratorUtilities;
-import org.unicode.cldr.util.UnitConverter;
-import org.unicode.cldr.util.Units;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 import org.unicode.cldr.util.XListFormatter.ListTypeLength;
-import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.FallbackFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.FormatParameters;
@@ -2359,7 +2339,7 @@ public class ExampleGenerator {
         if (listPlaceholders) {
             buffer.append(pathDescription.getPlaceholderDescription(xpath));
         }
-        if (xpath.startsWith("//ldml/annotations/annotation")) {
+        if (AnnotationUtil.pathIsAnnotation(xpath)) {
             XPathParts emoji = XPathParts.getFrozenInstance(xpath);
             String cp = emoji.getAttributeValue(-1, "cp");
             String minimal = Utility.hex(cp.replace("", "")).replace(',', '_').toLowerCase(Locale.ROOT);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -19,19 +19,7 @@ import java.util.regex.Pattern;
 
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.tool.Option.Params;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.LogicalGrouping;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.XMLSource;
-import org.unicode.cldr.util.XPathParts;
+import org.unicode.cldr.util.*;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -317,7 +305,7 @@ public class GenerateProductionData {
                 // special-case the root values that are only for Survey Tool use
 
                 if (isRoot) {
-                    if (xpath.startsWith("//ldml/annotations/annotation")) {
+                    if (AnnotationUtil.pathIsAnnotation(xpath)) {
                         toRemove.add(xpath);
                         continue;
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/AnnotationUtil.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/AnnotationUtil.java
@@ -1,0 +1,23 @@
+package org.unicode.cldr.util;
+
+import java.util.regex.Pattern;
+
+public class AnnotationUtil {
+    private static final String PATH_PREFIX = "//ldml/annotations/annotation";
+
+    private static final Pattern BAD_EMOJI = Pattern.compile("E\\d+(\\.\\d+)?-\\d+");
+
+    /**
+     * Does the given value match an annotation code like "E10-840"?
+     *
+     * @param value like "E10-836" (bad) or "grinning face" (good)
+     * @return true if value matches a code (bad), else false (good)
+     */
+    public static boolean matchesCode(String value) {
+        return BAD_EMOJI.matcher(value).matches();
+    }
+
+    public static boolean pathIsAnnotation(String path) {
+        return path.startsWith(PATH_PREFIX);
+    }
+}


### PR DESCRIPTION
-Revise CheckForCopy to recognize annotation codes like E10-836

-Move some code into new methods

-New class AnnotationUtil.java encapsulates info about annotation paths/values

-Revise import statements, done automatically by IntelliJ

CLDR-14064

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
