### PR TITLE
CLDR-15838 vxml annotations errs: missing ff, nb; dup kk names

### DIFF
--- a/common/annotations/ff.xml
+++ b/common/annotations/ff.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2022 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ff"/>
+	</identity>
+</ldml>

--- a/common/annotations/kk.xml
+++ b/common/annotations/kk.xml
@@ -991,8 +991,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="💔" type="tts">жаралы жүрек</annotation>
 		<annotation cp="❤‍🔥" draft="contributed">лаулап тұрған жүрек</annotation>
 		<annotation cp="❤‍🔥" type="tts" draft="contributed">лаулап тұрған жүрек</annotation>
-		<annotation cp="❤‍🩹" draft="contributed">жаралы жүрек</annotation>
-		<annotation cp="❤‍🩹" type="tts" draft="contributed">жаралы жүрек</annotation>
+		<annotation cp="❤‍🩹" draft="contributed">емдік жүрек</annotation>
+		<annotation cp="❤‍🩹" type="tts" draft="contributed">емдік жүрек</annotation>
 		<annotation cp="❤">жүрек | қызыл жүрек</annotation>
 		<annotation cp="❤" type="tts">қызыл жүрек</annotation>
 		<annotation cp="🧡">қызғылт-сары жүрек</annotation>
@@ -1948,7 +1948,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🪷">буддизм | Вьетнам | гүл | индуизм | лотос | тазалық | Үндістан</annotation>
 		<annotation cp="🪷" type="tts">лотос</annotation>
 		<annotation cp="🏵">өсімдік | раушан | розетта</annotation>
-		<annotation cp="🏵" type="tts">раушан</annotation>
+		<annotation cp="🏵" type="tts">розетта</annotation>
 		<annotation cp="🌹">әтіргүл | гүл | өсімдік | раушан</annotation>
 		<annotation cp="🌹" type="tts">раушан</annotation>
 		<annotation cp="🥀">гүл | солған</annotation>

--- a/common/annotations/nb.xml
+++ b/common/annotations/nb.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2022 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="nb"/>
+	</identity>
+</ldml>


### PR DESCRIPTION
CLDR-15838

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix remaining unittest failures in bis/v42vxml branch as follows:
1. Add missing stub files in common/annotations: ff.xml, nb.xml
2. Fix duplicate emoji tts names for kk as follows (we can update these later if we get better info from vetters, but this fixes the errors for now):
        * For 🏵 rosette, changed from  "раушан" (rose, duplicates another) to "розетта" (rosette, which was already one of the annotations)
        * For ❤️‍🩹 mending heart, changed from "жаралы жүрек" (broken heart, duplicates another name) to "емдік жүрек" (healing heart)

Once this is merged we can go on to fix the ConsoleCheckCLDR errors in the vxml branch.