### PR TITLE
CLDR-15804 cs: add availableFmts/intervalFmts for vvvv, with comma

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1615,7 +1615,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ELEMENT intervalFormatItem ( alias | ( greatestDifference*, special* ) ) >
 <!ATTLIST intervalFormatItem id NMTOKEN #REQUIRED >
     <!-- TODO: check to see if this should be minimized -->
-    <!--@MATCH:literal/Bh, Bhm, Gy, GyM, GyMEd, GyMMM, GyMMMEd, GyMMMd, GyMd, H, Hm, Hmv, Hv, M, MEd, MMM, MMMEEEEd, MMMEd, MMMM, MMMMEd, MMMMd, MMMd, Md, d, h, hm, hmv, hv, y, yM, yMEd, yMMM, yMMMEEEEd, yMMMEd, yMMMM, yMMMMEEEEd, yMMMMEd, yMMMMd, yMMMd, yMd, GGGGGyM, GGGGGyMEd, GGGGGyMd, GyMMMM, GyMMMMEd, GyMMMMd-->
+    <!--@MATCH:literal/Bh, Bhm, Gy, GyM, GyMEd, GyMMM, GyMMMEd, GyMMMd, GyMd, H, Hm, Hmv, Hmvvvv, Hv, Hvvvv, M, MEd, MMM, MMMEEEEd, MMMEd, MMMM, MMMMEd, MMMMd, MMMd, Md, d, h, hm, hmv, hmvvvv, hv, hvvvv, y, yM, yMEd, yMMM, yMMMEEEEd, yMMMEd, yMMMM, yMMMMEEEEd, yMMMMEd, yMMMMd, yMMMd, yMd, GGGGGyM, GGGGGyMEd, GGGGGyMd, GyMMMM, GyMMMMEd, GyMMMMd-->
 <!ATTLIST intervalFormatItem alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST intervalFormatItem draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -1521,12 +1521,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -2534,12 +2550,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -3606,12 +3638,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -3859,12 +3907,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M">M–M</greatestDifference>
@@ -4340,8 +4404,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="Hms">H:mm:ss</dateFormatItem>
 						<dateFormatItem id="hmsv">h:mm:ss a v</dateFormatItem>
 						<dateFormatItem id="Hmsv">H:mm:ss v</dateFormatItem>
+						<dateFormatItem id="hmsvvvv" draft="contributed">h:mm:ss a, vvvv</dateFormatItem>
+						<dateFormatItem id="Hmsvvvv" draft="contributed">H:mm:ss, vvvv</dateFormatItem>
 						<dateFormatItem id="hmv">h:mm a v</dateFormatItem>
 						<dateFormatItem id="Hmv">H:mm v</dateFormatItem>
+						<dateFormatItem id="hmvvvv" draft="contributed">h:mm a, vvvv</dateFormatItem>
+						<dateFormatItem id="Hmvvvv" draft="contributed">H:mm, vvvv</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">d. M.</dateFormatItem>
 						<dateFormatItem id="MEd">E d. M.</dateFormatItem>
@@ -4452,12 +4520,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a">h a – h a v</greatestDifference>
 							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M">M–M</greatestDifference>
@@ -4742,12 +4826,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -5020,12 +5120,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -5298,12 +5414,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -6191,12 +6323,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
@@ -6469,12 +6617,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
 							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
+						<intervalFormatItem id="hmvvvv">
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hmvvvv">
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm, vvvv</greatestDifference>
+						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="hvvvv">
+							<greatestDifference id="a" draft="contributed">h a – h a, vvvv</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a, vvvv</greatestDifference>
+						</intervalFormatItem>
+						<intervalFormatItem id="Hvvvv">
+							<greatestDifference id="H" draft="contributed">H–H, vvvv</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>


### PR DESCRIPTION
CLDR-15804

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

In CLDR 42 Survey Tool submission, Czech vetters added a comma to the standard full time format (with zzzz) `H:mm:ss, zzzz` (and this won), leaving the standard long time format (with just z) without a comma: `H:mm:ss z`. To match this and prevent associated warnings, we need to update the availableFormats and intervalFormats to add patterns that distinguish skeletons with `vvvv` (which should have comma) from skeletons with just `v` (which should not). Adding these was something the vetters could not do in the Survey Tool.