### PR TITLE
CLDR-15801 workaround for data from Turkmenistan

### DIFF
--- a/common/annotations/tk.xml
+++ b/common/annotations/tk.xml
@@ -3465,5 +3465,45 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="³" type="tts">ýokary indeks üç</annotation>
 		<annotation cp="µ">mikro belgisi | ölçeg</annotation>
 		<annotation cp="µ" type="tts">mikro belgisi</annotation>
+		<annotation cp="🫨" draft="contributed">ýertitreme | ýüz | titreýän | aňt-taňk | sandyramak</annotation>
+		<annotation cp="🫨" type="tts" draft="contributed">titreýan ýüz</annotation>
+		<annotation cp="🩵" draft="contributed">mawy | ýürek | açyk gök | pöwrize</annotation>
+		<annotation cp="🩵" type="tts" draft="contributed">açyk gök ýürek</annotation>
+		<annotation cp="🩶" draft="contributed">küljümek | ýürek | kümüş | plita</annotation>
+		<annotation cp="🩶" type="tts" draft="contributed">küljümek ýürek</annotation>
+		<annotation cp="🩷" draft="contributed">naşyja | ýürek | halamak | söýgi | gülgüne</annotation>
+		<annotation cp="🩷" type="tts" draft="contributed">gülgüne ýürek</annotation>
+		<annotation cp="🫷" draft="contributed">el götermek | çepe | itmek | garşy çykmak | dur | garaş</annotation>
+		<annotation cp="🫷" type="tts" draft="contributed">çepe itýän el</annotation>
+		<annotation cp="🫸" draft="contributed">el götermek | itmek | garşy çykmak | saga | dur | garaş</annotation>
+		<annotation cp="🫸" type="tts" draft="contributed">saga itýän el</annotation>
+		<annotation cp="🫎" draft="contributed">haýwan | şahlylar | los | süýdemdiriji</annotation>
+		<annotation cp="🫎" type="tts" draft="contributed">deresygyr</annotation>
+		<annotation cp="🫏" draft="contributed">haýwan | eşek | kürre | süýdemdiriji | gatyr | keçjal</annotation>
+		<annotation cp="🫏" type="tts" draft="contributed">eşek</annotation>
+		<annotation cp="🪽" draft="contributed">perişde | awiasiýa | guş | uçýan | mifologiýa</annotation>
+		<annotation cp="🪽" type="tts" draft="contributed">ganat</annotation>
+		<annotation cp="🪿" draft="contributed">guş | eldeki guş | gakyldy | samsyklaç</annotation>
+		<annotation cp="🪿" type="tts" draft="contributed">gaz</annotation>
+		<annotation cp="🪼" draft="contributed">ýanmak | oňurgasyz | meduza | deňiz | wäk | iňňeli</annotation>
+		<annotation cp="🪼" type="tts" draft="contributed">meduza</annotation>
+		<annotation cp="🪻" draft="contributed">gök börük | gül | lawanta | lýupin | ýolbarsyň agzy</annotation>
+		<annotation cp="🪻" type="tts" draft="contributed">giasint</annotation>
+		<annotation cp="🫚" draft="contributed">piwo | kök | hoşboý ysly</annotation>
+		<annotation cp="🫚" type="tts" draft="contributed">zenjebil köki</annotation>
+		<annotation cp="🫛" draft="contributed">noýba | edamame | kösükli | nohut | kösük | gök ot</annotation>
+		<annotation cp="🫛" type="tts" draft="contributed">nohudyň kösügi</annotation>
+		<annotation cp="🪭" draft="contributed">sowadýan | tans | ýelpewaç | pyrlanmak | gyzgyn | utanjaň</annotation>
+		<annotation cp="🪭" type="tts" draft="contributed">eplenýän el ýelpewajy</annotation>
+		<annotation cp="🪮" draft="contributed">Afro | darak | saç | saçgysgyç</annotation>
+		<annotation cp="🪮" type="tts" draft="contributed">saçgysgyç</annotation>
+		<annotation cp="🪇" draft="contributed">gural | saz | kakylýan | şakyrdawuk | çaýkamak</annotation>
+		<annotation cp="🪇" type="tts" draft="contributed">marakas</annotation>
+		<annotation cp="🪈" draft="contributed">durmuş | saz | turba | ýazga alyjy | üflenýän agaç</annotation>
+		<annotation cp="🪈" type="tts" draft="contributed">tüýdük</annotation>
+		<annotation cp="🪯" draft="contributed">Sih | din</annotation>
+		<annotation cp="🪯" type="tts" draft="contributed">khanda</annotation>
+		<annotation cp="🛜" draft="contributed">kompýuter | internet | tor</annotation>
+		<annotation cp="🛜" type="tts" draft="contributed">simsiz</annotation>
 	</annotations>
 </ldml>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -30,14 +30,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="alt">günorta Altaý dili</language>
 			<language type="am">amhar dili</language>
 			<language type="an">aragon dili</language>
+			<language type="ann" draft="contributed">Obolo dili</language>
 			<language type="anp">angika dili</language>
 			<language type="ar">arap dili</language>
 			<language type="ar_001">häzirki zaman standart arap dili</language>
 			<language type="arn">mapuçe dili</language>
 			<language type="arp">arapaho dili</language>
+			<language type="ars" draft="contributed">Nejdi arap dili</language>
 			<language type="as">assam dili</language>
 			<language type="asa">asu dili</language>
 			<language type="ast">asturiý dili</language>
+			<language type="atj" draft="contributed">Atikamekw dili</language>
 			<language type="av">awar dili</language>
 			<language type="awa">awadhi dili</language>
 			<language type="ay">aýmara dili</language>
@@ -63,6 +66,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="bug">bugiý dili</language>
 			<language type="byn">blin dili</language>
 			<language type="ca">katalan dili</language>
+			<language type="cay" draft="contributed">Kaýuga dili</language>
 			<language type="ccp">çakma dili</language>
 			<language type="ce">çeçen dili</language>
 			<language type="ceb">sebuan dili</language>
@@ -71,14 +75,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chk">çuuk dili</language>
 			<language type="chm">mariý dili</language>
 			<language type="cho">çokto</language>
+			<language type="chp" draft="contributed">Çipewýan dili</language>
 			<language type="chr">çeroki</language>
 			<language type="chy">şaýenn dili</language>
 			<language type="ckb">merkezi kürt dili</language>
 			<language type="ckb" alt="menu">merkezi kürt dili</language>
 			<language type="ckb" alt="variant">merkezi kürt dili</language>
+			<language type="clc" draft="contributed">Çilkotin dili</language>
 			<language type="co">korsikan dili</language>
+			<language type="crg" draft="contributed">Miçif dili</language>
+			<language type="crj" draft="contributed">Günorta-gündogar kri dili</language>
+			<language type="crk" draft="contributed">Düzdeçi kri dili</language>
+			<language type="crl" draft="contributed">Demirgazyk-gündogar kri dili</language>
+			<language type="crm" draft="contributed">Los-kri dili</language>
+			<language type="crr" draft="contributed">Karolina algonkin dili</language>
 			<language type="crs">seselwa kreole-fransuz dili</language>
 			<language type="cs">çeh dili</language>
+			<language type="csw" draft="contributed">Batgalyk kri dili</language>
 			<language type="cu">buthana slaw dili</language>
 			<language type="cv">çuwaş dili</language>
 			<language type="cy">walliý dili</language>
@@ -129,6 +142,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fr">fransuz dili</language>
 			<language type="fr_CA">↑↑↑</language>
 			<language type="fr_CH">↑↑↑</language>
+			<language type="frc" draft="contributed">Fransuz diliniň kajun şiwesi</language>
+			<language type="frr" draft="contributed">Demirgazyk friz dili</language>
 			<language type="fur">friul dili</language>
 			<language type="fy">günbatar friz dili</language>
 			<language type="ga">irland dili</language>
@@ -145,9 +160,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="gv">men dili</language>
 			<language type="gwi">gwiçin dili</language>
 			<language type="ha">hausa dili</language>
