### PR TITLE
CLDR-15707 Enable downloading error/missing/provisional as xml

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -13,7 +13,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader.PageId;
@@ -231,46 +230,11 @@ public class Dashboard {
         EnumSet<NotificationCategory> choiceSet = VettingViewer.getDashboardNotificationCategories(usersOrg);
         VettingParameters args = new VettingParameters(choiceSet, locale, coverageLevel);
         args.setUserAndOrganization(user.id, usersOrg);
-        setFiles(args, locale, sourceFactory);
+        args.setFiles(locale, sourceFactory, sm.getDiskFactory());
         if (xpath != null) {
             args.setXpath(xpath);
         }
         return reallyGet(vv, args);
-    }
-
-    public static void setFiles(VettingParameters args, CLDRLocale locale, STFactory sourceFactory) {
-        /*
-         * sourceFile provides the current winning values, taking into account recent votes.
-         * baselineFile provides the "baseline" (a.k.a. "trunk") values, i.e., the values that
-         * are in the current XML in the cldr version control repository. The baseline values
-         * are generally the last release values plus any changes that have been made by the
-         * technical committee by committing directly to version control rather than voting.
-         */
-        final String localeId = locale.getBaseName();
-        final CLDRFile sourceFile = sourceFactory.make(localeId);
-        final Factory baselineFactory = CookieSession.sm.getDiskFactory();
-        final CLDRFile baselineFile = baselineFactory.make(localeId, true);
-        args.setFiles(sourceFile, baselineFile);
-    }
-
-    /**
-     * Setup to calculate the baseline ('HEAD') error count
-     * @param args
-     * @param locale
-     * @param baselineFactory
-     */
-    public static void setFilesForBaseline(VettingParameters args, CLDRLocale locale, Factory baselineFactory) {
-        final String localeId = locale.getBaseName();
-        final CLDRFile baselineFile = baselineFactory.make(localeId, true);
-        /*
-         * sourceFile must be resolved, otherwise VettingViewer.getMissingStatus is liable
-         * to get a null value and return MissingStatus.ABSENT where a resolved file
-         * could result in a non-null inherited value (such as en_CA inheriting from en)
-         * and MissingStatus.PRESENT. Any such inconsistencies interfere with comparing
-         * the current and baseline stats.
-         */
-        final CLDRFile sourceFile = baselineFactory.make(localeId, true /* resolved */);
-        args.setFiles(sourceFile, baselineFile);
     }
 
     private ReviewOutput reallyGet(VettingViewer<Organization> vv, VettingParameters args) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
