### PR TITLE
CLDR-15842 vxml ConsoleCheck errs for ne, tok, ab, cv, hnj, myv

### DIFF
--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -2056,18 +2056,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">१२</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">वैशाख</month>
-							<month type="2">जेठ</month>
-							<month type="3">असार</month>
-							<month type="4">साउन</month>
-							<month type="5">भदौ</month>
-							<month type="6">असोज</month>
-							<month type="7">कात्तिक</month>
-							<month type="8">मङसिर</month>
-							<month type="9">पुस</month>
-							<month type="10">माघ</month>
-							<month type="11">फागुन</month>
-							<month type="12">चैत</month>
+							<month type="1" draft="contributed">चैत</month>
+							<month type="2" draft="contributed">वैशाख</month>
+							<month type="3" draft="contributed">जेठ</month>
+							<month type="4" draft="contributed">असार</month>
+							<month type="5" draft="contributed">साउन</month>
+							<month type="6" draft="contributed">भदौ</month>
+							<month type="7" draft="contributed">असोज</month>
+							<month type="8" draft="contributed">कात्तिक</month>
+							<month type="9" draft="contributed">मङसिर</month>
+							<month type="10" draft="contributed">पुस</month>
+							<month type="11" draft="contributed">माघ</month>
+							<month type="12" draft="contributed">फागुन</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">

--- a/common/main/tok.xml
+++ b/common/main/tok.xml
@@ -136,7 +136,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="IE" draft="unconfirmed">ma Alan</territory>
 			<territory type="IL" draft="unconfirmed">ma Isale</territory>
 			<territory type="IN" draft="unconfirmed">ma Palata</territory>
-			<territory type="IO">↑↑↑</territory>
 			<territory type="IQ" draft="unconfirmed">ma Ilakija</territory>
 			<territory type="IR" draft="unconfirmed">ma Ilan</territory>
 			<territory type="IS" draft="unconfirmed">ma Isilan</territory>
@@ -185,7 +184,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="PL" draft="unconfirmed">ma Posuka</territory>
 			<territory type="PS" draft="unconfirmed">ma Pilisin</territory>
 			<territory type="PT" draft="unconfirmed">ma Potuke</territory>
-			<territory type="RE">↑↑↑</territory>
 			<territory type="RO" draft="unconfirmed">ma Lomani</territory>
 			<territory type="RS" draft="unconfirmed">ma Sopisi</territory>
 			<territory type="RU" draft="unconfirmed">ma Lusi</territory>

--- a/seed/main/ab.xml
+++ b/seed/main/ab.xml
@@ -3030,7 +3030,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Alaska">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic draft="unconfirmed">Алиаска</generic>
 					<standard draft="unconfirmed">Алиаска, астандартә аамҭа</standard>
 					<daylight draft="unconfirmed">Алиаска, аԥхынтәи аамҭа</daylight>
 				</long>
@@ -3987,14 +3987,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<decimalFormatLength>
 				<decimalFormat>
 					<pattern draft="unconfirmed">#,##0.###</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-			<decimalFormatLength type="long">
-				<decimalFormat>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>

--- a/seed/main/cv.xml
+++ b/seed/main/cv.xml
@@ -17,7 +17,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<localeKeyTypePattern>↑↑↑</localeKeyTypePattern>
 		</localeDisplayPattern>
 		<languages>
-			<language type="af">↑↑↑</language>
 			<language type="ar">арап</language>
 			<language type="ar_001">арап литератури</language>
 			<language type="bn">бенгал</language>

--- a/seed/main/hnj.xml
+++ b/seed/main/hnj.xml
@@ -136,11 +136,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 				</months>
 				<days>
-					<dayContext type="format">
-						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-						</dayWidth>
-					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="wide">
 							<day type="sun">𞄎𞄤𞄲</day>

--- a/seed/main/myv.xml
+++ b/seed/main/myv.xml
@@ -637,11 +637,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Bangladesh">
 				<long>
 					<generic draft="unconfirmed">Бангладешень шка</generic>
+					<standard draft="unconfirmed">Бангладешень свалонь шка</standard>
+					<daylight draft="unconfirmed">Бангладешень кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Brasilia">
 				<long>
 					<generic draft="unconfirmed">Базилиянь шка</generic>
+					<standard draft="unconfirmed">Базилиянь свалонь шка</standard>
+					<daylight draft="unconfirmed">Базилиянь кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Chile">
@@ -654,6 +658,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="China">
 				<long>
 					<generic draft="unconfirmed">Китаень шка</generic>
+					<standard draft="unconfirmed">Китаень свалонь шка</standard>
+					<daylight draft="unconfirmed">Китаень кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cuba">
@@ -671,6 +677,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Iran">
 				<long>
 					<generic draft="unconfirmed">Иранонь шка</generic>
+					<standard draft="unconfirmed">Иранонь свалонь шка</standard>
+					<daylight draft="unconfirmed">Иранонь кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Japan">
@@ -693,6 +701,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Korea">
 				<long>
 					<generic draft="unconfirmed">Кореань шка</generic>
+					<standard draft="unconfirmed">Кореань свалонь шка</standard>
+					<daylight draft="unconfirmed">Кореань кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Moscow">
@@ -705,11 +715,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="New_Zealand">
 				<long>
 					<generic draft="unconfirmed">Од Зеландиянь шка</generic>
