### PR TITLE
CLDR-15716 in PathHeader personNameSection, rename "sorting" to "sorting/index"

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1890,6 +1890,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 order += (1 << pnAttrValues.indexOf(part));
                             }
                         }
+                        attrValues = attrValues.replace("sorting-", "sorting/index-");
                         return "PersonName Patterns for Order-Length: " + attrValues;
                     }
                     order = 40;


### PR DESCRIPTION
CLDR-15716

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

To clarify usage, change PathHeader (personNameSection) to rename the "Sorting" attribute value in a Survey Tool subsection head to "Sorting/Index" (affects Survey Tool only)