### PR TITLE
CLDR-15687 Add test for 8 votes, make changes in coverageLevels.xml

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -36,7 +36,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<approvalRequirement votes="=HIGH_BAR" locales="tr" paths="//ldml/localeDisplayNames/territories/territory\[@type=.CY.\]"/>
 			<approvalRequirement votes="=HIGH_BAR" locales="kea pt_CV" paths="//ldml/numbers/currencies/currency\[@type=.CVE.\]/(symbol|decimal)"/>
 			<!--  established locales - http://cldr.unicode.org/index/process#TOC-Draft-Status-of-Optimal-Field-Value -->
-			<approvalRequirement votes="=LOWER_BAR" locales="ar bn bg ca cs da de el en en_AU en_GB es_MX es et fa fi fil fr fr_CA gu he hi hr hu id is it ja kk kn ko lt lv mk ml mr ms nl nn no pa pl pt pt_PT ro ru sk sl sr sv ta te th tr ur uk vi zh zh_Hant" paths=""/>
+			<approvalRequirement votes="=LOWER_BAR" locales="ar bn bg ca cs da de el en en_AU en_GB es_MX es et fa fi fil fr fr_CA gu he hi hr hu id is it ja kk kn ko lt lv mk ml mr ms nl no pa pl pt pt_PT ro ru sk sl sr sv ta te th tr ur uk vi zh zh_Hant" paths=""/>
 			<!--  all other items -->
 			<approvalRequirement votes="=vetter" locales="*" paths=""/>
 		</approvalRequirements>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -36,7 +36,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<approvalRequirement votes="=HIGH_BAR" locales="tr" paths="//ldml/localeDisplayNames/territories/territory\[@type=.CY.\]"/>
 			<approvalRequirement votes="=HIGH_BAR" locales="kea pt_CV" paths="//ldml/numbers/currencies/currency\[@type=.CVE.\]/(symbol|decimal)"/>
 			<!--  established locales - http://cldr.unicode.org/index/process#TOC-Draft-Status-of-Optimal-Field-Value -->
-			<approvalRequirement votes="=LOWER_BAR" locales="am ar bn ca cs da de el en es et fa fi fil fr ga gu he hi hr hu id it ja kk kn ko ky lt lv mk ml mr ms nl no pa pl pt pt_PT ro ru sk sl sr sv ta te th tr ur uk vi zh zh_Hant" paths=""/>
+			<approvalRequirement votes="=LOWER_BAR" locales="ar bn bg ca cs da de el en en_AU en_GB es_MX es et fa fi fil fr fr_CA gu he hi hr hu id is it ja kk kn ko lt lv mk ml mr ms nl nn no pa pl pt pt_PT ro ru sk sl sr sv ta te th tr ur uk vi zh zh_Hant" paths=""/>
 			<!--  all other items -->
 			<approvalRequirement votes="=vetter" locales="*" paths=""/>
 		</approvalRequirements>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -546,7 +546,7 @@ Cldr	;	to	;	modern ; Tongan
 Cldr	;	mt	;	basic ; Maltese
 Cldr	;	tg	;	basic ; Tajik
 Cldr	;	ti	;	modern ; Tigrinya
-Cldr	;	tt	;	basic ; Tatar
+# Cldr	;	tt	;	basic ; Tatar
 Cldr	;	wo	;	basic ; Wolof
 
 Bangor_Univ ;   cy   ;    modern  ; Welsh
@@ -686,15 +686,15 @@ Microsoft	;	zh	;	modern	;	Chinese (Simplified)
 Microsoft	;	zh_Hant	;	modern	;	Chinese (Traditional)
 Microsoft	;	zh_Hant_HK	;	modern	;	Chinese (Traditional, Hong Kong)
 Microsoft	;	zu	;	modern	;	Zulu
-Microsoft	;	ig	;	moderate	;	Igbo
+Microsoft	;	ig	;	basic	;	Igbo
 Microsoft	;	nn	;	moderate	;	Norwegian Nynorsk
-Microsoft	;	tk	;	moderate	;	Turkmen
-Microsoft	;	ha	;	basic	;	Hausa
+Microsoft	;	tk	;	modern	;	Turkmen
+# Microsoft	;	ha	;	basic	;	Hausa
 Microsoft	;	mi	;	basic	;	Māori
 Microsoft	;	tg	;	basic	;	Tajik
-Microsoft	;	tt	;	basic	;	Tatar
+# Microsoft	;	tt	;	basic	;	Tatar
 Microsoft	;	wo	;	basic	;	Wolof