@@ -36,9 +36,9 @@ public class LocaleCompletionCounter {
         args = new VettingParameters(set, cldrLocale, level);
         args.setUserAndOrganization(0, VettingViewer.getNeutralOrgForSummary());
         if (isBaseline) {
-            Dashboard.setFilesForBaseline(args, cldrLocale, factory);
+            args.setFilesForBaseline(cldrLocale, factory);
         } else {
-            Dashboard.setFiles(args, cldrLocale, (STFactory) factory);
+            args.setFiles(cldrLocale, factory, sm.getDiskFactory());
         }
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/MissingPathXml.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/MissingPathXml.java
@@ -15,10 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.MissingXmlGetter;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.web.*;
 
 @ApplicationScoped
@@ -60,8 +57,13 @@ public class MissingPathXml {
         // *Beware*  org.unicode.cldr.util.Level (coverage) ≠ VoteResolver.Level (user)
         final Level coverageLevel = org.unicode.cldr.util.Level.fromString(level);
         try {
-            Factory factory = CookieSession.sm.getSTFactory();
-            final String xml = new MissingXmlGetter(loc, factory).getXml(coverageLevel);
+            final Factory factory = CookieSession.sm.getSTFactory();
+            final Factory baselineFactory = CookieSession.sm.getDiskFactory();
+            final VettingViewer.UsersChoice<Organization> usersChoice = new STUsersChoice(CookieSession.sm);
+            final Organization usersOrg = cs.user.vrOrg();
+            final MissingXmlGetter xmlGetter = new MissingXmlGetter(factory, baselineFactory);
+            xmlGetter.setUserInfo(cs.user.id, usersOrg, usersChoice);
+            final String xml = xmlGetter.getXml(loc, coverageLevel);
             return Response.ok().type(MediaType.APPLICATION_XML).entity(xml).build();
         } catch (IOException e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e).build();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MissingXmlGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MissingXmlGetter.java
@@ -1,15 +1,31 @@
 package org.unicode.cldr.util;
 
+import com.ibm.icu.impl.Row;
 import java.io.*;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class MissingXmlGetter {
 
-    private final CLDRFile cldrFile;
+    private final Factory factory;
+    private final CLDRFile englishFile;
+    private final Factory baselineFactory;
 
-    public MissingXmlGetter(CLDRLocale loc, Factory factory) {
-        this.cldrFile = factory.make(loc.getBaseName(), true/* resolved */);
+    private int userId = 0;
+    private Organization usersOrg = null;
+    private VettingViewer.UsersChoice<Organization> usersChoice = null;
+
+    public MissingXmlGetter(Factory factory, Factory baselineFactory) {
+        this.factory = factory;
+        this.baselineFactory = baselineFactory;
+        this.englishFile = factory.make("en", true);
+    }
+
+    public void setUserInfo(int userId, Organization usersOrg, VettingViewer.UsersChoice<Organization> usersChoice) {
+        this.userId = userId;
+        this.usersOrg = usersOrg;
+        this.usersChoice = usersChoice;
     }
 
     /**
@@ -17,19 +33,68 @@ public class MissingXmlGetter {
      * so that somebody can download and edit the .xml file to fill in the values and then do a bulk
      * submission of that file
      *
+     * @param locale the locale
      * @param coverageLevel the coverage level for paths to be included
      * @return the XML as a string
      * @throws IOException for StringWriter
      */
-    public String getXml(Level coverageLevel) throws IOException {
+    public String getXml(CLDRLocale locale, Level coverageLevel) throws IOException {
+        if (usersOrg == null || usersChoice == null) {
+            throw new IllegalArgumentException("usersOrg and usersChoice must be set");
+        }
+        final CLDRConfig config = CLDRConfig.getInstance();
+        final SupplementalDataInfo SDI = config.getSupplementalDataInfo();
+        final VettingViewer<Organization> vv = new VettingViewer<>(SDI, factory, usersChoice);
+        final EnumSet<NotificationCategory> choiceSet = VettingViewer.getDashboardNotificationCategories(usersOrg);
+        final VettingParameters args = new VettingParameters(choiceSet, locale, coverageLevel);
+        args.setUserAndOrganization(userId, usersOrg);
+        args.setFiles(locale, factory, baselineFactory);
+        final VettingViewer<Organization>.DashboardData dd = vv.generateDashboard(args);
+        return reallyGetXml(locale, dd);
+    }
+
+    private String reallyGetXml(CLDRLocale locale, VettingViewer<Organization>.DashboardData dd) throws IOException {
+        final XMLSource source = new SimpleXMLSource(locale.getBaseName());
+        final CLDRFile cldrFile = new CLDRFile(source);
+        populateMissingCldrFile(cldrFile, dd);
         try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
-            // TODO: add a new option telling cldrFile.write to write only the error/missing/provisional paths
-            // (at the given coverageLevel, adding a placeholder for the values) instead of
-            // the present paths
-            // Reference: https://unicode-org.atlassian.net/browse/CLDR-15707
             Map<String, Object> options = new TreeMap<>();
             cldrFile.write(pw, options);
             return sw.toString();
         }
+    }
+
+    private void populateMissingCldrFile(CLDRFile cldrFile, VettingViewer<Organization>.DashboardData dd) {
+        for (Map.Entry<Row.R2<PathHeader.SectionId, PathHeader.PageId>, VettingViewer<Organization>.WritingInfo> e : dd.sorted.entrySet()) {
+            final VettingViewer<Organization>.WritingInfo wi = e.getValue();
+            final String path = wi.codeOutput.getOriginalPath();
+            for (NotificationCategory cat : wi.problems) {
+                if (
+                    cat == NotificationCategory.error ||
+                    cat == NotificationCategory.missingCoverage ||
+                    cat == NotificationCategory.notApproved
+                ) {
+                    addPath(cldrFile, path, wi, cat);
+                }
+            }
+        }
+    }
+
+    private void addPath(
+        CLDRFile cldrFile,
+        String path,
+        VettingViewer<Organization>.WritingInfo wi,
+        NotificationCategory cat
+    ) {
+        cldrFile.add(path, "n/a");
+        // most common category is missingCoverage; only show category label for the others
+        String comment = (cat == NotificationCategory.missingCoverage) ? "" : cat.buttonLabel + "; ";
+        if (cat == NotificationCategory.error) {
+            comment += " " + wi.subtype + "; ";
+            // TODO: convert htmlMessage into plain text for legibility/legality inside xml comment
+            comment += " " + wi.htmlMessage + "; ";
+        }
+        comment += "English: " + englishFile.getStringValue(path);
+        cldrFile.addComment(path, comment, XPathParts.Comments.CommentType.PREBLOCK);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingParameters.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingParameters.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.util;
 import java.util.EnumSet;
 
 public class VettingParameters {
+
     final EnumSet<NotificationCategory> choices;
     final CLDRLocale locale;
     final Level coverageLevel;
@@ -21,6 +22,40 @@ public class VettingParameters {
         this.choices = choices;
         this.locale = locale;
         this.coverageLevel = coverageLevel;
+    }
+
+    public void setFiles(CLDRLocale locale, Factory sourceFactory, Factory baselineFactory) {
+        /*
+         * sourceFile provides the current winning values, taking into account recent votes.
+         * baselineFile provides the "baseline" (a.k.a. "trunk") values, i.e., the values that
+         * are in the current XML in the cldr version control repository. The baseline values
+         * are generally the last release values plus any changes that have been made by the
+         * technical committee by committing directly to version control rather than voting.
+         */
+        final String localeId = locale.getBaseName();
+        final CLDRFile sourceFile = sourceFactory.make(localeId, true/* resolved */);
+        final CLDRFile baselineFile = baselineFactory.make(localeId, true);
+        setFiles(sourceFile, baselineFile);
+    }
+
+    /**
+     * Setup to calculate the baseline ('HEAD') error count
+     *
+     * @param locale the CLDRLocale
+     * @param baselineFactory the baseline factory
+     */
+    public void setFilesForBaseline(CLDRLocale locale, Factory baselineFactory) {
+        final String localeId = locale.getBaseName();
+        final CLDRFile baselineFile = baselineFactory.make(localeId, true);
+        /*
+         * sourceFile must be resolved, otherwise VettingViewer.getMissingStatus is liable
+         * to get a null value and return MissingStatus.ABSENT where a resolved file
+         * could result in a non-null inherited value (such as en_CA inheriting from en)
+         * and MissingStatus.PRESENT. Any such inconsistencies interfere with comparing
+         * the current and baseline stats.
+         */
+        final CLDRFile sourceFile = baselineFactory.make(localeId, true/* resolved */);
+        setFiles(sourceFile, baselineFile);
     }
 
     public void setFiles(CLDRFile sourceFile, CLDRFile baselineFile) {


### PR DESCRIPTION
-Accessible through openapi/ui/ under api/missingxml for users with write permission for locale

-Implement by getting Dashboard data and adding paths that have notifications

-Show notification types/descriptions and English values in xml comments

-Move Dashboard.setFiles and setFilesForBaseline to VettingParameters in util, not limited to Dashboard

CLDR-15707

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
