### PR TITLE
CLDR-15282 Remove keywords for red

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -3528,11 +3528,11 @@ annotations.
 		<annotation cp="⏪" type="tts">fast reverse button</annotation>
 		<annotation cp="⏮">arrow | last track button | previous scene | previous track | triangle</annotation>
 		<annotation cp="⏮" type="tts">last track button</annotation>
-		<annotation cp="🔼">arrow | button | red | upwards button</annotation>
+		<annotation cp="🔼">arrow | button | upwards button</annotation>
 		<annotation cp="🔼" type="tts">upwards button</annotation>
 		<annotation cp="⏫">arrow | double | fast up button</annotation>
 		<annotation cp="⏫" type="tts">fast up button</annotation>
-		<annotation cp="🔽">arrow | button | down | downwards button | red</annotation>
+		<annotation cp="🔽">arrow | button | down | downwards button</annotation>
 		<annotation cp="🔽" type="tts">downwards button</annotation>
 		<annotation cp="⏬">arrow | double | down | fast down button</annotation>
 		<annotation cp="⏬" type="tts">fast down button</annotation>


### PR DESCRIPTION
CLDR-15282

Remove keywords for 'red' from upwards and downwards button since the representation is up to the vendor and may not be red.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
