### PR TITLE
CLDR-15646 Encapsulate VoteResolver.isUsingKeywordAnnotationVoting

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -896,17 +896,6 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             } else {
                 r.clear(); // reuse
             }
-            /* Apply special voting method adjustAnnotationVoteCounts only to certain bar-separated keyword annotations.
-             * See http://unicode.org/cldr/trac/ticket/10973
-             * The paths for keyword annotations start with "//ldml/annotations/annotation" and do NOT include Emoji.TYPE_TTS.
-             * Both name paths (cf. namePath, getNamePaths) and keyword paths (cf. keywordPath, getKeywordPaths)
-             * have "//ldml/annotations/annotation". Name paths include Emoji.TYPE_TTS, and keyword paths don't.
-             * Special voting is only for keyword paths, not for name paths.
-             * Compare path dependencies in DisplayAndInputProcessor.java. See also VoteResolver.splitAnnotationIntoComponentsList.
-             * Note: this does not affect the occurrences of "new VoteResolver" in ConsoleCheckCLDR.java or TestUtilities.java;
-             * if those tests ever involve annotation keywords, they could call setUsingKeywordAnnotationVoting as needed.
-             */
-            r.setUsingKeywordAnnotationVoting(AnnotationUtil.pathIsAnnotation(path) && !path.contains(Emoji.TYPE_TTS));
 
             final ValueChecker vc = ERRORS_ALLOWED_IN_VETTING ? null : new ValueChecker(path);
 


### PR DESCRIPTION
-Eliminate unneeded setUsingKeywordAnnotationVoting

-VoteResolver.isUsingKeywordAnnotationVoting gets path from pathHeader

-This change will facilitate implementing a UsersChoice with VoteResolver without votes

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
