### PR TITLE
CLDR-15765 refactor VoteResolver to fix static init

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -39,6 +39,7 @@ import org.unicode.cldr.util.LocaleSet;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.SpecialLocales;
 import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.util.VoterInfoList;
 import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
 
@@ -778,8 +779,9 @@ public class UserRegistry {
      *
      * @see #getVoterToInfo()
      */
-    private void userModified() {
+    void userModified() {
         voterInfo = null;
+        getVoterToInfo(); // reset maps
     }
 
     /**
@@ -1880,6 +1882,11 @@ public class UserRegistry {
         return getVoterToInfo().get(userid);
     }
 
+    public synchronized VoterInfoList getVoterInfoList() {
+        getVoterToInfo(); // to make sure voterInfoList is up to date
+        return voterInfoList;
+    }
+
     // Interface for VoteResolver interface
     /**
      * Fetch the user map in VoterInfo format.
@@ -1921,6 +1928,14 @@ public class UserRegistry {
                     map.put(u.id, v);
                 }
                 voterInfo = map;
+                VoterInfoList vil = voterInfoList;
+                if(voterInfoList == null) {
+                    vil = new VoterInfoList();
+                }
+                vil.setVoterToInfo(map);
+                if (voterInfoList != vil) {
+                    voterInfoList = vil;
+                }
             } catch (SQLException se) {
                 logger.log(java.util.logging.Level.SEVERE,
                     "UserRegistry: SQL error trying to  update VoterInfo - " + DBUtils.unchainSqlException(se), se);
@@ -1939,6 +1954,7 @@ public class UserRegistry {
      * VoterInfo map
      */
     private Map<Integer, VoterInfo> voterInfo = null;
+    VoterInfoList voterInfoList = null;
 
     /**
      * The list of organizations

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAnnotationVotes.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAnnotationVotes.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.unicode.cldr.unittest.web.TestAll.WebTestInfo;
 import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.util.VoterInfoList;
 
 import com.ibm.icu.dev.test.TestFmwk;
 
@@ -15,7 +16,7 @@ public class TestAnnotationVotes extends TestFmwk {
 
     TestAll.WebTestInfo testInfo = WebTestInfo.getInstance();
 
-    VoteResolver<String> r = new VoteResolver<>();
+    VoteResolver<String> r = new VoteResolver<>(new VoterInfoList());
     Set<String> sortedValuesI = null, sortedValuesO = null; // input and output
     HashMap<String, Long> voteCountI = null; // input
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -59,6 +59,7 @@ import org.unicode.cldr.util.StringId;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
 import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.util.VoterInfoList;
 import org.unicode.cldr.util.VoteResolver.CandidateInfo;
 import org.unicode.cldr.util.VoteResolver.UnknownVoterException;
 import org.unicode.cldr.util.XMLSource;
@@ -358,9 +359,9 @@ public class ConsoleCheckCLDR {
         if (options[VOTE_RESOLVE].doesOccur) {
             resolveVotesDirectory = CldrUtility.checkValidFile(CLDRPaths.BASE_DIRECTORY + "incoming/vetted/votes/",
                 true, null);
-            VoteResolver.setVoterToInfo(CldrUtility.checkValidFile(CLDRPaths.BASE_DIRECTORY
+            voterInfoList.setVoterToInfo(CldrUtility.checkValidFile(CLDRPaths.BASE_DIRECTORY
                 + "incoming/vetted/usersa/usersa.xml", false, null));
-            voteResolver = new VoteResolver<>();
+            voteResolver = new VoteResolver<>(voterInfoList);
         }
 
         String user = options[USER].value;
@@ -804,10 +805,10 @@ public class ConsoleCheckCLDR {
 
         public LocaleVotingData(String locale) {
 
-            Map<Organization, VoteResolver.Level> orgToMaxVote = VoteResolver.getOrganizationToMaxVote(locale);
+            Map<Organization, VoteResolver.Level> orgToMaxVote = voterInfoList.getOrganizationToMaxVote(locale);
 
             Map<Integer, Map<Integer, CandidateInfo>> info = VoteResolver
-                .getBaseToAlternateToInfo(resolveVotesDirectory + locale + ".xml");
+                .getBaseToAlternateToInfo(resolveVotesDirectory + locale + ".xml", voterInfoList);
 
             Map<String, Integer> valueToItem = new HashMap<>();
 
@@ -849,7 +850,7 @@ public class ConsoleCheckCLDR {
                 }
 
                 CandidateInfo candidateInfo = itemInfo.get(valueToItem.get(winningValue));
-                Map<Organization, VoteResolver.Level> orgToMaxVoteHere = VoteResolver
+                Map<Organization, VoteResolver.Level> orgToMaxVoteHere = voterInfoList
                     .getOrganizationToMaxVote(candidateInfo.voters);
 
                 // if the winning item is less than contributed, record the organizations that haven't given their
@@ -1483,6 +1484,7 @@ public class ConsoleCheckCLDR {
     }
 
     static String lastHtmlLocaleID = "";
+    private static VoterInfoList voterInfoList;
     private static VoteResolver<String> voteResolver;
     private static String resolveVotesDirectory;
     private static boolean idView;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -69,13 +69,19 @@ import com.ibm.icu.util.ULocale;
  * </pre>
  */
 public class VoteResolver<T> {
+    private final VoterInfoList voterInfoList;
+
+    public VoteResolver(VoterInfoList vil) {
+        voterInfoList = vil;
+    }
+
     private static final boolean DEBUG = false;
 
     /**
      * A placeholder for winningValue when it would otherwise be null.
      * It must match NO_WINNING_VALUE in the client JavaScript code.
      */
-    private static String NO_WINNING_VALUE = "no-winning-value";
+    private static final String NO_WINNING_VALUE = "no-winning-value";
 
     /**
      * The status levels according to the committee, in ascending order
@@ -409,6 +415,10 @@ public class VoteResolver<T> {
          */
         private Set<CLDRLocale> locales = new TreeSet<>();
 
+        public Iterable<CLDRLocale> getLocales() {
+            return locales;
+        }
+
         public VoterInfo(Organization organization, Level level, String name, LocaleSet localeSet) {
             this.setOrganization(organization);
             this.setLevel(level);
@@ -456,7 +466,7 @@ public class VoteResolver<T> {
             return name;
         }
 
-        private void addLocale(CLDRLocale locale) {
+        void addLocale(CLDRLocale locale) {
             this.locales.add(locale);
         }
 
@@ -506,7 +516,7 @@ public class VoteResolver<T> {
     /**
      * Internal class for getting from an organization to its vote.
      */
-    private static class OrganizationToValueAndVote<T> {
+    private class OrganizationToValueAndVote<T> {
         private final Map<Organization, MaxCounter<T>> orgToVotes = new EnumMap<>(Organization.class);
         private final Counter<T> totalVotes = new Counter<>();
         private final Map<Organization, Integer> orgToMax = new EnumMap<>(Organization.class);
@@ -559,7 +569,7 @@ public class VoteResolver<T> {
          * @param date
          */
         public void add(T value, int voter, Integer withVotes, Date date) {
-            final VoterInfo info = getVoterToInfo().get(voter);
+            final VoterInfo info = voterInfoList.get(voter);
             if (info == null) {
                 throw new UnknownVoterException(voter);
             }
@@ -770,13 +780,6 @@ public class VoteResolver<T> {
             return result;
         }
     }
-
-    /**
-     * Static info read from file
-     */
-    private static Map<Integer, VoterInfo> voterToInfo;
-
-    private static TreeMap<String, Map<Organization, Level>> localeToOrganizationToMaxVote;
 
     /**
      * Data built internally
@@ -1624,159 +1627,6 @@ public class VoteResolver<T> {
             + "}";
     }
 
-    private static Map<Integer, VoterInfo> getVoterToInfo() {
-        synchronized (VoteResolver.class) {
-            return voterToInfo;
-        }
-    }
-
-    public static VoterInfo getInfoForVoter(int voter) {
-        return getVoterToInfo().get(voter);
-    }
-
-    /**
-     * Set the voter info.
-     * <p>
-     * Synchronized, however, once this is called, you must NOT change the contents of your copy of testVoterToInfo. You
-     * can create a whole new one and set it.
-     */
-    public static void setVoterToInfo(Map<Integer, VoterInfo> testVoterToInfo) {
-        synchronized (VoteResolver.class) {
-            VoteResolver.voterToInfo = testVoterToInfo;
-        }
-        if (DEBUG) {
-            for (int id : testVoterToInfo.keySet()) {
-                System.out.println("\t" + id + "=" + testVoterToInfo.get(id));
-            }
-        }
-        computeMaxVotes();
-    }
-
-    /**
-     * Set the voter info from a users.xml file.
-     * <p>
-     * Synchronized, however, once this is called, you must NOT change the contents of your copy of testVoterToInfo. You
-     * can create a whole new one and set it.
-     */
-    public static void setVoterToInfo(String fileName) {
-        MyHandler myHandler = new MyHandler();
-        XMLFileReader xfr = new XMLFileReader().setHandler(myHandler);
-        xfr.read(fileName, XMLFileReader.CONTENT_HANDLER | XMLFileReader.ERROR_HANDLER, false);
-        setVoterToInfo(myHandler.testVoterToInfo);
-
-        computeMaxVotes();
-    }
-
-    private static synchronized void computeMaxVotes() {
-        // compute the localeToOrganizationToMaxVote
-        localeToOrganizationToMaxVote = new TreeMap<>();
-        for (int voter : getVoterToInfo().keySet()) {
-            VoterInfo info = getVoterToInfo().get(voter);
-            if (info.getLevel() == Level.tc || info.getLevel() == Level.locked) {
-                continue; // skip TCs, locked
-            }
-
-            for (CLDRLocale loc : info.locales) {
-                String locale = loc.getBaseName();
-                Map<Organization, Level> organizationToMaxVote = localeToOrganizationToMaxVote.get(locale);
-                if (organizationToMaxVote == null) {
-                    localeToOrganizationToMaxVote.put(locale,
-                        organizationToMaxVote = new TreeMap<>());
-                }
-                Level maxVote = organizationToMaxVote.get(info.getOrganization());
-                if (maxVote == null || info.getLevel().compareTo(maxVote) > 0) {
-                    organizationToMaxVote.put(info.getOrganization(), info.getLevel());
-                    // System.out.println("Example best voter for " + locale + " for " + info.organization + " is " +
-                    // info);
-                }
-            }
-        }
-        CldrUtility.protectCollection(localeToOrganizationToMaxVote);
-    }
-
-    /**
-     * Handles fine in xml format, turning into:
-     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/level[@n="1"][@type="TC"]
-     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/name
-     * Mike Tardif
-     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/org
-     * Adobe
-     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/locales[@type="edit"]
-     *
-     * Steven's new format:
-     * //users[@generated="Wed May 07 15:57:15 PDT 2008"][@host="tintin"][@obscured="true"]
-     * /user[@id="286"][@email="?@??.??"]
-     * /level[@n="1"][@type="TC"]
-     */
-
-    static class MyHandler extends XMLFileReader.SimpleHandler {
-        private static final Pattern userPathMatcher = Pattern
-            .compile(
-                "//users(?:[^/]*)"
-                    + "/user\\[@id=\"([^\"]*)\"](?:[^/]*)"
-                    + "/("
-                    + "org" +
-                    "|name" +
-                    "|level\\[@n=\"([^\"]*)\"]\\[@type=\"([^\"]*)\"]" +
-                    "|locales\\[@type=\"([^\"]*)\"]" +
-                    "(?:/locale\\[@id=\"([^\"]*)\"])?"
-                    + ")",
-                Pattern.COMMENTS);
-
-        enum Group {
-            all, userId, mainType, n, levelType, localeType, localeId;
-            String get(Matcher matcher) {
-                return matcher.group(this.ordinal());
-            }
-        }
-
-        private static final boolean DEBUG_HANDLER = false;
-        Map<Integer, VoterInfo> testVoterToInfo = new TreeMap<>();
-        Matcher matcher = userPathMatcher.matcher("");
-
-        @Override
-        public void handlePathValue(String path, String value) {
-            if (DEBUG_HANDLER)
-                System.out.println(path + "\t" + value);
-            if (matcher.reset(path).matches()) {
-                if (DEBUG_HANDLER) {
-                    for (int i = 1; i <= matcher.groupCount(); ++i) {
-                        Group group = Group.values()[i];
-                        System.out.println(i + "\t" + group + "\t" + group.get(matcher));
-                    }
-                }
-                int id = Integer.parseInt(Group.userId.get(matcher));
-                VoterInfo voterInfo = testVoterToInfo.get(id);
-                if (voterInfo == null) {
-                    testVoterToInfo.put(id, voterInfo = new VoterInfo());
-                }
-                final String mainType = Group.mainType.get(matcher);
-                if (mainType.equals("org")) {
-                    Organization org = Organization.fromString(value);
-                    voterInfo.setOrganization(org);
-                    value = org.name(); // copy name back into value
-                } else if (mainType.equals("name")) {
-                    voterInfo.setName(value);
-                } else if (mainType.startsWith("level")) {
-                    String level = Group.levelType.get(matcher).toLowerCase();
-                    voterInfo.setLevel(Level.valueOf(level));
-                } else if (mainType.startsWith("locale")) {
-                    final String localeIdString = Group.localeId.get(matcher);
-                    if (localeIdString != null) {
-                        CLDRLocale locale = CLDRLocale.getInstance(localeIdString.split("_")[0]);
-                        voterInfo.addLocale(locale);
-                    } else if (DEBUG_HANDLER) {
-                        System.out.println("\tskipping");
-                    }
-                } else if (DEBUG_HANDLER) {
-                    System.out.println("\tFailed match* with " + path + "=" + value);
-                }
-            } else {
-                System.out.println("\tFailed match with " + path + "=" + value);
-            }
-        }
-    }
-
     public static Map<Integer, String> getIdToPath(String fileName) {
         XPathTableHandler myHandler = new XPathTableHandler();
         XMLFileReader xfr = new XMLFileReader().setHandler(myHandler);
@@ -1800,9 +1650,9 @@ public class VoteResolver<T> {
         }
     }
 
-    public static Map<Integer, Map<Integer, CandidateInfo>> getBaseToAlternateToInfo(String fileName) {
+    public static Map<Integer, Map<Integer, CandidateInfo>> getBaseToAlternateToInfo(String fileName, VoterInfoList vil) {
         try {
-            VotesHandler myHandler = new VotesHandler();
+            VotesHandler myHandler = new VotesHandler(vil);
             XMLFileReader xfr = new XMLFileReader().setHandler(myHandler);
             xfr.read(fileName, XMLFileReader.CONTENT_HANDLER | XMLFileReader.ERROR_HANDLER, false);
             return myHandler.basepathToInfo;
@@ -1820,12 +1670,17 @@ public class VoteResolver<T> {
         public Type surveyType;
         public Status surveyStatus;
         public Set<Integer> voters = new TreeSet<>();
+        private VoterInfoList voterInfoList;
+
+        CandidateInfo(VoterInfoList vil) {
+            this.voterInfoList = vil;
+        }
 
         @Override
         public String toString() {
             StringBuilder voterString = new StringBuilder("{");
             for (int voter : voters) {
-                VoterInfo voterInfo = getInfoForVoter(voter);
+                VoterInfo voterInfo = voterInfoList.get(voter);
                 if (voterString.length() > 1) {
                     voterString.append(" ");
                 }
@@ -1858,6 +1713,11 @@ public class VoteResolver<T> {
      * A base path has a set of candidates. Each candidate has various items of information.
      */
     static class VotesHandler extends XMLFileReader.SimpleHandler {
+        private VoterInfoList voterInfoList;
+
+        VotesHandler(VoterInfoList vil) {
+            this.voterInfoList = vil;
+        }
         Map<Integer, Map<Integer, CandidateInfo>> basepathToInfo = new TreeMap<>();
 
         @Override
@@ -1876,7 +1736,7 @@ public class VoteResolver<T> {
                 int itemId = Integer.parseInt(parts.getAttributeValue(2, "xpath"));
                 CandidateInfo candidateInfo = info.get(itemId);
                 if (candidateInfo == null) {
-                    info.put(itemId, candidateInfo = new CandidateInfo());
+                    info.put(itemId, candidateInfo = new CandidateInfo(voterInfoList));
                     candidateInfo.surveyType = Type.valueOf(parts.getAttributeValue(2, "type"));
                     candidateInfo.surveyStatus = Status.valueOf(fixBogusDraftStatusValues(parts.getAttributeValue(2,
                         "status")));
@@ -1899,31 +1759,6 @@ public class VoteResolver<T> {
             }
         }
 
-    }
-
-    public static Map<Organization, Level> getOrganizationToMaxVote(String locale) {
-        locale = locale.split("_")[0]; // take base language
-        Map<Organization, Level> result = localeToOrganizationToMaxVote.get(locale);
-        if (result == null) {
-            result = Collections.emptyMap();
-        }
-        return result;
-    }
-
-    public static Map<Organization, Level> getOrganizationToMaxVote(Set<Integer> voters) {
-        Map<Organization, Level> orgToMaxVoteHere = new TreeMap<>();
-        for (int voter : voters) {
-            VoterInfo info = getInfoForVoter(voter);
-            if (info == null) {
-                continue; // skip unknown voter
-            }
-            Level maxVote = orgToMaxVoteHere.get(info.getOrganization());
-            if (maxVote == null || info.getLevel().compareTo(maxVote) > 0) {
-                orgToMaxVoteHere.put(info.getOrganization(), info.getLevel());
-                // System.out.println("*Best voter for " + info.organization + " is " + info);
-            }
-        }
-        return orgToMaxVoteHere;
     }
 
     public static class UnknownVoterException extends RuntimeException {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.util;
 public class VotelessUsersChoice implements VettingViewer.UsersChoice<Organization> {
 
     final PathHeader.Factory phf = PathHeader.getFactory();
+    static final VoterInfoList noUsers = new VoterInfoList();
 
     @Override
     public String getWinningValueForUsersOrganization(CLDRFile cldrFile, String path, Organization org) {
@@ -18,7 +19,7 @@ public class VotelessUsersChoice implements VettingViewer.UsersChoice<Organizati
 
     @Override
     public VoteResolver<String> getVoteResolver(CLDRFile cldrFile, CLDRLocale loc, String path) {
-        final VoteResolver<String> r = new VoteResolver<>();
+        final VoteResolver<String> r = new VoteResolver<>(noUsers);
         r.setLocale(loc, phf.fromPath(path));
 
         final String baileyValue = cldrFile.getBaileyValue(path, null, null);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterInfoList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterInfoList.java
@@ -1,0 +1,209 @@
+package org.unicode.cldr.util;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.unicode.cldr.util.VoteResolver.Level;
+import org.unicode.cldr.util.VoteResolver.VoterInfo;
+
+public class VoterInfoList {
+    /**
+     * Create a VoterInfoList with no users
+     */
+    public VoterInfoList() {
+        clearVoterToInfo();
+    }
+
+    /**
+     * Static info read from file
+     */
+    private Map<Integer, VoterInfo> voterToInfo;
+
+    private Map<String, Map<Organization, Level>> localeToOrganizationToMaxVote;
+
+    synchronized Map<Integer, VoterInfo> getVoterToInfo() {
+        return voterToInfo;
+    }
+
+    /**
+     * Clear out all users.
+     */
+    VoterInfoList clearVoterToInfo() {
+        setVoterToInfo(Collections.emptyMap());
+        return this;
+    }
+
+    public VoterInfo getInfoForVoter(int voter) {
+        return getVoterToInfo().get(voter);
+    }
+
+    /**
+     * Set the voter info.
+     * <p>
+     * Synchronized, however, once this is called, you must NOT change the contents of your copy of newVoterToInfo. You
+     * can create a whole new one and set it.
+     */
+    public VoterInfoList setVoterToInfo(Map<Integer, VoterInfo> newVoterToInfo) {
+        computeMaxVotesAndSet(newVoterToInfo);
+        return this;
+    }
+
+    /**
+     * Set the voter info from a users.xml file.
+     */
+    public VoterInfoList setVoterToInfo(String fileName) {
+        MyHandler myHandler = new MyHandler();
+        XMLFileReader xfr = new XMLFileReader().setHandler(myHandler);
+        xfr.read(fileName, XMLFileReader.CONTENT_HANDLER | XMLFileReader.ERROR_HANDLER, false);
+        return setVoterToInfo(myHandler.testVoterToInfo);
+    }
+
+    private void computeMaxVotesAndSet(Map<Integer, VoterInfo> newVoterToInfo) {
+        // compute the localeToOrganizationToMaxVote
+        Map<String, Map<Organization, Level>> newLocaleToOrganizationToMaxVote = new TreeMap<>();
+        for (int voter : newVoterToInfo.keySet()) {
+            VoterInfo info = newVoterToInfo.get(voter);
+            if (info.getLevel() == Level.tc || info.getLevel() == Level.locked) {
+                continue; // skip TCs, locked
+            }
+
+            for (CLDRLocale loc : info.getLocales()) {
+                String locale = loc.getBaseName();
+                Map<Organization, Level> organizationToMaxVote = newLocaleToOrganizationToMaxVote.get(locale);
+                if (organizationToMaxVote == null) {
+                    newLocaleToOrganizationToMaxVote.put(locale,
+                        organizationToMaxVote = new TreeMap<>());
+                }
+                Level maxVote = organizationToMaxVote.get(info.getOrganization());
+                if (maxVote == null || info.getLevel().compareTo(maxVote) > 0) {
+                    organizationToMaxVote.put(info.getOrganization(), info.getLevel());
+                    // System.out.println("Example best voter for " + locale + " for " + info.organization + " is " +
+                    // info);
+                }
+            }
+        }
+        // setters
+        synchronized (this) {
+            CldrUtility.protectCollection(newLocaleToOrganizationToMaxVote);
+            localeToOrganizationToMaxVote = newLocaleToOrganizationToMaxVote;
+            voterToInfo = Collections.unmodifiableMap(newVoterToInfo);
+        }
+    }
+
+    /**
+     * Handles fine in xml format, turning into:
+     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/level[@n="1"][@type="TC"]
+     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/name
+     * Mike Tardif
+     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/org
+     * Adobe
+     * //users[@host="sarasvati.unicode.org"]/user[@id="286"][@email="mike.tardif@adobe.com"]/locales[@type="edit"]
+     *
+     * Steven's new format:
+     * //users[@generated="Wed May 07 15:57:15 PDT 2008"][@host="tintin"][@obscured="true"]
+     * /user[@id="286"][@email="?@??.??"]
+     * /level[@n="1"][@type="TC"]
+     */
+
+    static class MyHandler extends XMLFileReader.SimpleHandler {
+        private static final Pattern userPathMatcher = Pattern
+            .compile(
+                "//users(?:[^/]*)"
+                    + "/user\\[@id=\"([^\"]*)\"](?:[^/]*)"
+                    + "/("
+                    + "org" +
+                    "|name" +
+                    "|level\\[@n=\"([^\"]*)\"]\\[@type=\"([^\"]*)\"]" +
+                    "|locales\\[@type=\"([^\"]*)\"]" +
+                    "(?:/locale\\[@id=\"([^\"]*)\"])?"
+                    + ")",
+                Pattern.COMMENTS);
+
+        enum Group {
+            all, userId, mainType, n, levelType, localeType, localeId;
+
+            String get(Matcher matcher) {
+                return matcher.group(this.ordinal());
+            }
+        }
+
+        private static final boolean DEBUG_HANDLER = false;
+        Map<Integer, VoterInfo> testVoterToInfo = new TreeMap<>();
+        Matcher matcher = userPathMatcher.matcher("");
+
+        @Override
+        public void handlePathValue(String path, String value) {
+            if (DEBUG_HANDLER)
+                System.out.println(path + "\t" + value);
+            if (matcher.reset(path).matches()) {
+                if (DEBUG_HANDLER) {
+                    for (int i = 1; i <= matcher.groupCount(); ++i) {
+                        Group group = Group.values()[i];
+                        System.out.println(i + "\t" + group + "\t" + group.get(matcher));
+                    }
+                }
+                int id = Integer.parseInt(Group.userId.get(matcher));
+                VoterInfo voterInfo = testVoterToInfo.get(id);
+                if (voterInfo == null) {
+                    testVoterToInfo.put(id, voterInfo = new VoterInfo());
+                }
+                final String mainType = Group.mainType.get(matcher);
+                if (mainType.equals("org")) {
+                    Organization org = Organization.fromString(value);
+                    voterInfo.setOrganization(org);
+                    value = org.name(); // copy name back into value
+                } else if (mainType.equals("name")) {
+                    voterInfo.setName(value);
+                } else if (mainType.startsWith("level")) {
+                    String level = Group.levelType.get(matcher).toLowerCase();
+                    voterInfo.setLevel(Level.valueOf(level));
+                } else if (mainType.startsWith("locale")) {
+                    final String localeIdString = Group.localeId.get(matcher);
+                    if (localeIdString != null) {
+                        CLDRLocale locale = CLDRLocale.getInstance(localeIdString.split("_")[0]);
+                        voterInfo.addLocale(locale);
+                    } else if (DEBUG_HANDLER) {
+                        System.out.println("\tskipping");
+                    }
+                } else if (DEBUG_HANDLER) {
+                    System.out.println("\tFailed match* with " + path + "=" + value);
+                }
+            } else {
+                System.out.println("\tFailed match with " + path + "=" + value);
+            }
+        }
+    }
+
+    public Map<Organization, Level> getOrganizationToMaxVote(String locale) {
+        locale = locale.split("_")[0]; // take base language
+        Map<Organization, Level> result = localeToOrganizationToMaxVote.get(locale);
+        if (result == null) {
+            result = Collections.emptyMap();
+        }
+        return result;
+    }
+
+    public Map<Organization, Level> getOrganizationToMaxVote(Set<Integer> voters) {
+        Map<Organization, Level> orgToMaxVoteHere = new TreeMap<>();
+        for (int voter : voters) {
+            VoterInfo info = getInfoForVoter(voter);
+            if (info == null) {
+                continue; // skip unknown voter
+            }
+            Level maxVote = orgToMaxVoteHere.get(info.getOrganization());
+            if (maxVote == null || info.getLevel().compareTo(maxVote) > 0) {
+                orgToMaxVoteHere.put(info.getOrganization(), info.getLevel());
+                // System.out.println("*Best voter for " + info.organization + " is " + info);
+            }
+        }
+        return orgToMaxVoteHere;
+    }
+
+    public VoterInfo get(int voter) {
+        return voterToInfo.get(voter);
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -51,6 +51,7 @@ import org.unicode.cldr.util.NotificationCategory;
 import org.unicode.cldr.util.VettingViewer.MissingStatus;
 import org.unicode.cldr.util.VettingViewer.VoteStatus;
 import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.util.VoterInfoList;
 import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.util.VoteResolver.Status;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
@@ -376,9 +377,12 @@ public class TestUtilities extends TestFmwkPlus {
         return TestUser.valueOf(s).voterId;
     }
 
+    private VoterInfoList getTestVoterInfoList() {
+        return new VoterInfoList().setVoterToInfo(testdata);
+    }
+
     public void TestTrunkStatus() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         resolver.setLocale(CLDRLocale.getInstance("de"), null);
 
         resolver.setBaseline("new-item", Status.approved);
@@ -392,8 +396,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestVoteResolverNgombaTrunkStatus() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         resolver.setLocale(CLDRLocale.getInstance("jgo"), null);
         final String jgo22trunk = "\uA78C"; // "[a á â ǎ b c d ɛ {ɛ́} {ɛ̂} {ɛ̌} {ɛ̀} {ɛ̄} f ɡ h i í î ǐ j k l m ḿ {m̀} {m̄} n ń ǹ {n̄} ŋ {ŋ́} {ŋ̀} {ŋ̄} ɔ {ɔ́} {ɔ̂} {ɔ̌} p {pf} s {sh} t {ts} u ú û ǔ ʉ {ʉ́} {ʉ̂} {ʉ̌} {ʉ̈} v w ẅ y z ꞌ]";
         resolver.setBaseline(jgo22trunk, Status.approved); // seed/jgo.xml from 22
@@ -404,8 +407,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestVoteStatus() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
 
         resolver.setLocale(CLDRLocale.getInstance("de"), null);
         resolver.setBaileyValue("bailey");
@@ -440,8 +442,7 @@ public class TestUtilities extends TestFmwkPlus {
         // missing}}
         // XPath: //ldml/localeDisplayNames/territories/territory[@type="BQ"]
         // gcvs.openoffice_org.example.com
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
 
         resolver.setLocale(CLDRLocale.getInstance("af"), null);
         resolver.setBaseline("BQ", Status.missing);
@@ -474,8 +475,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestTotalVotesStatus() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
 
         Status oldStatus = Status.unconfirmed;
 
@@ -507,8 +507,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestVoteDowngrade() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
 
         Status oldStatus = Status.unconfirmed;
 
@@ -573,8 +572,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestResolvedVoteCounts() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
 
         Status oldStatus = Status.unconfirmed;
 
@@ -627,8 +625,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestRequiredVotes() {
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         verifyRequiredVotes(resolver, "mt",
             "//ldml/localeDisplayNames/languages/language[@type=\"fr_CA\"]",
             Status.missing, ONE_VETTER_BAR);
@@ -688,7 +685,7 @@ public class TestUtilities extends TestFmwkPlus {
      */
     public void TestSublocaleRequiredVotes() {
         final Set<String> eightVoteSublocales = new HashSet<>(Arrays.asList("pt_PT", "zh_Hant", "en_AU", "en_GB", "es_MX", "fr_CA"));
-        final VoteResolver<String> resolver = new VoteResolver<>();
+        final VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         final String path = "//ldml/annotations/annotation[@cp=\"🌏\"][@type=\"tts\"]";
         for (String locale : SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES) {
             if (locale.contains("_")) {
@@ -702,8 +699,7 @@ public class TestUtilities extends TestFmwkPlus {
         // to make it easier to debug failures, the first digit is an org,
         // second is the individual in that org, and
         // third is the voting weight.
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         String[] tests = {
             "bailey=BAILEY",
             "comment=regression case from John Emmons",
@@ -1109,9 +1105,7 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void TestStevenTest() {
-
-        VoteResolver.setVoterToInfo(testdata);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
 
         String tests[] = {
             "bailey=BAILEY",
@@ -1258,8 +1252,8 @@ public class TestUtilities extends TestFmwkPlus {
     }
 
     public void testBaileyVotes() {
-        VoteResolver.setVoterToInfo(TestUser.TEST_USERS);
-        VoteResolver<String> resolver = new VoteResolver<>();
+        VoterInfoList vil = new VoterInfoList().setVoterToInfo(TestUser.TEST_USERS);
+        VoteResolver<String> resolver = new VoteResolver<>(vil);
         CLDRLocale locale = CLDRLocale.getInstance("de");
         PathHeader path = null;
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
@@ -26,6 +26,7 @@ class TestVettingViewer {
         final String loc = "de";
         final CLDRLocale locale = CLDRLocale.getInstance(loc);
         final PathHeader.Factory phf = PathHeader.getFactory();
+        final VoterInfoList vil = new VoterInfoList();
         VettingViewer<Organization> vv = new VettingViewer<>(SupplementalDataInfo.getInstance(), CLDRConfig.getInstance().getCldrFactory(), new VettingViewer.UsersChoice<Organization>(){
 
             @Override
@@ -45,7 +46,7 @@ class TestVettingViewer {
 
             @Override
             public VoteResolver<String> getVoteResolver(CLDRFile cldrFile, final CLDRLocale loc, final String path) {
-                VoteResolver<String> r = new VoteResolver<>();
+                VoteResolver<String> r = new VoteResolver<>(vil);
                 r.setLocale(locale, getPathHeader(path));
                 return r;
             }


### PR DESCRIPTION
- new class VoterInfoList, replaces hidden statics in VoteResolver
- VoterInfoList must be passed as the first arg of new VoteResolver()
- VoterInfoList is mutable (synchronized)
- Fixup tests to use VoterInfoList
- For SurveyTool, the UserRegistry manages the VoterInfoList along with the underlying
map

CLDR-15765

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
