### PR TITLE
CLDR-15652 integration cleanups: preserve space in foreignSpaceReplacement

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3170,6 +3170,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT foreignSpaceReplacement ( #PCDATA ) >
+<!ATTLIST foreignSpaceReplacement xml:space (default | preserve) "preserve" >
+    <!--@VALUE-->
 <!ATTLIST foreignSpaceReplacement alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST foreignSpaceReplacement draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5414,7 +5414,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<personNames>
 		<nameOrderLocales order="givenFirst">und</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">hu ja ko vi yue zh</nameOrderLocales>
-		<foreignSpaceReplacement/>
+		<foreignSpaceReplacement xml:space="preserve"> </foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -930,6 +930,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="personNames/nameOrderLocales[@order='%anyAttribute']"/>
+		<coverageLevel value="modern" match="personNames/foreignSpaceReplacement[@xml:space='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel value="modern" match="personNames/foreignSpaceReplacement[@xml:space='%anyAttribute']"/>
 		<coverageLevel value="modern" match="personNames/foreignSpaceReplacement[@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="personNames/foreignSpaceReplacement"/>
 		<coverageLevel value="modern" match="personNames/initialPattern[@type='%anyAttribute'][@alt='%anyAttribute']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/api/AttributeKey.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/api/AttributeKey.java
@@ -92,9 +92,9 @@ public final class AttributeKey {
         // 1) we don't expect the attribute name to have a namespace either,
         // 2) the attribute key should be in our cache of known instances.
         if (elementName.indexOf(':') == -1) {
-            checkArgument(attributeName.indexOf(':') == -1,
-                "attributes in an external namespace cannot be present in elements in the default"
-                    + " namespace: %s:%s",
+            checkArgument((attributeName.startsWith("xml:") || attributeName.indexOf(':') == -1),
+                "attributes in an external namespace other than xml: cannot be present in"
+                    + " elements in the default namespace: %s:%s",
                 elementName, attributeName);
             return checkNotNull(KNOWN_KEYS.get(elementName, attributeName),
                 "unknown attribute (was it deprecated?): %s:%s",

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -429,8 +429,10 @@ public class DisplayAndInputProcessor {
                 value = normalizeWhitespace(path, value);
             }
 
-            // all of our values should not have leading or trailing spaces, except insertBetween
-            if (!path.contains("/insertBetween") && !isUnicodeSet) {
+            // all of our values should not have leading or trailing spaces, except insertBetween,
+            // foreignSpaceReplacement, and anything with 
+            if (!path.contains("/insertBetween") && !path.contains("/foreignSpaceReplacement") &&
+                !path.contains("[@xml:space=\"preserve\"]") && !isUnicodeSet) {
                 value = value.trim();
             }
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -292,6 +292,8 @@
 
 //ldml/personNames/nameOrderLocales[@order=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1-$2
 //ldml/personNames/nameOrderLocales[@order=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(NameOrder) ; $1
+//ldml/personNames/foreignSpaceReplacement[@xml:space=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; foreignSpaceReplacement-$2
+//ldml/personNames/foreignSpaceReplacement[@xml:space=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; foreignSpaceReplacement
 //ldml/personNames/foreignSpaceReplacement[@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; foreignSpaceReplacement-$1
 //ldml/personNames/foreignSpaceReplacement   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; foreignSpaceReplacement
 //ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; pattern-$1-$2

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -191,6 +191,8 @@ public class TestExampleGenerator extends TestFmwk {
         "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard", // Error: (TestExampleGenerator.java:245) No background:   <Coordinated Universal Time>    〖Coordinated Universal Time〗
 
         "//ldml/personNames/nameOrderLocales[@order=\"([^\"]*+)\"]", // TODO CLDR-15384
+        "//ldml/personNames/foreignSpaceReplacement[@xml:space=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // TODO CLDR-15384
+        "//ldml/personNames/foreignSpaceReplacement[@xml:space=\"([^\"]*+)\"]", // TODO CLDR-15384
         "//ldml/personNames/foreignSpaceReplacement[@alt=\"([^\"]*+)\"]", // TODO CLDR-15384
         "//ldml/personNames/foreignSpaceReplacement", // TODO CLDR-15384
         "//ldml/personNames/initialPattern[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]", // TODO CLDR-15384


### PR DESCRIPTION
CLDR-15652

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Need to preserve a space as the value of the foreignSpaceReplacement element (it was getting stripped by e.g. CLDRModify -fp). There are a couple of issues:
- XML behavior for handling spaces (mainly an issue for third party clients of CLDR data). There is a standard xml:space attribute for controlling whether spaces are preserved in values.
- DAIP behavior. DAIP stripped except for hardcoded paths. Added foreignSpaceReplacement to that list but also made it pay attention to xml:space.

After fixing the above, restore the root value of foreignSpaceReplacement to be space.