### PR TITLE
CLDR-15795 Allow name for lang code gaa to be same as code, test for et (where needed)

### DIFF
--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -204,6 +204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fur">friuuli</language>
 			<language type="fy">läänefriisi</language>
 			<language type="ga">iiri</language>
+			<language type="gaa" draft="provisional">gaa</language>
 			<language type="gag">gagauusi</language>
 			<language type="gan">kani</language>
 			<language type="gay">gajo</language>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -50,7 +50,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
         .add("^//ldml/characterLabels/characterLabel", true)
         .add("^//ldml/dates/fields/field\\[@type=\"(era|week|minute|quarter|second)\"]/displayName", true)
         .add("^//ldml/localeDisplayNames/scripts/script\\[@type=\"(Jamo|Thai|Ahom|Loma|Moon|Newa|Arab|Lisu|Bali|Cham|Modi|Toto)\"]", true)
-        .add("^//ldml/localeDisplayNames/languages/language\\[@type=\"(fon|gan|luo|tiv|yao|vai)\"]", true)
+        .add("^//ldml/localeDisplayNames/languages/language\\[@type=\"(fon|gaa|gan|luo|tiv|yao|vai)\"]", true)
         .add("^//ldml/dates/timeZoneNames/metazone\\[@type=\"GMT\"]", true)
         .add("^//ldml/localeDisplayNames/territories/territory\\[@type=\"[^\"]*+\"]\\[@alt=\"short\"]", true)
         .add("^//ldml/localeDisplayNames/measurementSystemNames/measurementSystemName", true)


### PR DESCRIPTION
CLDR-15795

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Allow the name for language code `gaa` ("Ga" in English) to be the same as code, needed for `et` where the name should  be exactly "gaa". Add language name as provisional in `et` for testing. This is needed by Pikne, Wikimedia vetter for `et`.