### PR TITLE
CLDR-8666 fix nginx, not microprofile

### DIFF
--- a/tools/cldr-apps/src/main/webapp/META-INF/microprofile-config.properties
+++ b/tools/cldr-apps/src/main/webapp/META-INF/microprofile-config.properties
@@ -1,2 +1,0 @@
-mp.openapi.servers=/cldr-apps
-

--- a/tools/scripts/ansible/nginx-playbook.yml
+++ b/tools/scripts/ansible/nginx-playbook.yml
@@ -21,6 +21,7 @@
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
           }
           location /openapi/ {
             allow all;
@@ -28,6 +29,7 @@
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
           }
         marker: '# {mark} ANSIBLE MANAGED BLOCK'
         insertafter: '^[\s]*server_name' # the LAST uncommented server block


### PR DESCRIPTION
- add X-Forwarded-Proto: header as it should have been
- remove microprofile-config.properties as not needed

CLDR-8666

this fixes CLDR-15702