+			<language type="hai" draft="contributed">Haýda dili</language>
 			<language type="haw">gawaý dili</language>
+			<language type="hax" draft="contributed">Günorta haýda dili</language>
 			<language type="he">ýewreý dili</language>
 			<language type="hi">hindi dili</language>
+			<language type="hi_Latn" draft="contributed">Hindi dili (Latyn)</language>
+			<language type="hi_Latn" alt="variant" draft="contributed">Hingliş dili</language>
 			<language type="hil">hiligaýnon dili</language>
 			<language type="hmn">hmong dili</language>
 			<language type="hr">horwat dili</language>
@@ -155,6 +174,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ht">gaiti kreol dili</language>
 			<language type="hu">wenger dili</language>
 			<language type="hup">hupa</language>
+			<language type="hur" draft="contributed">Halkomelem dili</language>
 			<language type="hy">ermeni dili</language>
 			<language type="hz">gerero dili</language>
 			<language type="ia">interlingwa dili</language>
@@ -163,6 +183,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="id">indonez dili</language>
 			<language type="ig">igbo dili</language>
 			<language type="ii">syçuan-i dili</language>
+			<language type="ikt" draft="contributed">Günorta-kanada iniktitut dili</language>
 			<language type="ilo">iloko dili</language>
 			<language type="inh">inguş dili</language>
 			<language type="io">ido dili</language>
@@ -184,6 +205,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="kde">makonde dili</language>
 			<language type="kea">kabuwerdianu dili</language>
 			<language type="kfo">koro dili</language>
+			<language type="kgp" draft="contributed">Kaýngang dili</language>
 			<language type="kha">khasi dili</language>
 			<language type="khq">koýra-çini dili</language>
 			<language type="ki">kikuýu dili</language>
@@ -210,6 +232,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="kum">kumyk dili</language>
 			<language type="kv">komi dili</language>
 			<language type="kw">korn dili</language>
+			<language type="kwk" draft="contributed">Kwakwala dili</language>
 			<language type="ky">gyrgyz dili</language>
 			<language type="la">latyn dili</language>
 			<language type="lad">ladino dili</language>
@@ -218,11 +241,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lez">lezgin dili</language>
 			<language type="lg">ganda dili</language>
 			<language type="li">limburg dili</language>
+			<language type="lil" draft="contributed">Lilluet dili</language>
 			<language type="lkt">lakota dili</language>
 			<language type="ln">lingala dili</language>
 			<language type="lo">laos dili</language>
+			<language type="lou" draft="contributed">Luiziana kreol dili</language>
 			<language type="loz">lozi dili</language>
 			<language type="lrc">demirgazyk luri dili</language>
+			<language type="lsm" draft="contributed">Samiýa dili</language>
 			<language type="lt">litwa dili</language>
 			<language type="lu">luba-katanga dili</language>
 			<language type="lua">luba-Lulua dili</language>
@@ -251,6 +277,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ml">malaýalam dili</language>
 			<language type="mn">mongol dili</language>
 			<language type="mni">manipuri dili</language>
+			<language type="moe" draft="contributed">Innu-aýmun dili</language>
 			<language type="moh">mogauk dili</language>
 			<language type="mos">mossi dili</language>
 			<language type="mr">marathi dili</language>
@@ -289,6 +316,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ny">nýanja dili</language>
 			<language type="nyn">nýankole dili</language>
 			<language type="oc">oksitan dili</language>
+			<language type="ojb" draft="contributed">Demirgazyk-günbatar ojibwa dili</language>
+			<language type="ojc" draft="contributed">Merkezi ojibwa dili</language>
+			<language type="ojs" draft="contributed">Oji-kri dili</language>
+			<language type="ojw" draft="contributed">Günbatar ojibwa dili</language>
+			<language type="oka" draft="contributed">Okanagan dili</language>
 			<language type="om">oromo dili</language>
 			<language type="or">oriýa dili</language>
 			<language type="os">osetin dili</language>
@@ -298,7 +330,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="pap">papýamento dili</language>
 			<language type="pau">palau dili</language>
 			<language type="pcm">nigeriýa-pijin dili</language>
+			<language type="pis" draft="contributed">Pijin dili</language>
 			<language type="pl">polýak dili</language>
+			<language type="pqm" draft="contributed">Malisit-Passamakwodi dili</language>
 			<language type="prg">prussiýa dili</language>
 			<language type="ps">peştun dili</language>
 			<language type="pt">portugal dili</language>
@@ -338,6 +372,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="si">singal dili</language>
 			<language type="sk">slowak dili</language>
 			<language type="sl">slowen dili</language>
+			<language type="slh" draft="contributed">Günorta Luşutsid dili</language>
 			<language type="sm">samoa dili</language>
 			<language type="sma">günorta saam dili</language>
 			<language type="smj">lule-saam dili</language>
@@ -352,6 +387,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ss">swati dili</language>
 			<language type="ssy">saho dili</language>
 			<language type="st">günorta soto dili</language>
+			<language type="str" draft="contributed">Demirgazyk bogaz saliş dili</language>
 			<language type="su">sundan dili</language>
 			<language type="suk">sukuma dili</language>
 			<language type="sv">şwed dili</language>
@@ -360,23 +396,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="swb">komor dili</language>
 			<language type="syr">siriýa dili</language>
 			<language type="ta">tamil dili</language>
+			<language type="tce" draft="contributed">Günorta Tutçone dili</language>
 			<language type="te">telugu dili</language>
 			<language type="tem">temne dili</language>
 			<language type="teo">teso dili</language>
 			<language type="tet">tetum dili</language>
 			<language type="tg">täjik dili</language>
+			<language type="tgx" draft="contributed">Tagiş dili</language>
 			<language type="th">taý dili</language>
+			<language type="tht" draft="contributed">Taltan dili</language>
 			<language type="ti">tigrinýa dili</language>
 			<language type="tig">tigre dili</language>
 			<language type="tk">türkmen dili</language>
 			<language type="tlh">klingon dili</language>
+			<language type="tli" draft="contributed">Tlinkit dili</language>
 			<language type="tn">tswana dili</language>
 			<language type="to">tongan dili</language>
+			<language type="tok" draft="contributed">Toki Pona dili</language>
 			<language type="tpi">tok-pisin dili</language>
 			<language type="tr">türk dili</language>
 			<language type="trv">taroko dili</language>
 			<language type="ts">tsonga dili</language>
 			<language type="tt">tatar dili</language>
+			<language type="ttm" draft="contributed">Demirgazyk tutçone dili</language>
 			<language type="tum">tumbuka dili</language>
 			<language type="tvl">tuwalu dili</language>
 			<language type="twq">tasawak dili</language>
@@ -400,6 +442,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="wal">wolaýta dili</language>
 			<language type="war">waraý dili</language>
 			<language type="wo">wolof dili</language>
+			<language type="wuu" draft="contributed">U hytaý dili</language>
 			<language type="xal">galmyk dili</language>
 			<language type="xh">kosa dili</language>
 			<language type="xog">soga dili</language>
@@ -407,6 +450,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ybb">ýemba dili</language>
 			<language type="yi">idiş dili</language>
 			<language type="yo">ýoruba dili</language>
+			<language type="yrl" draft="contributed">Nhengatu dili</language>
 			<language type="yue">kanton dili</language>
 			<language type="yue" alt="menu">hytaý dili, kantonça</language>
 			<language type="zgh">standart Marokko tamazight dili</language>
@@ -422,11 +466,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zza">zazaki dili</language>
 		</languages>
 		<scripts>
+			<script type="Adlm" draft="contributed">Adlam</script>
 			<script type="Arab">Arap elipbiýi</script>
+			<script type="Aran" draft="contributed">Nastalik ýazuwy</script>
 			<script type="Armn">Ermeni elipbiýi</script>
 			<script type="Beng">Bengal elipbiýi</script>
 			<script type="Bopo">Bopomofo elipbiýi</script>
 			<script type="Brai">Braýl elipbiýi</script>
