### PR TITLE
CLDR-13449 ar short date formats, improve consistency

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -1480,8 +1480,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="hms">h:mm:ss a</dateFormatItem>
 						<dateFormatItem id="Hms">HH:mm:ss</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
-						<dateFormatItem id="Md">d/‏M</dateFormatItem>
-						<dateFormatItem id="MEd">E، d/‏M</dateFormatItem>
+						<dateFormatItem id="Md">d‏/M</dateFormatItem>
+						<dateFormatItem id="MEd">E، d‏/M</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E، d MMM</dateFormatItem>
@@ -1491,7 +1491,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyy">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM">M‏/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMd">d‏/M‏/y G</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">E، d/‏M/‏y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E، d‏/M‏/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">E، d MMM y G</dateFormatItem>
@@ -1587,12 +1587,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d-M – d-M</greatestDifference>
-							<greatestDifference id="M">d-M – d-M</greatestDifference>
+							<greatestDifference id="d">d‏/M – d‏/M</greatestDifference>
+							<greatestDifference id="M">d‏/M – d‏/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E، d/‏M –‏ E، d/‏M</greatestDifference>
-							<greatestDifference id="M">E، d/‏M – E، d/‏M</greatestDifference>
+							<greatestDifference id="d">E، d‏/M – E، d‏/M</greatestDifference>
+							<greatestDifference id="M">E، d‏/M – E، d‏/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -2057,8 +2057,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="hmv">h:mm a v</dateFormatItem>
 						<dateFormatItem id="Hmv">HH:mm v</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
-						<dateFormatItem id="Md">d/‏M</dateFormatItem>
-						<dateFormatItem id="MEd">E، d/‏M</dateFormatItem>
+						<dateFormatItem id="Md">d‏/M</dateFormatItem>
+						<dateFormatItem id="MEd">E، d‏/M</dateFormatItem>
 						<dateFormatItem id="MMdd">dd‏/MM</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
@@ -2075,7 +2075,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="y">y</dateFormatItem>
 						<dateFormatItem id="yM">M‏/y</dateFormatItem>
 						<dateFormatItem id="yMd">d‏/M‏/y</dateFormatItem>
-						<dateFormatItem id="yMEd">E، d/‏M/‏y</dateFormatItem>
+						<dateFormatItem id="yMEd">E، d‏/M‏/y</dateFormatItem>
 						<dateFormatItem id="yMM">MM‏/y</dateFormatItem>
 						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
 						<dateFormatItem id="yMMMd">d MMM y</dateFormatItem>
@@ -2181,12 +2181,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d-M – d-M</greatestDifference>
-							<greatestDifference id="M">M/d – M/d</greatestDifference>
+							<greatestDifference id="d">d‏/M – d‏/M</greatestDifference>
+							<greatestDifference id="M">d‏/M – d‏/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E، d/‏M –‏ E، d/‏M</greatestDifference>
-							<greatestDifference id="M">E، d/‏M – E، d/‏M</greatestDifference>
+							<greatestDifference id="d">E، d‏/M – E، d‏/M</greatestDifference>
+							<greatestDifference id="M">E، d‏/M – E، d‏/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -2491,8 +2491,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="hms">h:mm:ss a</dateFormatItem>
 						<dateFormatItem id="Hms">HH:mm:ss</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
-						<dateFormatItem id="Md">d/‏M</dateFormatItem>
-						<dateFormatItem id="MEd">E، d/‏M</dateFormatItem>
+						<dateFormatItem id="Md">d‏/M</dateFormatItem>
+						<dateFormatItem id="MEd">E، d‏/M</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E، d MMM</dateFormatItem>
@@ -2501,7 +2501,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyy">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM">M‏/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMd">d‏/M‏/y G</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">E، d/‏M/‏y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E، d‏/M‏/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">E، d MMM y G</dateFormatItem>


### PR DESCRIPTION
CLDR-13449

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Improve the consistency of short date formats in Arabic.
- One part of this was just making sure that in the combination of RLM and '/', the RLM consistently comes first (easier to compare formats). That fix was also related to https://unicode-org.atlassian.net/browse/CLDR-14076. Also removed unnecessary RLMs on the en-dash in a couple of intervalFormats.
- For Md intervalFormats, most greatestDifference values used d/M (with RLM), but:
    - 3 used d-M (one of these was mixed with d/M for the same skeleton).
    - 1 used M/d without RLM to try and get right layout (but with wrong field order).
    - Made them all consistently use d/M (with RLM before /).
