### PR TITLE
CLDR-13263 Constructed-value-related clean-up

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
@@ -5,10 +5,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
-import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.RegexUtilities;
 
 public class CheckNames extends CheckCLDR {
-    private static final Pattern YEAR_PATTERN = PatternCache.get("\\d{3,4}");
     private static final Pattern YEARS_NOT_ALLOWED = Pattern
         .compile(
             "//ldml/localeDisplayNames/(languages|currencies|scripts|territories|measurementSystemNames|transformNames)/.*");
@@ -23,7 +22,7 @@ public class CheckNames extends CheckCLDR {
             !getCldrFileToCheck().isNotRoot(path)) {
             return this;
         }
-        Matcher matcher = YEAR_PATTERN.matcher(value);
+        Matcher matcher = RegexUtilities.DIGIT_PATTERN.matcher(value);
         if (matcher.find()) {
             // If same as the code-fallback value (territories) then no error
             if (path.startsWith("//ldml/localeDisplayNames/territories") &&
@@ -43,11 +42,6 @@ public class CheckNames extends CheckCLDR {
             }
         }
         return this;
-    }
-
-    public static boolean matchDigitPattern(String value) {
-        Matcher matcher = YEAR_PATTERN.matcher(value);
-        return matcher.find();
     }
 
     private boolean isEnclosedByBraces(Matcher matcher, String value, char startBrace, char endBrace) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
@@ -1,7 +1,16 @@
 package org.unicode.cldr.util;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.ibm.icu.text.MessageFormat;
+import com.ibm.icu.text.Transform;
 import com.ibm.icu.util.Output;
-import org.unicode.cldr.test.CheckNames;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Automatically construct language names (glossonyms)
@@ -57,7 +66,7 @@ public class GlossonymConstructor {
      * @return true if bogus
      */
     public static boolean valueIsBogus(String value) {
-        return value == null || value.contains(CODE_SEPARATOR) || CheckNames.matchDigitPattern(value);
+        return value == null || value.contains(CODE_SEPARATOR) || RegexUtilities.matchDigitPattern(value);
     }
 
     private final CLDRFile cldrFile;
@@ -80,7 +89,12 @@ public class GlossonymConstructor {
     public String getValueAndTrack(String xpath, Output<String> pathWhereFound, Output<String> localeWhereFound) {
         final String constructedValue = getValue(xpath);
         if (constructedValue != null) {
-            track(pathWhereFound, localeWhereFound);
+            if (localeWhereFound != null) {
+                localeWhereFound.value = cldrFile.getLocaleID();
+            }
+            if (pathWhereFound != null) {
+                pathWhereFound.value = PSEUDO_PATH;
+            }
             return constructedValue;
         }
         return null;
@@ -111,14 +125,5 @@ public class GlossonymConstructor {
             }
         }
         return null;
-    }
-
-    private void track(Output<String> pathWhereFound, Output<String> localeWhereFound) {
-        if (localeWhereFound != null) {
-            localeWhereFound.value = cldrFile.getLocaleID();
-        }
-        if (pathWhereFound != null) {
-            pathWhereFound.value = PSEUDO_PATH;
-        }
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/RegexUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/RegexUtilities.java
@@ -31,4 +31,11 @@ public class RegexUtilities {
         Matcher m = p.matcher("");
         return showMismatch(m, s);
     }
+
+    public static final Pattern DIGIT_PATTERN = PatternCache.get("\\d{3,4}");
+
+    public static boolean matchDigitPattern(String value) {
+        Matcher matcher = DIGIT_PATTERN.matcher(value);
+        return matcher.find();
+    }
 }


### PR DESCRIPTION
-Move matchDigitPattern into util/RegexUtilities

-Remove GlossonymConstructor.track, inline the code instead

-Move ten cldr.getName functions and related subroutines/data to bottom of CLDRFile.java in preparation for refactoring as separate class

-Comments

CLDR-13263

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
