### PR TITLE
CLDR-15833 vxml errs: hi empty zone name, hi_Latn needs noon, update ja personName example

### DIFF
--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -5136,9 +5136,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<long>
 					<standard>ग्रीनविच मीन टाइम</standard>
 				</long>
-				<short>
-					<standard>↑↑↑</standard>
-				</short>
 			</metazone>
 			<metazone type="Greenland_Eastern">
 				<long>

--- a/common/supplemental/dayPeriods.xml
+++ b/common/supplemental/dayPeriods.xml
@@ -277,6 +277,14 @@
 			<dayPeriodRule type="evening1" from="16:00" before="20:00"/>	<!-- शाम -->
 			<dayPeriodRule type="night1" from="20:00" before="04:00"/>	<!-- रात -->
 		</dayPeriodRules>
+		<dayPeriodRules locales="hi_Latn"> <!-- Also needs noon defined since it inherits from en_IN -->
+			<dayPeriodRule type="midnight" at="00:00"/>	<!-- आधी रात -->
+			<dayPeriodRule type="noon" at="12:00"/>	<!-- noon -->
+			<dayPeriodRule type="morning1" from="04:00" before="12:00"/>	<!-- सुबह -->
+			<dayPeriodRule type="afternoon1" from="12:00" before="16:00"/>	<!-- दोपहर -->
+			<dayPeriodRule type="evening1" from="16:00" before="20:00"/>	<!-- शाम -->
+			<dayPeriodRule type="night1" from="20:00" before="04:00"/>	<!-- रात -->
+		</dayPeriodRules>
 		<dayPeriodRules locales="bn ccp">
 			<dayPeriodRule type="morning1" from="04:00" before="06:00"/>	<!-- ভোর -->
 			<dayPeriodRule type="morning2" from="06:00" before="12:00"/>	<!-- সকাল -->

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -388,10 +388,10 @@ public class TestPersonNameFormatter extends TestFmwk{
         };
         ExampleGenerator exampleGenerator = checkExamples(ENGLISH, tests);
 
-        String[][] jaTests = { // note: will need updated once we add real Japanese data.
+        String[][] jaTests = {
             {
                 "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"long\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
-                "〖アルベルト・アインシュタイン〗"
+                "〖慎太郎〗〖一郎 安藤〗〖太郎 トーマス 山田〗〖ドクター 英子 ソフィア 内田さん〗〖アルベルト・アインシュタイン〗"
             }
         };
         ExampleGenerator jaExampleGenerator = checkExamples(jaCldrFile, jaTests);


### PR DESCRIPTION
CLDR-15833

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

On the brs/v42vxml branch, fix the following unittest failures from the imported CDR 42 vxml:
```
  TestDayPeriods {
    TestAttributes {
      Error: (TestFmwkPlus.java:49) File TestDayPeriods.java, Line 86 hi_Latn : ‹[midnight, night1, morning1, afternoon1, evening1, night1]› NOT contains ‹noon›; expected true
      Error: (TestFmwkPlus.java:49) File TestDayPeriods.java, Line 86 hi_Latn : ‹[midnight, night1, morning1, afternoon1, evening1, night1]› NOT contains ‹noon›; expected true
      Error: (TestFmwkPlus.java:49) File TestDayPeriods.java, Line 86 hi_Latn : ‹[midnight, night1, morning1, afternoon1, evening1, night1]› NOT contains ‹noon›; expected true
      Error: (TestFmwkPlus.java:49) File TestDayPeriods.java, Line 86 hi_Latn : ‹[midnight, night1, morning1, afternoon1, evening1, night1]› NOT contains ‹noon›; expected true
      Error: (TestFmwkPlus.java:49) File TestDayPeriods.java, Line 86 hi_Latn : ‹[midnight, night1, morning1, afternoon1, evening1, night1]› NOT contains ‹noon›; expected true
      Error: (TestFmwkPlus.java:49) File TestDayPeriods.java, Line 86 hi_Latn : ‹[midnight, night1, morning1, afternoon1, evening1, night1]› NOT contains ‹noon›; expected true

  TestDisplayAndInputProcessor {
    TestAll {
      Error: (TestAll.java:178) (TestAll.java:178) java.lang.NullPointerException
java.lang.NullPointerException
	at org.unicode.cldr.unittest.TestDisplayAndInputProcessor.showCldrFile(TestDisplayAndInputProcessor.java:317)
	at org.unicode.cldr.unittest.TestDisplayAndInputProcessor.TestAll(TestDisplayAndInputProcessor.java:29)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	...

  TestPersonNameFormatter {
    TestExampleGenerator {
      Error: (TestPersonNameFormatter.java:442) : Example for {prefix} {given} {given2} {surname}{suffix}:
      expected "〖アルベルト・アインシュタイン〗",
      got "〖慎太郎〗〖一郎 安藤〗〖太郎 トーマス 山田〗〖ドクター 英子 ソフィア 内田さん〗〖アルベルト・アインシュタイン〗"
    } (0.086s) FAILED (1 failure(s))
```
1. For the first one: Since `hi_Latn` inherits from `en_IN`, `hi_Latn` day periods need to add the definition of "noon" (which does not exist in `hi` but does exist in `en`).
2. For the second, `hi` had added an entry `↑↑↑` for `//ldml/dates/timeZoneNames/metazone[@type="GMT"]/short/standard`, importing from root which has no value for this. Just deleted the bogus entry.
3. For the third, just updated the expected results in TestPersonNameFormatter now that we have actual data for `ja`.