### PR TITLE
CLDR-15646 Prevent baselineCount from depending on votes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -18,7 +18,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -29,7 +28,6 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
-import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
@@ -823,58 +821,6 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         }
 
         /**
-         * Utility class for testing values
-         * @author srl
-         *
-         */
-        private class ValueChecker {
-            private final String path;
-            /*
-             * Use 8 for initial HashSet size; 16 is probably too many values for best performance
-             */
-            HashSet<String> goodValues = new HashSet<>(8);
-            HashSet<String> badValues = new HashSet<>(8);
-
-            LinkedList<CheckCLDR.CheckStatus> result = null;
-            TestResultBundle testBundle = null;
-
-            ValueChecker(String path) {
-                this.path = path;
-            }
-
-            boolean canUseValue(String value) {
-                if (value == null || goodValues.contains(value)) {
-                    return true;
-                } else if (badValues.contains(value)) {
-                    return false;
-                } else {
-                    if (testBundle == null) {
-                        testBundle = getDiskTestBundle(locale);
-                        result = new LinkedList<>();
-                    } else {
-                        result.clear();
-                    }
-
-                    testBundle.check(path, result, value);
-                    if (false) System.out.println("Checking result of " + path + " = " + value + " := haserr " + CheckCLDR.CheckStatus.hasError(result));
-                    if (CheckCLDR.CheckStatus.hasError(result)) {
-                        badValues.add(value);
-                        return false;
-                    } else {
-                        goodValues.add(value);
-                        return true; // OK
-                    }
-                }
-            }
-
-        }
-
-        /**
-         * Disable ValueChecker
-         */
-        private static final boolean ERRORS_ALLOWED_IN_VETTING = true;
-
-        /**
          * Create or update a VoteResolver for this item
          *
          * @param perXPathData
@@ -897,18 +843,14 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 r.clear(); // reuse
             }
 
-            final ValueChecker vc = ERRORS_ALLOWED_IN_VETTING ? null : new ValueChecker(path);
-
             // Set established locale
             r.setLocale(locale, getPathHeader(path));
 
             // set current Trunk (baseline) value (if present)
             final String currentValue = diskData.getValueAtDPath(path);
-            final Status currentStatus = calculateStatus(diskFile, diskFile, path);
-            if (ERRORS_ALLOWED_IN_VETTING || vc.canUseValue(currentValue)) {
-                r.setBaseline(currentValue, currentStatus);
-                r.add(currentValue);
-            }
+            final Status currentStatus = VoteResolver.calculateStatus(diskFile, path);
+            r.setBaseline(currentValue, currentStatus);
+            r.add(currentValue);
 
             CLDRFile cf = make(locale, true);
             r.setBaileyValue(cf.getBaileyValue(path, null, null));
@@ -917,11 +859,8 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             if (perXPathData != null && !perXPathData.isEmpty()) {
                 for (Entry<User, PerLocaleData.PerXPathData.PerUserData> e : perXPathData.getVotes()) {
                     PerLocaleData.PerXPathData.PerUserData v = e.getValue();
-
-                    if (ERRORS_ALLOWED_IN_VETTING || vc.canUseValue(v.getValue())) {
-                        r.add(v.getValue(), // user's vote
+                    r.add(v.getValue(), // user's vote
                             e.getKey().id, v.getOverride(), v.getWhen()); // user's id
-                    }
                 }
             }
             return r;
@@ -2181,11 +2120,6 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
 
     /**
      * Read back a dir full of pxml files
-     *
-     * @param sm
-     * @param inFile
-     *            dir containing pxmls
-     * @return
      */
     public Integer[] readPXMLFiles(final File inFileList[]) {
         int nusers = 0;
@@ -2287,38 +2221,5 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
     public static final String getLastVoteTable() {
         final String dbName = DBUtils.Table.VOTE_VALUE.forVersion(SurveyMain.getLastVoteVersion(), false).toString();
         return dbName;
-    }
-
-    /**
-     * Utility function to calculate CLDRFile.Status
-     * @param cldrFile the CLDR File to use
-     * @param diskFile the 'baseline' file to use
-     * @param path xpath
-     * @param value current string value
-     * @return
-     */
-    public static final Status calculateStatus(CLDRFile cldrFile, CLDRFile diskFile, String path) {
-        String fullXPath = cldrFile.getFullXPath(path);
-        if (fullXPath == null) {
-            fullXPath = path;
-        }
-        XPathParts xpp = XPathParts.getFrozenInstance(fullXPath);
-        String draft = xpp.getAttributeValue(-1, LDMLConstants.DRAFT);
-        Status status = draft == null ? Status.approved : VoteResolver.Status.fromString(draft);
-
-        /*
-         * Reset to missing if the value is inherited from root or code-fallback, unless the XML actually
-         * contains INHERITANCE_MARKER. Pass false for skipInheritanceMarker so that status will not be
-         * missing for explicit INHERITANCE_MARKER. Reference: https://unicode.org/cldr/trac/ticket/11857
-         */
-        final String srcid = cldrFile.getSourceLocaleIdExtended(path, null, false /* skipInheritanceMarker */);
-        if (srcid.equals(XMLSource.CODE_FALLBACK_ID)) {
-            status = Status.missing;
-        } else if (srcid.equals("root")) {
-            if (!srcid.equals(diskFile.getLocaleID())) {
-                status = Status.missing;
-            }
-        }
-        return status;
     }
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STUsersChoice.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STUsersChoice.java
@@ -31,7 +31,7 @@ public class STUsersChoice implements UsersChoice<Organization> {
     }
 
     @Override
-    public VoteResolver<String> getVoteResolver(CLDRLocale loc, String path) {
+    public VoteResolver<String> getVoteResolver(CLDRFile cldrFile, CLDRLocale loc, String path) {
         BallotBox<User> ballotBox = getBox(sm, loc);
         return ballotBox.getResolver(path);
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
@@ -28,7 +28,10 @@ public class LocaleCompletionCounter {
         localeId = cldrLocale.toString();
         level = StandardCodes.make().getTargetCoverageLevel(localeId);
         final SurveyMain sm = CookieSession.sm;
-        vv = new VettingViewer<>(sm.getSupplementalDataInfo(), factory, new STUsersChoice(sm));
+        final VettingViewer.UsersChoice<Organization> userVoteStatus = isBaseline
+            ? new VotelessUsersChoice()
+            : new STUsersChoice(sm);
+        vv = new VettingViewer<>(sm.getSupplementalDataInfo(), factory, userVoteStatus);
         final EnumSet<VettingViewer.Choice> set = VettingViewer.getLocaleCompletionCategories();
         args = new VettingViewer.DashboardArgs(set, cldrLocale, level);
         args.setUserAndOrganization(0, VettingViewer.getNeutralOrgForSummary());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -260,7 +260,7 @@ public class VettingViewer<T> {
          */
         boolean userDidVote(int userId, CLDRLocale loc, String path);
 
-        VoteResolver<String> getVoteResolver(CLDRLocale loc, String path);
+        VoteResolver<String> getVoteResolver(CLDRFile baselineFile, CLDRLocale loc, String path);
     }
 
     public interface ErrorChecker {
@@ -558,11 +558,13 @@ public class VettingViewer<T> {
         }
 
         private CLDRFile sourceFile = null;
+        private CLDRFile baselineFile = null;
         private CLDRFile baselineFileUnresolved = null;
         private boolean latin = false;
 
         private void setFiles(CLDRFile sourceFile, CLDRFile baselineFile) {
             this.sourceFile = sourceFile;
+            this.baselineFile = baselineFile;
             this.baselineFileUnresolved = (baselineFile == null) ? null : baselineFile.getUnresolved();
             this.latin = VettingViewer.isLatinScriptLocale(sourceFile);
         }
@@ -712,7 +714,7 @@ public class VettingViewer<T> {
 
         private MissingStatus recordMissingChangedEtc(String path,
             boolean itemsOkIfVoted, String value, String oldValue) {
-            VoteResolver<String> resolver = userVoteStatus.getVoteResolver(cldrLocale, path);
+            VoteResolver<String> resolver = userVoteStatus.getVoteResolver(baselineFile, cldrLocale, path);
             MissingStatus missingStatus;
             if (resolver.getWinningStatus() == VoteResolver.Status.missing) {
                 missingStatus = getMissingStatus(sourceFile, path, latin);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
@@ -1,0 +1,38 @@
+package org.unicode.cldr.util;
+
+public class VotelessUsersChoice implements VettingViewer.UsersChoice<Organization> {
+
+    final PathHeader.Factory phf = PathHeader.getFactory();
+
+    @Override
+    public String getWinningValueForUsersOrganization(CLDRFile cldrFile, String path, Organization org) {
+        final CLDRLocale loc = CLDRLocale.getInstance(cldrFile.getLocaleID());
+        return getVoteResolver(cldrFile, loc, path).getOrgVote(org);
+    }
+
+    @Override
+    public VettingViewer.VoteStatus getStatusForUsersOrganization(CLDRFile cldrFile, String path, Organization org) {
+        final CLDRLocale loc = CLDRLocale.getInstance(cldrFile.getLocaleID());
+        return getVoteResolver(cldrFile, loc, path).getStatusForOrganization(org);
+    }
+
+    @Override
+    public VoteResolver<String> getVoteResolver(CLDRFile cldrFile, CLDRLocale loc, String path) {
+        final VoteResolver<String> r = new VoteResolver<>();
+        r.setLocale(loc, phf.fromPath(path));
+
+        final String baileyValue = cldrFile.getBaileyValue(path, null, null);
+        r.setBaileyValue(baileyValue);
+
+        final String baselineValue = cldrFile.getWinningValue(path);
+        final VoteResolver.Status status = VoteResolver.calculateStatus(cldrFile, path);
+        r.setBaseline(baselineValue, status);
+
+        return r;
+    }
+
+    @Override
+    public boolean userDidVote(int userId, CLDRLocale loc, String path) {
+        return false;
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
@@ -45,7 +45,7 @@ class TestVettingViewer {
             }
 
             @Override
-            public VoteResolver<String> getVoteResolver(final CLDRLocale loc, final String path) {
+            public VoteResolver<String> getVoteResolver(CLDRFile cldrFile, final CLDRLocale loc, final String path) {
                 VoteResolver<String> r = new VoteResolver<>();
                 r.setLocale(locale, getPathHeader(path));
                 return r;


### PR DESCRIPTION
-New VotelessUsersChoice implements UsersChoice

-Add cldrFile parameter to UsersChoice.getVoteResolver

-Remove unused ValueChecker and ERRORS_ALLOWED_IN_VETTING (making ERRORS_ALLOWED_IN_VETTING permanently true); otherwise VotelessUsersChoice would need to reference them, and they would need to move from web to util

-Move calculateStatus from web/STFactory.java to util/VoteResolver

-Combine 1st/2nd parameters of calculateStatus which were always the same

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
