### PR TITLE
CLDR-15900 BRS v42: update SLE/SLL legal tender

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5795,14 +5795,14 @@ annotations.
 				<displayName count="other">Slovak korunas</displayName>
 			</currency>
 			<currency type="SLE">
-				<displayName>Sierra Leonean New Leone</displayName>
-				<displayName count="one">Sierra Leonean new leone</displayName>
-				<displayName count="other">Sierra Leonean new leones</displayName>
-			</currency>
-			<currency type="SLL">
 				<displayName>Sierra Leonean Leone</displayName>
 				<displayName count="one">Sierra Leonean leone</displayName>
 				<displayName count="other">Sierra Leonean leones</displayName>
+			</currency>
+			<currency type="SLL">
+				<displayName>Sierra Leonean Leone (1964—2022)</displayName>
+				<displayName count="one">Sierra Leonean leone (1964—2022)</displayName>
+				<displayName count="other">Sierra Leonean leones (1964—2022)</displayName>
 			</currency>
 			<currency type="SOS">
 				<displayName>Somali Shilling</displayName>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -6711,12 +6711,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol>SHP</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
-			<currency type="SLL">
-				<displayName>Sierra Leonean Leone</displayName>
-				<displayName count="one">Sierra Leonean leone</displayName>
-				<displayName count="other">Sierra Leonean leones</displayName>
-				<symbol>SLL</symbol>
-			</currency>
 			<currency type="SOS">
 				<displayName>Somali Shilling</displayName>
 				<displayName count="one">Somali shilling</displayName>

--- a/common/main/en_SL.xml
+++ b/common/main/en_SL.xml
@@ -39,7 +39,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</dates>
 	<numbers>
 		<currencies>
-			<currency type="SLL">
+			<currency type="SLE">
 				<symbol>Le</symbol>
 			</currency>
 		</currencies>

--- a/common/main/ff_Adlm_SL.xml
+++ b/common/main/ff_Adlm_SL.xml
@@ -49,7 +49,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="GNF">
 				<symbol>GNF</symbol>
 			</currency>
-			<currency type="SLL">
+			<currency type="SLE">
 				<symbol>Le</symbol>
 			</currency>
 		</currencies>

--- a/common/main/ff_Latn_SL.xml
+++ b/common/main/ff_Latn_SL.xml
@@ -46,7 +46,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</dates>
 	<numbers>
 		<currencies>
-			<currency type="SLL">
+			<currency type="SLE">
 				<symbol>Le</symbol>
 			</currency>
 		</currencies>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -956,8 +956,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="CSK" from="1953-06-01" to="1992-12-31"/>
         </region>
         <region iso3166="SL">
-            <currency iso4217="SLE" from="2022-04-01" tender="false"/>
-            <currency iso4217="SLL" from="1964-08-04"/>
+            <currency iso4217="SLE" from="2022-07-01"/>
+            <currency iso4217="SLL" from="1964-08-04" to="2022-10-01"/>
             <currency iso4217="GBP" from="1808-11-30" to="1966-02-04"/>
         </region>
         <region iso3166="SM">


### PR DESCRIPTION
- SLE became legal tender 2022-07-01
- SLL will cease to be tender 2022-10-01

This PR:
- updates metadata
- moves SLL to SLE in symbol
- add (1964-2022) to SLL in en name

References:
- https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/news/sierra-leone.pdf
- https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl_currency_iso_amendment_172.pdf

CLDR-15900 followon to #1825 

- [X] This PR completes the ticket.

ALLOW_MULTI_COMMITS=true
ALLOW_MANY_COMMITS=true