### PR TITLE
CLDR-15844 vxml ConsoleCheck errs for chr, mai, mt, and partially for syr

### DIFF
--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -9257,7 +9257,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<featureName type="zero">ᎠᎦᎵᏓ ᎧᏂᎩᏗ</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrderLocales order="givenFirst">und en</nameOrderLocales>
+		<nameOrderLocales order="givenFirst">und chr en</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
 		<foreignSpaceReplacement>↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -4019,6 +4019,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="New_Caledonia">
 				<long>
 					<generic>न्यू केलैडोनिया समय</generic>
+					<standard>न्यू केलैडोनिया मानक समय</standard>
+					<daylight>न्यू केलैडोनिया डेलाइट समय</daylight>
 				</long>
 			</metazone>
 			<metazone type="New_Zealand">
@@ -4118,6 +4120,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="Samoa">
 				<long>
 					<generic>सामोआ समय</generic>
+					<standard>सामोआ मानक समय</standard>
+					<daylight>सामोआ समर समय</daylight>
 				</long>
 			</metazone>
 			<metazone type="Seychelles">

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -1672,9 +1672,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month">
 				<displayName>xahar</displayName>
-				<relative type="-1">Ix-xahar li għadda</relative>
-				<relative type="0">Dan ix-xahar</relative>
-				<relative type="1">Ix-xahar id-dieħel</relative>
+				<relative type="-1">ix-xahar li għadda</relative>
+				<relative type="0">dan ix-xahar</relative>
+				<relative type="1">ix-xahar id-dieħel</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa xahar ieħor</relativeTimePattern>
 					<relativeTimePattern count="two">fi xahrejn oħra</relativeTimePattern>
@@ -1692,7 +1692,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>Xahar</displayName>
+				<relative type="-1" draft="unconfirmed">ix-xahar li għadda</relative>
 				<relative type="0" draft="unconfirmed">dan ix-xahar</relative>
+				<relative type="1" draft="unconfirmed">ix-xahar id-dieħel</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa xahar ieħor</relativeTimePattern>
 					<relativeTimePattern count="two">sa xahrejn oħra</relativeTimePattern>

--- a/seed/main/syr.xml
+++ b/seed/main/syr.xml
@@ -6855,6 +6855,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="length-inch">
 				<displayName>ܐܢ܊</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/ܐܢܟ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">


### PR DESCRIPTION
CLDR-15844

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix the following ConsoleCheck errors in the vxml:
```
chr [Cherokee]	error,chr.xml:9260	▸Miscellaneous|Person_Name_Formats|NameOrder_for_Locales|givenFirst◂	〈und en〉	【】	〈und en〉	«=»	【】	⁅missing language⁆	❮Error: Your locale code (chr) must be explicitly listed in one of the nameOrderLocales: either in givenFirst or in surnameFirst.❯
chr [Cherokee]	error,root.xml:5416	▸Miscellaneous|Person_Name_Formats|NameOrder_for_Locales|surnameFirst◂	〈ja ko zh〉	【】	〈hu ja ko vi yue zh〉	«=»	【】⁅missing language⁆	❮Error: Your locale code (chr) must be explicitly listed in one of the nameOrderLocales: either in givenFirst or in surnameFirst.❯	root

mai [Maithili]	error	▸Timezones|Oceania|New_Caledonia|daylight-long◂	〈New Caledonia Summer Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback
mai [Maithili]	error	▸Timezones|Oceania|Samoa|daylight-long◂	〈Samoa Daylight Time〉	【】	〈null〉	«»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [standard-long, daylight-long]; level=moderate❯	code-fallback

mt [Maltese]	error	▸Date_&_Time|Fields|Relative_Month_Short|-1◂	〈last mo.〉	【】	〈Ix-xahar li għadda〉	«=»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [1, -1]; level=moderate❯	//ldml/dates/fields/field[@type="month"]/relative[@type="-1"]

syr [Syriac]	error	▸Units|Length|inch|narrow-other-nominative◂	〈{0}″〉	【】	〈{0} ܐܢ܊〉	«=»	【】	⁅incomplete logical group⁆	❮Error: Incomplete logical group - missing values for: [narrow-other-nominative]; level=modern❯	//ldml/units/unitLength[@type="short"]/unit[@type="length-inch"]/unitPattern[@count="other"]
```

These were logical group errors, plus a missing language code in Cherokee personNames data. Also fixed a capitalization inconsistency in Maltese.