### PR TITLE
CLDR-15557 keyboard: work around XPath issue for doublequote

### DIFF
--- a/keyboards/und/pcm-t-k0-windows.xml
+++ b/keyboards/und/pcm-t-k0-windows.xml
@@ -106,7 +106,7 @@
 		<map iso="B07" to="&lt;"/>
 		<map iso="B08" to="&gt;"/>
 		<map iso="B09" to=":"/>
-		<map iso="B10" to="&quot;"/>
+		<map iso="B10" to="\u{22}"/>
 	</keyMap>
 	<keyMap modifiers="caps">
                 <map iso="E00" to="`"/>


### PR DESCRIPTION
- use \u{22} instead of &quot; as with other files

CLDR-15557

- [ ] This PR completes the ticket.