### PR TITLE
CLDR-15749 Add extra paths for ca, es, gl names

### DIFF
--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -10731,4 +10731,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="tnum">números tabulars</featureName>
 		<featureName type="zero">zero amb barra</featureName>
 	</typographicNames>
+	<personNames>
+		<personName order="sorting" length="long" usage="referring" formality="formal">
+			<namePattern alt='1' draft='provisional'>{surname}, {prefix} {given} {given2}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="informal">
+			<namePattern alt='1' draft='provisional'>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="formal">
+			<namePattern alt='1' draft='provisional'>{surname}, {prefix} {given} {given2}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="informal">
+			<namePattern alt='1' draft='provisional'>{surname}, {given-informal}</namePattern>
+		</personName>
+	</personNames>
 </ldml>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -11103,4 +11103,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="tnum">números tabulares</featureName>
 		<featureName type="zero">cero cruzado</featureName>
 	</typographicNames>
+	<personNames>
+		<personName order="sorting" length="long" usage="referring" formality="formal">
+			<namePattern alt='1' draft='provisional'>{surname}, {prefix} {given} {given2}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="informal">
+			<namePattern alt='1' draft='provisional'>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="formal">
+			<namePattern alt='1' draft='provisional'>{surname}, {prefix} {given} {given2}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="informal">
+			<namePattern alt='1' draft='provisional'>{surname}, {given-informal}</namePattern>
+		</personName>
+	</personNames>
 </ldml>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -9512,4 +9512,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="tnum">números tabulares</featureName>
 		<featureName type="zero">cero cruzado</featureName>
 	</typographicNames>
+		<personNames>
+		<personName order="sorting" length="long" usage="referring" formality="formal">
+			<namePattern alt='1' draft='provisional'>{surname}, {prefix} {given} {given2}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="informal">
+			<namePattern alt='1' draft='provisional'>{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="formal">
+			<namePattern alt='1' draft='provisional'>{surname}, {prefix} {given} {given2}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="informal">
+			<namePattern alt='1' draft='provisional'>{surname}, {given-informal}</namePattern>
+		</personName>
+	</personNames>
 </ldml>


### PR DESCRIPTION
CLDR-15749

As per discussions in person-names WG.
* These are added as alt='1' and provisional, so vetters will need to confirm the value and change as needed.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
