### PR TITLE
CLDR-15508 Spanish numbers use thin space for group

### DIFF
--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -5796,7 +5796,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<minimumGroupingDigits>2</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
-			<group>.</group>
+			<group> </group>
 			<list>;</list>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>


### PR DESCRIPTION
[CLDR-15508](https://unicode-org.atlassian.net/browse/CLDR-15508)

- [x] This PR completes the ticket.

It replace `.` group separator by thin space (unicode U+2009)