### PR TITLE
CLDR-15722 Change NZ Alt to Aotearoa

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1134,7 +1134,7 @@ annotations.
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">New Zealand</territory>
-			<territory type="NZ" alt="variant">Aotearoa New Zealand</territory>
+			<territory type="NZ" alt="variant">Aotearoa</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>


### PR DESCRIPTION
CLDR-15722

Change NZ Alt to Aotearoa since a compound can be made out of the two names if needed.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
