### PR TITLE
CLDR-8666 Reports: Updated API for using VoteResolver 

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MemVoterReportStatus.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MemVoterReportStatus.java
@@ -1,17 +1,22 @@
 package org.unicode.cldr.util;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Trivial, in-memory implementation of a VoterReportStatus<> and ReportStatusUpdater<>
  */
-class MemVoterReportStatus<T extends Comparable<T>> extends VoterReportStatus<T> implements ReportStatusUpdater<T> {
+public class MemVoterReportStatus<T extends Comparable<T>> extends VoterReportStatus<T> implements ReportStatusUpdater<T> {
     Map<Pair<T, CLDRLocale>, ReportStatus> data = new HashMap<>();
 
     @Override
     public ReportStatus getReportStatus(T user, CLDRLocale locale) {
         return data.computeIfAbsent(Pair.of(user, locale), k -> new ReportStatus());
+    }
+
+    public void markReportComplete(T user, CLDRLocale locale, ReportId r, boolean marked, boolean acceptable, Date date) {
+        getReportStatus(user, locale).mark(r, marked, acceptable, date);
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterReportStatus.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterReportStatus.java
@@ -1,7 +1,9 @@
 package org.unicode.cldr.util;
 
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.Set;
+
 
 /**
  * This interface is for objects which can expose information on which reports have been completed.
@@ -38,8 +40,13 @@ public abstract class VoterReportStatus<T> {
     public static class ReportStatus {
         public EnumSet<ReportId> completed = EnumSet.noneOf(ReportId.class);
         public EnumSet<ReportId> acceptable = EnumSet.noneOf(ReportId.class);
+        public Date date = null;
 
         public ReportStatus mark(ReportId r, boolean asComplete, boolean asAcceptable) {
+            return this.mark(r, asComplete, asAcceptable, null);
+        }
+
+        public ReportStatus mark(ReportId r, boolean asComplete, boolean asAcceptable, Date date) {
             if (!asComplete && asAcceptable) {
                 throw new IllegalArgumentException("Cannot be !complete&&acceptable");
             }
@@ -53,7 +60,12 @@ public abstract class VoterReportStatus<T> {
             } else {
                 acceptable.remove(r);
             }
+            this.date = date;
             return this;
+        }
+
+        public Date getDate() {
+            return date;
         }
 
         /**
@@ -89,7 +101,7 @@ public abstract class VoterReportStatus<T> {
             final ReportAcceptability acc = rs.getAcceptability(r);
             if (acc != null) {
                 // if not an abstention, add
-                res.add(acc, (Integer) id); // TODO: Cast because T must be an Integer. Refactor class to not be templatized
+                res.add(acc, (Integer) id, null, rs.getDate()); // TODO: Cast because T must be an Integer. Refactor class to not be templatized
             }
         });
         return res;


### PR DESCRIPTION
- move MemVoterReportStatus out of tests and back into cldr-code
- add a 'date' field to ReportStatus and MemVoterReportStatus, for date dependent
vote resolution
- add a ReportsDB.clone() function which make a subset copy of the database
This makes it much more performant to update VoteResolvers- one query instead of
thousands

CLDR-8666

- [ ] This PR completes the ticket.