### PR TITLE
CLDR-15845 more xml errors

### DIFF
--- a/common/annotations/kab.xml
+++ b/common/annotations/kab.xml
@@ -1623,14 +1623,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="♊" type="tts" draft="unconfirmed">Akniwen</annotation>
 		<annotation cp="♋">Afurray</annotation>
 		<annotation cp="♋" type="tts" draft="unconfirmed">Afurray</annotation>
-		<annotation cp="♌">Izem</annotation>
-		<annotation cp="♌" type="tts" draft="unconfirmed">Izem</annotation>
 		<annotation cp="♍">Taḥbayrit</annotation>
 		<annotation cp="♍" type="tts" draft="unconfirmed">Taḥbayrit</annotation>
 		<annotation cp="♎">Tacihant</annotation>
 		<annotation cp="♎" type="tts" draft="unconfirmed">Tacihant</annotation>
-		<annotation cp="♏">Tiɣirdemt</annotation>
-		<annotation cp="♏" type="tts" draft="unconfirmed">Tiɣirdemt</annotation>
 		<annotation cp="♐">Amnaccab</annotation>
 		<annotation cp="♐" type="tts" draft="unconfirmed">Amnaccab</annotation>
 		<annotation cp="♑">Aqelwac</annotation>

--- a/common/main/bn_IN.xml
+++ b/common/main/bn_IN.xml
@@ -846,9 +846,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimalPairs>
 			<pluralMinimalPairs count="one" draft="contributed">{0}টি দিন</pluralMinimalPairs>
 			<pluralMinimalPairs count="other" draft="contributed">{0} দিন</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="few">ডান দিকে {0} নম্বর র্বাঁকটি নিন।</ordinalMinimalPairs>
-			<ordinalMinimalPairs ordinal="many">ডান দিকে {0} নম্বর বাঁকটি নিন।</ordinalMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">ডান দিকে {0} নম্বর বাঁকটি নিন।</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -2357,7 +2357,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning1">umaga</dayPeriod>
 							<dayPeriod type="morning2">madaling-araw</dayPeriod>
 							<dayPeriod type="afternoon1">hapon</dayPeriod>
-							<dayPeriod type="evening1">gabi</dayPeriod>
+							<dayPeriod type="evening1">ng gabi</dayPeriod>
 							<dayPeriod type="night1">gabi</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
@@ -2368,7 +2368,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning1">umaga</dayPeriod>
 							<dayPeriod type="morning2">madaling-araw</dayPeriod>
 							<dayPeriod type="afternoon1">hapon</dayPeriod>
-							<dayPeriod type="evening1">gabi</dayPeriod>
+							<dayPeriod type="evening1">sa gabi</dayPeriod>
 							<dayPeriod type="night1">gabi</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
@@ -2379,8 +2379,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning1">umaga</dayPeriod>
 							<dayPeriod type="morning2">madaling-araw</dayPeriod>
 							<dayPeriod type="afternoon1">hapon</dayPeriod>
-							<dayPeriod type="evening1">gabi</dayPeriod>
-							<dayPeriod type="night1">hatinggabi</dayPeriod>
+							<dayPeriod type="evening1">ng gabi</dayPeriod>
+							<dayPeriod type="night1">gabi</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>


### PR DESCRIPTION
CLDR-15845

common/annotations/kab.xml
Deleted the 2 zodiac symbols that were colliding

common/main/bn_IN.xml
The bn.xml patterns didn't have the problem, so reverted to them (by deletion). The new values were broken anyway because they were only partial : all of the patterns have to be in parallel, and have the same meaning.
We need to alert the vetters for next time to review these (and work in coordination with bn.xml)

common/main/fil.xml
One was an obvious error, and I picked formatting versions for some of the collisions.
There are still oddities, like the following:
```
2,325: <dayPeriod type="evening1">ng gabi</dayPeriod> 
2,336: <dayPeriod type="evening1">sa gabi</dayPeriod> 
2,347: <dayPeriod type="evening1">ng gabi</dayPeriod> 
```
The abbreviated and wide are 'na', while the narrow form is 'sa' — that is no narrower, so the change is very odd. 
We need to alert the vetters for next time to review all of these in context.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
