### PR TITLE
CLDR-15646 Priority Items Summary: improve snapshot id, subheaders

### DIFF
--- a/tools/cldr-apps/js/src/views/VettingSummary.vue
+++ b/tools/cldr-apps/js/src/views/VettingSummary.vue
@@ -41,7 +41,7 @@
               title="Show the indicated snapshot of the Priority Items Summary"
               @click="showSnapshot(snapshotId)"
             >
-              {{ snapshotId }}
+              {{ humanizeSnapId(snapshotId) }}
             </button>
           </span>
         </span>
@@ -181,7 +181,7 @@ export default {
         return null;
       }
       if (cldrPriorityItems.snapshotIdIsValid(snapshotId)) {
-        return "Snapshot " + snapshotId;
+        return "Snapshot " + this.humanizeSnapId(snapshotId);
       } else if (this.canUseSnapshots) {
         return "Latest (not a snapshot)";
       } else {
@@ -230,6 +230,19 @@ export default {
 
     humanizeLocale(locale) {
       return cldrLoad.getLocaleName(locale);
+    },
+
+    /**
+     * Display a more user-friendly snapshot id
+     *
+     * @param id like “2022-05-16T08:15:25.083077935Z”
+     * @return like “2022-05-16 08:15 GMT”
+     */
+    humanizeSnapId(id) {
+      if (!id.match(/^\d+\-\d+\-\d+T\d\d:\d\d:\d\d\..+Z$/)) {
+        return id;
+      }
+      return id.replace("T", " ").replace(/:\d\d\..+Z/, " GMT");
     },
 
     reportClass(kind) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -995,13 +995,12 @@ public class VettingViewer<T> {
                 if (DEBUG_THREADS) {
                     System.out.println("Appending " + name + " - " + outputs[n].length());
                 }
-                output.append(outputs[n]);
-
                 char nextChar = name.charAt(0);
                 if (lastChar != nextChar) {
                     output.append(this.header);
                     lastChar = nextChar;
                 }
+                output.append(outputs[n]);
             }
         }
 


### PR DESCRIPTION
-Display snapshot id like 2022-05-16 08:15 GMT instead of 2022-05-16T08:15:25.083077935Z

-Fix the subheader lines, they are supposed to be between different first letters of locales

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
