### PR TITLE
CLDR-15318 Make sure it appears (as missing) in all locales

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -102,6 +102,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
          * The toString() format is suitable for printing to the command line
          * and has the format 'file:line:column: '
          */
+        @Override
         public String toString() {
             return toString(null);
         }
@@ -1551,6 +1552,11 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             addFallbackCode(CLDRFile.TERRITORY_NAME, "FK", "FK", "variant");
             addFallbackCode(CLDRFile.TERRITORY_NAME, "TL", "TL", "variant");
             addFallbackCode(CLDRFile.TERRITORY_NAME, "SZ", "SZ", "variant");
+
+            // new alternate name
+
+            addFallbackCode(CLDRFile.TERRITORY_NAME, "TR", "TR", "variant");
+
 
             addFallbackCode(CLDRFile.TERRITORY_NAME, "XA", "XA");
             addFallbackCode(CLDRFile.TERRITORY_NAME, "XB", "XB");


### PR DESCRIPTION
CLDR-15318

To make the alt=variant (Türkiye) appears in all files, we need to add this one extra step (addFallbackCode, in XMLSource.java).
(The @Override is just from reformatting.)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
