### PR TITLE
CLDR-15671 xml: attribute tests, explicitly list as @METADATA, prettyPaths for personNames

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3171,6 +3171,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT foreignSpaceReplacement ( #PCDATA ) >
 <!ATTLIST foreignSpaceReplacement xml:space (default | preserve) "preserve" >
+    <!--@METADATA-->
 <!ATTLIST foreignSpaceReplacement alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST foreignSpaceReplacement draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestXPathTable.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestXPathTable.java
@@ -133,13 +133,15 @@ public class TestXPathTable extends TestFmwk {
             "numbers=hebrew",
             "//ldml/dates/calendars/calendar[@type=\"chinese\"]/dateFormats/dateFormatLength[@type=\"medium\"]/dateFormat[@type=\"standard\"]/pattern[@type=\"standard\"][@alt=\"variant-proposedx333\"][@numbers=\"hanidec\"][@draft=\"true\"]",
             "numbers=hanidec",
+            "//ldml/personNames/foreignSpaceReplacement[@xml:space=\"preserve\"]",
+            "",
 
         };
 
         for (int i = 0; i < xpaths.length; i += 2) {
             String xpath = xpaths[i + 0];
             String expect = xpaths[i + 1];
-            Map<String, String> ueMap = xpt.getUndistinguishingElementsFor(xpath);
+            Map<String, String> ueMap = xpt.getUndistinguishingElementsFor(xpath); // just calls XPathParts.getSpecialNondistinguishingAttributes()
             if (ueMap != null) {
                 logln(xpath + "\n -> " + ueMap.toString() + " expect " + expect);
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2519,6 +2519,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         }
 
         public static String getDistinguishingXPath(String xpath, String[] normalizedPath) {
+            // For example, this removes [@xml:space="preserve"] from a path with element foreignSpaceReplacement.
             //     synchronized (distinguishingMap) {
             String result = distinguishingMap.get(xpath);
             if (result == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
@@ -1312,6 +1312,11 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
     }
 
     public Map<String, String> getSpecialNondistinguishingAttributes() {
+        // This returns the collection of non-distinguishing attribute values that
+        // *should* appear with blue background in the Survey Tool left column
+        // (e.g. the numbers attribute for some date patterns). Non-distinguishing
+        // attributes that should *not* appear must be explicitly listed as
+        // exclusions here (and distinguishing attributes are all excluded here).
         Map<String, String> ueMap = null; // common case, none found.
         for (int i = 0; i < this.size(); i++) {
             // taken from XPathTable.getUndistinguishingElementsFor, with some cleanup
@@ -1320,7 +1325,8 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
                 String k = entry.getKey();
                 if (getDtdData().isDistinguishing(getElement(i), k)
                     || k.equals("alt") // is always distinguishing, so we don't really need this.
-                    || k.equals("draft")) {
+                    || k.equals("draft")
+                    || k.startsWith("xml:")) {
                     continue;
                 }
                 if (ueMap == null) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/prettyPath.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/prettyPath.txt
@@ -127,6 +127,7 @@ $element=[a-zA-Z0-9]+;
 '$%%/months/default' > '|default|monthFormat';
 '$%%/days/default' > '|default|dayFormat';
 '$%%/dateTimeFormats/dateTimeFormatLength/dateTimeFormat[@type="standard"]/pattern[@type="standard"]' > '|pattern|date+time';
+'$%%/dateTimeFormats/dateTimeFormatLength/dateTimeFormat[@type="atTime"]/pattern[@type="standard"]' > '|pattern|date+atTime';
 '$%%/dateTimeFormats/alias' > '|date+time|alias';
 '$%%/dateFormats/alias' > '|date|alias';
 '$%%/timeFormats/alias' > '|time|alias';
@@ -192,6 +193,14 @@ $element=[a-zA-Z0-9]+;
 '/layout/inText[@type="' ($avalue) '"]' > '1-misc|casing|' $1;
 
 '/numbers/scientificFormats/default' > '3-deprecated|default|scientificFormats';
+
+# personName formats
+'/personNames/nameOrderLocales[@order="' ($avalue) '"]' > 'personNames|nameOrder-' $1;
+'/personNames/foreignSpaceReplacement[@xml:space="' ($avalue) '"]' > 'personNames|auxItems|foreignSpaceReplacement';
+'/personNames/foreignSpaceReplacement' > 'personNames|auxItems|foreignSpaceReplacement';
+'/personNames/initialPattern[@type="' ($avalue) '"]' > 'personNames|auxItems|initialPattern-' $1;
+'/personNames/personName[@order="' ($avalue) '"][@length="' ($avalue) '"][@usage="' ($avalue) '"][@formality="' ($avalue) '"]/namePattern' > 'personNames|personNam-' $1 '-' $2 '-' $3 '-' $4;
+'/personNames/sampleName[@item="' ($avalue) '"]/nameField[@type="' ($avalue) '"]' > 'personNames|sampleName-' $1 '|nameField-' $2;
 
 # This is used to mark any transformation that fails at some point
 (.*) > '?%%' $1;


### PR DESCRIPTION
CLDR-15671

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This is a follow-on to #2087 that attempts to do a few more things that should fix the problem with the xml:space=preserve attribute showing in Survey Tool for the foreignSpaceReplacement element.
1. First I re-ran GenerateDtd; this added an explicit `@METADATA` annotation in the dtd for xml:space (even though we set this status in code anyway). This also responds to an issue Steven raised in a comment on #2087.
2. Finally understand what XPathParts.getSpecialNondistinguishingAttributes() is supposed to do (return  the collection of non-distinguishing attribute values that *should* appear with blue background in the Survey Tool left column) so fixed it to exclude xml: attributes from this collection, and added a function description to alleviate future confusion. Also added a comment for CLDRFile.getDistinguishingXPath(), which *should* and *does* remove the xml:space attribute when normalizing a path.
3. Probably not relevant to this issue but needed doing anyway: Added prettyPaths for the personNames items (and for the dateTimeFormat atTime type).