### PR TITLE
CLDR-10564 Logical groups; unit test and refactoring

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
@@ -3,21 +3,14 @@ package org.unicode.cldr.test;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
-import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LogicalGrouping;
-import org.unicode.cldr.util.LogicalGrouping.PathType;
 import org.unicode.cldr.util.With;
-import org.unicode.cldr.util.XMLSource;
-import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
@@ -28,17 +21,12 @@ import com.google.common.collect.TreeMultiset;
 import com.ibm.icu.dev.util.UnicodeMap;
 import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.text.UnicodeSet;
-import com.ibm.icu.util.Output;
 
 public class CheckLogicalGroupings extends FactoryCheckCLDR {
     // Change MINIMUM_DRAFT_STATUS to DraftStatus.contributed if you only care about
     // contributed or higher. This can help to reduce the error count when you have a lot of new data.
-
     static final DraftStatus MIMIMUM_DRAFT_STATUS = DraftStatus.contributed;
     static final Set<Phase> PHASES_CAUSE_ERROR = ImmutableSet.of(Phase.FINAL_TESTING, Phase.VETTING);
-
-    private boolean phaseCausesError;
-    private CoverageLevel2 coverageLevel;
 
     public CheckLogicalGroupings(Factory factory) {
         super(factory);
@@ -59,191 +47,18 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
         String parent = LocaleIDParser.getParent(cldrFileToCheck.getLocaleID());
         boolean isTopLevel = parent == null || parent.equals("root");
         setSkipTest(!isTopLevel);
-        phaseCausesError = PHASES_CAUSE_ERROR.contains(getPhase());
-
-        coverageLevel = CoverageLevel2.getInstance(cldrFileToCheck.getLocaleID());
-
         return this;
     }
-
 
     // remember to add this class to the list in CheckCLDR.getCheckAll
     // to run just this test, on just locales starting with 'nl', use CheckCLDR with -fnl.* -t.*LogicalGroupings.*
 
-    /**
-     * We are not as strict with sublocales (where the parent is neither root nor code_fallback).
-     * @param path
-     * @return
-     */
-    public boolean isHereOrNonRoot(String path) {
-        if (getCldrFileToCheck().isHere(path)) {
-            return true;
-        }
-        if (!getCldrFileToCheck().getLocaleID().contains("_")) { // quick check for top level
-            return false;
-        }
-        String value = getResolvedCldrFileToCheck().getStringValue(path);
-        if (value == null) {
-            return false;
-        }
-        // the above items are just for fast checking.
-        // check the origin of the value, and make sure it is not ≥ root
-        String source = getResolvedCldrFileToCheck().getSourceLocaleID(path, null);
-        return !source.equals(XMLSource.ROOT_ID) && !source.equals(XMLSource.CODE_FALLBACK_ID);
-    }
-
-    static final int LIMIT_DISTANCE = 5;
-
     @Override
-    public CheckCLDR handleCheck(String path, String fullPath, String value, Options options,
-        List<CheckStatus> result) {
-
-        // if (fullPath == null) return this; // skip paths that we don't have
+    public CheckCLDR handleCheck(String path, String fullPath, String value, Options options, List<CheckStatus> result) {
         if (LogicalGrouping.isOptional(getCldrFileToCheck(), path)) {
             return this;
         }
-
-        Output<PathType> pathType = new Output<>();
-        Set<String> paths = LogicalGrouping.getPaths(getCldrFileToCheck(), path, pathType);
-        if (paths == null || paths.size() < 2) return this; // skip if not part of a logical grouping
-
-        // check the edit distances for count, gender, case
-        switch(pathType.value) {
-        case COUNT_CASE:
-        case COUNT:
-        case COUNT_CASE_GENDER:
-            // only check the first path
-            TreeSet<String> sorted = new TreeSet<>(paths);
-            if (path.equals(sorted.iterator().next())) {
-                Multiset<String> values = TreeMultiset.create();
-                int maxDistance = getMaxDistance(path, value, sorted, values);
-                if (maxDistance >= LIMIT_DISTANCE) {
-                    maxDistance = getMaxDistance(path, value, paths, values);
-                    result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.warningType)
-                        .setSubtype(Subtype.largerDifferences) // typically warningType or errorType
-                        .setMessage("{0} different characters within {1}; {2}", maxDistance, showInvisibles(values), pathType.value));
-                }
-            }
-            break;
-        default: break;
-        }
-
-
-        // TODO make this more efficient
-        Set<String> paths2 = new HashSet<>(paths);
-        for (String p : paths2) {
-            if (LogicalGrouping.isOptional(getCldrFileToCheck(), p)) {
-                paths.remove(p);
-            }
-        }
-        if (paths.size() < 2) return this; // skip if not part of a logical grouping
-
-
-        Set<String> missingPaths = new HashSet<>();
-        boolean havePath = false;
-        String firstPath = null;
-        for (String apath : paths) {
-            if (isHereOrNonRoot(apath)) { // ok
-                havePath = true;
-            } else {
-                if (missingPaths.isEmpty()) {
-                    firstPath = apath; // pick the first one in sorted order (LogicalGrouping.getPaths is sorted)
-                }
-                missingPaths.add(apath);
-            }
-        }
-
-        if (havePath && !missingPaths.isEmpty()) {
-            if (path.equals(firstPath)) {
-                Set<String> missingCodes = missingPaths
-                    .stream()
-                    .map(x -> getPathReferenceForMessage(x, true))
-                    .collect(Collectors.toSet());
-                Level cLevel = coverageLevel.getLevel(path);
-
-                CheckStatus.Type showError = phaseCausesError ? CheckStatus.errorType : CheckStatus.warningType;
-                result.add(new CheckStatus().setCause(this).setMainType(showError)
-                    .setSubtype(Subtype.incompleteLogicalGroup)
-                    .setMessage("Incomplete logical group - missing values for: {0}; level={1}", missingCodes.toString(), cLevel));
-            }
-            // skip other errors once we find missing paths
-            return this;
-        }
-
-        // Special test during vetting phase to allow changes in a logical group when another item in the group
-        // contains an error or warning.  See http://unicode.org/cldr/trac/ticket/4943.
-        // I added the option lgWarningCheck so that we don't loop back on ourselves forever.
-        // JCE: 2015-04-13: I don't think we need this any more, since we implemented
-        // http://unicode.org/cldr/trac/ticket/6480, and it really slows things down.
-        // I'll just comment it out until we get through a whole release without it.
-        // TODO: Remove it completely if we really don't need it.
-        //if (Phase.VETTING.equals(this.getPhase()) && options.get(Options.Option.lgWarningCheck) != "true") {
-        //    Options checkOptions = options.clone();
-        //    checkOptions.set("lgWarningCheck", "true");
-        //    List<CheckStatus> statuses = new ArrayList<CheckStatus>();
-        //    CompoundCheckCLDR secondaryChecker = CheckCLDR.getCheckAll(CLDRConfig.getInstance().getFullCldrFactory(), ".*");
-        //    secondaryChecker.setCldrFileToCheck(getCldrFileToCheck(), checkOptions, statuses);
-
-        //    for (String apath : paths) {
-        //        if (apath == path) {
-        //            continue;
-        //        }
-        //        String fPath = getCldrFileToCheck().getFullXPath(apath);
-        //        if (fPath == null) {
-        //            continue;
-        //        }
-        //        secondaryChecker.check(apath, fPath, getCldrFileToCheck().getWinningValue(apath), checkOptions, statuses);
-        //        if (CheckStatus.hasType(statuses, Type.Error) || CheckStatus.hasType(statuses, Type.Warning)) {
-        //            result.add(new CheckStatus().setCause(this).setMainType(CheckStatus.warningType)
-        //                .setSubtype(Subtype.errorOrWarningInLogicalGroup)
-        //                .setMessage("Error or warning within this logical group.  May require a change on this item to make the group correct."));
-        //            break;
-        //        }
-        //    }
-        //}
-
-        //if (Phase.FINAL_TESTING.equals(this.getPhase())) {
-
-        // Change the structure so we only check for draft status if this path fails;
-        // avoids work for ones we are not going to alert on anyway.
-
-        // If the draft status of something in the set is lower, then an implementation that filters out that draft status
-        // will get the wrong value.
-
-        String fPath = getCldrFileToCheck().getFullXPath(path);
-        XPathParts parts = XPathParts.getFrozenInstance(fPath);
-        DraftStatus myStatus = DraftStatus.forString(parts.findFirstAttributeValue("draft"));
-        if (myStatus.compareTo(MIMIMUM_DRAFT_STATUS) >= 0) {
-            return this; // bail if we are ok
-        }
-
-        // If some other path in the LG has a higher draft status, then cause error on this path.
-        // NOTE: changed to show in Vetting, not just Resolution
-
-        for (String apath : paths) {
-            if (apath.equals(path) || missingPaths.contains(apath)) { // skip this path, skip others unless present
-                continue;
-            }
-            fPath = getCldrFileToCheck().getFullXPath(apath);
-            if (fPath == null) {
-                continue;
-            }
-            parts = XPathParts.getFrozenInstance(fPath);
-            DraftStatus draftStatus = DraftStatus.forString(parts.findFirstAttributeValue("draft"));
-
-            // Cause error for anything above myStatus
-
-            if (draftStatus.compareTo(myStatus) > 0) {
-                CheckStatus.Type showError = phaseCausesError ? CheckStatus.errorType : CheckStatus.warningType;
-                result.add(new CheckStatus().setCause(this).setMainType(showError)
-                    .setSubtype(Subtype.inconsistentDraftStatus) // typically warningType or errorType
-                    .setMessage("This item has draft status={0}, which is lower than the status={1} (for {2}).",
-                        myStatus.name(),
-                        draftStatus.name(),
-                        getPathReferenceForMessage(apath, true))); // the
-                break; // no need to continue
-            }
-        }
+        new LogicalGroupChecker(this, path, value, result).run();
         return this;
     }
 
