### PR TITLE
CLDR-15910 For word break MidLetter class, only include COLON for fi,sv

### DIFF
--- a/common/segments/fi.xml
+++ b/common/segments/fi.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!--
+Copyright © 1991-2015 Unicode, Inc.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+For terms of use, see http://www.unicode.org/copyright.html
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="fi"/>
+	</identity>
+	<segmentations>
+		<segmentation type="WordBreak">
+			<variables>
+				<variable id="$MidLetter">\p{Word_Break=MidLetter}</variable>
+			</variables>
+		</segmentation>
+	</segmentations>
+</ldml>

--- a/common/segments/root.xml
+++ b/common/segments/root.xml
@@ -349,7 +349,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<variable id="$Format">\p{Word_Break=Format}</variable>
 				<variable id="$Katakana">\p{Word_Break=Katakana}</variable>
 				<variable id="$ALetter">\p{Word_Break=ALetter}</variable>
-				<variable id="$MidLetter">\p{Word_Break=MidLetter}</variable>
+				<variable id="$MidLetter">[[\p{Word_Break=MidLetter}] - [\u003A \uFE55 \uFF1A]]</variable>
 				<variable id="$MidNum">\p{Word_Break=MidNum}</variable>
 				<variable id="$MidNumLet">\p{Word_Break=MidNumLet}</variable>
 				<variable id="$Numeric">\p{Word_Break=Numeric}</variable>

--- a/common/segments/sv.xml
+++ b/common/segments/sv.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!--
+Copyright © 1991-2015 Unicode, Inc.
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+For terms of use, see http://www.unicode.org/copyright.html
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="sv"/>
+	</identity>
+	<segmentations>
+		<segmentation type="WordBreak">
+			<variables>
+				<variable id="$MidLetter">\p{Word_Break=MidLetter}</variable>
+			</variables>
+		</segmentation>
+	</segmentations>
+</ldml>


### PR DESCRIPTION
CLDR-15910

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

For word break in CLDR, remove colons from MidLetter class for root version, but add tailorings for fi,sv that include colons for MidLetter. Colons include:
```
003A # Po COLON
FE55 # Po SMALL COLON
FF1A # Po FULLWIDTH COLON
```