### PR TITLE
CLDR-15799 Adapt GenerateProductionData to the CLDR-13263 change to use PSEUDO_PATH

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -493,9 +493,9 @@ public class GenerateProductionData {
         if (desiredPath.contains("type=\"en_GB\"") && desiredPath.contains("alt=")) {
             int debug = 0;
         }
-        if (foundPath == null) {
-            // We can do this, because the bailey value has already been checked
-            // Since it isn't null, a null indicates a constructed alt value
+        if (foundPath == null || foundPath.equals(GlossonymConstructor.PSEUDO_PATH)) {
+            // We can do this, because the bailey value has already been checked.
+            // Since it isn't null, a null or PSEUDO_PATH indicates a constructed alt value.
             return true;
         }
         XPathParts desiredPathParts = XPathParts.getFrozenInstance(desiredPath);


### PR DESCRIPTION
CLDR-15799

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Per [CLDR-13263](https://unicode-org.atlassian.net/browse/CLDR-13263) which added GlossonymConstructor, the path PSEUDO_PATH ("constructed") is now used to indicate the path for constructed fallback values for locale display names. However, GenerateProductionData had not been updated to handle this, leading to exceptions when "constructed" was passed down to XPathParts Apis that expected a real path beginning with '/'. This PR updates GenerateProductionData to handle PSEUDO_PATH. This also means that production data will remove a lot of display names that duplicate the inherited or constructed value.