### PR TITLE
CLDR-15912 un-parallelize GenerateProductionData to avoid crashes

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -138,8 +138,9 @@ public class GenerateProductionData {
 
         // get directories
 
-        Arrays.asList(DtdType.values()).parallelStream()
-            .unordered()
+        Arrays.asList(DtdType.values())
+            //.parallelStream()
+            //.unordered()
             .forEach(type -> {
             boolean isLdmlDtdType = type == DtdType.ldml;
 
@@ -227,7 +228,7 @@ public class GenerateProductionData {
             final Factory theFactory = factory;
             final boolean isLdmlDtdType2 = isLdmlDtdType;
             sorted
-                .parallelStream()
+                //.parallelStream()
                 .forEach(file -> {
                     File sourceFile2 = new File(sourceFile, file);
                     File destinationFile2 = new File(destinationFile, file);


### PR DESCRIPTION
CLDR-15912

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

When running the CLDR-ICU integration, I periodically encounter hard-to-diagnose crashes in GenerateProductionData (usually NPE) that sometimes go away if I re-run it or if there is a slight data change, and go away if I temporarily de-parallelize GenerateProductionData. So I am just going to commit the de-parallelized version, the 2 or so minutes of speedup from the parallel version are not worth the occasional crashes. At some point we can investigate these crashes.