### PR TITLE
CLDR-15646 Priority Items: avoid flicker and phantom fetch

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrPriorityItems.js
+++ b/tools/cldr-apps/js/src/esm/cldrPriorityItems.js
@@ -78,10 +78,16 @@ function viewCreated(setData, setSnap) {
 }
 
 function fetchStatus() {
-  if (canSnap) {
-    listSnapshots();
+  if (!canSum || "vsummary" !== cldrStatus.getCurrentSpecial()) {
+    canSum = canSnap = canCreateSnap = false;
+    return;
   }
-  requestSummary(new SummaryArgs(latestArgs, LOAD_NOSTART));
+  if (canSum) {
+    if (canSnap) {
+      listSnapshots();
+    }
+    requestSummary(new SummaryArgs(latestArgs, LOAD_NOSTART));
+  }
 }
 
 function start() {
@@ -144,13 +150,17 @@ function listSnapshots() {
     .catch((error) => console.log(error));
 }
 
+function snapshotIdIsValid(snapshotId) {
+  return snapshotId && snapshotId !== SNAPID_NOT_APPLICABLE;
+}
+
 export {
-  SNAPID_NOT_APPLICABLE,
   canCreateSnapshots,
   canUseSnapshots,
   canUseSummary,
   createSnapshot,
   showSnapshot,
+  snapshotIdIsValid,
   start,
   stop,
   viewCreated,

--- a/tools/cldr-apps/js/src/views/VettingSummary.vue
+++ b/tools/cldr-apps/js/src/views/VettingSummary.vue
@@ -25,7 +25,7 @@
         Create New Summary
       </button>
     </p>
-    <section v-if="canUseSnapshots" class="snapSection">
+    <section v-if="snapshotsAreReady" class="snapSection">
       <h2 class="snapHeading">Snapshots</h2>
       <p>
         <button
@@ -67,6 +67,7 @@ export default {
       output: null,
       percent: 0,
       snapshotArray: null,
+      snapshotsAreReady: false,
       status: null,
       whenReceived: null,
     };
@@ -110,6 +111,9 @@ export default {
         this.heading = this.makeHeading(data.snapshotId);
         this.helpMessage = this.makeHelp(data.snapshotId);
         this.whenReceived = this.makeWhenReceived(data.snapshotId);
+        this.snapshotsAreReady =
+          this.canUseSnapshots &&
+          cldrPriorityItems.snapshotIdIsValid(data.snapshotId);
       }
     },
 
@@ -117,10 +121,7 @@ export default {
       if (!this.output) {
         return null;
       }
-      if (
-        snapshotId &&
-        snapshotId !== cldrPriorityItems.SNAPID_NOT_APPLICABLE
-      ) {
+      if (cldrPriorityItems.snapshotIdIsValid(snapshotId)) {
         return null;
       } else {
         // only show "when received" if it's not a snapshot
@@ -132,10 +133,7 @@ export default {
       if (!this.output) {
         return null;
       }
-      if (
-        snapshotId &&
-        snapshotId !== cldrPriorityItems.SNAPID_NOT_APPLICABLE
-      ) {
+      if (cldrPriorityItems.snapshotIdIsValid(snapshotId)) {
         return "Snapshot " + snapshotId;
       } else if (this.canUseSnapshots) {
         return "Latest (not a snapshot)";
@@ -149,10 +147,7 @@ export default {
         return null;
       }
       let help = cldrText.get("summary_help") + " ";
-      if (
-        snapshotId &&
-        snapshotId !== cldrPriorityItems.SNAPID_NOT_APPLICABLE
-      ) {
+      if (cldrPriorityItems.snapshotIdIsValid(snapshotId)) {
         help += cldrText.get("summary_coverage_neutral");
       } else {
         help += cldrText.get("summary_coverage_org_specific");
@@ -162,8 +157,15 @@ export default {
 
     setSnapshots(snapshots) {
       this.snapshotArray = snapshots.array.sort().reverse();
-      if (!this.output && this.snapshotArray[0]) {
-        this.showSnapshot(this.snapshotArray[0]);
+      if (!this.output) {
+        if (this.snapshotArray[0]) {
+          // request this most recent snapshot from the back end
+          // -- wait until get response to set snapshotsAreReady
+          this.showSnapshot(this.snapshotArray[0]);
+        } else {
+          // no snapshots are available; we're ready to show the empty menu
+          this.snapshotsAreReady = this.canUseSnapshots;
+        }
       }
     },
 


### PR DESCRIPTION
-New snapshotsAreReady in VettingSummary.vue, false while awaiting recent snapshot

-New method cldrPriorityItems.snapshotIdIsValid; make SNAPID_NOT_APPLICABLE private

-Revise cldrPriorityItems.fetchStatus to stop when vsummary no longer current special

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
