### PR TITLE
CLDR-8666 Reports: correction to table uniqueness

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReportsDB.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReportsDB.java
@@ -55,8 +55,8 @@ public class ReportsDB extends VoterReportStatus<Integer> implements ReportStatu
         try (
             Connection conn = DBUtils.getInstance().getDBConnection();
             PreparedStatement ps = DBUtils.prepareStatementWithArgsUpdateable(conn,
-                String.format("INSERT INTO %s (submitter, locale, report, completed, acceptable) " +
-                    "VALUES(?,?,?,?,?) ON DUPLICATE KEY UPDATE completed=?,acceptable=?", table),
+                String.format("INSERT INTO %s (submitter, locale, report, completed, acceptable, last_mod) " +
+                    "VALUES(?,?,?,?,?, CURRENT_TIMESTAMP) ON DUPLICATE KEY UPDATE completed=?,acceptable=?,last_mod=CURRENT_TIMESTAMP", table),
                 user, locale.getBaseName(), r.name(), completed ? 1 : 0, acceptable ? 1 : 0,
                 completed ? 1 : 0, acceptable ? 1 : 0);) {
             ps.execute();
@@ -72,7 +72,7 @@ public class ReportsDB extends VoterReportStatus<Integer> implements ReportStatu
         try (
             Connection conn = DBUtils.getInstance().getAConnection();
             PreparedStatement ps = DBUtils.prepareStatementWithArgsFRO(conn,
-                String.format("SELECT report, completed, acceptable FROM %s WHERE submitter=? AND locale=?", table),
+                String.format("SELECT report, completed, acceptable FROM %s WHERE submitter=? AND locale=? order by last_mod asc", table),
                 user, locale.getBaseName());
             ResultSet rs = ps.executeQuery();) {
             while (rs.next()) {
@@ -147,19 +147,19 @@ public class ReportsDB extends VoterReportStatus<Integer> implements ReportStatu
     private PreparedStatement getAllReportsStatement(Connection conn, Integer onlyId, CLDRLocale onlyLoc) throws SQLException {
         if (onlyId != null && onlyLoc != null) {
             return DBUtils.prepareStatementWithArgsFRO(conn,
-                String.format("SELECT * FROM %s WHERE submitter=? and locale=?", table),
+                String.format("SELECT * FROM %s WHERE submitter=? and locale=? order by last_mod a", table),
                 onlyId, onlyLoc);
         } else if (onlyId != null) {
             return DBUtils.prepareStatementWithArgsFRO(conn,
-                String.format("SELECT * FROM %s WHERE submitter=?", table),
+                String.format("SELECT * FROM %s WHERE submitter=? order by last_mod asc", table),
                 onlyId);
         } else if (onlyLoc != null) {
             return DBUtils.prepareStatementWithArgsFRO(conn,
-                String.format("SELECT * FROM %s WHERE locale=?", table),
+                String.format("SELECT * FROM %s WHERE locale=? order by last_mod asc", table),
                 onlyLoc);
         } else {
             return DBUtils.prepareStatementWithArgsFRO(conn,
-                String.format("SELECT * FROM %s", table));
+                String.format("SELECT * FROM %s order by last_mod asc", table));
         }
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
@@ -70,7 +70,7 @@ public class ReportAPI {
             UserRegistry.User u = mySession.sm.reg.getInfo(id);
             if (u == null) {
                 return Response.status(Status.NOT_FOUND).build();
-            } else if (!(mySession.user.id == id || !mySession.user.isAdminFor(u))) {
+            } else if (!(mySession.user.id == id || mySession.user.isAdminFor(u))) {
                 return Response.status(Status.FORBIDDEN).build();
             }
         }

--- a/tools/cldr-apps/src/main/resources/org/unicode/cldr/web/sql/cldr-reports-db.sql
+++ b/tools/cldr-apps/src/main/resources/org/unicode/cldr/web/sql/cldr-reports-db.sql
@@ -9,4 +9,4 @@ CREATE TABLE VOTE_REPORTS (
     last_mod TIMESTAMP
 );
 
-CREATE INDEX VOTE_REPORTS_slr ON VOTE_REPORTS (submitter, locale, report);
+CREATE UNIQUE INDEX VOTE_REPORTS_slr ON VOTE_REPORTS (submitter, locale, report);


### PR DESCRIPTION
- CLDR_VOTE_REPORTS* index needed to be unique.
This is now fixed, meaning that future versions will create this table with a unique index.
- For the current release, ensure that votes are  queried in
last_mod ascending order, meaning that the latest vote wins
- Fix a logic bug in the report API

CLDR-8666

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