-Microsoft	;	yo	;	basic	;	Yoruba
+# Microsoft	;	yo	;	basic	;	Yoruba
 Microsoft ; * ; moderate ; All Others, provisionally
 
 Pakistan	;	ur	;	modern	;	Urdu

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -9,11 +9,13 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.MinimizeRegex;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
@@ -53,36 +55,35 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         // We add in additionsToTranslate below the set in attributeValueValidity.xml $languageExceptions
         // (both sets are included in SDI.getCLDRLanguageCodes() but we do not use that until later).
         Set<String> additionsToTranslate = ImmutableSortedSet.of("zxx", "mul",
-                        "ab", "ace", "ada", "ady", "ain", "ale", "alt", "an", "anp", "arn", "arp", "ars", "atj", "av", "awa", "ay",
-                        "ba", "ban", "bho", "bi", "bin", "bla", "bug", "byn",
-                        "cay", "ch", "chk", "chm", "cho", "chp", "chy", "clc", "co", "crg", "crj", "crk", "crl", "crm", "crr", "csw", "cv",
-                        "dak", "dar", "dgr", "dv", "dzg",
-                        "efi", "eka",
-                        "fj", "fon", "frc",
-                        "gaa", "gez", "gil", "gn", "gor", "gwi",
-                        "hai", "hax", "hil", "hmn", "ht", "hup", "hur", "hz",
-                        "iba", "ibb", "ikt", "ilo", "inh", "io", "iu",
-                        "jbo",
-                        "kac", "kaj", "kbd", "kcg", "kfo", "kha", "kj", "kmb", "kpe", "kr", "krc", "krl", "kru", "kum", "kv", "kwk",
-                        "la", "lad", "lez", "li", "lil", "lou", "loz", "lsm", "lua", "lun", "lus",
-                        "mad", "mag", "mak", "mdf", "men", "mh", "mic", "min", "moe", "moh", "mos", "mus", "mwl", "myv",
-                        "na", "nap", "new", "ng", "nia", "niu", "nog", "nqo", "nr", "nso", "nv", "ny",
-                        "oc", "ojb", "ojc", "ojs", "ojw", "oka",
-                        "pag", "pam", "pap", "pau", "pqm",
-                        "rap", "rar", "rhg", "rup",
-                        "sad", "sba", "scn", "sco", "shn", "slh", "sm", "snk", "srn", "ss", "st", "str", "suk", "swb", "syr",
-                        "tce", "tem", "tet", "tgx", "tht", "tig", "tlh", "tli", "tn", "tpi", "trv", "ts", "ttm", "tum", "tvl", "ty", "tyv",
-                        "udm", "umb",
-                        "ve",
-                        "wa", "wal", "war", "wuu",
-                        "xal",
-                        "ybb",
-                        "zun", "zza" );
+            "ab", "ace", "ada", "ady", "ain", "ale", "alt", "an", "anp", "arn", "arp", "ars", "atj", "av", "awa", "ay",
+            "ba", "ban", "bho", "bi", "bin", "bla", "bug", "byn",
+            "cay", "ch", "chk", "chm", "cho", "chp", "chy", "clc", "co", "crg", "crj", "crk", "crl", "crm", "crr", "csw", "cv",
+            "dak", "dar", "dgr", "dv", "dzg",
+            "efi", "eka",
+            "fj", "fon", "frc",
+            "gaa", "gez", "gil", "gn", "gor", "gwi",
+            "hai", "hax", "hil", "hmn", "ht", "hup", "hur", "hz",
+            "iba", "ibb", "ikt", "ilo", "inh", "io", "iu",
+            "jbo",
+            "kac", "kaj", "kbd", "kcg", "kfo", "kha", "kj", "kmb", "kpe", "kr", "krc", "krl", "kru", "kum", "kv", "kwk",
+            "la", "lad", "lez", "li", "lil", "lou", "loz", "lsm", "lua", "lun", "lus",
+            "mad", "mag", "mak", "mdf", "men", "mh", "mic", "min", "moe", "moh", "mos", "mus", "mwl", "myv",
+            "na", "nap", "new", "ng", "nia", "niu", "nog", "nqo", "nr", "nso", "nv", "ny",
+            "oc", "ojb", "ojc", "ojs", "ojw", "oka",
+            "pag", "pam", "pap", "pau", "pqm",
+            "rap", "rar", "rhg", "rup",
+            "sad", "sba", "scn", "sco", "shn", "slh", "sm", "snk", "srn", "ss", "st", "str", "suk", "swb", "syr",
+            "tce", "tem", "tet", "tgx", "tht", "tig", "tlh", "tli", "tn", "tpi", "trv", "ts", "ttm", "tum", "tvl", "ty", "tyv",
+            "udm", "umb",
+            "ve",
+            "wa", "wal", "war", "wuu",
+            "xal",
+            "ybb",
+            "zun", "zza" );
 
-        warnln("Locales added for translation; revisit each release: " + additionsToTranslate);
-
-        Set<String> localeIdsAtComprehensive = ImmutableSortedSet.of();
-        warnln("Locales set to comprehensive; revisit each release: " + localeIdsAtComprehensive);
+        warnln("Locales added for translation; revisit each release:\n"
+            + Joiner.on("\n")
+            .join(additionsToTranslate.stream().map(x -> x + "\t(" + ENGLISH.getName(x) + ")").collect(Collectors.toList())));
 
         Map<String, Status> validity = Validity.getInstance().getCodeToStatus(LstrType.language);
         Multimap<Status, String> statusToLang = Multimaps.invertFrom(Multimaps.forMap(validity), TreeMultimap.create());
