### PR TITLE
CLDR-15691 fix sampleName field order in ST; remove surname from full if we have surname-prefix/-suffix

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9474,7 +9474,6 @@ annotations.
 			<nameField type="given">Ada Cornelia</nameField>
 			<nameField type="given-informal">Neele</nameField>
 			<nameField type="given2">Eva Sophia</nameField>
-			<nameField type="surname">van den Wolf</nameField>
 			<nameField type="surname-prefix">van den</nameField>
 			<nameField type="surname-core">Wolf</nameField>
 			<nameField type="surname2">Becker Schmidt</nameField>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -20017,7 +20017,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="given">Ingrid</nameField>
 			<nameField type="given-informal">Ingy</nameField>
 			<nameField type="given2">Francina Zoë</nameField>
-			<nameField type="surname">van den Berg</nameField>
 			<nameField type="surname-prefix">van den</nameField>
 			<nameField type="surname-core">Berg</nameField>
 			<nameField type="suffix">PhD</nameField>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5596,7 +5596,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="given">∅∅∅</nameField>
 			<nameField type="given-informal">∅∅∅</nameField>
 			<nameField type="given2">∅∅∅</nameField>
-			<nameField type="surname">∅∅∅</nameField>
 			<nameField type="surname-prefix">∅∅∅</nameField>
 			<nameField type="surname-core">∅∅∅</nameField>
 			<nameField type="surname2">∅∅∅</nameField>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1924,8 +1924,8 @@ public class PathHeader implements Comparable<PathHeader> {
                     // The various nameField attribute values: each group in desired
                     // sort order, but groups from least important to most
                     final List<String> attrValues = Arrays.asList(
-                        "informal", // modifiers for nameField type
-                        "prefix", "given", "given2", "surname", "surname-prefix", "surname-core", "surname2", "suffix"); // values for nameField type
+                        "informal", "prefix", "core", // modifiers for nameField type
+                        "prefix", "given", "given2", "surname", "surname2", "suffix"); // values for nameField type
 
                     List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                     order = 0;


### PR DESCRIPTION
CLDR-15691

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

- In ST display of sampleName fields for full sample, fix ordering of surname-prefix vs surname-core
- In full sample data, remove surname field if we have both surname-prefix and surname-core (note that nl_BE does not have surname-prefix and surname-core, just surname)
