### PR TITLE
CLDR-10674 Bidi examples: better header & cell background, fix symbolIsLetters, extend to other numberPatterns

### DIFF
--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -1935,7 +1935,7 @@ p.errCodeMsg .fgred {
 }
 
 .cldr_background_auto {
-	background-color: #E8E8E8;
+	background-color: #EAEAF2;
     font-weight: normal;
     font-style: normal;
 }
@@ -1953,7 +1953,7 @@ p.errCodeMsg .fgred {
 	margin-top:-1px;
 	padding:1px;
 	text-align: center;
-	background-color: #E8E8E8;
+	background-color: #EAEAF2;
 }
 
 /* set the direction using html dir, not CSS direction */


### PR DESCRIPTION
CLDR-10674

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Improve the bidi examples using multiple contexts:
- Better cell background for neutral examples
- Better phrasing for header
- Simpler set for BIDI_MARKS
- Better determination of when to use neutral or strong symbol for currency examples
- Extend the multi-context examples to other number patterns
- Avoid invisible characters in code
