### PR TITLE
CLDR-10720 TestCLDRLinks: fix URL parsing, was too restrictive

### DIFF
--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/util/TestCLDRLinks.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/util/TestCLDRLinks.java
@@ -121,7 +121,7 @@ public class TestCLDRLinks {
         return l.stream();
     }
 
-    private static final Pattern URL_PATTERN = Pattern.compile("(https?)://[^ -]*[^ .-]"); // very simplistic
+    private static final Pattern URL_PATTERN = Pattern.compile("(https?)://[^ ]*[^ .]"); // very simplistic
 
     /**
      * Split a String into URLs. Skips trailing period.


### PR DESCRIPTION
CLDR-10720

- [X] This PR completes the ticket.

( Note: https://unicode-org.atlassian.net/browse/CLDR-15678 has been updated with  the results of this test.) 