+			<script type="Cakm" draft="contributed">Çakma</script>
+			<script type="Cans" draft="contributed">Kanadanyň ýerlileriniň bogunlarynyň bitewileşdirilen ulgamy</script>
+			<script type="Cher" draft="contributed">Çeroki</script>
 			<script type="Cyrl">Kiril elipbiýi</script>
 			<script type="Deva">Dewanagari elipbiýi</script>
 			<script type="Ethi">Efiop elipbiýi</script>
@@ -454,14 +503,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Latn">Latyn elipbiýi</script>
 			<script type="Mlym">Malaýalam elipbiýi</script>
 			<script type="Mong">Mongol elipbiýi</script>
+			<script type="Mtei" draft="contributed">Meýteý Maýek</script>
 			<script type="Mymr">Mýanma elipbiýi</script>
+			<script type="Nkoo" draft="contributed">N'Ko</script>
+			<script type="Olck" draft="contributed">Ol Çiki</script>
 			<script type="Orya">Oriýa elipbiýi</script>
+			<script type="Rohg" draft="contributed">Hanifi</script>
 			<script type="Sinh">Singal elipbiýi</script>
+			<script type="Sund" draft="contributed">Sundanez ýazuwy</script>
+			<script type="Syrc" draft="contributed">Siriýa ýazuwy</script>
 			<script type="Taml">Tamil elipbiýi</script>
 			<script type="Telu">Telugu elipbiýi</script>
+			<script type="Tfng" draft="contributed">Tifinag ýazuwy</script>
 			<script type="Thaa">Taana elipbiýi</script>
 			<script type="Thai">Taý elipbiýi</script>
 			<script type="Tibt">Tibet elipbiýi</script>
+			<script type="Vaii" draft="contributed">Waý ýazuwy</script>
+			<script type="Yiii" draft="contributed">Ýi ýazuwy</script>
 			<script type="Zmth">Matematiki belgiler</script>
 			<script type="Zsye">Emoji</script>
 			<script type="Zsym">Nyşanlar</script>
@@ -687,6 +745,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Täze Zelandiýa</territory>
+			<territory type="NZ" alt="variant" draft="contributed">Aotearoa Täze Zelandiýa</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -746,6 +805,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Türkiýe</territory>
+			<territory type="TR" alt="variant" draft="contributed">Türkiýe</territory>
 			<territory type="TT">Trinidad we Tobago</territory>
 			<territory type="TV">Tuwalu</territory>
 			<territory type="TW">Taýwan</territory>
@@ -795,11 +855,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<types>
 			<type key="calendar" type="buddhist">Buddist senenamasy</type>
 			<type key="calendar" type="chinese">Hytaý senenamasy</type>
+			<type key="calendar" type="coptic" draft="contributed">Kopt senenamasy</type>
 			<type key="calendar" type="dangi">Dangi senenamasy</type>
 			<type key="calendar" type="ethiopic">Efiop senenamasy</type>
+			<type key="calendar" type="ethiopic-amete-alem" draft="contributed">Efiopiýa Amete Alem senenamasy</type>
 			<type key="calendar" type="gregorian">Grigorian senenamasy</type>
 			<type key="calendar" type="hebrew">Ýewreý senenamasy</type>
 			<type key="calendar" type="islamic">Hijri-kamary senenamasy</type>
+			<type key="calendar" type="islamic-civil" draft="contributed">Hijri-kamary senenamasy (tablisaly, raýat eýýamy)</type>
+			<type key="calendar" type="islamic-tbla" draft="contributed">Hijri-kamary senenamasy (tablisaly, astronimiýa eýýamy)</type>
+			<type key="calendar" type="islamic-umalqura" draft="contributed">Hijri-kamary senenamasy (Umm al-Kura)</type>
 			<type key="calendar" type="iso8601">ISO-8601 senenamasy</type>
 			<type key="calendar" type="japanese">Ýapon senenamasy</type>
 			<type key="calendar" type="persian">Pars senenamasy</type>
@@ -824,6 +889,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="numbers" type="armn">Ermeni sanlary</type>
 			<type key="numbers" type="armnlow">Ermeni setir sanlary</type>
 			<type key="numbers" type="beng">Bengal sanlary</type>
+			<type key="numbers" type="cakm" draft="contributed">Çakma sanlary</type>
 			<type key="numbers" type="deva">Dewanagari sanlary</type>
 			<type key="numbers" type="ethi">Efiop sanlary</type>
 			<type key="numbers" type="fullwide">Doly giňlikdäki sanlar</type>
@@ -838,6 +904,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="numbers" type="hant">Adaty hytaý sanlary</type>
 			<type key="numbers" type="hantfin">Adaty hytaý maliýe sanlary</type>
 			<type key="numbers" type="hebr">Ýewreý sanlary</type>
+			<type key="numbers" type="java" draft="contributed">Ýawa sanlary</type>
 			<type key="numbers" type="jpan">Ýapon sanlary</type>
 			<type key="numbers" type="jpanfin">Ýapon maliýe sanlary</type>
 			<type key="numbers" type="khmr">Khmer sanlary</type>
@@ -845,7 +912,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="numbers" type="laoo">Laos sanlary</type>
 			<type key="numbers" type="latn">Latyn sanlary</type>
 			<type key="numbers" type="mlym">Malaýalam sanlary</type>
+			<type key="numbers" type="mtei" draft="contributed">Miteý Maýek sanlary</type>
 			<type key="numbers" type="mymr">Mýanma sanlary</type>
+			<type key="numbers" type="olck" draft="contributed">Ol Çiki sanlary</type>
 			<type key="numbers" type="orya">Oriýa sanlary</type>
 			<type key="numbers" type="roman">Rim sanlary</type>
 			<type key="numbers" type="romanlow">Rim setir sanlary</type>
@@ -854,6 +923,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="numbers" type="telu">Telugu sanlary</type>
 			<type key="numbers" type="thai">Taý sanlary</type>
 			<type key="numbers" type="tibt">Tibet sanlary</type>
+			<type key="numbers" type="vaii" draft="contributed">Waý sanlary</type>
 		</types>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
@@ -949,20 +1019,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1} 'sagat' {0}</pattern>
+						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1} 'sagat' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1}, {0}</pattern>
+						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1474,20 +1556,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1} 'sagat' {0}</pattern>
+						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1} 'sagat' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1}, {0}</pattern>
+						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
 							<pattern>{1} {0}</pattern>
