### PR TITLE
CLDR-14660 he currency formats, add RLM before currency sign

### DIFF
--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -6979,10 +6979,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
+					<pattern>‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>#,##0.00 ¤</pattern>
+					<pattern>‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>


### PR DESCRIPTION
CLDR-14660

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

In the Hebrew standard currency format, add RLM before the currency symbol in both the positive and negative formats. As demonstrated in smoketest using the new bidi examples, this makes currency lay out the same regardless of positive of negative form, ISO 4217 symbol (strong LR) or shekel symbol, and R-L or neutral context.

And then since the accounting format did not seem to be trying to do anything special, copy the standard currency format to the accounting format.

I plan to discuss this during the CLDR TC meeting 2022-08-01.