### PR TITLE
CLDR-8666 Reports updates

### DIFF
--- a/tools/cldr-apps/js/src/views/ReportResponse.vue
+++ b/tools/cldr-apps/js/src/views/ReportResponse.vue
@@ -18,14 +18,14 @@
     </p>
 
     <a-radio-group v-model:value="state" @change="changed">
-      <a-radio style="radioStyle" value="acceptable">
+      <a-radio :style="radioStyle" value="acceptable">
         I have reviewed the items below, and they are all acceptable</a-radio
       >
-      <a-radio style="radioStyle" value="unacceptable">
+      <a-radio :style="radioStyle" value="unacceptable">
         The items are not all acceptable, but I have entered in votes for the
         right ones or filed a ticket.</a-radio
       >
-      <a-radio style="radioStyle" value="incomplete">
+      <a-radio :style="radioStyle" value="incomplete">
         I have not reviewed the items.</a-radio
       >
     </a-radio-group>
@@ -37,7 +37,6 @@ import * as cldrClient from "../esm/cldrClient.js";
 import * as cldrReport from "../esm/cldrReport.js";
 import * as cldrStatus from "../esm/cldrStatus.js";
 import * as cldrText from "../esm/cldrText.js";
-
 export default {
   props: [
     "report", // e.g. 'numbers'
@@ -49,6 +48,7 @@ export default {
       loaded: false,
       error: null,
       state: null,
+      radioStyle: { display: "block" },
     };
   },
   created: async function () {
@@ -160,17 +160,12 @@ export default {
 </script>
 
 <style scoped>
-.radioStyle {
-  display: flex;
-}
-
 .reportResponse {
   border: 1px solid gray;
   padding: 0.5em;
   margin: 1em;
   box-shadow: 1em;
   background-color: bisque;
-  width: 50%;
 }
 
 .reportResponse .statusCell,

--- a/tools/cldr-apps/js/src/views/VettingSummary.vue
+++ b/tools/cldr-apps/js/src/views/VettingSummary.vue
@@ -53,6 +53,7 @@
     <section class="snapSection">
       <h2 class="snapHeading">Report Status</h2>
       <button @click="fetchReports">Load</button>
+      <button @click="downloadReports">Download</button>
       <table class="reportTable" v-if="reports">
         <thead>
           <tr>
@@ -70,18 +71,20 @@
             :key="locale"
           >
             <td>
-              <tt>{{ locale }}—{{ humanizeLocale(locale) }}</tt>
+              <code>{{ locale }}—{{ humanizeLocale(locale) }}</code>
             </td>
             <td>
               <span
                 class="reportEntry"
-                v-for="[kind, count] of Object.entries(
-                  reports.byLocale[locale]
-                )"
+                v-for="kind of ['acceptable', 'unacceptable', 'totalVoters']"
                 :key="kind"
               >
-                <i v-if="count" :class="reportClass(kind)">&nbsp;</i>
-                {{ kind }}={{ count }}
+                <i
+                  v-if="reports.byLocale[locale][kind]"
+                  :class="reportClass(kind)"
+                  >&nbsp;</i
+                >
+                {{ kind }}={{ reports.byLocale[locale][kind] }}
               </span>
             </td>
           </tr>
@@ -239,6 +242,9 @@ export default {
       } else {
         return cldrReport.reportClass(false, false);
       }
+    },
+    downloadReports() {
+      return cldrReport.downloadAllReports("-");
     },
   },
 };

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
@@ -55,8 +55,8 @@ public class ReportAPI {
         Integer id;
         if (user.equals("-")) {
             id = null;
-            if (!UserRegistry.userIsTC(mySession.user)) {
-                // only TC can do this
+            if (!UserRegistry.userIsManagerOrStronger(mySession.user)) {
+                // only Manager+ can do this
                 return Response.status(Status.FORBIDDEN).build();
             }
         } else {


### PR DESCRIPTION
- fixed CSS for report header
- add Download link to Report Status

CLDR-8666

- [ ] This PR completes the ticket.

UI improvement:
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/855219/172464141-7016f10e-e94f-410b-bcd8-1660f831653d.png">

in Vetting Summary, download provides XLS (attached)

[survey_reports_-(6).xlsx](https://github.com/unicode-org/cldr/files/8855939/survey_reports_-.6.xlsx)

