### PR TITLE
CLDR-15646 Priority Items Summary: Progress column improvements

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -228,7 +228,7 @@ public class Dashboard {
         STFactory sourceFactory = sm.getSTFactory();
         VettingViewer<Organization> vv = new VettingViewer<>(sm.getSupplementalDataInfo(), sourceFactory,
             new STUsersChoice(sm));
-        EnumSet<VettingViewer.Choice> choiceSet = VettingViewer.getChoiceSetForOrg(usersOrg);
+        EnumSet<VettingViewer.Choice> choiceSet = VettingViewer.getDashboardNotificationCategories(usersOrg);
         DashboardArgs args = new DashboardArgs(choiceSet, locale, coverageLevel);
         args.setUserAndOrganization(user.id, usersOrg);
         setFiles(args, locale, sourceFactory);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
@@ -273,43 +273,15 @@ public class VettingViewerQueue {
             n = 0;
             vv.setProgressCallback(new CLDRProgressCallback(progress, Thread.currentThread()));
 
-            EnumSet<VettingViewer.Choice> choiceSet = VettingViewer.getChoiceSetForOrg(usersOrg);
-            choiceSet.remove(VettingViewer.Choice.abstained);
+            EnumSet<VettingViewer.Choice> choiceSet = VettingViewer.getPriorityItemsSummaryCategories(usersOrg);
             if (DEBUG) {
                 System.out.println("Starting generation of Priority Items Summary");
             }
-            vv.setLocaleToProgress(getLocaleToProgress(vv, usersOrg));
             vv.generatePriorityItemsSummary(aBuffer, choiceSet, usersOrg);
             if (myThread.isAlive()) {
                 aBuffer.append("<hr/>Processing time: " + ElapsedTimer.elapsedTime(start));
                 entry.output.put(usersOrg, new VVOutput(aBuffer));
             }
-        }
-
-        /**
-         * Get a map from locale id string to progress percentage string, to be
-         * used in the "Progress" column of the Priority Items Summary
-         *
-         * @param vv the VettingViewer
-         * @param org the Organization
-         * @return the map
-         *
-         * Note: unless the locale completion results have already been cached, this method may
-         * be inefficient since it loops with VettingViewer through all the paths in each locale,
-         * and then the Priority Items Summary again loops with VettingViewer through all the paths
-         * in each locale. It might be up to twice as efficient, especially when values are not yet
-         * cached, to gather the progress stats during the same single pass as the rest of the summary info.
-         */
-        private HashMap<String, String> getLocaleToProgress(VettingViewer<Organization> vv, Organization org) {
-            final HashMap<String, String> map = new HashMap<>();
-            final ArrayList<String> localeList = vv.getLocaleList(org);
-            for (String localeId : localeList) {
-                final CLDRLocale loc = CLDRLocale.getInstance(localeId);
-                final LocaleCompletion.LocaleCompletionResponse response = LocaleCompletion.handleGetLocaleCompletion(loc);
-                final int percent = (100 * response.votes / response.total);
-                map.put(localeId, Integer.toString(percent));
-            }
-            return map;
         }
 
         private int getPercent() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
@@ -10,13 +10,6 @@ public class LocaleCompletionCounter {
 
     private static final Logger logger = SurveyLog.forClass(LocaleCompletionCounter.class);
 
-    private static final EnumSet<VettingViewer.Choice> choiceSet = EnumSet.of(
-        VettingViewer.Choice.error,
-        VettingViewer.Choice.hasDispute,
-        VettingViewer.Choice.notApproved,
-        VettingViewer.Choice.missingCoverage
-    );
-
     private final String localeId;
     private final Level level;
     private final LocaleCompletion.LocaleCompletionResponse lcr;
@@ -29,7 +22,8 @@ public class LocaleCompletionCounter {
         lcr = new LocaleCompletion.LocaleCompletionResponse(level);
         final SurveyMain sm = CookieSession.sm;
         vv = new VettingViewer<>(sm.getSupplementalDataInfo(), stFactory, new STUsersChoice(sm));
-        args = new VettingViewer.DashboardArgs(choiceSet, cldrLocale, level);
+        final EnumSet<VettingViewer.Choice> set = VettingViewer.getLocaleCompletionCategories();
+        args = new VettingViewer.DashboardArgs(set, cldrLocale, level);
         args.setUserAndOrganization(0, VettingViewer.getNeutralOrgForSummary());
         Dashboard.setFiles(args, cldrLocale, stFactory);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterProgress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterProgress.java
@@ -1,15 +1,23 @@
 package org.unicode.cldr.util;
 
+// TODO: rename this to VettingProgress, since now it is used not only for
+// "voter completion" which is user-specific, but also for "locale completion" which isn't
 public class VoterProgress {
     /**
      * The number of paths for which this user is expected to vote
      * (in this locale, limited by the coverage level)
+     *
+     * More generally (as for locale completion), the number of tasks
+     * that are expected to be completed
      */
     private int votablePathCount = 0;
 
     /**
      * The number of paths for which this user already has voted
      * (in this locale, limited by the coverage level)
+     *
+     * More generally (as for locale completion), the number of tasks
+     * that have already been completed (normally <= votablePathCount)
      */
     private int votedPathCount = 0;
 
@@ -22,10 +30,32 @@ public class VoterProgress {
     }
 
     public void incrementVotablePathCount() {
-        this.votablePathCount++;
+        votablePathCount++;
     }
 
     public void incrementVotedPathCount() {
-        this.votedPathCount++;
+        votedPathCount++;
+    }
+
+    public int friendlyPercent() {
+        if (votablePathCount <= 0) {
+            // The task is finished since nothing needed to be done
+            // Do not divide by zero (0 / 0 = NaN%)
+            return 100;
+        }
+        if (votedPathCount <= 0) {
+            return 0;
+        }
+        // Do not round 99.9 up to 100
+        final int floor = (int) Math.floor((100 * (float) votedPathCount) / (float) votablePathCount);
+        if (floor == 0) {
+            // Do not round 0.001 down to zero
+            // Instead, provide indication of slight progress
+            return 1;
+        }
+        if (floor > 100) {
+            return 100;
+        }
+        return floor;
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestVettingViewer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestVettingViewer.java
@@ -1,0 +1,28 @@
+package org.unicode.cldr.unittest;
+
+import com.ibm.icu.dev.test.TestFmwk;
+import java.util.*;
+import org.unicode.cldr.util.*;
+
+public class TestVettingViewer extends TestFmwk {
+
+    public void TestNotificationCategories() {
+        final Organization org = VettingViewer.getNeutralOrgForSummary();
+        final EnumSet<VettingViewer.Choice> set1 = VettingViewer.getPriorityItemsSummaryCategories(org);
+        final EnumSet<VettingViewer.Choice> set2 = VettingViewer.getLocaleCompletionCategories();
+        if (set1.contains(VettingViewer.Choice.abstained)) {
+            errln("getPriorityItemsSummaryCategories should not contain abstained");
+        }
+        if (!set1.contains(VettingViewer.Choice.warning)) {
+            errln("getPriorityItemsSummaryCategories should contain warning");
+        }
+        if (set2.contains(VettingViewer.Choice.warning)) {
+            errln("getLocaleCompletionCategories should not contain warning");
+        }
+        if (!set1.containsAll(set2)) {
+            // This assumption is implicit in the way the Progress column of Priority Items Summary is
+            // calculated in the same pass as the other Priority Items Summary columns
+            errln("getLocaleCompletionCategories be a subset of getPriorityItemsSummaryCategories");
+        }
+    }
+}


### PR DESCRIPTION
-Make only one pass through paths for Summary, calculate locale completion in the same pass

-New VettingViewer.getLocaleCompletionCategories and getPriorityItemsSummaryCategories

-Rename getChoiceSetForOrg to getDashboardNotificationCategories for clarity

-New FileInfo.hasLocaleProblems to ignore warnings for locale completion

-New TestVettingViewer.java, make sure Summary notifications are superset of locale completion notifications

-New VoterProgress.friendlyPercent to round Progress column like progress meters

-Remove setLocaleToProgress and related code that was for double pass

-Remove unused parameter of updateVotedOrAbstained

-Comments

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
