### PR TITLE
CLDR-13263 Merge getConstructedBaileyValue and getBaileyValue

### DIFF
--- a/common/main/uz_Cyrl.xml
+++ b/common/main/uz_Cyrl.xml
@@ -122,7 +122,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="gl">галицийча</language>
 			<language type="gn">гуарани</language>
 			<language type="gor">горонтало</language>
-			<language type="gsw">немисча (Швейцария)</language>
 			<language type="gu">гужаротча</language>
 			<language type="guz">гусии</language>
 			<language type="gv">мэнча</language>

--- a/seed/main/syr.xml
+++ b/seed/main/syr.xml
@@ -31,7 +31,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="en_US">↑↑↑</language>
 			<language type="en_US" alt="short" draft="unconfirmed">ܐܢܓܠܝܼܫ ܕܐܘܚܕ̈ܢܐ ܡܚܝܕ̈ܐ</language>
 			<language type="es">ܣܦܢܝܝܐ</language>
-			<language type="es_419">↑↑↑</language>
 			<language type="es_ES">↑↑↑</language>
 			<language type="es_MX">↑↑↑</language>
 			<language type="fr">ܦܪܢܣܝܬ݂</language>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataSection.java
@@ -678,7 +678,7 @@ public class DataSection implements JSONString {
          *
          * Sequential order in which addItem may be called (as of 2019-04-19) for a given DataRow:
          *
-         * (1) For INHERITANCE_MARKER (if inheritedValue = ourSrc.getConstructedBaileyValue not null):
+         * (1) For INHERITANCE_MARKER (if inheritedValue = ourSrc.getBaileyValue not null):
          *     in updateInheritedValue (called by populateFromThisXpath):
          *         inheritedItem = addItem(CldrUtility.INHERITANCE_MARKER, "inherited");
          *
@@ -891,7 +891,7 @@ public class DataSection implements JSONString {
              */
             Output<String> inheritancePathWhereFound = new Output<>(); // may become pathWhereFound
             Output<String> localeWhereFound = new Output<>(); // may be used to construct inheritedLocale
-            inheritedValue = ourSrc.getConstructedBaileyValue(xpath, inheritancePathWhereFound, localeWhereFound);
+            inheritedValue = ourSrc.getBaileyValue(xpath, inheritancePathWhereFound, localeWhereFound);
 
             if (TRACE_TIME) {
                 System.err.println("@@1:" + (System.currentTimeMillis() - lastTime));
@@ -908,7 +908,7 @@ public class DataSection implements JSONString {
                  * xpath = //ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMMMEEEEd"]
                  * ourValueIsInherited = false; ourValue = "EEEE, d/MM/y"; isExtraPath = false
                  *
-                 * TODO: what are the implications when ourSrc.getConstructedBaileyValue has returned null?
+                 * TODO: what are the implications when ourSrc.getBaileyValue has returned null?
                  * Unless we're at root, shouldn't there always be a non-null inheritedValue here?
                  * See https://unicode.org/cldr/trac/ticket/11299
                  */
@@ -1061,7 +1061,10 @@ public class DataSection implements JSONString {
         }
 
         public String getInheritedXPath() {
-            return (pathWhereFound != null) ? XPathTable.getStringIDString(pathWhereFound) : null;
+            if (pathWhereFound != null && !pathWhereFound.equals(GlossonymConstructor.PSEUDO_PATH)) {
+                return XPathTable.getStringIDString(pathWhereFound);
+            }
+            return null;
         }
 
         private String getWinningVHash() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -922,7 +922,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             }
 
             CLDRFile cf = make(locale, true);
-            r.setBaileyValue(cf.getConstructedBaileyValue(path, null, null));
+            r.setBaileyValue(cf.getBaileyValue(path, null, null));
 
             // add each vote
             if (perXPathData != null && !perXPathData.isEmpty()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -312,18 +312,7 @@ public class VoteAPIHelper {
         if (val != null) {
             try (SurveyMain.UserLocaleStuff uf = sm.getUserFile(mySession, locale);) {
                 final CLDRFile file = uf.cldrfile;
-                final String checkval = val;
-                if (CldrUtility.INHERITANCE_MARKER.equals(val)) {
-                    final Output<String> localeWhereFound = new Output<>();
-                    /*
-                     * TODO: this looks dubious, see https://unicode.org/cldr/trac/ticket/11299
-                     * temporarily for debugging, don't change checkval, but do call
-                     * getBaileyValue in order to get localeWhereFound
-                     */
-                    // checkval = file.getBaileyValue(xp, null, localeWhereFound);
-                    file.getBaileyValue(xp, null, localeWhereFound);
-                }
-                cc.check(xp, result, checkval);
+                cc.check(xp, result, val);
                 r.dataEmpty = file.isEmpty();
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -402,9 +402,13 @@ public class Ldml2JsonConverter {
             final String path = it.next();
             String fullPath = file.getFullXPath(path);
             String value = file.getWinningValue(path);
+            /*
+             * TODO: check whether this next block is superfluous, and remove it if so
+             * Reference: https://unicode-org.atlassian.net/browse/CLDR-13263
+             */
             if (path.startsWith("//ldml/localeDisplayNames/languages") &&
                 file.getSourceLocaleID(path, null).equals("code-fallback")) {
-                value = file.getConstructedBaileyValue(path, null, null);
+                value = file.getBaileyValue(path, null, null);
             }
 
             if (fullPath == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -1115,7 +1115,7 @@ abstract public class CheckCLDR {
         // If we're being asked to run tests for an inheritance marker, then we need to change it
         // to the "real" value first before running tests. Testing the value CldrUtility.INHERITANCE_MARKER ("↑↑↑") doesn't make sense.
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-            value = cldrFileToCheck.getConstructedBaileyValue(path, null, null);
+            value = cldrFileToCheck.getBaileyValue(path, null, null);
             // If it hasn't changed, then don't run any tests.
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
                 return this;
@@ -1212,7 +1212,7 @@ abstract public class CheckCLDR {
             // If we're being asked to run tests for an inheritance marker, then we need to change it
             // to the "real" value first before running tests. Testing the value CldrUtility.INHERITANCE_MARKER ("↑↑↑") doesn't make sense.
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-                value = getCldrFileToCheck().getConstructedBaileyValue(path, null, null);
+                value = getCldrFileToCheck().getBaileyValue(path, null, null);
             }
             for (Iterator<CheckCLDR> it = filteredCheckList.iterator(); it.hasNext();) {
                 CheckCLDR item = it.next();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -108,13 +108,12 @@ public class CheckForCopy extends FactoryCheckCLDR {
          * otherwise nothing prevents voting to inherit the code value.
          *
          * TODO: clarify the purpose of using topStringValue and getConstructedValue here;
-         * cf. getConstructedBaileyValue. This code is confusing and warrants explanation.
-         * The meaning of "explicit" here seems to be the opposite of its meaning elsewhere.
+         * This code is confusing and warrants explanation.
          */
         String topStringValue = unresolvedFile.getStringValue(path);
-        final boolean isExplicitBailey = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
+        final boolean topValueIsInheritanceMarker = CldrUtility.INHERITANCE_MARKER.equals(topStringValue);
         String loc = cldrFile.getSourceLocaleID(path, status);
-        if (!contextIsVoteSubmission && !isExplicitBailey) {
+        if (!contextIsVoteSubmission && !topValueIsInheritanceMarker) {
             if (!cldrFile.getLocaleID().equals(loc)
                 || !path.equals(status.pathWhereFound)) {
                 return Failure.ok;
@@ -149,7 +148,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
             return Failure.ok;
         }
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-            value = cldrFile.getConstructedBaileyValue(path, null, null);
+            value = cldrFile.getBaileyValue(path, null, null);
             if (value == null) {
                 return Failure.ok;
             }
@@ -158,7 +157,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
             return Failure.ok;
         }
         String value2 = value;
-        if (isExplicitBailey) {
+        if (topValueIsInheritanceMarker) {
             value2 = cldrFile.getConstructedValue(path);
             if (value2 == null) { // no special constructed value
                 value2 = value;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
@@ -45,6 +45,11 @@ public class CheckNames extends CheckCLDR {
         return this;
     }
 
+    public static boolean matchDigitPattern(String value) {
+        Matcher matcher = YEAR_PATTERN.matcher(value);
+        return matcher.find();
+    }
+
     private boolean isEnclosedByBraces(Matcher matcher, String value, char startBrace, char endBrace) {
         return value.lastIndexOf(startBrace, matcher.start()) > -1 &&
             value.indexOf(endBrace, matcher.end()) >= -1;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -343,7 +343,7 @@ public class ExampleGenerator {
         String result = null;
         try {
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-                value = cldrFile.getConstructedBaileyValue(xpath, null, null);
+                value = cldrFile.getBaileyValue(xpath, null, null);
                 if (value == null) {
                     /*
                      * This can happen for some paths, such as
@@ -1985,7 +1985,7 @@ public class ExampleGenerator {
                 if (value != null && !value.equals(type)) {
                     result = value;
                 } else {
-                    result = cldrFile.getConstructedBaileyValue(xpath, null, null);
+                    result = cldrFile.getBaileyValue(xpath, null, null);
                 }
             } else {
                 value = setBackground(value);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -442,11 +442,11 @@ public class ChartDelta extends Chart {
 
                                 currentValue = current.getStringValue(path);
                                 if (CldrUtility.INHERITANCE_MARKER.equals(currentValue)) {
-                                    currentValue = current.getConstructedBaileyValue(path, null, null);
+                                    currentValue = current.getBaileyValue(path, null, null);
                                 }
                                 oldValue = hasReformattedValue.value ? reformattedValue.value : old.getStringValue(path);
                                 if (CldrUtility.INHERITANCE_MARKER.equals(oldValue)) {
-                                    oldValue = old.getConstructedBaileyValue(path, null, null);
+                                    oldValue = old.getBaileyValue(path, null, null);
                                 }
                             }
                             if (highLevelOnly && new SuspiciousChange(oldValue, currentValue, path, locale).isDisruptive() == false) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindFlipFlops.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindFlipFlops.java
@@ -266,7 +266,7 @@ public class FindFlipFlops {
     private static String getProcessedStringValue(String xpath, CLDRFile file, DisplayAndInputProcessor processor) {
         String value = file.getStringValue(xpath);
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
-            value = file.getConstructedBaileyValue(xpath, null, null);
+            value = file.getBaileyValue(xpath, null, null);
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
                 System.out.println("Warning: INHERITANCE_MARKER not resolved in FindFlipFlops: " + xpath);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -225,7 +225,7 @@ public class GenerateDerivedAnnotations {
 
                 // remove items that are the same as their bailey values. This also catches Inheritance Marker
 
-                String bailey = cldrFileResolved.getConstructedBaileyValue(xpath, null, null);
+                String bailey = cldrFileResolved.getBaileyValue(xpath, null, null);
                 if (value.equals(bailey)) {
                     toRemove.add(xpath);
                     continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -318,7 +318,7 @@ public class GenerateProductionData {
 
                 // remove items that are the same as their bailey values. This also catches Inheritance Marker
 
-                String bailey = cldrFileResolved.getConstructedBaileyValue(xpath, pathWhereFound, localeWhereFound);
+                String bailey = cldrFileResolved.getBaileyValue(xpath, pathWhereFound, localeWhereFound);
                 if (value.equals(bailey)
                     && (!ADD_SIDEWAYS
                         || pathEqualsOrIsAltVariantOf(xpath, pathWhereFound.value))

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -295,7 +295,7 @@ public class GetChanges {
 //                    continue;
 //                }
                 // skip inherited
-                String baileyValue = snapshot.getConstructedBaileyValue(xpath, pathWhereFound, localeWhereFound);
+                String baileyValue = snapshot.getBaileyValue(xpath, pathWhereFound, localeWhereFound);
                 if (!"root".equals(localeWhereFound.value)
                     && !"code-fallback".equals(localeWhereFound.value)
                     && CldrUtility.equals(valueSnapshot, baileyValue)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
@@ -1,0 +1,124 @@
+package org.unicode.cldr.util;
+
+import com.ibm.icu.util.Output;
+import org.unicode.cldr.test.CheckNames;
+
+/**
+ * Automatically construct language names (glossonyms)
+ *
+ * Example: in German (de), for the path
+ *
+ *       //ldml/localeDisplayNames/languages/language[@type="ro_MD"]
+ *
+ * the value "Rumänisch (Republik Moldau)" is automatically constructed based on the code "ro_MD".
+ *
+ * The constructed value is a default if no preferable value is submitted or inherited.
+ * A different (non-constructed) value, such as "Moldauisch", may become the winning
+ * value instead of the constructed value.
+ */
+public class GlossonymConstructor {
+
+    /**
+     * Some paths with this prefix can get automatically constructed values
+     */
+    public static final String PATH_PREFIX = "//ldml/localeDisplayNames/languages/language[@type=\"";
+
+    /**
+     * The code such as "ro_MD" must contain an underscore, otherwise there is no constructed value.
+     * Underscore also serves as a clue for recognizing a value that is from code-fallback; for example,
+     * when the value "ro_MD" is inherited, the underscore implies it's a raw code ("bogus value") and should
+     * be replaced by a constructed value like "Rumänisch (Republik Moldau)"; but when the value "Moldauisch"
+     * (without underscore) is inherited, it should not be replaced by a constructed value
+     */
+    private static final String CODE_SEPARATOR = "_";
+
+    /**
+     * For "pathWhereFound" when the value is constructed.
+     * It is non-null to satisfy TestPathHeadersAndValues.
+     * It should not be treated as an actual path; for example, the
+     * Survey Tool Info Panel should not show a broken "Jump to original" link.
+     */
+    public static final String PSEUDO_PATH = "constructed";
+
+    /**
+     * Is the given path eligible for getting a constructed value?
+     *
+     * @param xpath the given path
+     * @return true if eligible
+     */
+    public static boolean pathIsEligible(String xpath) {
+        return xpath.startsWith(PATH_PREFIX) && xpath.contains(CODE_SEPARATOR);
+    }
+
+    /**
+     * Is the given value bogus, and therefore eligible for getting replaced by a constructed value?
+     *
+     * @param value the given value
+     * @return true if bogus
+     */
+    public static boolean valueIsBogus(String value) {
+        return value == null || value.contains(CODE_SEPARATOR) || CheckNames.matchDigitPattern(value);
+    }
+
+    private final CLDRFile cldrFile;
+
+    public GlossonymConstructor(CLDRFile cldrFile) {
+        this.cldrFile = cldrFile;
+        if (!cldrFile.isResolved()) {
+            throw new IllegalArgumentException("Unresolved CLDRFile in GlossonymConstructor constructor");
+        }
+    }
+
+    /**
+     * Get the constructed value and fill in tracking information about where it was found
+     *
+     * @param xpath the path
+     * @param pathWhereFound if not null, to be filled in
+     * @param localeWhereFound if not null, to be filled in
+     * @return the constructed value, or null
+     */
+    public String getValueAndTrack(String xpath, Output<String> pathWhereFound, Output<String> localeWhereFound) {
+        final String constructedValue = getValue(xpath);
+        if (constructedValue != null) {
+            track(pathWhereFound, localeWhereFound);
+            return constructedValue;
+        }
+        return null;
+    }
+
+    /**
+     * Get the constructed value for the given path
+     *
+     * @param xpath the given path
+     * @return the constructed value, or null
+     */
+    public String getValue(String xpath) {
+        if (pathIsEligible(xpath)) {
+            return reallyGetValue(xpath);
+        }
+        return null;
+    }
+
+    private synchronized String reallyGetValue(String xpath) {
+        final XPathParts parts = XPathParts.getFrozenInstance(xpath);
+        final String type = parts.getAttributeValue(-1, "type");
+        if (type.contains(CODE_SEPARATOR)) {
+            final String alt = parts.getAttributeValue(-1, "alt");
+            final CLDRFile.SimpleAltPicker altPicker = (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
+            final String value = cldrFile.getName(type, true, altPicker);
+            if (!valueIsBogus(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private void track(Output<String> pathWhereFound, Output<String> localeWhereFound) {
+        if (localeWhereFound != null) {
+            localeWhereFound.value = cldrFile.getLocaleID();
+        }
+        if (pathWhereFound != null) {
+            pathWhereFound.value = PSEUDO_PATH;
+        }
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -642,7 +642,7 @@ public class VettingViewer<T> {
             if (ph == null || ph.shouldHide()) {
                 return;
             }
-            String value = sourceFile.getWinningValueForVettingViewer(path);
+            String value = sourceFile.getWinningValue(path);
             statusMessage.setLength(0);
             subtypes.clear();
             ErrorChecker.Status errorStatus = errorChecker.getErrorStatus(path, value, statusMessage, subtypes);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -92,7 +92,7 @@ public class TestAlt extends TestFmwk {
         assertEquals("Regular, pathWhereFound", plain, pathWhereFound.value);
         assertEquals("Regular, localeWhereFound", "fr_CA", localeWhereFound.value);
 
-        String actualBailey = testCldrFile.getConstructedBaileyValue(plain+altMedium, pathWhereFound, localeWhereFound);
+        String actualBailey = testCldrFile.getBaileyValue(plain+altMedium, pathWhereFound, localeWhereFound);
         assertEquals("Bailey, " + plain+altMedium, expected, actualBailey);
         
         assertEquals("Bailey, pathWhereFound", plain, pathWhereFound.value);


### PR DESCRIPTION
-Remove getConstructedBaileyValue, call getBaileyValue instead

-Remove getWinningValueForVettingViewer, call getWinningValue instead

-In getStringValue and getBaileyValue, get constructed value when appropriate

-New GlossonymConstructor.java to encapsulate language name construction

-New getStringValueWithBaileyNotConstructed prevents getName from using constructed values recursively

-Disallow constructed names that would get error CheckStatus.Subtype.nameContainsYear

-Change TestConstructedBailey to TestConstructedValue, test getConstructedValue

-Delete INHERITANCE_MARKER from syr.xml, since it inherits code es_419

-Delete language type=gsw from uz_Cyrl.xml, duplicates constructed type=de_CH

-Rename isExplicitBailey to topValueIsInheritanceMarker for clarity

-Delete dead code in VoteAPIHelper and elsewhere

-Change method from public to private if possible

-Comments

CLDR-13263

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
