### PR TITLE
CLDR-15628 Extra char in one nameField placeholder example; incomplete comment elsewhere

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -418,7 +418,7 @@ public class DisplayAndInputProcessor {
             }
 
             // all of our values should not have leading or trailing spaces, except insertBetween,
-            // foreignSpaceReplacement, and anything with 
+            // foreignSpaceReplacement, and anything with built-in attribute xml:space="preserve"
             if (!path.contains("/insertBetween") && !path.contains("/foreignSpaceReplacement") &&
                 !path.contains("[@xml:space=\"preserve\"]") && !isUnicodeSet) {
                 value = value.trim();

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -251,4 +251,4 @@
 
 //ldml/personNames/initialPattern\[@type="initial"] ; {0}=NAME_INITIAL J
 //ldml/personNames/initialPattern\[@type="initialSequence"] ; {0}=PREVIOUS_NAME_INITIALS J.R.; {1}=ADD_NAME_INITIAL R.
-//ldml/personNames/personName\[@order="%A"]\[@length="%A"]\[@usage="%A"]\[@formality="%A"]/namePattern ; optional ; {prefix}=NAME_PREFIX Dr. ; {given}=GIVEN_NAME Cornelia ; {given-informal}=INFORMAL_NAME Neele ; {given2}=GIVEN_NAME_2 Sophia ; {surname}=SURNAME van den Wolf ; {surname-prefix}=SURNAME_PREFIX van den ; {surname-core}=SURNAME_CORE Wolf ; {surname2}=SURNAME_2 Becker ; {suffix}=NAME_SUFFIX >M.D.
+//ldml/personNames/personName\[@order="%A"]\[@length="%A"]\[@usage="%A"]\[@formality="%A"]/namePattern ; optional ; {prefix}=NAME_PREFIX Dr. ; {given}=GIVEN_NAME Cornelia ; {given-informal}=INFORMAL_NAME Neele ; {given2}=GIVEN_NAME_2 Sophia ; {surname}=SURNAME van den Wolf ; {surname-prefix}=SURNAME_PREFIX van den ; {surname-core}=SURNAME_CORE Wolf ; {surname2}=SURNAME_2 Becker ; {suffix}=NAME_SUFFIX M.D.


### PR DESCRIPTION
CLDR-15628

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Remove an extra character that found its way into on nameField placeholder example.

Also finish an incomplete comment that was part of a different PR (#2025)