### PR TITLE
CLDR-15686 preserve spaces

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.js
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.js
@@ -348,7 +348,7 @@ function updateRowVoteInfo(tr, theRow) {
       );
       isectionIsUsed = true;
     }
-    cldrSurvey.setLang(valdiv);
+    cldrSurvey.setLang(valdiv); // want the whole div to be marked as cldrValue
     if (value === cldrSurvey.INHERITANCE_MARKER) {
       /*
        * theRow.inheritedValue can be undefined here; then do not append
@@ -600,7 +600,6 @@ function showItemInfoFn(theRow, item) {
     }
 
     var span = cldrVote.appendItem(h3, displayValue, item.pClass);
-    cldrSurvey.setLang(span);
     h3.className = "span";
     td.appendChild(h3);
 

--- a/tools/cldr-apps/js/src/esm/cldrLoad.js
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.js
@@ -1001,6 +1001,23 @@ function getTheLocaleMap() {
   return locmap;
 }
 
+/**
+ * Get the direction of a locale, if available
+ * @param {String} locale
+ * @returns null or 'ltr' or 'rtl'
+ */
+function getLocaleDir(locale) {
+  const locmap = getTheLocaleMap();
+  let localeDir = null;
+  if (locale) {
+    const localeInfo = locmap.getLocaleInfo(locale);
+    if (localeInfo) {
+      localeDir = localeInfo.dir;
+    }
+  }
+  return localeDir;
+}
+
 function setTheLocaleMap(lm) {
   locmap = lm;
 }
@@ -1117,6 +1134,7 @@ export {
   flipToGenericNoLocale,
   flipToOtherDiv,
   getHash,
+  getLocaleDir,
   getLocaleName,
   getTheLocaleMap,
   handleCoverageChanged,

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -795,6 +795,13 @@ function setOverrideDir(dir) {
   overridedir = dir;
 }
 
+/**
+ * Set the dir and lang attributes for a node that represents
+ * a CLDR value.
+ * Also appends the 'cldrValue' class to the node.
+ * @param {Node} node DOM node
+ * @param {String} loc locale
+ */
 function setLang(node, loc) {
   var info = locInfo(loc);
 
@@ -807,6 +814,9 @@ function setLang(node, loc) {
   if (info && info.bcp47) {
     node.lang = info.bcp47;
   }
+
+  // defined in surveytool.css and shared with CldrValue.vue
+  node.classList.add("cldrValue");
 }
 
 /**

--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -1059,7 +1059,6 @@ function addVitem(td, tr, theRow, item, newButton) {
   var span = cldrVote.appendItem(subSpan, displayValue, item.pClass);
   choiceField.appendChild(subSpan);
 
-  cldrSurvey.setLang(span);
   checkLRmarker(choiceField, item.value);
 
   if (item.isBaselineValue == true) {

--- a/tools/cldr-apps/js/src/esm/cldrVote.js
+++ b/tools/cldr-apps/js/src/esm/cldrVote.js
@@ -297,7 +297,6 @@ function showProposedItem(inTd, tr, theRow, value, tests, json) {
     }
     var h3 = document.createElement("span");
     var span = appendItem(h3, value, "value");
-    cldrSurvey.setLang(span);
     ourDiv.appendChild(h3);
     if (otherCell) {
       otherCell.appendChild(tr.myProposal);
@@ -375,7 +374,6 @@ function showProposedItem(inTd, tr, theRow, value, tests, json) {
     if (!ourItem) {
       var h3 = document.createElement("h3");
       var span = appendItem(h3, value, "value");
-      cldrSurvey.setLang(span);
       h3.className = "span";
       div3.appendChild(h3);
     }
@@ -476,6 +474,7 @@ function wrapRadio(button) {
 
 /**
  * Append just an editable span representing a candidate voting item
+ * Calls setLang() automatically
  *
  * @param div {DOM} div to append to
  * @param value {String} string value
@@ -496,6 +495,7 @@ function appendItem(div, value, pClass) {
   } else {
     span.className = "value";
   }
+  cldrSurvey.setLang(span);
   div.appendChild(span);
   return span;
 }

--- a/tools/cldr-apps/js/src/getCldrOpts.js
+++ b/tools/cldr-apps/js/src/getCldrOpts.js
@@ -6,13 +6,7 @@ import * as cldrSurvey from "./esm/cldrSurvey.js";
 function getCldrOpts() {
   const locale = cldrStatus.getCurrentLocale();
   const locmap = cldrLoad.getTheLocaleMap();
-  let localeDir = null;
-  if (locale) {
-    const localeInfo = locmap.getLocaleInfo(locale);
-    if (localeInfo) {
-      localeDir = localeInfo.dir;
-    }
-  }
+  const localeDir = cldrLoad.getLocaleDir(locale);
   return {
     // modules
     cldrLoad,

--- a/tools/cldr-apps/js/src/views/CldrRow.vue
+++ b/tools/cldr-apps/js/src/views/CldrRow.vue
@@ -14,11 +14,9 @@
     </td>
     <td title="$flyoverproposed" class="d-win proposedcell">
       <div v-for="item in row.items" :key="item.value">
-        <cldr-value
-          v-if="item.value == row.resolver.winningValue"
-          :value="item.value"
-          :dir="row.dir"
-        />
+        <cldr-value v-if="item.value == row.resolver.winningValue">{{
+          item.value
+        }}</cldr-value>
       </div>
     </td>
     <td title="$flyoveradd" class="d-win addcell">
@@ -28,9 +26,9 @@
       <div v-for="item in row.items" :key="item.value">
         <cldr-value
           v-if="item.value != row.resolver.winningValue"
-          :value="item.value"
           :dir="row.dir"
-        />
+          >{{ item.value }}</cldr-value
+        >
       </div>
     </td>
   </tr>

--- a/tools/cldr-apps/js/src/views/CldrValue.vue
+++ b/tools/cldr-apps/js/src/views/CldrValue.vue
@@ -1,18 +1,47 @@
 <template>
-  <span v-bind:dir="dir" class="cldrValue">
-    {{ value }}
-  </span>
+  <span
+    v-bind:dir="dir"
+    v-bind:lang="lang"
+    v-bind:title="title"
+    :class="myClass"
+    ><slot
+  /></span>
 </template>
 
 <script>
+import * as cldrLoad from "../esm/cldrLoad.js";
+import * as cldrStatus from "../esm/cldrStatus.js";
 export default {
-  props: ["value", "dir"],
+  computed: {
+    myClass() {
+      return "cldrValue " + (this.class || "");
+    },
+  },
+  props: {
+    class: {
+      type: String,
+      // any additional classes
+      default: "",
+    },
+    title: {
+      type: String,
+      // any additional classes
+      default: null,
+    },
+    dir: {
+      type: String,
+      // defaults to current locale's dir
+      default: () => cldrLoad.getLocaleDir(cldrStatus.getCurrentLocale()),
+    },
+    lang: {
+      type: String,
+      // defaults to current locale's lang
+      default: () => cldrStatus.getCurrentLocale(),
+    },
+  },
 };
 </script>
 
 <style scoped>
-.cldrValue {
-  font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
-}
+/* Note: cldrValue is defined in surveytool.css */
 </style>
->

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -98,23 +98,25 @@
                     |
                     <span class="code" title="code">{{ entry.code }}</span>
                     |
-                    <span
+                    <cldr-value
                       class="previous-english"
                       title="previous English"
+                      lang="en"
+                      dir="ltr"
                       v-if="entry.previousEnglish"
+                      >{{ entry.previousEnglish }} →</cldr-value
                     >
-                      {{ entry.previousEnglish }} →
-                    </span>
-                    <span class="english" title="English">{{
-                      entry.english
-                    }}</span>
+                    <cldr-value
+                      class="english"
+                      lang="en"
+                      dir="ltr"
+                      title="English"
+                      >{{ entry.english }}</cldr-value
+                    >
                     |
-                    <span
-                      class="winning"
-                      title="Winning"
-                      v-bind:dir="$cldrOpts.localeDir"
-                      >{{ entry.winning }}</span
-                    >
+                    <cldr-value class="winning" title="Winning">{{
+                      entry.winning
+                    }}</cldr-value>
                     <template v-if="entry.comment">
                       |
                       <span v-html="entry.comment" title="comment"></span>

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -1726,6 +1726,13 @@ table#voteinfo thead th:first-child {
 
 /* @group voteInfo_perValue */
 
+/* This is a global style used in several places in the ST
+	Notably cldrSurvey.setLang() and also the <cldr-value> Vue control
+*/
+.cldrValue {
+	white-space: pre-wrap;
+}
+
 .voteInfo_perValue {
 	display:  inline-table;
 	vertical-align: top;


### PR DESCRIPTION
- setLang() (raw js) and CldrValue (Vue) encapsulate what is needed for display
of a CLDR value
- use <cldr-value> in DashboardWidget
- add cldrLoad.getLocaleDir() (refactoring code out of getCldrOpts)
- add a "cldrValue" class in surveytool.css, used everywhere and with
  white-space: pre-wrap

CLDR-15686

- [X] This PR completes the ticket.