+						</dateTimeFormat>
+						<dateTimeFormat type="atTime">
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1689,6 +1783,169 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic">
+				<months>
+					<monthContext type="format">
+						<!-- UPLOAD ERRORS  
+						<monthWidth type="abbreviated">
+							<month type="1" draft="contributed">Aşyr</month>
+							<month type="2" draft="contributed">Sap.</month>
+							<month type="3" draft="contributed">4 tir 1</month>
+							<month type="4" draft="contributed">4 tir 2</month>
+							<month type="5" draft="contributed">4 tir 3</month>
+							<month type="6" draft="contributed">4 tir 4</month>
+							<month type="7" draft="contributed">Rej.</month>
+							<month type="8" draft="contributed">Mer.</month>
+							<month type="9" draft="contributed">Ora.</month>
+							<month type="10" draft="contributed">Baýr.</month>
+							<month type="11" draft="contributed">Boş aý</month>
+							<month type="12" draft="contributed">Gur.</month>
+						</monthWidth>
+						-->
+						<monthWidth type="narrow">
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1" draft="contributed">Aşyr</month>
+							<month type="2" draft="contributed">Sapar</month>
+							<month type="3" draft="contributed">Dört tirkeşik 1</month>
+							<month type="4" draft="contributed">Dört tirkeşik 2</month>
+							<month type="5" draft="contributed">Dört tirkeşik 3</month>
+							<month type="6" draft="contributed">Dört tirkeşik 4</month>
+							<month type="7" draft="contributed">Rejep</month>
+							<month type="8" draft="contributed">Meret</month>
+							<month type="9" draft="contributed">Oraza</month>
+							<month type="10" draft="contributed">Baýram</month>
+							<month type="11" draft="contributed">Boş aý</month>
+							<month type="12" draft="contributed">Gurban</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<!-- UPLOAD ERRORS 
+						<monthWidth type="abbreviated">
+							<month type="1" draft="contributed">Aşyr</month>
+							<month type="2" draft="contributed">Sap.</month>
+							<month type="3" draft="contributed">4 tir 1</month>
+							<month type="4" draft="contributed">4 tir 2</month>
+							<month type="5" draft="contributed">4 tir 3</month>
+							<month type="6" draft="contributed">4 tir 4</month>
+							<month type="7" draft="contributed">Rej.</month>
+							<month type="8" draft="contributed">Mer.</month>
+							<month type="9" draft="contributed">Ora.</month>
+							<month type="10" draft="contributed">Baýr.</month>
+							<month type="11" draft="contributed">Boş aý</month>
+							<month type="12" draft="contributed">Gur.</month>
+						</monthWidth>
+						 -->
+						<monthWidth type="narrow">
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1" draft="contributed">Aşyr</month>
+							<month type="2" draft="contributed">Sapar</month>
+							<month type="3" draft="contributed">Dört tirkeşik 1</month>
+							<month type="4" draft="contributed">Dört tirkeşik 2</month>
+							<month type="5" draft="contributed">Dört tirkeşik 3</month>
+							<month type="6" draft="contributed">Dört tirkeşik 4</month>
+							<month type="7" draft="contributed">Rejep</month>
+							<month type="8" draft="contributed">Meret</month>
+							<month type="9" draft="contributed">Oraza</month>
+							<month type="10" draft="contributed">Baýram</month>
+							<month type="11" draft="contributed">Boş aý</month>
+							<month type="12" draft="contributed">Gurban</month>
+						</monthWidth>
+					</monthContext>
+				</months>
+				<eras>
+					<eraAbbr>
+						<era type="0" draft="contributed">HS</era>
+					</eraAbbr>
+				</eras>
+				<!-- UPLOAD ERRORS
+				<dateFormats>
+					<dateFormatLength type="full">
+						<dateFormat>
+							<pattern draft="contributed">EEEE, AAAA g, ý G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="long">
+						<dateFormat>
+							<pattern draft="contributed">AAAA g, ý G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="medium">
+						<dateFormat>
+							<pattern draft="contributed">AAA g, ý G</pattern>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern draft="contributed">g/A/ý GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="d" draft="contributed">g</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">g E</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">b G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">g/A/ý GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">AAA ý G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">AAA g, ý G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E, AAA g, ý G</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">A/g</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, A/g</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">AAA g</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, AAA g</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">AAAA g</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">ý G</dateFormatItem>
+						<dateFormatItem id="yM" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yMd" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yMEd" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yMMM" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yMMMd" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yMMMEd" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yMMMM" draft="contributed">d/d</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">ý G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="contributed">A/ý GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="contributed">g/A/ý GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="contributed">E, g/A/ý GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">AAA ý G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">AAA g, ý G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">E, AAA g, ý G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="contributed">AAAA ý G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ ý G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ ý G</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+				 -->
 			</calendar>
 		</calendars>
 		<fields>
@@ -2983,6 +3240,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>Enderberi</exemplarCity>
+			</zone>
+			<zone type="Pacific/Kanton">
+				<exemplarCity draft="contributed">Kanton</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>Kiritimati</exemplarCity>
@@ -4639,7 +4899,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -4670,6 +4930,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 trln ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -6075,6 +6336,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ýyl</unitPattern>
 				<perUnitPattern>{0}/ý</perUnitPattern>
 			</unit>
+			<unit type="duration-quarter">
+				<displayName draft="contributed">çärýek</displayName>
+				<unitPattern count="one" draft="contributed">{0} çärýek</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} çärýek</unitPattern>
+				<perUnitPattern draft="contributed">{0}/ç</perUnitPattern>
+			</unit>
 			<unit type="duration-month">
 				<displayName>aý</displayName>
 				<unitPattern count="one">{0} aý</unitPattern>
@@ -7119,6 +7386,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} ý.</unitPattern>
 				<unitPattern count="other">{0} ý.</unitPattern>
 				<perUnitPattern>{0}/ý.</perUnitPattern>
+			</unit>
+			<unit type="duration-quarter">
+				<displayName draft="contributed">çär</displayName>
+				<unitPattern count="one" draft="contributed">{0} çär</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} çär</unitPattern>
+				<perUnitPattern draft="contributed">{0}/ç</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>aý</displayName>
@@ -8165,6 +8438,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ý</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
+			<unit type="duration-quarter">
+				<displayName draft="contributed">çär</displayName>
+				<unitPattern count="one" draft="contributed">{0}ç</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}ç</unitPattern>
+				<perUnitPattern draft="contributed">{0}/ç</perUnitPattern>
+			</unit>
 			<unit type="duration-month">
 				<displayName>a</displayName>
 				<unitPattern count="one">{0}a</unitPattern>
@@ -9126,4 +9405,158 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<featureName type="tnum">tabulýar sanlar</featureName>
 		<featureName type="zero">ýapgyt 0</featureName>
 	</typographicNames>
