### PR TITLE
CLDR-15737 The test for compact numbers was not actually being run

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
@@ -239,6 +239,7 @@ public class TestAll extends TestGroup {
             "org.unicode.cldr.unittest.TestNumbers",
             "org.unicode.cldr.unittest.TestLocaleCanonicalizer",
             "org.unicode.cldr.unittest.TestPersonNameFormatter",
+            "org.unicode.cldr.unittest.TestCompactNumbers",
             //            "org.unicode.cldr.unittest.TestCollators" See Ticket #8288
             "org.unicode.cldr.api.AllTests",
         },

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompactNumbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompactNumbers.java
@@ -17,15 +17,18 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.VerifyCompactNumbers;
 
+import com.google.common.base.Objects;
+import com.ibm.icu.impl.locale.XCldrStub.Splitter;
 import com.ibm.icu.text.CompactDecimalFormat;
 import com.ibm.icu.text.CompactDecimalFormat.CompactStyle;
+import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.PluralRules.FixedDecimal;
 import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.ULocale;
 
 public class TestCompactNumbers  extends TestFmwkPlus {
-    static final boolean DEBUG = true;
+    static final boolean DEBUG = false;
     private static StandardCodes sc = StandardCodes.make();
     private static final CLDRConfig CLDRCONFIG = CLDRConfig.getInstance();
     private static final SupplementalDataInfo SDI = CLDRCONFIG.getSupplementalDataInfo();
@@ -104,10 +107,12 @@ public class TestCompactNumbers  extends TestFmwkPlus {
         String oldLocale = "";
         String oldCurrencyCode = "";
         CompactDecimalFormat cdfCurr = null;
-
+        CompactStyle compactStyle = null;
+        CurrencyStyle currencyStyle = null;
+        CLDRFile cldrFile = null;
 
         Object[][] tests = {
-            {"cs", "", 1100000d, "1,1 milionu"}, // should be 'many', not 1,1 milionů == 'other'
+            {"cs", null, 1100000d, "1,1 milionu"}, // should be 'many', not 1,1 milionů == 'other'
             /* Background for cs
              * <pattern type="1000000" count="one">0 milion</pattern>
              * <pattern type="1000000" count="few">0 miliony</pattern>
@@ -115,31 +120,41 @@ public class TestCompactNumbers  extends TestFmwkPlus {
              * <pattern type="1000000" count="other">0 milionů</pattern>
              * https://unicode-org.github.io/cldr-staging/charts/41/supplemental/language_plural_rules.html#cs
              */
-            {"fr", "EUR", 100d, "100 €"},
+            {"fr", "EUR", 100d, "100 €"},
             {"fr", "EUR", 1000d, "1 k €"},
         };
 
         for (Object[] row : tests) {
             String locale = row[0].toString();
-            String currencyCode = row[1].toString();
+            String currencyCode = row[1] == null ? null : row[1].toString();
             double value = (double) row[2];
             String expected = row[3].toString();
 
-            if (!locale.equals(oldLocale) || !currencyCode.equals(oldCurrencyCode)) {
+
+            if (!locale.equals(oldLocale) || Objects.equal(currencyCode, oldCurrencyCode)) {
                 oldLocale = locale;
                 oldCurrencyCode = currencyCode;
-                CLDRFile cldrFile = factory2.make(locale, true);
+                cldrFile = factory2.make(locale, true);
 
                 debugCreationErrors.clear();
-                if (currencyCode.isBlank()) {
+                if (currencyCode == null) {
+                    compactStyle = CompactStyle.LONG;
+                    currencyStyle = CurrencyStyle.PLAIN;
+
                     cdfCurr = BuildIcuCompactDecimalFormat.build(cldrFile, debugCreationErrors,
-                        debugOriginals, CompactStyle.LONG, ULocale.forLanguageTag(locale),
-                        CurrencyStyle.PLAIN, null);
+                        debugOriginals, compactStyle, ULocale.forLanguageTag(locale),
+                        currencyStyle, null);
+
                     // note: custom data looks good:
                     // 1000000={other=0 milionů, one=0 milion, few=0 miliony, many=0 milionu}
+
                 } else {
+                    compactStyle = CompactStyle.SHORT;
+                    currencyStyle = CurrencyStyle.CURRENCY;
+
                     cdfCurr = BuildIcuCompactDecimalFormat.build(cldrFile, debugCreationErrors,
-                        debugOriginals, CompactStyle.SHORT, ULocale.forLanguageTag(locale), CurrencyStyle.CURRENCY, currencyCode);
+                        debugOriginals, compactStyle, ULocale.forLanguageTag(locale),
+                        currencyStyle, currencyCode);
 
                     cdfCurr.setCurrency(Currency.getInstance(currencyCode));
                     int sigDigits = 3;
@@ -148,12 +163,29 @@ public class TestCompactNumbers  extends TestFmwkPlus {
             }
             String actual = cdfCurr.format(value);
             if (!assertEquals("Formatted " + value, expected, actual)) {
+                if (DEBUG) {
                 PluralInfo rules = SupplementalDataInfo.getInstance().getPlurals(locale);
                 int v, f, e;
                 FixedDecimal fd = new FixedDecimal(1.1d, 1, 1, 0);
                 Count count = rules.getCount(fd);
-                System.out.println(fd + " => " + count);
+                System.out.println("Locale: " + locale);
+                ICUServiceBuilder builder = new ICUServiceBuilder().setCldrFile(cldrFile);
+
+                DecimalFormat decimalFormat = currencyStyle == CurrencyStyle.PLAIN
+                    ?  builder.getNumberFormat(1)
+                        : builder.getCurrencyFormat(currencyCode);
+                final String pattern = decimalFormat.toPattern();
+
+                System.out.println("Fallback pattern: " + pattern);
+                System.out.println("Plural Rules: ");
+                semiSplit.split(rules.getRules()).forEach(x -> System.out.println("\t" + x + ";"));
+                System.out.println("Plural sample result: " + fd + " => " + count);
+
+                Map<String, Map<String, String>> customData = BuildIcuCompactDecimalFormat.buildCustomData(cldrFile, compactStyle, currencyStyle);
+                customData.forEach((k, vv) -> System.out.println("\t" + k + "\t" + vv));
+                }
             }
         }
     }
+    static final Splitter semiSplit = Splitter.on(';').trimResults();
 }


### PR DESCRIPTION
The test for compact numbers was not actually being run, so enabling that, and cleaning up the test a bit.

CLDR-15737

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
