### PR TITLE
CLDR-15646 Make baselineCount more consistent with non-baseline

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -2109,21 +2109,23 @@ public class VoteResolver<T> {
         }
         final XPathParts xpp = XPathParts.getFrozenInstance(fullXPath);
         final String draft = xpp.getAttributeValue(-1, LDMLConstants.DRAFT);
-        Status status = draft == null ? Status.approved : VoteResolver.Status.fromString(draft);
+        VoteResolver.Status resolverStatus = draft == null ? Status.approved : VoteResolver.Status.fromString(draft);
 
         /*
-         * Reset to missing if the value is inherited from root or code-fallback, unless the XML actually
+         * Reset to missing if the value is constructed or inherited from root or code-fallback, unless the XML actually
          * contains INHERITANCE_MARKER. Pass false for skipInheritanceMarker so that status will not be
          * missing for explicit INHERITANCE_MARKER.
          */
-        final String srcid = baselineFile.getSourceLocaleIdExtended(path, null, false /* skipInheritanceMarker */);
-        if (srcid.equals(XMLSource.CODE_FALLBACK_ID)) {
-            status = Status.missing;
+        CLDRFile.Status fileStatus = new CLDRFile.Status();
+        final String srcid = baselineFile.getSourceLocaleIdExtended(path, fileStatus, false /* skipInheritanceMarker */);
+        if (srcid.equals(XMLSource.CODE_FALLBACK_ID)
+                || GlossonymConstructor.PSEUDO_PATH.equals(fileStatus.pathWhereFound)) {
+            resolverStatus = Status.missing;
         } else if (srcid.equals("root")) {
             if (!srcid.equals(baselineFile.getLocaleID())) {
-                status = Status.missing;
+                resolverStatus = Status.missing;
             }
         }
-        return status;
+        return resolverStatus;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
@@ -24,7 +24,8 @@ public class VotelessUsersChoice implements VettingViewer.UsersChoice<Organizati
         final String baileyValue = cldrFile.getBaileyValue(path, null, null);
         r.setBaileyValue(baileyValue);
 
-        final String baselineValue = cldrFile.getWinningValue(path);
+        final XMLSource xmlSource = cldrFile.dataSource;
+        final String baselineValue = xmlSource.isHere(path) ? xmlSource.getValueAtDPath(path) : null;
         final VoteResolver.Status status = VoteResolver.calculateStatus(cldrFile, path);
         r.setBaseline(baselineValue, status);
 


### PR DESCRIPTION
-Treat constructed values as missing in VoteResolver.calculateStatus

-In VotelessUsersChoice set baseline value using xmlSource.isHere. getValueAtDPath

CLDR-15646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