@@ -275,25 +90,13 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
         return b.append('}').toString();
     }
 
-    private int getMaxDistance(String path, String value, Set<String> paths, Multiset<String> values) {
-        values.clear();
-        final CLDRFile cldrFileToCheck = getCldrFileToCheck();
-        Set<Fingerprint> fingerprints = new HashSet<>();
-        for (String path1 : paths) {
-            final String pathValue = cleanSpaces(path.contentEquals(path1) ? value : cldrFileToCheck.getWinningValue(path1));
-            values.add(pathValue);
-            fingerprints.add(Fingerprint.make(pathValue));
-        }
-        return Fingerprint.maxDistanceBetween(fingerprints);
-    }
-
     private static final UnicodeMap<String> OTHER_SPACES = new UnicodeMap<String>().putAll(new UnicodeSet("[[:Z:][:S:][:whitespace:]]"), " ").freeze();
     public static String cleanSpaces(String pathValue) {
         return OTHER_SPACES.transform(pathValue);
     }
 
     // Later
-    private static ConcurrentHashMap<String, Fingerprint> FINGERPRINT_CACHE = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, Fingerprint> FINGERPRINT_CACHE = new ConcurrentHashMap<>();
 
     /**
      * Use cheap distance metric for testing differences; just the number of characters of each kind.
@@ -342,7 +145,7 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
         }
 
         public static Fingerprint make(String value) {
-            return FINGERPRINT_CACHE.computeIfAbsent(value, v -> new Fingerprint(v));
+            return FINGERPRINT_CACHE.computeIfAbsent(value, Fingerprint::new);
         }
 
         @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/LogicalGroupChecker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/LogicalGroupChecker.java
@@ -1,0 +1,256 @@
+package org.unicode.cldr.test;
+
+import com.google.common.collect.Multiset;
+import com.google.common.collect.TreeMultiset;
+import com.ibm.icu.util.Output;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.unicode.cldr.util.*;
+
+public class LogicalGroupChecker {
+
+    private static final int LIMIT_DISTANCE = 5;
+
+    private final CheckLogicalGroupings checkLogicalGroupings;
+    private final String path;
+    private final String value;
+    private final Output<LogicalGrouping.PathType> pathType;
+    private final CLDRFile cldrFile;
+    private final List<CheckCLDR.CheckStatus> result;
+    private final Set<String> paths;
+
+    private final boolean phaseCausesError;
+    private final CoverageLevel2 coverageLevel;
+
+    private boolean havePath = false;
+    private String firstPath = null;
+    private Set<String> missingPaths = null;
+    private CLDRFile.DraftStatus myStatus;
+
+    public LogicalGroupChecker(
+        CheckLogicalGroupings checkLogicalGroupings,
+        String path,
+        String value,
+        List<CheckCLDR.CheckStatus> result
+    ) {
+        this.checkLogicalGroupings = checkLogicalGroupings;
+        this.path = path;
+        this.value = value;
+        this.result = result;
+        pathType = new Output<>();
+        cldrFile = checkLogicalGroupings.getCldrFileToCheck();
+        paths = LogicalGrouping.getPaths(cldrFile, path, pathType);
+        coverageLevel = CoverageLevel2.getInstance(SupplementalDataInfo.getInstance(), cldrFile.getLocaleID());
+        phaseCausesError = CheckLogicalGroupings.PHASES_CAUSE_ERROR.contains(checkLogicalGroupings.getPhase());
+    }
+
+    public void run() {
+        if (isTrivial()) {
+            return; // skip if not part of a logical grouping
+        }
+        checkEditDistances();
+        removeOptionalPaths();
+        if (isTrivial()) {
+            return; // skip if not part of a logical grouping
+        }
+        if (findMissingPaths()) {
+            return; // skip other errors once we find missing paths
+        }
+        if (avoidWork()) {
+            return; // bail if we are ok
+        }
+        loop();
+    }
+
+    private boolean isTrivial() {
+        // skip if not part of a logical grouping
+        return (paths == null || paths.size() < 2);
+    }
+
+    private void checkEditDistances() {
+        switch (pathType.value) {
+            case COUNT_CASE:
+            case COUNT:
+            case COUNT_CASE_GENDER:
+                // only check the first path
+                TreeSet<String> sorted = new TreeSet<>(paths);
+                if (path.equals(sorted.iterator().next())) {
+                    reallyCheckEditDistances(sorted);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void reallyCheckEditDistances(TreeSet<String> sorted) {
+        Multiset<String> values = TreeMultiset.create();
+        int maxDistance = getMaxDistance(sorted, values);
+        if (maxDistance >= LIMIT_DISTANCE) {
+            maxDistance = getMaxDistance(paths, values);
+            result.add(
+                new CheckCLDR.CheckStatus()
+                    .setCause(checkLogicalGroupings)
+                    .setMainType(CheckCLDR.CheckStatus.warningType)
+                    .setSubtype(CheckCLDR.CheckStatus.Subtype.largerDifferences) // typically warningType or errorType
+                    .setMessage(
+                        "{0} different characters within {1}; {2}",
+                        maxDistance,
+                        CheckLogicalGroupings.showInvisibles(values),
+                        value
+                    )
+            );
+        }
+    }
+
+    private int getMaxDistance(Set<String> paths, Multiset<String> values) {
+        values.clear();
+        Set<CheckLogicalGroupings.Fingerprint> fingerprints = new HashSet<>();
+        for (String path1 : paths) {
+            final String pathValue = CheckLogicalGroupings.cleanSpaces(
+                path.contentEquals(path1) ? value : cldrFile.getWinningValue(path1)
+            );
+            values.add(pathValue);
+            fingerprints.add(CheckLogicalGroupings.Fingerprint.make(pathValue));
+        }
+        return CheckLogicalGroupings.Fingerprint.maxDistanceBetween(fingerprints);
+    }
+
+    private void removeOptionalPaths() {
+        LogicalGrouping.removeOptionalPaths(paths, cldrFile);
+    }
+
+    private boolean findMissingPaths() {
+        missingPaths = getMissingPaths();
+        if (havePath && !missingPaths.isEmpty()) {
+            if (path.equals(firstPath)) {
+                handleMissingPaths();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void handleMissingPaths() {
+        Set<String> missingCodes = missingPaths
+            .stream()
+            .map(x -> checkLogicalGroupings.getPathReferenceForMessage(x, true))
+            .collect(Collectors.toSet());
+        Level cLevel = coverageLevel.getLevel(path);
+
+        CheckCLDR.CheckStatus.Type showError = phaseCausesError
+            ? CheckCLDR.CheckStatus.errorType
+            : CheckCLDR.CheckStatus.warningType;
+        result.add(
+            new CheckCLDR.CheckStatus()
+                .setCause(checkLogicalGroupings)
+                .setMainType(showError)
+                .setSubtype(CheckCLDR.CheckStatus.Subtype.incompleteLogicalGroup)
+                .setMessage(
+                    "Incomplete logical group - missing values for: {0}; level={1}",
+                    missingCodes.toString(),
+                    cLevel
+                )
+        );
+    }
+
+    private Set<String> getMissingPaths() {
+        Set<String> missingPaths = new HashSet<>();
+        for (String apath : paths) {
+            if (isHereOrNonRoot(apath)) { // ok
+                havePath = true;
+            } else {
+                if (missingPaths.isEmpty()) {
+                    firstPath = apath; // pick the first one in sorted order (LogicalGrouping.getPaths is sorted)
+                }
+                missingPaths.add(apath);
+            }
+        }
+        return missingPaths;
+    }
+
+    /**
+     * We are not as strict with sublocales (where the parent is neither root nor code_fallback).
+     *
+     * @param path the path
+     * @return true or false
+     */
+    private boolean isHereOrNonRoot(String path) {
+        if (cldrFile.isHere(path)) {
+            return true;
+        }
+        if (!cldrFile.getLocaleID().contains("_")) { // quick check for top level
+            return false;
+        }
+        final CLDRFile resolvedCldrFile = checkLogicalGroupings.getResolvedCldrFileToCheck();
+        if (resolvedCldrFile.getStringValue(path) == null) {
+            return false;
+        }
+        // the above items are just for fast checking.
+        // check the origin of the value, and make sure it is not ≥ root
+        String source = resolvedCldrFile.getSourceLocaleID(path, null);
+        return !source.equals(XMLSource.ROOT_ID) && !source.equals(XMLSource.CODE_FALLBACK_ID);
+    }
+
+    /**
+     * Return true if we're finished
+     *
+     * @return true or false
+     */
+    private boolean avoidWork() {
+        // only check for draft status if this path fails;
+        // avoids work for ones we are not going to alert on anyway.
+
+        // If the draft status of something in the set is lower, then an implementation that filters out that draft status
+        // will get the wrong value.
+        final String fPath = cldrFile.getFullXPath(path);
+        final XPathParts parts = XPathParts.getFrozenInstance(fPath);
+        myStatus = CLDRFile.DraftStatus.forString(parts.findFirstAttributeValue("draft"));
+        return myStatus.compareTo(CheckLogicalGroupings.MIMIMUM_DRAFT_STATUS) >= 0;
+    }
+
+    private void loop() {
+        // If some other path in the LG has a higher draft status, then cause error on this path.
+        // NOTE: changed to show in Vetting, not just Resolution
+        for (String apath : paths) {
+            if (apath.equals(path) || missingPaths.contains(apath)) { // skip this path, skip others unless present
+                continue;
+            }
+            final String fPath = cldrFile.getFullXPath(apath);
+            if (fPath == null) {
+                continue;
+            }
+            final XPathParts parts = XPathParts.getFrozenInstance(fPath);
+            final CLDRFile.DraftStatus draftStatus = CLDRFile.DraftStatus.forString(
+                parts.findFirstAttributeValue("draft")
+            );
+
+            // Cause error for anything above myStatus
+            if (draftStatus.compareTo(myStatus) > 0) {
+                addOneHigherStatus(apath, myStatus, draftStatus);
+                break; // no need to continue
+            }
+        }
+    }
+
+    private void addOneHigherStatus(String apath, CLDRFile.DraftStatus myStatus, CLDRFile.DraftStatus draftStatus) {
+        CheckCLDR.CheckStatus.Type showError = phaseCausesError
+            ? CheckCLDR.CheckStatus.errorType
+            : CheckCLDR.CheckStatus.warningType;
+        result.add(
+            new CheckCLDR.CheckStatus()
+                .setCause(checkLogicalGroupings)
+                .setMainType(showError)
+                .setSubtype(CheckCLDR.CheckStatus.Subtype.inconsistentDraftStatus) // typically warningType or errorType
+                .setMessage(
+                    "This item has draft status={0}, which is lower than the status={1} (for {2}).",
+                    myStatus.name(),
+                    draftStatus.name(),
+                    checkLogicalGroupings.getPathReferenceForMessage(apath, true)
+                )
+        );
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LogicalGrouping.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LogicalGrouping.java
@@ -77,8 +77,10 @@ public class LogicalGrouping {
 
     /**
      * Return a sorted set of paths that are in the same logical set as the given path
+     *
+     * @param cldrFile the CLDRFile
      * @param path the distinguishing xpath
-     * @param pathType TODO
+     * @param pathTypeOut if not null, gets filled in with the PathType
      *
      * @return the set of paths, or null (to be treated as equivalent to empty set)
      *
@@ -96,13 +98,10 @@ public class LogicalGrouping {
      * Caches: Most of the calculations are independent of the locale, and can be cached on a static basis.
      * The paths that are locale-dependent are /dayPeriods and @count. Those can be computed on a per-locale basis;
      * and cached (they are shared across a number of locales).
-     *
-     * Reference: https://unicode.org/cldr/trac/ticket/11854
      */
     public static Set<String> getPaths(CLDRFile cldrFile, String path, Output<PathType> pathTypeOut) {
         if (path == null) {
             return null; // return null for null path
-            // return new TreeSet<String>(); // return empty set for null path
         }
         XPathParts parts = null;
         PathType pathType = null;
@@ -126,7 +125,6 @@ public class LogicalGrouping {
         if (pathType == PathType.SINGLETON) {
             /*
              * Skip cache for PathType.SINGLETON and simply return a set of one.
-             * TODO: should we ever return null instead of singleton here?
              */
             Set<String> set = new TreeSet<>();
             set.add(path);
@@ -201,13 +199,6 @@ public class LogicalGrouping {
             return true;
         case "zero": case "one":
             break; // continue
-//        case "many": // special case for french
-//            String localeId = cldrFile.getLocaleID();
-//            if (localeId.startsWith("fr")
-//                && (localeId.length() == 2 || localeId.charAt(2) == '_')) {
-//                return true;
-//            }
-//            return false;
         default:
             return false;
         }
@@ -233,6 +224,15 @@ public class LogicalGrouping {
             }
         }
         return false;
+    }
+
+    public static void removeOptionalPaths(Set<String> grouping, CLDRFile cldrFile) {
+        Set<String> grouping2 = new HashSet<>(grouping);
+        for (String p : grouping2) {
+            if (LogicalGrouping.isOptional(cldrFile, p)) {
+                grouping.remove(p);
+            }
+        }
     }
 
     /**
@@ -428,9 +428,7 @@ public class LogicalGrouping {
                 Collection<String> rawGenders = grammarInfo.get(GrammaticalTarget.nominal, GrammaticalFeature.grammaticalGender, GrammaticalScope.units);
                 setGrammarAttributes(set, parts, pluralTypes, rawCases, rawGenders);
             }
-        }
-
-        ;
+        };
 
         abstract void addPaths(Set<String> set, CLDRFile cldrFile, String path, XPathParts parts);
 


### PR DESCRIPTION
-New unit test TestCheckLogicalGroupings.testSameCoverageLevel

-Take isOptional into account for the unit test

-Refactor CheckLogicalGroupings.java, especially extremely long method handleCheck

-New LogicalGroupingChecker.java encapsulates the refactored code with shorter methods

CLDR-10564

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