+					<standard draft="unconfirmed">Од Зеландиянь свалонь шка</standard>
+					<daylight draft="unconfirmed">Од Зеландиянь кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Omsk">
 				<long>
 					<generic draft="unconfirmed">Омскоень шка</generic>
+					<standard draft="unconfirmed">Омскоень свалонь шка</standard>
+					<daylight draft="unconfirmed">Омскоень кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Paraguay">
@@ -722,6 +736,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Sakhalin">
 				<long>
 					<generic draft="unconfirmed">Сахалинэнь шка</generic>
+					<standard draft="unconfirmed">Сахалинэнь свалонь шка</standard>
+					<daylight draft="unconfirmed">Сахалинэнь кизэнь шка</daylight>
 				</long>
 			</metazone>
 			<metazone type="Uruguay">
@@ -734,6 +750,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Uzbekistan">
 				<long>
 					<generic draft="unconfirmed">Узбекистанонь шка</generic>
+					<standard draft="unconfirmed">Узбекистанонь свалонь шка</standard>
+					<daylight draft="unconfirmed">Узбекистанонь кизэнь шка</daylight>
 				</long>
 			</metazone>
 		</timeZoneNames>


### PR DESCRIPTION
CLDR-15842

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix the following ConsoleCheck errors in the vxml:
```
ne [Nepali]	error,ne.xml:2068	▸Date_&_Time|Indian|Months_-_wide_-_Formatting|Oct◂	〈Pausa〉	【】	〈माघ〉	«=»	【】	⁅date symbol collision⁆	❮Error: The date value “माघ” is the same as what is used for a different item: [Months - wide - Standalone: Nov]❯
ne [Nepali]	error,ne.xml:2113	▸Date_&_Time|Indian|Months_-_wide_-_Standalone|Nov◂	〈Magha〉	【】	〈माघ〉	«=»	【】	⁅date symbol collision⁆	❮Error: The date value “माघ” is the same as what is used for a different item: [Months - wide - Formatting: Oct]❯

tok [Toki Pona]	error	▸Locale_Display_Names|Territories_(Africa)|Eastern_Africa|IO◂	〈British Indian Ocean Territory〉	【】	〈IO〉	«=»	【】⁅same as code⁆	❮Error: The value is the same as the 'code'❯	code-fallback
tok [Toki Pona]	error	▸Locale_Display_Names|Territories_(Africa)|Eastern_Africa|RE◂	〈Réunion〉	【】	〈RE〉	«=»	【】	⁅same as code⁆	❮Error: The value is the same as the 'code'.❯	code-fallback

ab [Abkhazian]	error,ab.xml:3034	▸Timezones|North_America|Alaska|standard-long◂	〈Alaska Standard Time〉	【】	〈Алиаска, астандартә аамҭа〉	«=»	【】	⁅inconsistent draft status⁆	❮Error: This item has draft status=unconfirmed, which is lower than the status=approved (for generic-long).❯
ab [Abkhazian]	error,ab.xml:3035	▸Timezones|North_America|Alaska|daylight-long◂	〈Alaska Daylight Time〉	【】	〈Алиаска, аԥхынтәи аамҭа〉	«=»	【】	⁅inconsistent draft status⁆	❮Error: This item has draft status=unconfirmed, which is lower than the status=approved (for generic-long).❯
ab [Abkhazian]	error	▸Numbers|Compact_Decimal_Formatting|Long_Formats_|8-digits-long-other◂	〈00 million〉	【】	〈00M〉	«=»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [9-digits-long-other, 8-digits-long-other]; level=modern❯	root	//ldml/numbers/decimalFormats[@numberSystem="latn"]/decimalFormatLength[@type="short"]/decimalFormat[@type="standard"]/pattern[@type="10000000"][@count="other"]

cv [Chuvash]	error	▸Locale_Display_Names|Languages_(A-D)|A|Afrikaans_►_af◂	〈Afrikaans〉	【】	〈af〉	«=»	【】	⁅same as code⁆	❮Error: The value is the same as the 'code': see <a target='CLDR-ST-DOCS' href='https://cldr.unicode.org/translation/error-and-warning-codes'>Fixing Errors and Warnings</a>.❯	code-fallback

hnj [Hmong Njua]	error	▸Date_&_Time|Gregorian|Days_-_abbreviated_-_Formatting|fri◂	〈Fri〉	【】	〈Fri〉	«=»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [thu, tue, sat, wed, fri, mon]; level=moderate❯	root	//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="wide"]/day[@type="fri"]

myv [Erzya]	error	▸Timezones|Russia|Omsk|daylight-long◂	〈Omsk Summer Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Russia|Sakhalin|daylight-long◂	〈Sakhalin Summer Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Central_Asia|Uzbekistan|daylight-long◂	〈Uzbekistan Summer Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Eastern_Asia|China|daylight-long◂	〈China Daylight Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Eastern_Asia|Korea|daylight-long◂	〈Korean Daylight Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Southern_Asia|Bangladesh|daylight-long◂	〈Bangladesh Summer Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Southern_Asia|Iran|daylight-long◂	〈Iran Daylight Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
myv [Erzya]	error	▸Timezones|Australasia|New_Zealand|daylight-long◂	〈New Zealand Daylight Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
```

Most were simple same-as-code errors (delete entry) or incomplete logical groups that could be completed easily. The `ne` error was interesting: the format wide months for the Indian calendar were rotated by one month compared to the other values (these only had one vetter, from Microsoft, while the other styles and widths had vetters from both Microsoft and Google). I just rotated these to match the others.