### PR TITLE
CLDR-15646 Use baselineCount for 3rd meter and summary Progress column

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -258,12 +258,18 @@ public class Dashboard {
      * @param args
      * @param locale
      * @param baselineFactory
-     * @param isBaseline
      */
     public static void setFilesForBaseline(DashboardArgs args, CLDRLocale locale, Factory baselineFactory) {
         final String localeId = locale.getBaseName();
         final CLDRFile baselineFile = baselineFactory.make(localeId, true);
-        final CLDRFile sourceFile = baselineFactory.make(localeId, false);
+        /*
+         * sourceFile must be resolved, otherwise VettingViewer.getMissingStatus is liable
+         * to get a null value and return MissingStatus.ABSENT where a resolved file
+         * could result in a non-null inherited value (such as en_CA inheriting from en)
+         * and MissingStatus.PRESENT. Any such inconsistencies interfere with comparing
+         * the current and baseline stats.
+         */
+        final CLDRFile sourceFile = baselineFactory.make(localeId, true /* resolved */);
         args.setFiles(sourceFile, baselineFile);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CompletionPercent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CompletionPercent.java
@@ -1,0 +1,29 @@
+package org.unicode.cldr.util;
+
+public class CompletionPercent {
+    /**
+     * Calculate a "user-friendly" percentage value between 0 and 100
+     *
+     * @param done the number of tasks that have been completed
+     * @param total the total number of tasks
+     * @return a number between 0 and 100
+     */
+    public static int calculate(int done, int total) {
+        if (total <= 0) {
+            // The task is finished since nothing needed to be done
+            // Do not divide by zero
+            return 100;
+        }
+        if (done <= 0) {
+            return 0;
+        }
+        // Do not round 99.9 up to 100
+        final int floor = (int) Math.floor((100 * (float) done) / (float) total);
+        if (floor == 0) {
+            // Do not round 0.001 down to zero
+            // Instead, provide indication of slight progress
+            return 1;
+        }
+        return Math.min(floor, 100);
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleCompletionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleCompletionData.java
@@ -1,0 +1,29 @@
+package org.unicode.cldr.util;
+
+public class LocaleCompletionData {
+    final private int error;
+    final private int missing;
+    final private int provisional;
+
+    public LocaleCompletionData(Counter<VettingViewer.Choice> problemCounter) {
+        error = (int) problemCounter.get(VettingViewer.Choice.error);
+        missing = (int) problemCounter.get(VettingViewer.Choice.missingCoverage);
+        provisional = (int) problemCounter.get(VettingViewer.Choice.notApproved);
+    }
+
+    public int errorCount() {
+        return error;
+    }
+
+    public int missingCount() {
+        return missing;
+    }
+
+    public int provisionalCount() {
+        return provisional;
+    }
+
+    public int problemCount() {
+        return error + missing + provisional;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterProgress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterProgress.java
@@ -1,23 +1,16 @@
 package org.unicode.cldr.util;
 
-// TODO: rename this to VettingProgress, since now it is used not only for
-// "voter completion" which is user-specific, but also for "locale completion" which isn't
 public class VoterProgress {
+
     /**
      * The number of paths for which this user is expected to vote
      * (in this locale, limited by the coverage level)
-     *
-     * More generally (as for locale completion), the number of tasks
-     * that are expected to be completed
      */
     private int votablePathCount = 0;
 
     /**
      * The number of paths for which this user already has voted
      * (in this locale, limited by the coverage level)
-     *
-     * More generally (as for locale completion), the number of tasks
-     * that have already been completed (normally <= votablePathCount)
      */
     private int votedPathCount = 0;
 
@@ -35,27 +28,5 @@ public class VoterProgress {
 
     public void incrementVotedPathCount() {
         votedPathCount++;
-    }
-
-    public int friendlyPercent() {
-        if (votablePathCount <= 0) {
-            // The task is finished since nothing needed to be done
-            // Do not divide by zero (0 / 0 = NaN%)
-            return 100;
-        }
-        if (votedPathCount <= 0) {
-            return 0;
-        }
-        // Do not round 99.9 up to 100
-        final int floor = (int) Math.floor((100 * (float) votedPathCount) / (float) votablePathCount);
-        if (floor == 0) {
-            // Do not round 0.001 down to zero
-            // Instead, provide indication of slight progress
-            return 1;
-        }
-        if (floor > 100) {
-            return 100;
-        }
-        return floor;
     }
 }


### PR DESCRIPTION
-Fix baselineCount by using a resolved CLDRFile for sourceFile

-Throw exception in generateLocaleCompletion unless sourceFile.isResolved

-Change calculation of locale completion percentage to use baselineCount

-Percentage cannot be less than 0 or greater than 100

-New interface LocaleBaselineCount, implemented by VVQueueLocaleBaselineCount

-New VettingViewer.localeBaselineCount, with setter

-New static LocaleCompletion.getBaselineCount

-Refactor LocaleCompletionCounter constructors to avoid duplication

-New CompletionPercent.java in util

-Move LocaleCompletionData to its own file LocaleCompletionData.java in util

-Encapsulate formula errors+missing+provisional with method LocaleCompletionData.problemCount

-Minor refactoring; final where possible; reduce public members, use getters/setters

-Java formatting, including some re-ordering of imports

-Remove dead code

-Comments

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
