### PR TITLE
CLDR-15863 add fallback zDefault ruleset to NumberingSystemRules

### DIFF
--- a/common/rbnf/root.xml
+++ b/common/rbnf/root.xml
@@ -691,6 +691,9 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="0">=%tamil=;</rbnfrule>
                 <rbnfrule value="1000">←←௲[→→];</rbnfrule>
             </ruleset>
+            <ruleset type="zDefault">
+                <rbnfrule value="0">=#,##0=;</rbnfrule>
+            </ruleset>
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <ruleset type="digits-ordinal">


### PR DESCRIPTION
CLDR-15863

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Add a fallback xDefault ruleset to rbnf root NumberingSystemRules; for motivation see https://unicode-org.atlassian.net/browse/ICU-22088