### PR TITLE
CLDR-15671 treat xml: attributes as metadata, should not show in ST

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3171,7 +3171,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT foreignSpaceReplacement ( #PCDATA ) >
 <!ATTLIST foreignSpaceReplacement xml:space (default | preserve) "preserve" >
-    <!--@VALUE-->
 <!ATTLIST foreignSpaceReplacement alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST foreignSpaceReplacement draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -117,7 +117,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         private final Set<String> commentsPre;
         private Set<String> commentsPost;
         private boolean isDeprecatedAttribute;
-        public AttributeStatus attributeStatus = AttributeStatus.distinguished; // default unless reset by annotations
+        public AttributeStatus attributeStatus = AttributeStatus.distinguished; // default unless reset by annotations, or for xml: attributes
         private Set<String> deprecatedValues = Collections.emptySet();
         public MatchValue matchValue;
         private final Comparator<String> attributeValueComparator;
@@ -136,6 +136,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                         System.out.println(element.getName() + ":" + element.getChildren());
                     }
                 }
+            } else if (name.startsWith("xml:")) {
+                attributeStatus = AttributeStatus.metadata;
             }
             mode = mode2;
             defaultValue = value2 == null ? null


### PR DESCRIPTION
CLDR-15671

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

In DtdData, treat all xml: attributes as metadata. Hopefully this is enough to make the xml:space attribute not show in ST,
- I don't want to just ignore/discard them entirely, since we want to be able to use the xml:space attribute as an indicator for space trimming in places like DAIP
- This should produce the desired result in XPathParts.getSpecialNondistinguishingAttributes()
- This allows us to remove `@VALUE` from the xml:space attribute in the dtd (and we don't need to replace it with `@METADATA`)