### PR TITLE
CLDR-15840 hy collation: sort ech-yiwn ligature between lowercase and titlecase ech+vew

### DIFF
--- a/common/collation/hy.xml
+++ b/common/collation/hy.xml
@@ -14,7 +14,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <collation type="standard">
                 <cr><![CDATA[
 [reorder Armn]
-&ք<և<<<Եւ
+&եվ<<<և
                 ]]></cr>
             </collation>
         </collations>


### PR DESCRIPTION
CLDR-15840

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

For hy: sort ech-yiwn ligature between lowercase and titlecase ech+vew, per [L2/22-124](https://www.unicode.org/L2/L2022/22124-utc172-properties-recs.pdf) item Coll2.