### PR TITLE
CLDR-15603 Rename Swedish collation standards

### DIFF
--- a/common/collation/sv.xml
+++ b/common/collation/sv.xml
@@ -18,7 +18,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				[import sv-u-co-standard]
 			]]></cr>
 		</collation>
-		<collation type="standard">
+		<collation type="traditional">
 			<cr><![CDATA[
 				&D<<đ<<<Đ<<ð<<<Ð
 				&t<<<þ/h
@@ -28,7 +28,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				&[before 1]ǀ<å<<<Å<ä<<<Ä<<æ<<<Æ<<ę<<<Ę<ö<<<Ö<<ø<<<Ø<<ő<<<Ő<<œ<<<Œ<<ô<<<Ô
 			]]></cr>
 		</collation>
-		<collation type="reformed">
+		<collation type="standard">
 			<cr><![CDATA[
 				&D<<đ<<<Đ<<ð<<<Ð
 				&t<<<þ/h


### PR DESCRIPTION
Renaming the two collation standards per the ticket's suggestion.

CLDR-15603

- [x] This PR completes the ticket.

