### PR TITLE
CLDR-15667 More DAIP adjustments for intvFmtFallback, space in short/narrow AM/PM, ...

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1824,7 +1824,7 @@ annotations.
 						<dateFormatItem id="yyyyQQQQ">QQQQ r(U)</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
 							<greatestDifference id="h">h – h B</greatestDifference>
@@ -2041,7 +2041,7 @@ annotations.
 						<appendItem request="Year">{0} {1}</appendItem>
 					</appendItems>
 					<intervalFormats>
-						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
 							<greatestDifference id="h">h – h B</greatestDifference>
@@ -2521,7 +2521,7 @@ annotations.
 						<appendItem request="Year">{0} {1}</appendItem>
 					</appendItems>
 					<intervalFormats>
-						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
 							<greatestDifference id="h">h – h B</greatestDifference>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -481,7 +481,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
-						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
 							<greatestDifference id="h">h–h B</greatestDifference>
@@ -997,7 +997,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
-						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
 							<greatestDifference id="h">h–h B</greatestDifference>
@@ -1444,7 +1444,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
-						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
 							<greatestDifference id="h">h–h B</greatestDifference>

--- a/common/main/wae.xml
+++ b/common/main/wae.xml
@@ -551,7 +551,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMEd" draft="contributed">E, d. MMM y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">{0} - {1}</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d – d</greatestDifference>
 						</intervalFormatItem>
@@ -876,7 +876,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMEd" draft="contributed">E, d. MMM y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">{0} - {1}</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d – d</greatestDifference>
 						</intervalFormatItem>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -502,34 +502,43 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         PathSpaceAdjustData[] testItems = {
             new PathSpaceAdjustData("en",
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/timeFormats/timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
-                    "h:mm a", "h:mm a"), // \u202F
+                    "h:mm a", "h:mm\u202Fa"),
+            new PathSpaceAdjustData("en",
+                    "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/timeFormats/timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
+                    "h:mm aaaa", "h:mm aaaa"), // no adjustment for aaaa
             new PathSpaceAdjustData("ja",
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"hm\"]",
                     "a K:mm", "a K:mm"),
             new PathSpaceAdjustData("en",
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"hm\"]/greatestDifference[@id=\"a\"]",
-                    "h:mm - h:m a", "h:mm – h:m a"), // \u2009\u2013\u2009, \u202F
+                    "h:mm - h:mm a", "h:mm\u2009–\u2009h:mm\u202Fa"),
+            new PathSpaceAdjustData("en",
+                    "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/intervalFormats/intervalFormatFallback",
+                    "{0} – {1}", "{0}\u2009–\u2009{1}"),
             new PathSpaceAdjustData("uk",
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateFormats/dateFormatLength[@type=\"medium\"]/dateFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
-                    "d MMM y 'р'.", "d MMM y 'р'."), // \u202F after y
+                    "d MMM y 'р'.", "d MMM y\u202F'р'."),
             new PathSpaceAdjustData("uk",
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"yMMMd\"]",
-                    "d MMM y 'р'.", "d MMM y 'р'."), // \u202F after y
+                    "d MMM y 'р'.", "d MMM y\u202F'р'."),
             new PathSpaceAdjustData("uk",
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"yMMMd\"]/greatestDifference[@id=\"M\"]",
-                    "d MMM - d MMM y 'р'.", "d MMM – d MMM y 'р'."), // \u2013, \u202F after y
+                    "d MMM - d MMM y 'р'.", "d MMM – d MMM y\u202F'р'."),
+            new PathSpaceAdjustData("es",
+                    "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dayPeriods/dayPeriodContext[@type=\"format\"]/dayPeriodWidth[@type=\"narrow\"]/dayPeriod[@type=\"am\"]",
+                    "a. m.", "a.\u202Fm."),
             new PathSpaceAdjustData("en",
                     "//ldml/units/unitLength[@type=\"narrow\"]unit[@type=\"mass-gram\"]/unitPattern[@count=\"other\"]",
-                    "{0} g", "{0} g"), //  \u202F
+                    "{0} g", "{0}\u202Fg"),
             new PathSpaceAdjustData("en",
                     "//ldml/units/unitLength[@type=\"narrow\"]unit[@type=\"mass-gram\"]/unitPattern[@count=\"other\"]",
-                    "g {0}", "g {0}"), //  \u202F
+                    "g {0}", "g\u202F{0}"),
             new PathSpaceAdjustData("en",
                     "//ldml/units/unitLength[@type=\"short\"]unit[@type=\"mass-gram\"]/unitPattern[@count=\"other\"]",
-                    "{0} g", "{0} g"), // \u00A0
+                    "{0} g", "{0}\u00A0g"),
             new PathSpaceAdjustData("en",
                     "//ldml/units/unitLength[@type=\"short\"]unit[@type=\"mass-gram\"]/unitPattern[@count=\"other\"]",
-                    "g {0}", "g {0}"), // \u00A0
+                    "g {0}", "g\u00A0{0}"),
         };
 
        for (PathSpaceAdjustData testItem: testItems) {


### PR DESCRIPTION
CLDR-15667

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

This is a follow-on to [CLDR-14032: Propose more sophisticated DAIP handling of spacesDONE](https://unicode-org.atlassian.net/browse/CLDR-14032) to refine the space adjustments from that. Here:
- When converting spaces around em-dash intervalFormats to THIN SPACE \u2009, need to also handle the intervalFormatFallback element
- Per the original ticket we changed space between 12-hour time and AM/PM marker 'a' to NNBSP \u202F for Latn, Cyrl, Grek. Two refinements:
    - We should _not_ do that for formats with the long AM/PM marker “aaaa”. There may not be many of those (if any) in CLDR data, but check anyway. (This check is currently a bit awkward)
    - Spaces in short and narrow AM/PM markers (e.g. “a. m.”) should be converted to \u202F NNBSP. Some short and narrow AM/PM markers are not actually very short; perhaps we should skip doing this for those?

To get tests to pass, I also had to fix the intervalFormatFallback data in root, en, and wae to be what DAIP would produce.