### PR TITLE
CLDR-15357 LocaleCompletion: add baseline count to back end

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -253,6 +253,20 @@ public class Dashboard {
         args.setFiles(sourceFile, baselineFile);
     }
 
+    /**
+     * Setup to calculate the baseline ('HEAD') error count
+     * @param args
+     * @param locale
+     * @param baselineFactory
+     * @param isBaseline
+     */
+    public static void setFilesForBaseline(DashboardArgs args, CLDRLocale locale, Factory baselineFactory) {
+        final String localeId = locale.getBaseName();
+        final CLDRFile baselineFile = baselineFactory.make(localeId, true);
+        final CLDRFile sourceFile = baselineFactory.make(localeId, false);
+        args.setFiles(sourceFile, baselineFile);
+    }
+
     private ReviewOutput reallyGet(VettingViewer<Organization> vv, DashboardArgs args) {
         VettingViewer<Organization>.DashboardData dd;
         dd = vv.generateDashboard(args);


### PR DESCRIPTION
CLDR-15357 

- [ ] This PR completes the ticket.

It's an incremental step.

`GET /api/completion/locale/es` for example now returns:

```json
{
  "baselineCount": 6,
  "error": 0,
  "level": "MODERN",
  "missing": 7,
  "provisional": 0,
  "total": 8653,
  "votes": 8632
}
```

That `6` is missing+error+provisional from HEAD (current .xml).