### PR TITLE
CLDR-15603 sv: also update defaultCollation from "reformed" to "standard"

### DIFF
--- a/common/collation/sv.xml
+++ b/common/collation/sv.xml
@@ -11,7 +11,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<language type="sv"/> 
 	</identity>
 	<collations>
-		<defaultCollation>reformed</defaultCollation>
+		<defaultCollation>standard</defaultCollation>
 		<collation type="search">
 			<cr><![CDATA[
 				[import und-u-co-search]


### PR DESCRIPTION
CLDR-15603

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
 For Swedish, https://github.com/unicode-org/cldr/pull/2171 renamed the "reformed" collation to "standard" (after renaming the previous "standard" to "traditional". However it not update the defaultCollation element, which still pointed to the now non-existent "reformed". This fixes that. (Note there is a separate CLDR ticket to add a test that should detect this kind of problem).