### PR TITLE
CLDR-15903 further coverage chart refinements

### DIFF
--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -37,7 +37,7 @@ es ;	modern
 et ;	modern
 eu ;	modern
 fa ;	modern
-ff_Adlm ;	moderate
+ff_Adlm ;	basic
 fi ;	modern
 fil ;	modern
 fo ;	basic
@@ -116,7 +116,7 @@ ta ;	modern
 te ;	modern
 tg ;	basic
 th ;	modern
-tk ;	basic
+tk ;	modern
 to ;	basic
 tr ;	modern
 tt ;	basic

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -814,9 +814,9 @@ public class ShowLocaleCoverage {
                         pathHeaderFactory, foundCounter, unconfirmedCounter,
                         missingCounter, missingPaths, unconfirmed);
                     {
-                        int found = 0;
-                        int unconfirmedc = 0;
-                        int missing = 0;
+                        long found = 0;
+                        long unconfirmedc = 0;
+                        long missing = 0;
                         Level adjustedGoal = cldrLocaleLevelGoal.compareTo(Level.BASIC) < 0 ? Level.BASIC : cldrLocaleLevelGoal;
                         for (Level level : Level.values()) {
                             if (level.compareTo(adjustedGoal) <= 0) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -127,6 +127,7 @@ public class ShowLocaleCoverage {
 ;
 
     private static final String TSV_MISSING_BASIC_HEADER = "#Locale\tMissing\tProvisional\tPath*";
+    private static final String TSV_MISSING_COUNTS_HEADER = "#Locale\tTargetLevel\t№ Found\t№ Unconfirmed\t№ Missing";
 
     private static final boolean DEBUG = true;
     private static final char DEBUG_FILTER = 0; // use letter to only load locales starting with that letter
@@ -588,11 +589,14 @@ public class ShowLocaleCoverage {
             PrintWriter tsv_missing = FileUtilities.openUTF8Writer(CLDRPaths.CHART_DIRECTORY + "tsv/", "locale-missing.tsv");
             PrintWriter tsv_missing_summary = FileUtilities.openUTF8Writer(CLDRPaths.CHART_DIRECTORY + "tsv/", "locale-missing-summary.tsv");
             PrintWriter tsv_missing_basic = FileUtilities.openUTF8Writer(CLDRPaths.CHART_DIRECTORY + "tsv/", "locale-missing-basic.tsv");
+            PrintWriter tsv_missing_counts = FileUtilities.openUTF8Writer(CLDRPaths.CHART_DIRECTORY + "tsv/", "locale-missing-counts.tsv");
             PrintWriter propertiesCoverage = FileUtilities.openUTF8Writer(CLDRPaths.COMMON_DIRECTORY + "properties/", "coverageLevels.txt");
             ){
             tsv_missing_summary.println(TSV_MISSING_SUMMARY_HEADER);
             tsv_missing.println(TSV_MISSING_HEADER);
             tsv_missing_basic.println(TSV_MISSING_BASIC_HEADER);
+            tsv_missing_counts.println(TSV_MISSING_COUNTS_HEADER);
+
             propertiesCoverage.println(PROPERTIES_HEADER);
 
             Set<String> checkModernLocales = STANDARD_CODES.getLocaleCoverageLocales(Organization.cldr, EnumSet.of(Level.MODERN));
@@ -631,7 +635,8 @@ public class ShowLocaleCoverage {
                 + "<tr><th>Default Region</th><td>The default region for locale code, based on likely subtags</td></tr>\n"
                 + "<tr><th>№ Locales</th><td>Note that the coverage of regional locales inherits from their parents.</td></tr>\n"
                 + "<tr><th>Target Level</th><td>The default target Coverage Level in CLDR. "
-                + "Particular organizations may have different target levels.</td></tr>\n"
+                + "Particular organizations may have different target levels. "
+                + "Languages with high levels of coverage are marked with ‡, even though they are not tracked by the technical committee.</td></tr>\n"
                 + "<tr><th>≟</th><td>Indicates whether the Computed Level equals the CLDR Target or not.</td></tr>\n"
                 + "<tr><th>Computed Level</th><td>Computed from the percentage values, "
                 + "taking the first level that meets a threshold (currently 🄼 "
@@ -654,11 +659,13 @@ public class ShowLocaleCoverage {
                 + "They are listed if missing at the computed level.<br>"
                 + "Example: <i>ⓜ collation</i> means this feature should be supported at a Moderate level.<br>"
                 + "<i>Except for Core, these are not accounted for in the percent values.</i></td></tr>\n"
-                + "<tr><th><a href='https://github.com/unicode-org/cldr-staging/tree/main/docs/charts/41/tsv'>TSV Files</a>:</th><td>\n"
+                + "<tr><th><a href='https://github.com/unicode-org/cldr-staging/tree/main/docs/charts/42/tsv'>TSV Files</a>:</th><td>\n"
                 + "<ul><li>locale-coverage.tsv — A version of this file, suitable for loading into a spreadsheet.</li>\n"
                 + "<li>locale-missing.tsv — Missing items for the CLDR target locales.</li>\n"
                 + "<li>locale-missing-summary.tsv — Summary of missing items for the CLDR target locales, by Section/Page/Header.</li>\n"
                 + "<li>locale-missing-basic.tsv — Missing items that keep locales from reaching the Basic level.</li></td></tr>\n"
+                + "<li>locale-missing-count.tsv — Counts of items per locale that are found, unconfirmed, or missing, at the target level. "
+                + "(Or at *basic, if there is no target level.)</li></td></tr>\n"
                 + "</table>\n"
                 );
 
@@ -774,6 +781,7 @@ public class ShowLocaleCoverage {
                     tsv_missing_summary.flush();
                     tsv_missing.flush();
                     tsv_missing_basic.flush();
+                    tsv_missing_counts.flush();
 
                     boolean isSeed = new File(CLDRPaths.SEED_DIRECTORY, locale + ".xml").exists();
 
@@ -805,6 +813,21 @@ public class ShowLocaleCoverage {
                     VettingViewer.getStatus(pathSource, file,
                         pathHeaderFactory, foundCounter, unconfirmedCounter,
                         missingCounter, missingPaths, unconfirmed);
+                    {
+                        int found = 0;
+                        int unconfirmedc = 0;
+                        int missing = 0;
+                        Level adjustedGoal = cldrLocaleLevelGoal.compareTo(Level.BASIC) < 0 ? Level.BASIC : cldrLocaleLevelGoal;
+                        for (Level level : Level.values()) {
+                            if (level.compareTo(adjustedGoal) <= 0) {
+                                found += foundCounter.get(level);
+                                unconfirmedc += unconfirmedCounter.get(level);
+                                missing += missingCounter.get(level);
+                            }
+                        }
+                        String goalFlag = cldrLocaleLevelGoal == adjustedGoal ? "" : "*";
+                        tsv_missing_counts.println(specialFlag + locale + "\t" + goalFlag + adjustedGoal + "\t" + found + "\t" + unconfirmedc + "\t" + missing);
+                    }
 
                     Collection<String> sublocales = languageToRegion.asMap().get(language);
                     if (sublocales == null) {
@@ -879,12 +902,12 @@ public class ShowLocaleCoverage {
                         for (Entry<String, StatusData> starred : starredCounter.starredPathToData.entrySet()) {
                             String starredPath = starred.getKey();
                             StatusData statusData = starred.getValue();
-                            tsv_missing_basic.println(locale + specialFlag //
+                            tsv_missing_basic.println(specialFlag + locale //
                                 + "\t" + statusData.missing //
                                 + "\t" + statusData.provisional //
                                 + "\t" + starredPath.replace("\"*\"", "'*'"));
                         }
-                        tsv_missing_basic.println(locale + specialFlag //
+                        tsv_missing_basic.println(specialFlag + locale  //
                             + "\t" + starredCounter.missingTotal //
                             + "\t" + starredCounter.provisionalTotal //
                             + "\tTotals");
@@ -975,13 +998,13 @@ public class ShowLocaleCoverage {
 
                     tablePrinter.addRow()
                     .addCell(seedString)
-                    .addCell(language + specialFlag)
+                    .addCell(language)
                     .addCell(ENGLISH.getName(language))
                     .addCell(file.getName(language))
                     .addCell(script)
                     .addCell(defRegion)
                     .addCell(sublocales.size())
-                    .addCell(cldrLocaleLevelGoal == Level.UNDETERMINED ? "" : cldrLocaleLevelGoal.toString())
+                    .addCell(cldrLocaleLevelGoal == Level.UNDETERMINED ? "" : specialFlag + cldrLocaleLevelGoal.toString())
                     .addCell(computed == cldrLocaleLevelGoal ? " ≡" : " ≠")
                     .addCell(visibleComputed)
                     .addCell(getIcuValue(language))
@@ -1280,7 +1303,7 @@ public class ShowLocaleCoverage {
         }
 
         String line =
-            language + specialFlag
+            specialFlag + language
             + "\t" + ENGLISH.getName(language)
             + "\t" + ENGLISH.getName("script", script)
             + "\t" + cldrLocaleLevelGoal

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1469,12 +1469,15 @@ public class VettingViewer<T> {
             }
 
             Level level = coverageLevel2.getLevel(path);
+            if (level.compareTo(Level.MODERN) > 0) {
+                continue;
+            }
             MissingStatus missingStatus = VettingViewer.getMissingStatus(file, path, latin);
 
             switch (missingStatus) {
             case ABSENT:
                 missingCounter.add(level, 1);
-                if (missingPaths != null && level.compareTo(Level.MODERN) <= 0) {
+                if (missingPaths != null) {
                     missingPaths.put(missingStatus, path);
                 }
                 break;
@@ -1484,7 +1487,7 @@ public class VettingViewer<T> {
                 if (fullPath.contains("unconfirmed")
                     || fullPath.contains("provisional")) {
                     unconfirmedCounter.add(level, 1);
-                    if (unconfirmedPaths != null && level.compareTo(Level.MODERN) <= 0) {
+                    if (unconfirmedPaths != null) {
                         unconfirmedPaths.add(path);
                     }
                 } else {


### PR DESCRIPTION
Further coverage chart refinements to extract exact counts of items for each locale. Also adds a bit of documentation to the .html chart.

CLDR-15903

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
