### PR TITLE
CLDR-15746 os_ES, copy missing MMMM ("de MMMM") date formats from es

### DIFF
--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -17,4 +17,52 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<exemplarCharacters type="numbers">[\- ‑ , . % ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐ ‑ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” « » ( ) \[ \] § @ * / \&amp; # † ‡ ⋅]</exemplarCharacters>
 	</characters>
+	<dates>
+		<calendars>
+			<calendar type="generic">
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMMMM" draft="provisional">MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMd" draft="provisional">d 'de' MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd" draft="provisional">E, d 'de' MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="provisional">E, d 'de' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd" draft="provisional">d 'de' MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd" draft="provisional">EEE, d 'de' MMMM 'de' y G</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="gregorian">
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMMMM" draft="provisional">MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMd" draft="provisional">d 'de' MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd" draft="provisional">E, d 'de' MMMM 'de' y G</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="provisional">E, d 'de' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMMd" draft="provisional">d 'de' MMMM 'de' y</dateFormatItem>
+						<dateFormatItem id="yMMMMEd" draft="provisional">EEE, d 'de' MMMM 'de' y</dateFormatItem>
+					</availableFormats>
+					<intervalFormats>
+						<intervalFormatItem id="MMMMd">
+							<greatestDifference id="d" draft="provisional">d–d 'de' MMMM</greatestDifference>
+							<greatestDifference id="M" draft="provisional">d 'de' MMMM – d 'de' MMMM</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="MMMMEd">
+							<greatestDifference id="d" draft="provisional">E, d 'de' MMMM – E, d 'de' MMMM</greatestDifference>
+							<greatestDifference id="M" draft="provisional">E, d 'de' MMMM – E, d 'de' MMMM</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="yMMMMd">
+							<greatestDifference id="d" draft="provisional">d–d 'de' MMMM 'de' y</greatestDifference>
+							<greatestDifference id="M" draft="provisional">d 'de' MMMM – d 'de' MMMM 'de' y</greatestDifference>
+							<greatestDifference id="y" draft="provisional">d 'de' MMMM 'de' y – d 'de' MMMM 'de' y</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="yMMMMEd">
+							<greatestDifference id="d" draft="provisional">E, d 'de' MMMM – E, d 'de' MMMM 'de' y</greatestDifference>
+							<greatestDifference id="M" draft="provisional">E, d 'de' MMMM – E, d 'de' MMMM 'de' y</greatestDifference>
+							<greatestDifference id="y" draft="provisional">E, d 'de' MMMM 'de' y – E, d 'de' MMMM 'de' y</greatestDifference>
+						</intervalFormatItem>
+					</intervalFormats>
+				</dateTimeFormats>
+			</calendar>
+		</calendars>
+	</dates>
 </ldml>


### PR DESCRIPTION
CLDR-15746

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

For `oc_ES`, the vetter requested adding some missing `MMMM` date formats (cannot be added in Survey Tool), copying the missing forms from `es` which has them.