+	<personNames>
+		<nameOrderLocales order="givenFirst" draft="contributed">und tk</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst" draft="contributed"/>
+		<initialPattern type="initial" draft="contributed">{0}.</initialPattern>
+		<initialPattern type="initialSequence" draft="contributed">{0} {1}</initialPattern>
+		<personName order="givenFirst" length="long" usage="referring" formality="formal">
+			<namePattern draft="contributed">{given} {given2} {surname} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="referring" formality="informal">
+			<namePattern draft="contributed">{given-informal} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
+			<namePattern draft="contributed">{prefix} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
+			<namePattern draft="contributed">{given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
+			<namePattern draft="contributed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
+			<namePattern draft="contributed">{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
+			<namePattern draft="contributed">{given} {given2-initial} {surname} {suffix}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
+			<namePattern draft="contributed">{given-informal} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
+			<namePattern draft="contributed">{prefix} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
+			<namePattern draft="contributed">{given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
+			<namePattern draft="contributed">{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
+			<namePattern draft="contributed">{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="referring" formality="formal">
+			<namePattern draft="contributed">{given-initial} {given2-initial} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="referring" formality="informal">
+			<namePattern draft="contributed">{given-informal} {surname-initial}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
+			<namePattern draft="contributed">{prefix} {surname}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
+			<namePattern draft="contributed">{given-informal}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
+			<namePattern draft="contributed">{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
+			<namePattern draft="contributed">{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
+			<namePattern draft="contributed">{surname} {given} {given2} {suffix}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
+			<namePattern draft="contributed">{surname} {given-informal}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
+			<namePattern draft="contributed">{prefix} {surname}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
+			<namePattern draft="contributed">{given-informal}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
+			<namePattern draft="contributed">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
+			<namePattern draft="contributed">{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
+			<namePattern draft="contributed">{surname} {given} {given2-initial} {suffix}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
+			<namePattern draft="contributed">{surname} {given-informal}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
+			<namePattern draft="contributed">{prefix} {surname}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
+			<namePattern draft="contributed">{given-informal}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
+			<namePattern draft="contributed">{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
+			<namePattern draft="contributed">{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
+			<namePattern draft="contributed">{surname} {given-initial} {given2-initial}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
+			<namePattern draft="contributed">{surname} {given-initial}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
+			<namePattern draft="contributed">{prefix} {surname}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
+			<namePattern draft="contributed">{given-informal}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
+			<namePattern draft="contributed">{surname-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
+			<namePattern draft="contributed">{given-informal-monogram-allCaps}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="formal">
+			<namePattern draft="contributed">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="long" usage="referring" formality="informal">
+			<namePattern draft="contributed">{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="formal">
+			<namePattern draft="contributed">{surname-core}, {given} {given2-initial} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="medium" usage="referring" formality="informal">
+			<namePattern draft="contributed">{surname}, {given-informal}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="referring" formality="formal">
+			<namePattern draft="contributed">{surname-core}, {given-initial} {given2-initial} {surname-prefix}</namePattern>
+		</personName>
+		<personName order="sorting" length="short" usage="referring" formality="informal">
+			<namePattern draft="contributed">{surname}, {given-informal}</namePattern>
+		</personName>
+		<sampleName item="givenOnly">
+			<nameField type="given" draft="contributed">Gurban</nameField>
+		</sampleName>
+		<sampleName item="givenSurnameOnly">
+			<nameField type="given" draft="contributed">Amangeldi</nameField>
+			<nameField type="surname" draft="contributed">Saparow</nameField>
+		</sampleName>
+		<sampleName item="given12Surname">
+			<nameField type="given" draft="contributed">Meretgeldi</nameField>
+			<nameField type="given2" draft="contributed">Durdyýewiç</nameField>
+			<nameField type="surname" draft="contributed">Gurbanow</nameField>
+		</sampleName>
+		<sampleName item="full">
+			<nameField type="prefix" draft="contributed">Prof. Dr.</nameField>
+			<nameField type="given" draft="contributed">Gurban Saparow</nameField>
+			<nameField type="given-informal" draft="contributed">Aman</nameField>
+			<nameField type="given2" draft="contributed">Aman Saparow</nameField>
+			<nameField type="surname-prefix" draft="contributed">wan den</nameField>
+			<nameField type="surname-core" draft="contributed">Gurdow</nameField>
+			<nameField type="surname2" draft="contributed">Gurbangeldiýew</nameField>
+			<nameField type="suffix" draft="contributed">magistr, ylymlaryň kandidaty</nameField>
+		</sampleName>
+	</personNames>
 </ldml>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,196 +1,305 @@
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-g-force"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} ге силу
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-g-force"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} ге силе
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-g-force"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} ге силом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="acceleration-g-force"]/unitPattern[@count="one"]; new_value={0} ге сила
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} лучни минут
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} лучног минута
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} лучним минутом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"]; new_value={0} лучни минут
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} лучну секунду
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} лучне секунде
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} лучном секундом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"]; new_value={0} лучна секунда
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-degree"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} степен
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-degree"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} степена
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-degree"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} степеном
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-degree"]/unitPattern[@count="one"]; new_value={0} степен
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-radian"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} радијан
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-radian"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} радијана
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-radian"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} радијаном
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-radian"]/unitPattern[@count="one"]; new_value={0} радијан
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-revolution"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} обртај
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-revolution"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} обртаја
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-revolution"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} обртајем
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-revolution"]/unitPattern[@count="one"]; new_value={0} обртај
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-hectare"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} хектар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-hectare"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} хектара
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-hectare"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} хектаром
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-hectare"]/unitPattern[@count="one"]; new_value={0} хектар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-bit"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} бит
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-bit"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} бита
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-bit"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} битом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-bit"]/unitPattern[@count="one"]; new_value={0} бит
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-byte"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} бајт
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-byte"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} бајта
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-byte"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} бајтом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-byte"]/unitPattern[@count="one"]; new_value={0} бајт
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-day"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} дан
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-day"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} дана
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-day"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} даном
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-day"]/unitPattern[@count="one"]; new_value={0} дан
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-hour"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} сат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-hour"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} сата
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-hour"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} сатом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-hour"]/unitPattern[@count="one"]; new_value={0} сат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-minute"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} минут
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-minute"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} минута
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-minute"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} минутом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-minute"]/unitPattern[@count="one"]; new_value={0} минут
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-second"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} секунду
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-second"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} секунде
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-second"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} секундом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-second"]/unitPattern[@count="one"]; new_value={0} секунда
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-week"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} недељу
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-week"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} недеље
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-week"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} недељом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-week"]/unitPattern[@count="one"]; new_value={0} недеља
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ampere"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} ампер
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ampere"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} ампера
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ampere"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} ампером
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ampere"]/unitPattern[@count="one"]; new_value={0} ампер
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ohm"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} ом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ohm"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} ома
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ohm"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} омом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ohm"]/unitPattern[@count="one"]; new_value={0} ом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-calorie"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} калорију
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-calorie"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} калорије
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-calorie"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} калоријом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-calorie"]/unitPattern[@count="one"]; new_value={0} калорија
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-joule"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} џул
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-joule"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} џула
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-joule"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} џулом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-joule"]/unitPattern[@count="one"]; new_value={0} џул
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-newton"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} њутн
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-newton"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} њутна
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-newton"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} њутном
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="force-newton"]/unitPattern[@count="one"]; new_value={0} њутн
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-hertz"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} херц
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-hertz"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} херца
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-hertz"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} херцом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-hertz"]/unitPattern[@count="one"]; new_value={0} херц
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-pixel"]/unitPattern[@count="one"]; new_value={0} px
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lux"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} лукс
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lux"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} лукса
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lux"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} луксом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lux"]/unitPattern[@count="one"]; new_value={0} лукс
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} метар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} метра
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} метром
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"]; new_value={0} метар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} скандинавску миљу
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} скандинавске миље
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} скандинавском миљом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"]; new_value={0} скандинавска миља
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} лумен
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} лумена
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} луменом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="one"]; new_value={0} лумен
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-candela"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} канделу
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-candela"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} канделе
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-candela"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} канделом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-candela"]/unitPattern[@count="one"]; new_value={0} кандела
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-carat"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} карат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-carat"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} карата
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-carat"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} каратом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-carat"]/unitPattern[@count="one"]; new_value={0} карат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-gram"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} грам
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-gram"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} грама
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-gram"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} грамом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-gram"]/unitPattern[@count="one"]; new_value={0} грам
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} килограм
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} килограма
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} килограмом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"]; new_value={0} килограм
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} метричку тону
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} метричке тоне
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} метричком тоном
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-metric-ton"]/unitPattern[@count="one"]; new_value={0} метричка тона
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-karat"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} карат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-karat"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} карата
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-karat"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} каратом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-karat"]/unitPattern[@count="one"]; new_value={0} карат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permillion"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} честицу на милион
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permillion"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} честице на милион
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permillion"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} честицом на милион
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permillion"]/unitPattern[@count="one"]; new_value={0} честица на милион
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} проценат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} процента
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} процентом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-percent"]/unitPattern[@count="one"]; new_value={0} проценат
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} промил
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} промила
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} промилом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permille"]/unitPattern[@count="one"]; new_value={0} промил
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permyriad"]/unitPattern[@count="one"]; new_value={0}‱
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-watt"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} ват
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-watt"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} вата
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-watt"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} ватом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-watt"]/unitPattern[@count="one"]; new_value={0} ват
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-atmosphere"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} атмосферу
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-atmosphere"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} атмосфере
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-atmosphere"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} атмосфером
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-atmosphere"]/unitPattern[@count="one"]; new_value={0} атмосфера
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-bar"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} бар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-bar"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} бара
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-bar"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} баром
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-bar"]/unitPattern[@count="one"]; new_value={0} бар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-pascal"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} паскал
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-pascal"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} паскала
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-pascal"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} паскалом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-pascal"]/unitPattern[@count="one"]; new_value={0} паскал
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-mole"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} мол
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-mole"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} мола
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-mole"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} молом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-mole"]/unitPattern[@count="one"]; new_value={0} мол
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-generic"]/unitPattern[@count="one"]; new_value={0}°
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} степен Целзијуса
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} степена Целзијуса
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} степеном Целзијуса
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"]; new_value={0} степен Целзијуса
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} келвин
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} келвина
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} келвином
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="one"]; new_value={0} келвин
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-em"]/unitPattern[@count="one"]; new_value={0} em
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-volt"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} волт
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-volt"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} волта
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-volt"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} волтом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-volt"]/unitPattern[@count="one"]; new_value={0} волт
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup-metric"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} метричку шољу
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup-metric"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} метричке шоље
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup-metric"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} метричком шољом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup-metric"]/unitPattern[@count="one"]; new_value={0} метричка шоља
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} литар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} литра
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} литром
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"]; new_value={0} литар
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} метричку пинту
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} метричке пинте
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} метричком пинтом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"]; new_value={0} метричка пинта
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-century"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} век
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-century"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} века
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-century"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} веком
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-century"]/unitPattern[@count="one"]; new_value={0} век
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-decade"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} деценију
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-decade"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} деценије
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-decade"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} деценијом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-decade"]/unitPattern[@count="one"]; new_value={0} деценија
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-month"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} месец
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-month"]/unitPattern[@count="one"][@case="genitive"]; new_value=месеца
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-month"]/unitPattern[@count="one"][@case="instrumental"]; new_value=месецом
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-month"]/unitPattern[@count="one"]; new_value={0} месец
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"][@case="accusative"]; new_value={0} годину
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"][@case="genitive"]; new_value={0} године
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"][@case="instrumental"]; new_value={0} годином
-locale=sr; action=add; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"]; new_value={0} година
+# constructed line for modify_config.txt file
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="atj"][@draft="contributed"] ; new_value=Atikamekw dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="frc"][@draft="contributed"] ; new_value=Fransuz diliniň kajun şiwesi
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="crr"][@draft="contributed"] ; new_value=Karolina algonkin dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="cay"][@draft="contributed"] ; new_value=Kaýuga dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ojc"][@draft="contributed"] ; new_value=Merkezi ojibwa dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="clc"][@draft="contributed"] ; new_value=Çilkotin dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="chp"][@draft="contributed"] ; new_value=Çipewýan dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="hai"][@draft="contributed"] ; new_value=Haýda dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="hur"][@draft="contributed"] ; new_value=Halkomelem dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="hi_Latn"][@draft="contributed"] ; new_value=Hindi dili (Latyn)
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="hi_Latn"][@alt="variant"][@draft="contributed"] ; new_value=Hingliş dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="moe"][@draft="contributed"] ; new_value=Innu-aýmun dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="kgp"][@draft="contributed"] ; new_value=Kaýngang dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="kwk"][@draft="contributed"] ; new_value=Kwakwala dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="lil"][@draft="contributed"] ; new_value=Lilluet dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="lou"][@draft="contributed"] ; new_value=Luiziana kreol dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="pqm"][@draft="contributed"] ; new_value=Malisit-Passamakwodi dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="crg"][@draft="contributed"] ; new_value=Miçif dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="crm"][@draft="contributed"] ; new_value=Los-kri dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ars"][@draft="contributed"] ; new_value=Nejdi arap dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="yrl"][@draft="contributed"] ; new_value=Nhengatu dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="crl"][@draft="contributed"] ; new_value=Demirgazyk-gündogar kri dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="frr"][@draft="contributed"] ; new_value=Demirgazyk friz dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ttm"][@draft="contributed"] ; new_value=Demirgazyk tutçone dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ojb"][@draft="contributed"] ; new_value=Demirgazyk-günbatar ojibwa dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ann"][@draft="contributed"] ; new_value=Obolo dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ojs"][@draft="contributed"] ; new_value=Oji-kri dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="oka"][@draft="contributed"] ; new_value=Okanagan dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="pis"][@draft="contributed"] ; new_value=Pijin dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="crk"][@draft="contributed"] ; new_value=Düzdeçi kri dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="lsm"][@draft="contributed"] ; new_value=Samiýa dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="crj"][@draft="contributed"] ; new_value=Günorta-gündogar kri dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="hax"][@draft="contributed"] ; new_value=Günorta haýda dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="slh"][@draft="contributed"] ; new_value=Günorta Luşutsid dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="tce"][@draft="contributed"] ; new_value=Günorta Tutçone dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="str"][@draft="contributed"] ; new_value=Demirgazyk bogaz saliş dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="csw"][@draft="contributed"] ; new_value=Batgalyk kri dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="tgx"][@draft="contributed"] ; new_value=Tagiş dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="tht"][@draft="contributed"] ; new_value=Taltan dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="tli"][@draft="contributed"] ; new_value=Tlinkit dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="tok"][@draft="contributed"] ; new_value=Toki Pona dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ikt"][@draft="contributed"] ; new_value=Günorta-kanada iniktitut dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="ojw"][@draft="contributed"] ; new_value=Günbatar ojibwa dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/languages/language[@type="wuu"][@draft="contributed"] ; new_value=U hytaý dili
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Adlm"][@draft="contributed"] ; new_value=Adlam
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Cakm"][@draft="contributed"] ; new_value=Çakma
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Cans"][@draft="contributed"] ; new_value=Kanadanyň ýerlileriniň bogunlarynyň bitewileşdirilen ulgamy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Cher"][@draft="contributed"] ; new_value=Çeroki
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Mtei"][@draft="contributed"] ; new_value=Meýteý Maýek
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Nkoo"][@draft="contributed"] ; new_value=N'Ko
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Olck"][@draft="contributed"] ; new_value=Ol Çiki
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Rohg"][@draft="contributed"] ; new_value=Hanifi
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Sund"][@draft="contributed"] ; new_value=Sundanez ýazuwy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Syrc"][@draft="contributed"] ; new_value=Siriýa ýazuwy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Tfng"][@draft="contributed"] ; new_value=Tifinag ýazuwy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Vaii"][@draft="contributed"] ; new_value=Waý ýazuwy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Yiii"][@draft="contributed"] ; new_value=Ýi ýazuwy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/scripts/script[@type="Aran"][@draft="contributed"] ; new_value=Nastalik ýazuwy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/territories/territory[@type="TR"][@alt="variant"][@draft="contributed"] ; new_value=Türkiýe
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/territories/territory[@type="NZ"][@alt="variant"][@draft="contributed"] ; new_value=Aotearoa Täze Zelandiýa
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="coptic"][@draft="contributed"] ; new_value=Kopt senenamasy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="ethiopic-amete-alem"][@draft="contributed"] ; new_value=Efiopiýa Amete Alem senenamasy
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="islamic-civil"][@draft="contributed"] ; new_value=Hijri-kamary senenamasy (tablisaly, raýat eýýamy)
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="islamic-tbla"][@draft="contributed"] ; new_value=Hijri-kamary senenamasy (tablisaly, astronimiýa eýýamy)
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="calendar"][@type="islamic-umalqura"][@draft="contributed"] ; new_value=Hijri-kamary senenamasy (Umm al-Kura)
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="numbers"][@type="cakm"][@draft="contributed"] ; new_value=Çakma sanlary
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="numbers"][@type="java"][@draft="contributed"] ; new_value=Ýawa sanlary
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="numbers"][@type="mtei"][@draft="contributed"] ; new_value=Miteý Maýek sanlary
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="numbers"][@type="olck"][@draft="contributed"] ; new_value=Ol Çiki sanlary
+locale=tk ; action=add ; new_path=//ldml/localeDisplayNames/types/type[@key="numbers"][@type="vaii"][@draft="contributed"] ; new_value=Waý sanlary
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/dateTimeFormatLength[@type="full"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1} sagat {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/dateTimeFormatLength[@type="long"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1} sagat {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/dateTimeFormatLength[@type="medium"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1}, {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/dateTimeFormatLength[@type="short"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1}, {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/dateTimeFormatLength[@type="full"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1} sagat {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/dateTimeFormatLength[@type="long"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1} sagat {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/dateTimeFormatLength[@type="medium"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1}, {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/dateTimeFormatLength[@type="short"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"][@draft="contributed"] ; new_value={1}, {0}
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/eras/eraAbbr/era[@type="0"][@draft="contributed"] ; new_value=HS
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="1"][@draft="contributed"] ; new_value=Aşyr
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="2"][@draft="contributed"] ; new_value=Sapar
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="3"][@draft="contributed"] ; new_value=Dört tirkeşik 1
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="4"][@draft="contributed"] ; new_value=Dört tirkeşik 2
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="5"][@draft="contributed"] ; new_value=Dört tirkeşik 3
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="6"][@draft="contributed"] ; new_value=Dört tirkeşik 4
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="7"][@draft="contributed"] ; new_value=Rejep
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="8"][@draft="contributed"] ; new_value=Meret
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="9"][@draft="contributed"] ; new_value=Oraza
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="10"][@draft="contributed"] ; new_value=Baýram
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="11"][@draft="contributed"] ; new_value=Boş aý
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="wide"]/month[@type="12"][@draft="contributed"] ; new_value=Gurban
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="1"][@draft="contributed"] ; new_value=Aşyr
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="2"][@draft="contributed"] ; new_value=Sapar
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="3"][@draft="contributed"] ; new_value=Dört tirkeşik 1
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="4"][@draft="contributed"] ; new_value=Dört tirkeşik 2
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="5"][@draft="contributed"] ; new_value=Dört tirkeşik 3
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="6"][@draft="contributed"] ; new_value=Dört tirkeşik 4
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"][@draft="contributed"] ; new_value=Rejep
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="8"][@draft="contributed"] ; new_value=Meret
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="9"][@draft="contributed"] ; new_value=Oraza
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="10"][@draft="contributed"] ; new_value=Baýram
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="11"][@draft="contributed"] ; new_value=Boş aý
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="12"][@draft="contributed"] ; new_value=Gurban
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="1"][@draft="contributed"] ; new_value=Aşyr
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="2"][@draft="contributed"] ; new_value=Sap.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="3"][@draft="contributed"] ; new_value=4 tir 1
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="4"][@draft="contributed"] ; new_value=4 tir 2
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="5"][@draft="contributed"] ; new_value=4 tir 3
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="6"][@draft="contributed"] ; new_value=4 tir 4
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="7"][@draft="contributed"] ; new_value=Rej.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="8"][@draft="contributed"] ; new_value=Mer.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="9"][@draft="contributed"] ; new_value=Ora.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="10"][@draft="contributed"] ; new_value=Baýr.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="11"][@draft="contributed"] ; new_value=Boş aý
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="12"][@draft="contributed"] ; new_value=Gur.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="1"][@draft="contributed"] ; new_value=Aşyr
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="2"][@draft="contributed"] ; new_value=Sap.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="3"][@draft="contributed"] ; new_value=4 tir 1
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="4"][@draft="contributed"] ; new_value=4 tir 2
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="5"][@draft="contributed"] ; new_value=4 tir 3
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="6"][@draft="contributed"] ; new_value=4 tir 4
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"][@draft="contributed"] ; new_value=Rej.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="8"][@draft="contributed"] ; new_value=Mer.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"][@draft="contributed"] ; new_value=Ora.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="10"][@draft="contributed"] ; new_value=Baýr.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="11"][@draft="contributed"] ; new_value=Boş aý
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="12"][@draft="contributed"] ; new_value=Gur.
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="1"][@draft="contributed"] ; new_value=1
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="2"][@draft="contributed"] ; new_value=2
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="3"][@draft="contributed"] ; new_value=3
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="4"][@draft="contributed"] ; new_value=4
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="5"][@draft="contributed"] ; new_value=5
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="6"][@draft="contributed"] ; new_value=6
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="7"][@draft="contributed"] ; new_value=7
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="8"][@draft="contributed"] ; new_value=8
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="9"][@draft="contributed"] ; new_value=9
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="10"][@draft="contributed"] ; new_value=10
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="11"][@draft="contributed"] ; new_value=11
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="12"][@draft="contributed"] ; new_value=12
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="1"][@draft="contributed"] ; new_value=1
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="2"][@draft="contributed"] ; new_value=2
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="3"][@draft="contributed"] ; new_value=3
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="4"][@draft="contributed"] ; new_value=4
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="5"][@draft="contributed"] ; new_value=5
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="6"][@draft="contributed"] ; new_value=6
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="7"][@draft="contributed"] ; new_value=7
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="8"][@draft="contributed"] ; new_value=8
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="9"][@draft="contributed"] ; new_value=9
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="10"][@draft="contributed"] ; new_value=10
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="11"][@draft="contributed"] ; new_value=11
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="narrow"]/month[@type="12"][@draft="contributed"] ; new_value=12
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="full"]/dateFormat[@type="standard"]/pattern[@type="standard"][@draft="contributed"] ; new_value=EEEE, AAAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="long"]/dateFormat[@type="standard"]/pattern[@type="standard"][@draft="contributed"] ; new_value=AAAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="medium"]/dateFormat[@type="standard"]/pattern[@type="standard"][@draft="contributed"] ; new_value=AAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"][@draft="contributed"] ; new_value=g/A/ý GGGGG
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="d"][@draft="contributed"] ; new_value=g
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="E"][@draft="contributed"] ; new_value=ccc
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ed"][@draft="contributed"] ; new_value=g E
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Gy"][@draft="contributed"] ; new_value=b G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"][@draft="contributed"] ; new_value=g/A/ý GGGGG
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMM"][@draft="contributed"] ; new_value=AAA ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMd"][@draft="contributed"] ; new_value=AAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMEd"][@draft="contributed"] ; new_value=E, AAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="M"][@draft="contributed"] ; new_value=L
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"][@draft="contributed"] ; new_value=A/g
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"][@draft="contributed"] ; new_value=E, A/g
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMM"][@draft="contributed"] ; new_value=LLL
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMd"][@draft="contributed"] ; new_value=AAA g
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMEd"][@draft="contributed"] ; new_value=E, AAA g
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMMd"][@draft="contributed"] ; new_value=AAAA g
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMMEd"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="y"][@draft="contributed"] ; new_value=ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yM"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMd"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMEd"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMMM"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMMMd"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMMMEd"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMMMM"][@draft="contributed"] ; new_value=d/d
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyy"][@draft="contributed"] ; new_value=ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"][@draft="contributed"] ; new_value=A/ý GGGGG
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"][@draft="contributed"] ; new_value=g/A/ý GGGGG
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"][@draft="contributed"] ; new_value=E, g/A/ý GGGGG
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMM"][@draft="contributed"] ; new_value=AAA ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMd"][@draft="contributed"] ; new_value=AAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMEd"][@draft="contributed"] ; new_value=E, AAA g, ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMM"][@draft="contributed"] ; new_value=AAAA ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyQQQ"][@draft="contributed"] ; new_value=QQQ ý G
+locale=tk ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyQQQQ"][@draft="contributed"] ; new_value=QQQQ ý G
+locale=tk ; action=add ; new_path=//ldml/dates/timeZoneNames/zone[@type="Pacific/Kanton"]/exemplarCity[@draft="contributed"] ; new_value=Kanton
+locale=tk ; action=add ; new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/currencyFormatLength/currencyFormat[@type="accounting"]/pattern[@type="standard"][@alt="noCurrency"][@draft="contributed"] ; new_value=#,##0.00\x23(#,##0.00)
+locale=tk ; action=add ; new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/currencyPatternAppendISO[@draft="contributed"] ; new_value={0} ¤¤
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-quarter"]/displayName[@draft="contributed"] ; new_value=çärýek
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-quarter"]/displayName[@draft="contributed"] ; new_value=çär
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-quarter"]/displayName[@draft="contributed"] ; new_value=çär
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-quarter"]/perUnitPattern[@draft="contributed"] ; new_value={0}/ç
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-quarter"]/perUnitPattern[@draft="contributed"] ; new_value={0}/ç
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-quarter"]/perUnitPattern[@draft="contributed"] ; new_value={0}/ç
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-quarter"]/unitPattern[@count="one"][@draft="contributed"] ; new_value={0} çärýek
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-quarter"]/unitPattern[@count="other"][@draft="contributed"] ; new_value={0} çärýek
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-quarter"]/unitPattern[@count="one"][@draft="contributed"] ; new_value={0} çär
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-quarter"]/unitPattern[@count="other"][@draft="contributed"] ; new_value={0} çär
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-quarter"]/unitPattern[@count="one"][@draft="contributed"] ; new_value={0}ç
+locale=tk ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-quarter"]/unitPattern[@count="other"][@draft="contributed"] ; new_value={0}ç
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫨"][@type="tts"][@draft="contributed"] ; new_value=titreýan ýüz
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫨"][@draft="contributed"] ; new_value=ýertitreme | ýüz | titreýän | aňt-taňk | sandyramak
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🩵"][@type="tts"][@draft="contributed"] ; new_value=açyk gök ýürek
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🩵"][@draft="contributed"] ; new_value=mawy | ýürek | açyk gök | pöwrize
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🩶"][@type="tts"][@draft="contributed"] ; new_value=küljümek ýürek
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🩶"][@draft="contributed"] ; new_value=küljümek | ýürek | kümüş | plita
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🩷"][@type="tts"][@draft="contributed"] ; new_value=gülgüne ýürek
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🩷"][@draft="contributed"] ; new_value=naşyja | ýürek | halamak | söýgi | gülgüne
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫷"][@type="tts"][@draft="contributed"] ; new_value=çepe itýän el
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫷"][@draft="contributed"] ; new_value=el götermek | çepe | itmek | garşy çykmak | dur | garaş
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫸"][@type="tts"][@draft="contributed"] ; new_value=saga itýän el
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫸"][@draft="contributed"] ; new_value=el götermek | itmek | garşy çykmak | saga | dur | garaş
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫎"][@type="tts"][@draft="contributed"] ; new_value=deresygyr
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫎"][@draft="contributed"] ; new_value=haýwan | şahlylar | los | süýdemdiriji
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫏"][@type="tts"][@draft="contributed"] ; new_value=eşek
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫏"][@draft="contributed"] ; new_value=haýwan | eşek | kürre | süýdemdiriji | gatyr | keçjal
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪽"][@type="tts"][@draft="contributed"] ; new_value=ganat
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪽"][@draft="contributed"] ; new_value=perişde | awiasiýa | guş | uçýan | mifologiýa
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪿"][@type="tts"][@draft="contributed"] ; new_value=gaz
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪿"][@draft="contributed"] ; new_value=guş | eldeki guş | gakyldy | samsyklaç
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪼"][@type="tts"][@draft="contributed"] ; new_value=meduza
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪼"][@draft="contributed"] ; new_value=ýanmak | oňurgasyz | meduza | deňiz | wäk | iňňeli
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪻"][@type="tts"][@draft="contributed"] ; new_value=giasint
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪻"][@draft="contributed"] ; new_value=gök börük | gül | lawanta | lýupin | ýolbarsyň agzy
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫚"][@type="tts"][@draft="contributed"] ; new_value=zenjebil köki
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫚"][@draft="contributed"] ; new_value=piwo | kök | hoşboý ysly
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫛"][@type="tts"][@draft="contributed"] ; new_value=nohudyň kösügi
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🫛"][@draft="contributed"] ; new_value=noýba | edamame | kösükli | nohut | kösük | gök ot
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪭"][@type="tts"][@draft="contributed"] ; new_value=eplenýän el ýelpewajy
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪭"][@draft="contributed"] ; new_value=sowadýan | tans | ýelpewaç | pyrlanmak | gyzgyn | utanjaň
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪮"][@type="tts"][@draft="contributed"] ; new_value=saçgysgyç
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪮"][@draft="contributed"] ; new_value=Afro | darak | saç | saçgysgyç
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪇"][@type="tts"][@draft="contributed"] ; new_value=marakas
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪇"][@draft="contributed"] ; new_value=gural | saz | kakylýan | şakyrdawuk | çaýkamak
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪈"][@type="tts"][@draft="contributed"] ; new_value=tüýdük
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪈"][@draft="contributed"] ; new_value=durmuş | saz | turba | ýazga alyjy | üflenýän agaç
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪯"][@type="tts"][@draft="contributed"] ; new_value=khanda
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🪯"][@draft="contributed"] ; new_value=Sih | din
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🛜"][@type="tts"][@draft="contributed"] ; new_value=simsiz
+locale=tk ; action=add ; new_path=//ldml/annotations/annotation[@cp="🛜"][@draft="contributed"] ; new_value=kompýuter | internet | tor
+locale=tk ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"][@draft="contributed"] ; new_value=und tk
+locale=tk ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"][@draft="contributed"] ; new_value=
+locale=tk ; action=add ; new_path=//ldml/personNames/initialPattern[@type="initial"][@draft="contributed"] ; new_value={0}.
+locale=tk ; action=add ; new_path=//ldml/personNames/initialPattern[@type="initialSequence"][@draft="contributed"] ; new_value={0} {1}
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="givenOnly"]/nameField[@type="given"][@draft="contributed"] ; new_value=Gurban
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="givenSurnameOnly"]/nameField[@type="given"][@draft="contributed"] ; new_value=Amangeldi
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="givenSurnameOnly"]/nameField[@type="surname"][@draft="contributed"] ; new_value=Saparow
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="given12Surname"]/nameField[@type="given"][@draft="contributed"] ; new_value=Meretgeldi
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="given12Surname"]/nameField[@type="given2"][@draft="contributed"] ; new_value=Durdyýewiç
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="given12Surname"]/nameField[@type="surname"][@draft="contributed"] ; new_value=Gurbanow
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="prefix"][@draft="contributed"] ; new_value=Prof. Dr.
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="given"][@draft="contributed"] ; new_value=Gurban Saparow
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="given-informal"][@draft="contributed"] ; new_value=Aman
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="given2"][@draft="contributed"] ; new_value=Aman Saparow
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="surname-prefix"][@draft="contributed"] ; new_value=wan den
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="surname-core"][@draft="contributed"] ; new_value=Gurdow
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="surname2"][@draft="contributed"] ; new_value=Gurbangeldiýew
+locale=tk ; action=add ; new_path=//ldml/personNames/sampleName[@item="full"]/nameField[@type="suffix"][@draft="contributed"] ; new_value=magistr, ylymlaryň kandidaty
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="long"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={given} {given2} {surname} {suffix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="long"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="long"][@usage="addressing"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={prefix} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="long"][@usage="addressing"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="long"][@usage="monogram"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="long"][@usage="monogram"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal-monogram-allCaps}{surname-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="medium"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={given} {given2-initial} {surname} {suffix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="medium"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="medium"][@usage="addressing"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={prefix} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="medium"][@usage="addressing"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="medium"][@usage="monogram"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="medium"][@usage="monogram"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="short"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={given-initial} {given2-initial} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="short"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal} {surname-initial}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="short"][@usage="addressing"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={prefix} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="short"][@usage="addressing"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="short"][@usage="monogram"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="givenFirst"][@length="short"][@usage="monogram"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="long"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname} {given} {given2} {suffix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="long"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname} {given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="long"][@usage="addressing"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={prefix} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="long"][@usage="addressing"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="long"][@usage="monogram"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="long"][@usage="monogram"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname-monogram-allCaps}{given-informal-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="medium"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname} {given} {given2-initial} {suffix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="medium"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname} {given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="medium"][@usage="addressing"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={prefix} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="medium"][@usage="addressing"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="medium"][@usage="monogram"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="medium"][@usage="monogram"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="short"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname} {given-initial} {given2-initial}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="short"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname} {given-initial}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="short"][@usage="addressing"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={prefix} {surname}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="short"][@usage="addressing"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="short"][@usage="monogram"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="surnameFirst"][@length="short"][@usage="monogram"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={given-informal-monogram-allCaps}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="sorting"][@length="long"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-core}, {given} {given2} {surname-prefix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="sorting"][@length="long"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname}, {given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="sorting"][@length="medium"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-core}, {given} {given2-initial} {surname-prefix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="sorting"][@length="medium"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname}, {given-informal}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="sorting"][@length="short"][@usage="referring"][@formality="formal"]/namePattern[@draft="contributed"] ; new_value={surname-core}, {given-initial} {given2-initial} {surname-prefix}
+locale=tk ; action=add ; new_path=//ldml/personNames/personName[@order="sorting"][@length="short"][@usage="referring"][@formality="informal"]/namePattern[@draft="contributed"] ; new_value={surname}, {given-informal}


### PR DESCRIPTION
CLDR-15801

1. The data is marked as draft=contributed.
2. Some of the XML data was commented out, because they caused errors. 
    1. The date formats were malformed. Using AAAA instead of MMMM for long month, and ý for year.
    2. The abbreviated islamic months require language knowledge to fix. 
    3. In both cases, the Survey tool alerts people to the problems as they enter them, allowing them to fix the syntax.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
