### PR TITLE
CLDR-15628 Handle non-numeric placeholders for personName nameField, add descriptions

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PatternPlaceholders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PatternPlaceholders.java
@@ -17,7 +17,8 @@ public class PatternPlaceholders {
         DISALLOWED("No placeholders allowed."),//
         REQUIRED("Specific number of placeholders allowed."),//
         LOCALE_DEPENDENT("Some placeholders may be omitted in certain locales"),//
-        MULTIPLE("May have multiple instances of the same placeholder, eg “{0} cats and {0} dogs”.")//
+        MULTIPLE("May have multiple instances of the same placeholder, eg “{0} cats and {0} dogs”."),//
+        OPTIONAL("Any specific placeholder is optional (and non-numeric); there must be at least one.")//
         ;
 
         private final String message;
@@ -94,6 +95,9 @@ public class PatternPlaceholders {
                     case "multiple":
                         result.status = PlaceholderStatus.MULTIPLE;
                         continue;
+                    case "optional":
+                        result.status = PlaceholderStatus.OPTIONAL;
+                        continue;
                     default:
                         int equalsPos = part.indexOf('=');
                         String id = part.substring(0, equalsPos).trim();
@@ -106,6 +110,12 @@ public class PatternPlaceholders {
                         } else {
                             example = "";
                         }
+                        // TODO Some normalization of personName namePattern placeholder ids.
+                        // Hack for now, later do something maybe using PersonNameFormatter.ModifiedField
+                        id = id.replace("-allCaps", "");
+                        id = id.replace("-initialCap", "");
+                        id = id.replace("-initial", "");
+                        id = id.replace("-monogram", "");
 
                         PlaceholderInfo old = result.data.get(id);
                         if (old != null) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -4,6 +4,7 @@
 # That default is overridden if the line has as the X parameter: locale or multiple.
 #	locale: there is a count= or ordinal=, so the value is subject to the locale; may be zero or one.
 #	multiple: there may be zero or more placeholders (normally only in count or ordinal minimalPairs)
+#	optional: there may be one or more placeholders; and they have alpha ids, not numeric ids.
 
 %A = [^"]*+
 %L = (long|short|narrow)
@@ -250,4 +251,4 @@
 
 //ldml/personNames/initialPattern\[@type="initial"] ; {0}=NAME_INITIAL J
 //ldml/personNames/initialPattern\[@type="initialSequence"] ; {0}=PREVIOUS_NAME_INITIALS J.R.; {1}=ADD_NAME_INITIAL R.
-
+//ldml/personNames/personName\[@order="%A"]\[@length="%A"]\[@usage="%A"]\[@formality="%A"]/namePattern ; optional ; {prefix}=NAME_PREFIX Dr. ; {given}=GIVEN_NAME Cornelia ; {given-informal}=INFORMAL_NAME Neele ; {given2}=GIVEN_NAME_2 Sophia ; {surname}=SURNAME van den Wolf ; {surname-prefix}=SURNAME_PREFIX van den ; {surname-core}=SURNAME_CORE Wolf ; {surname2}=SURNAME_2 Becker ; {suffix}=NAME_SUFFIX >M.D.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -275,7 +275,11 @@ public class TestCheckCLDR extends TestFmwk {
         // given "?"
         // and that every non-pattern doesn't have an error in CheckCLDR for
         // patterns when given "?"
-        Matcher messagePlaceholder = PatternCache.get("\\{\\d+\\}").matcher("");
+        //
+        // For the following: traditional placeholders just have {0}, {1}, {2}, ...
+        // But personName namePattern placeHolders start with [a-z], then continue with [0-9a-zA-Z-]+
+        // They need to be distinguished from non-placeholder patterns using {} in UnicodeSets
+        Matcher messagePlaceholder = CheckForExemplars.PLACEHOLDER.matcher("");
         PatternPlaceholders patternPlaceholders = PatternPlaceholders
             .getInstance();
 
@@ -296,6 +300,11 @@ public class TestCheckCLDR extends TestFmwk {
 
         for (PathHeader pathHeader : sorted) {
             String path = pathHeader.getOriginalPath();
+            if (path.contains("/exemplarCharacters") || path.contains("/parseLenients")) {
+                // skip some paths with UnicodeSets that may include {} constructs
+                // that should not be interpreted as placeholders
+                continue;
+            }
             String value = cldrFileToTest.getStringValue(path);
             if (value == null) {
                 continue;
@@ -323,7 +332,7 @@ public class TestCheckCLDR extends TestFmwk {
                 } while (messagePlaceholder.find());
 
                 if (!found.equals(placeholderInfo.keySet())) {
-                    if (placeholderStatus != PlaceholderStatus.LOCALE_DEPENDENT) {
+                    if (placeholderStatus != PlaceholderStatus.LOCALE_DEPENDENT && placeholderStatus != PlaceholderStatus.OPTIONAL) {
                         errln(cldrFileToTest.getLocaleID() + " Value (" + value + ") has different placeholders than placeholder info «" + placeholderInfo.keySet() + "»\t" + path);
                     }
                 } else {


### PR DESCRIPTION
CLDR-15628

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Handle non-numeric placeholders for personName nameField, add descriptions:
- Change regex for matching placeholders to accommodate the personName nameField style of placeholder
- Add new PlaceholderStatus OPTIONAL("Any specific placeholder is optional (and non-numeric); there must be at least one.")
- For a first pass, when generating placeholder id ignore some of the modifiers to allow one description to handle various modifier combinations.
- Add the placeholder descriptions for {prefix} {given} {given-informal} {given2} {surname} {surname-prefix} {surname-core} {surname2} {suffix} (in any combination with ignored modifiers -allCaps -initialCap -initial -monogram)