@@ -102,7 +103,6 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         Set<String> localesForNames = new TreeSet<>();
         localesForNames.addAll(mainLocales);
         localesForNames.addAll(additionsToTranslate);
-        localesForNames.removeAll(localeIdsAtComprehensive);
         localesForNames = ImmutableSet.copyOf(localesForNames);
 
         assertContains("regularPlus.containsAll(mainLocales)", regularPlus, localesForNames);
@@ -249,6 +249,18 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             Level googleLevel = google.get(locale);
             Level microsoftLevel = microsoft.get(locale);
             Level specialLevel = special.get(locale);
+
+            // check the 8 vote count
+
+            int count = (appleLevel == null ? 0 : 1)
+                + (googleLevel == null ? 0 : 1)
+                + (microsoftLevel == null ? 0 : 1)
+                ;
+            int defaultVotes = SupplementalDataInfo.getInstance().getRequiredVotes(CLDRLocale.getInstance(locale), null);
+            assertEquals("8 votes for " + locale + " at " + cldrLevel, count > 2, defaultVotes == 8);
+
+            // check the max level
+
             Level maxLevel = Level.max(appleLevel, googleLevel, microsoftLevel, specialLevel);
             assertEquals("cldr level = max for " + locale + " (" + ENGLISH.getName(locale) + ")", cldrLevel, maxLevel);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -252,12 +252,12 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
 
             // check the 8 vote count
 
-            int count = (appleLevel == null ? 0 : 1)
-                + (googleLevel == null ? 0 : 1)
-                + (microsoftLevel == null ? 0 : 1)
+            int count = getLevelCount(appleLevel)
+                + getLevelCount(googleLevel)
+                + getLevelCount(microsoftLevel)
                 ;
             int defaultVotes = SupplementalDataInfo.getInstance().getRequiredVotes(CLDRLocale.getInstance(locale), null);
-            assertEquals("8 votes for " + locale + " at " + cldrLevel, count > 2, defaultVotes == 8);
+            assertEquals("8 votes for " + locale + " at " + cldrLevel, count > 2 && cldrLevel.compareTo(Level.MODERN) >= 0, defaultVotes == 8);
 
             // check the max level
 
@@ -277,6 +277,11 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         checkDisjoint("special", special, "apple", apple);
         checkDisjoint("special", special, "google", google);
         checkDisjoint("special", special, "microsoft", microsoft);
+    }
+
+    private int getLevelCount(Level appleLevel) {
+        return appleLevel == null ? 0
+            : appleLevel.compareTo(Level.MODERN) >= 0 ? 1 : 0;
     }
 
     private static final Set<String> ANY_LOCALE_SET = ImmutableSet.of("*");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -623,7 +623,7 @@ public class TestUtilities extends TestFmwkPlus {
                 .fromPath(xpath);
         }
         resolver.setLocale(CLDRLocale.getInstance(locale), ph);
-        assertEquals("verifyRequiredVotes: " + ph.toString(), required, resolver.getRequiredVotes());
+        assertEquals(locale + " verifyRequiredVotes: " + ph.toString(), required, resolver.getRequiredVotes());
     }
 
     public void TestRequiredVotes() {
@@ -687,7 +687,7 @@ public class TestUtilities extends TestFmwkPlus {
      * the two locales pt_PT and zh_Hant
      */
     public void TestSublocaleRequiredVotes() {
-        final Set<String> eightVoteSublocales = new HashSet<>(Arrays.asList("pt_PT", "zh_Hant"));
+        final Set<String> eightVoteSublocales = new HashSet<>(Arrays.asList("pt_PT", "zh_Hant", "en_AU", "en_GB", "es_MX", "fr_CA"));
         final VoteResolver<String> resolver = new VoteResolver<>();
         final String path = "//ldml/annotations/annotation[@cp=\"🌏\"][@type=\"tts\"]";
         for (String locale : SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES) {


### PR DESCRIPTION
CLDR-15687

This adds a test for the 8 vote locales, according to the following policy.
 * If a locale is in Locales.txt under Organization=Cldr, and has > 2 TC org locales at Modern, then it needs 8 votes.
 * Otherwise it needs 4.

This involved making some small changes to coverageLevels.txt
* setting 3 locales to 4 votes that didn't make the bar: am, ga, ky
* setting some locales that did make the bar to 8 votes: bg, 'is' and the sublocales en_AU, en_GB, es_MX, fr_CA,

And some unrelated cleanup
* dropping 1 warning that isn't relevant anymore
* reformatting the output of another to be more readable.

Review the ticket with hiding whitespace to avoid some noise introduced by re-indenting.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
