### PR TITLE
CLDR-8666 Implementation for Vote Report Resolver

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReportsDB.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReportsDB.java
@@ -5,9 +5,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,9 +13,10 @@ import java.util.logging.Logger;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.ReportStatusUpdater;
 import org.unicode.cldr.util.VoterReportStatus;
 
-public class ReportsDB implements VoterReportStatus<Integer>, ReportStatusUpdater<Integer> {
+public class ReportsDB extends VoterReportStatus<Integer> implements ReportStatusUpdater<Integer>{
     public static ReportsDB getInstance() {
         return ReportsDBHelper.INSTANCE;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReportStatusUpdater.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReportStatusUpdater.java
@@ -1,7 +1,4 @@
-package org.unicode.cldr.web;
-
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.VoterReportStatus;
+package org.unicode.cldr.util;
 
 /**
  * Interface for an object that can update report status

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterReportStatus.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterReportStatus.java
@@ -1,11 +1,13 @@
 package org.unicode.cldr.util;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * This interface is for objects which can expose information on which reports have been completed.
+ * @param T the type for each voter. Must be an Integer.
  */
-public interface VoterReportStatus<T> {
+public abstract class VoterReportStatus<T> {
     /**
      * Enumeration for the reports. In order.
      */
@@ -13,7 +15,25 @@ public interface VoterReportStatus<T> {
         datetime, zones, compact, // aka 'numbers'
     };
 
-    public ReportStatus getReportStatus(T user, CLDRLocale locale);
+    public enum ReportAcceptability {
+        notAcceptable, acceptable;
+
+        boolean isAcceptable() {
+            return this == acceptable;
+        }
+
+        static ReportAcceptability fromPair(boolean isComplete, boolean isAcceptable) {
+            if (isAcceptable) {
+                return acceptable;
+            } else if (isComplete) {
+                return notAcceptable;
+            } else {
+                return null;
+            }
+        }
+    };
+
+    public abstract ReportStatus getReportStatus(T user, CLDRLocale locale);
 
     public static class ReportStatus {
         public EnumSet<ReportId> completed = EnumSet.noneOf(ReportId.class);
@@ -35,5 +55,43 @@ public interface VoterReportStatus<T> {
             }
             return this;
         }
+
+        /**
+         * Return the acceptability enum for this report type
+         * @param r report type
+         * @return the acceptability enum, or null if there was no entry
+         */
+        public ReportAcceptability getAcceptability(ReportId r) {
+            return ReportAcceptability.fromPair(completed.contains(r), acceptable.contains(r));
+        }
+    }
+
+    /**
+     * Update a Resolver for a particular Report. The resolver will be cleared.
+     * Note that T must be an Integer for this to succeed.
+     * @param l locale
+     * @param r which report
+     * @param userList set of users
+     * @param status the source
+     * @param res which
+     * @return resolver
+     */
+    public VoteResolver<ReportAcceptability>
+    updateResolver(CLDRLocale l, ReportId r,
+        Set<T> userList, VoteResolver<ReportAcceptability> res) {
+        res.clear();
+        res.setBaileyValue(null);
+        // Get the report status for each user
+        userList.forEach(id -> {
+            // get the report status for this user
+            final ReportStatus rs = getReportStatus(id, l);
+            // convert the ReportStatus for the specific id, into an enum (or null)
+            final ReportAcceptability acc = rs.getAcceptability(r);
+            if (acc != null) {
+                // if not an abstention, add
+                res.add(acc, (Integer) id); // TODO: Cast because T must be an Integer. Refactor class to not be templatized
+            }
+        });
+        return res;
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/MemVoterReportStatus.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/MemVoterReportStatus.java
@@ -1,0 +1,21 @@
+package org.unicode.cldr.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Trivial, in-memory implementation of a VoterReportStatus<> and ReportStatusUpdater<>
+ */
+class MemVoterReportStatus<T extends Comparable<T>> extends VoterReportStatus<T> implements ReportStatusUpdater<T> {
+    Map<Pair<T, CLDRLocale>, ReportStatus> data = new HashMap<>();
+
+    @Override
+    public ReportStatus getReportStatus(T user, CLDRLocale locale) {
+        return data.computeIfAbsent(Pair.of(user, locale), k -> new ReportStatus());
+    }
+
+    @Override
+    public void markReportComplete(T user, CLDRLocale locale, ReportId r, boolean marked, boolean acceptable) {
+        getReportStatus(user, locale).mark(r, marked, acceptable);
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestReportStatus.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestReportStatus.java
@@ -1,11 +1,18 @@
 package org.unicode.cldr.util;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.unicode.cldr.util.VoteResolver.Status;
+import org.unicode.cldr.util.VoteResolver.VoterInfo;
+import org.unicode.cldr.util.VoterReportStatus.ReportAcceptability;
 import org.unicode.cldr.util.VoterReportStatus.ReportId;
 import org.unicode.cldr.util.VoterReportStatus.ReportStatus;
 
@@ -20,7 +27,7 @@ public class TestReportStatus {
         // punch some buttons
         status.mark(ReportId.compact, true, false);
         assertEquals(EnumSet.of(ReportId.compact),
-        status.completed, "after marking 'compact' set");
+            status.completed, "after marking 'compact' set");
         assertEquals(EnumSet.noneOf(ReportId.class),
             status.acceptable, "after marking 'compact' set");
 
@@ -63,5 +70,89 @@ public class TestReportStatus {
             assertEquals(s.size(), ReportId.values().length - 1,
                 () -> "Expected all but one was set after unsetting compact: " + s.toString());
         }
+    }
+
+    @Test
+    @Disabled("until CLDR-15765 merged, not reliable due to static init")
+    void testResolver() {
+        Map<Integer, VoterInfo> m = new HashMap<>();
+        final int VETTER1 = 1;
+        final int GUEST2 = 2;
+        final int TC3 = 3;
+        final int VETTER4 = 4;
+        m.put(VETTER1, new VoterInfo(
+            Organization.meta,
+            VoteResolver.Level.vetter,
+            "1-meta-vetter",
+            new LocaleSet(true)));
+        m.put(GUEST2, new VoterInfo(
+            Organization.guest,
+            VoteResolver.Level.street,
+            "2-guest-guest",
+            new LocaleSet(true)));
+        m.put(TC3, new VoterInfo(
+            Organization.surveytool,
+            VoteResolver.Level.tc,
+            "3-st-tc",
+            new LocaleSet(true)));
+        m.put(VETTER4, new VoterInfo(
+            Organization.wikimedia,
+            VoteResolver.Level.vetter,
+            "1-wiki-vetter",
+            new LocaleSet(true)));
+        // TODO: next two clauses: "NEW" = post CLDR-15765, "OLD" = pre.
+        VoteResolver.setVoterToInfo(m); // OLD - REMOVE after CLDR-15765
+        VoteResolver<ReportAcceptability> res = new VoteResolver<>(
+        // new VoterInfoList().setVoterToInfo(m) // NEW - UNCOMMENT after CLDR-15765
+        );
+
+        MemVoterReportStatus<Integer> mrv = new MemVoterReportStatus<>();
+
+        final CLDRLocale french = CLDRLocale.getInstance("fr");
+        final CLDRLocale assamese = CLDRLocale.getInstance("ssy");
+
+        // update resolver
+        mrv.updateResolver(french, ReportId.compact, m.keySet(), res);
+
+        // should be missing
+        assertAll("fr: no votes yet",
+            () -> assertEquals(Status.missing, res.getWinningStatus()));
+
+        mrv.markReportComplete(VETTER1, french, ReportId.compact, true, true);
+        mrv.updateResolver(french, ReportId.compact, m.keySet(), res);
+        assertAll("fr: vetter1 voted",
+            () -> assertEquals(Status.approved, res.getWinningStatus()),
+            () -> assertEquals(ReportAcceptability.acceptable, res.getWinningValue()));
+
+        // now dispute it as a guest (mark as not acceptable)
+        mrv.markReportComplete(GUEST2, french, ReportId.compact, true, false);
+        mrv.updateResolver(french, ReportId.compact, m.keySet(), res);
+        assertAll("fr: guest2 unacceptable",
+            () -> assertEquals(Status.approved, res.getWinningStatus()),
+            () -> assertEquals(ReportAcceptability.acceptable, res.getWinningValue()));
+        // more support for unacceptability
+        mrv.markReportComplete(VETTER4, french, ReportId.compact, true, false);
+        mrv.updateResolver(french, ReportId.compact, m.keySet(), res);
+        assertAll("fr: vetter4 also unacceptable",
+            () -> assertEquals(Status.approved, res.getWinningStatus()),
+            () -> assertEquals(ReportAcceptability.notAcceptable, res.getWinningValue()));
+        // guest drops out (abstention). Now it is a dispute.
+        mrv.markReportComplete(GUEST2, french, ReportId.compact, false, false);
+        mrv.updateResolver(french, ReportId.compact, m.keySet(), res);
+        assertAll("fr: guest2 unvotes",
+            // now provisional
+            () -> assertEquals(Status.provisional, res.getWinningStatus())
+        // Winning value is acceptable - is that due to comparison  (a… < n…)?
+        // () -> assertEquals(ReportAcceptability.acceptable, res.getWinningValue())
+        );
+
+        // Now in Assamese.
+        mrv.markReportComplete(GUEST2, assamese, ReportId.zones, true, false);
+        mrv.updateResolver(assamese, ReportId.zones, m.keySet(), res);
+        assertAll("ssy: guest2 votes notAcceptable",
+            // now unconfirmed
+            () -> assertEquals(Status.unconfirmed, res.getWinningStatus()),
+            // Winning value is acceptable - is that due to comparison  (a… < n…)?
+            () -> assertEquals(ReportAcceptability.notAcceptable, res.getWinningValue()));
     }
 }


### PR DESCRIPTION
CLDR-8666 Vote Report Resolver and tests

- also make VoterReportStatus abstract instead of interface
- move ReportStatusUpdater into org.unicode.cldr.util (not web specific)
- tests added, but they depend on CLDR-15765 to be safe (so disabled for now)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
