### PR TITLE
CLDR-10674 Survey Tool to display bidi examples in default and RL context; pass 1 currencyFmts

### DIFF
--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -1939,12 +1939,34 @@ p.errCodeMsg .fgred {
     font-style: normal;
 }
 
+.cldr_background_auto {
+	background-color: #E8E8E8;
+    font-weight: normal;
+    font-style: normal;
+}
 
 
 .cldr_example {
     border: 1px solid #66666E;
 	margin-top:-1px;
 	padding:1px;
+}
+
+/* set the direction using html dir, not CSS direction */
+.cldr_example_auto {
+    border: 1px solid #66666E;
+	margin-top:-1px;
+	padding:1px;
+	text-align: center;
+	background-color: #E8E8E8;
+}
+
+/* set the direction using html dir, not CSS direction */
+.cldr_example_rtl {
+    border: 1px solid #66666E;
+	margin-top:-1px;
+	padding:1px;
+	text-align: center;
 }
 
 div.d-example {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -656,6 +656,16 @@ public class TestExampleGenerator extends TestFmwk {
             "〖€ ❬1295,00❭〗〖-€ ❬1295,00❭〗", actual);
     }
 
+    public void TestCurrencyFormatsWithContext() {
+        ExampleGenerator exampleGenerator = getExampleGenerator("he");
+        String actual = simplify(exampleGenerator
+            .getExampleHtml(
+                "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength/currencyFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
+                "‏#,##0.00 ¤;‏-#,##0.00 ¤"));
+        assertEquals("Currency format example faulty",
+            "【‏❬1,295❭.❬00❭ ₪〗【⃪‏❬1,295❭.❬00❭ ₪〗【‏‎-❬1,295❭.❬00❭ ₪〗【⃪‏‎-❬1,295❭.❬00❭ ₪〗【‏❬1,295❭.❬00❭ ILS〗【⃪‏❬1,295❭.❬00❭ ILS〗【‏‎-❬1,295❭.❬00❭ ILS〗【⃪‏‎-❬1,295❭.❬00❭ ILS〗", actual);
+    }
+
     public void TestSymbols() {
         CLDRFile english = info.getEnglish();
         ExampleGenerator exampleGenerator = new ExampleGenerator(english,


### PR DESCRIPTION
CLDR-10674

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This PR adds the infrastructure to display bidi examples in both default and RTL context, and implements it for just currencyFormats. Once we see how that looks, I will create a separate PR to implement it for more cases (units, short date formats?) and also to refine the behavior based on this first pass.
