### PR TITLE
CLDR-15707 Enable downloading error/missing/provisional as xml

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/MissingPathXml.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/MissingPathXml.java
@@ -20,7 +20,7 @@ import org.unicode.cldr.web.*;
 
 @ApplicationScoped
 @Path("/missingxml")
-@Tag(name = "Missing XML", description = "Generate XML for error/missing/provisional paths")
+@Tag(name = "missing xml", description = "Generate XML for error/missing/provisional paths")
 public class MissingPathXml {
 
     @GET


### PR DESCRIPTION
-New constant VALUE_PLACEHOLDER for n/a

-Show actual value for provisional and error

-If both provisional and error, show provisional first; no duplicate English

CLDR-15707

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
