### PR TITLE
CLDR-15646 Prevent baselineCount from depending on votes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
@@ -28,7 +28,10 @@ public class LocaleCompletionCounter {
         localeId = cldrLocale.toString();
         level = StandardCodes.make().getTargetCoverageLevel(localeId);
         final SurveyMain sm = CookieSession.sm;
-        vv = new VettingViewer<>(sm.getSupplementalDataInfo(), factory, new STUsersChoice(sm));
+        final VettingViewer.UsersChoice<Organization> userVoteStatus = isBaseline
+            ? new VettingViewer.EmptyUsersChoice()
+            : new STUsersChoice(sm);
+        vv = new VettingViewer<>(sm.getSupplementalDataInfo(), factory, userVoteStatus);
         final EnumSet<VettingViewer.Choice> set = VettingViewer.getLocaleCompletionCategories();
         args = new VettingViewer.DashboardArgs(set, cldrLocale, level);
         args.setUserAndOrganization(0, VettingViewer.getNeutralOrgForSummary());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -263,6 +263,34 @@ public class VettingViewer<T> {
         VoteResolver<String> getVoteResolver(CLDRLocale loc, String path);
     }
 
+    public static class EmptyUsersChoice implements UsersChoice<Organization> {
+        final PathHeader.Factory phf = PathHeader.getFactory();
+
+        @Override
+        public String getWinningValueForUsersOrganization(CLDRFile cldrFile, String path, Organization org) {
+            CLDRLocale loc = CLDRLocale.getInstance(cldrFile.getLocaleID());
+            return getVoteResolver(loc, path).getOrgVote(org);
+        }
+
+        @Override
+        public VoteStatus getStatusForUsersOrganization(CLDRFile cldrFile, String path, Organization org) {
+            CLDRLocale loc = CLDRLocale.getInstance(cldrFile.getLocaleID());
+            return getVoteResolver(loc, path).getStatusForOrganization(org);
+        }
+
+        @Override
+        public VoteResolver<String> getVoteResolver(final CLDRLocale loc, final String path) {
+            VoteResolver<String> r = new VoteResolver<>();
+            r.setLocale(loc, phf.fromPath(path));
+            return r;
+        }
+
+        @Override
+        public boolean userDidVote(int userId, CLDRLocale loc, String path) {
+            return false;
+        }
+    }
+
     public interface ErrorChecker {
         enum Status {
             ok, error, warning


### PR DESCRIPTION
-New VettingViewer.EmptyUsersChoice implements UsersChoice

-Use EmptyUsersChoice instead of STUsersChoice if isBaseline

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
