### PR TITLE
CLDR-15739 allow vote for empty list of locales

### DIFF
--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -11561,7 +11561,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und en</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">hu ja ko vi yue zh el</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">el hu ja ko vi yue zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -18911,7 +18911,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und eu</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zh ja ko</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ja ko zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve"> </foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -13591,7 +13591,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und fr</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -13387,7 +13387,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="zero">אפס עם קו חוצה</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrderLocales order="givenFirst">he und</nameOrderLocales>
+		<nameOrderLocales order="givenFirst">und he</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -10259,7 +10259,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und hy</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">{0}․</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -7796,7 +7796,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und ig</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -9300,7 +9300,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<featureName type="zero">чийилген нөл</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrderLocales order="givenFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="givenFirst"/>
 		<nameOrderLocales order="surnameFirst">und ky</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -10742,7 +10742,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und mk</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -11627,7 +11627,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">↑↑↑</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">hu ja ko vi yue zh mn</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">hu ja ko mn vi yue zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -10046,39 +10046,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Acre-standaardtijd</standard>
 					<daylight draft="contributed">Acre-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Afghanistan">
 				<long>
-
 					<standard>Afghaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Africa_Central">
 				<long>
-
 					<standard>Centraal-Afrikaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Africa_Eastern">
 				<long>
-
 					<standard>Oost-Afrikaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Africa_Southern">
 				<long>
-
 					<standard>Zuid-Afrikaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Africa_Western">
 				<long>
@@ -10086,7 +10073,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>West-Afrikaanse standaardtijd</standard>
 					<daylight>West-Afrikaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Alaska">
 				<long>
@@ -10106,7 +10092,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Alma-Ata-standaardtijd</standard>
 					<daylight draft="contributed">Alma-Ata-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Amazon">
 				<long>
@@ -10114,7 +10099,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Amazone-standaardtijd</standard>
 					<daylight>Amazone-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="America_Central">
 				<long>
@@ -10170,7 +10154,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Anadyr-standaardtijd</standard>
 					<daylight draft="contributed">Anadyr-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Apia">
 				<long>
@@ -10178,7 +10161,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Apia-standaardtijd</standard>
 					<daylight>Apia-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Aqtau">
 				<long>
@@ -10186,7 +10168,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Aqtau-standaardtijd</standard>
 					<daylight draft="contributed">Aqtau-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Aqtobe">
 				<long>
@@ -10194,7 +10175,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Aqtöbe-standaardtijd</standard>
 					<daylight draft="contributed">Aqtöbe-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Arabian">
 				<long>
@@ -10202,7 +10182,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Arabische standaardtijd</standard>
 					<daylight>Arabische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Argentina">
 				<long>
@@ -10210,7 +10189,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Argentijnse standaardtijd</standard>
 					<daylight>Argentijnse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Argentina_Western">
 				<long>
@@ -10218,7 +10196,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>West-Argentijnse standaardtijd</standard>
 					<daylight>West-Argentijnse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Armenia">
 				<long>
@@ -10226,7 +10203,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Armeense standaardtijd</standard>
 					<daylight>Armeense zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Atlantic">
 				<long>
@@ -10246,7 +10222,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Midden-Australische standaardtijd</standard>
 					<daylight>Midden-Australische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Australia_CentralWestern">
 				<long>
@@ -10254,7 +10229,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Midden-Australische westelijke standaardtijd</standard>
 					<daylight>Midden-Australische westelijke zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Australia_Eastern">
 				<long>
@@ -10262,7 +10236,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Oost-Australische standaardtijd</standard>
 					<daylight>Oost-Australische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Australia_Western">
 				<long>
@@ -10270,7 +10243,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>West-Australische standaardtijd</standard>
 					<daylight>West-Australische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Azerbaijan">
 				<long>
@@ -10278,7 +10250,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Azerbeidzjaanse standaardtijd</standard>
 					<daylight>Azerbeidzjaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Azores">
 				<long>
@@ -10286,7 +10257,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Azoren-standaardtijd</standard>
 					<daylight>Azoren-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Bangladesh">
 				<long>
@@ -10294,23 +10264,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Bengalese standaardtijd</standard>
 					<daylight>Bengalese zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Bhutan">
 				<long>
-
 					<standard>Bhutaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Bolivia">
 				<long>
-
 					<standard>Boliviaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Brasilia">
 				<long>
@@ -10318,15 +10281,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Braziliaanse standaardtijd</standard>
 					<daylight>Braziliaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Brunei">
 				<long>
-
 					<standard>Bruneise tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Cape_Verde">
 				<long>
@@ -10334,23 +10293,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Kaapverdische standaardtijd</standard>
 					<daylight>Kaapverdische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Casey">
 				<long>
-
 					<standard draft="contributed">Casey tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Chamorro">
 				<long>
-
 					<standard>Chamorro-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Chatham">
 				<long>
@@ -10358,7 +10310,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Chatham-standaardtijd</standard>
 					<daylight>Chatham-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Chile">
 				<long>
@@ -10366,7 +10317,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Chileense standaardtijd</standard>
 					<daylight>Chileense zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="China">
 				<long>
@@ -10374,7 +10324,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Chinese standaardtijd</standard>
 					<daylight>Chinese zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Choibalsan">
 				<long>
@@ -10382,23 +10331,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Tsjojbalsan-standaardtijd</standard>
 					<daylight>Tsjojbalsan-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Christmas">
 				<long>
-
 					<standard>Christmaseilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Cocos">
 				<long>
-
 					<standard>Cocoseilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Colombia">
 				<long>
@@ -10406,7 +10348,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Colombiaanse standaardtijd</standard>
 					<daylight>Colombiaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Cook">
 				<long>
@@ -10414,7 +10355,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Cookeilandse standaardtijd</standard>
 					<daylight>Cookeilandse halve zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Cuba">
 				<long>
@@ -10422,31 +10362,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Cubaanse standaardtijd</standard>
 					<daylight>Cubaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Davis">
 				<long>
-
 					<standard>Davis-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="DumontDUrville">
 				<long>
-
 					<standard>Dumont-d’Urville-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="East_Timor">
 				<long>
-
 					<standard>Oost-Timorese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Easter">
 				<long>
@@ -10454,15 +10384,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Paaseilandse standaardtijd</standard>
 					<daylight>Paaseilandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Ecuador">
 				<long>
-
 					<standard>Ecuadoraanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Europe_Central">
 				<long>
@@ -10490,11 +10416,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Europe_Further_Eastern">
 				<long>
-
 					<standard>Verder-oostelijk-Europese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Europe_Western">
 				<long>
@@ -10514,7 +10437,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Falklandeilandse standaardtijd</standard>
 					<daylight>Falklandeilandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Fiji">
 				<long>
@@ -10522,39 +10444,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Fijische standaardtijd</standard>
 					<daylight>Fijische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="French_Guiana">
 				<long>
-
 					<standard>Frans-Guyaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="French_Southern">
 				<long>
-
 					<standard>Franse zuidelijke en Antarctische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Galapagos">
 				<long>
-
 					<standard>Galapagoseilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Gambier">
 				<long>
-
 					<standard>Gambiereilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Georgia">
 				<long>
@@ -10562,26 +10471,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Georgische standaardtijd</standard>
 					<daylight>Georgische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Gilbert_Islands">
 				<long>
-
 					<standard>Gilberteilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="GMT">
 				<long>
-
 					<standard>Greenwich Mean Time</standard>
-
 				</long>
 				<short>
-
 					<standard draft="contributed">GMT</standard>
-
 				</short>
 			</metazone>
 			<metazone type="Greenland_Eastern">
@@ -10590,7 +10491,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Oost-Groenlandse standaardtijd</standard>
 					<daylight>Oost-Groenlandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Greenland_Western">
 				<long>
@@ -10598,31 +10498,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>West-Groenlandse standaardtijd</standard>
 					<daylight>West-Groenlandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Guam">
 				<long>
-
 					<standard draft="contributed">Guamese standaardtijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Gulf">
 				<long>
-
 					<standard>Golf-standaardtijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Guyana">
 				<long>
-
 					<standard>Guyaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
@@ -10642,7 +10532,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Hongkongse standaardtijd</standard>
 					<daylight>Hongkongse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Hovd">
 				<long>
@@ -10650,55 +10539,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Hovd-standaardtijd</standard>
 					<daylight>Hovd-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="India">
 				<long>
-
 					<standard>Indiase tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Indian_Ocean">
 				<long>
-
 					<standard>Indische Oceaan-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Indochina">
 				<long>
-
 					<standard>Indochinese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Indonesia_Central">
 				<long>
-
 					<standard>Centraal-Indonesische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Indonesia_Eastern">
 				<long>
-
 					<standard>Oost-Indonesische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Indonesia_Western">
 				<long>
-
 					<standard>West-Indonesische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Iran">
 				<long>
@@ -10706,7 +10576,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Iraanse standaardtijd</standard>
 					<daylight>Iraanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Irkutsk">
 				<long>
@@ -10714,7 +10583,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Irkoetsk-standaardtijd</standard>
 					<daylight>Irkoetsk-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Israel">
 				<long>
@@ -10722,7 +10590,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Israëlische standaardtijd</standard>
 					<daylight>Israëlische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Japan">
 				<long>
@@ -10730,7 +10597,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Japanse standaardtijd</standard>
 					<daylight>Japanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Kamchatka">
 				<long>
@@ -10738,23 +10604,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Petropavlovsk-Kamtsjatski-standaardtijd</standard>
 					<daylight draft="contributed">Petropavlovsk-Kamtsjatski-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Kazakhstan_Eastern">
 				<long>
-
 					<standard>Oost-Kazachse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Kazakhstan_Western">
 				<long>
-
 					<standard>West-Kazachse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Korea">
 				<long>
@@ -10762,15 +10621,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Koreaanse standaardtijd</standard>
 					<daylight>Koreaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Kosrae">
 				<long>
-
 					<standard>Kosraese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Krasnoyarsk">
 				<long>
@@ -10778,31 +10633,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Krasnojarsk-standaardtijd</standard>
 					<daylight>Krasnojarsk-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Kyrgystan">
 				<long>
-
 					<standard>Kirgizische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Lanka">
 				<long>
-
 					<standard draft="contributed">Lanka-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Line_Islands">
 				<long>
-
 					<standard>Line-eilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Lord_Howe">
 				<long>
@@ -10810,7 +10655,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Lord Howe-eilandse standaardtijd</standard>
 					<daylight>Lord Howe-eilandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Macau">
 				<long>
@@ -10818,15 +10662,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Macause standaardtijd</standard>
 					<daylight draft="contributed">Macause zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Macquarie">
 				<long>
-
 					<standard>Macquarie-eilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Magadan">
 				<long>
@@ -10834,39 +10674,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Magadan-standaardtijd</standard>
 					<daylight>Magadan-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Malaysia">
 				<long>
-
 					<standard>Maleisische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Maldives">
 				<long>
-
 					<standard>Maldivische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Marquesas">
 				<long>
-
 					<standard>Marquesaseilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Marshall_Islands">
 				<long>
-
 					<standard>Marshalleilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Mauritius">
 				<long>
@@ -10874,15 +10701,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Mauritiaanse standaardtijd</standard>
 					<daylight>Mauritiaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Mawson">
 				<long>
-
 					<standard>Mawson-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Mexico_Northwest">
 				<long>
@@ -10890,7 +10713,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Noordwest-Mexicaanse standaardtijd</standard>
 					<daylight>Noordwest-Mexicaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Mexico_Pacific">
 				<long>
@@ -10898,7 +10720,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Mexicaanse Pacific-standaardtijd</standard>
 					<daylight>Mexicaanse Pacific-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Mongolia">
 				<long>
@@ -10906,7 +10727,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Ulaanbaatar-standaardtijd</standard>
 					<daylight>Ulaanbaatar-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Moscow">
 				<long>
@@ -10914,31 +10734,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Moskou-standaardtijd</standard>
 					<daylight>Moskou-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Myanmar">
 				<long>
-
 					<standard>Myanmarese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Nauru">
 				<long>
-
 					<standard>Nauruaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Nepal">
 				<long>
-
 					<standard>Nepalese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="New_Caledonia">
 				<long>
@@ -10946,7 +10756,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Nieuw-Caledonische standaardtijd</standard>
 					<daylight>Nieuw-Caledonische zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="New_Zealand">
 				<long>
@@ -10954,7 +10763,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Nieuw-Zeelandse standaardtijd</standard>
 					<daylight>Nieuw-Zeelandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Newfoundland">
 				<long>
@@ -10962,15 +10770,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Newfoundland-standaardtijd</standard>
 					<daylight>Newfoundland-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Niue">
 				<long>
-
 					<standard>Niuese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Norfolk">
 				<long>
@@ -10978,7 +10782,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Norfolkeilandse standaardtijd</standard>
 					<daylight>Norfolkeilandse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Noronha">
 				<long>
@@ -10986,15 +10789,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Fernando de Noronha-standaardtijd</standard>
 					<daylight>Fernando de Noronha-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="North_Mariana">
 				<long>
-
 					<standard draft="contributed">Noordelijk Mariaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Novosibirsk">
 				<long>
@@ -11002,7 +10801,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Novosibirsk-standaardtijd</standard>
 					<daylight>Novosibirsk-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Omsk">
 				<long>
@@ -11010,7 +10808,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Omsk-standaardtijd</standard>
 					<daylight>Omsk-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Pakistan">
 				<long>
@@ -11018,23 +10815,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Pakistaanse standaardtijd</standard>
 					<daylight>Pakistaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Palau">
 				<long>
-
 					<standard>Belause tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Papua_New_Guinea">
 				<long>
-
 					<standard>Papoea-Nieuw-Guineese tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Paraguay">
 				<long>
@@ -11042,7 +10832,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Paraguayaanse standaardtijd</standard>
 					<daylight>Paraguayaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Peru">
 				<long>
@@ -11050,7 +10839,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Peruaanse standaardtijd</standard>
 					<daylight>Peruaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Philippines">
 				<long>
@@ -11058,15 +10846,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Filipijnse standaardtijd</standard>
 					<daylight>Filipijnse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Phoenix_Islands">
 				<long>
-
 					<standard>Phoenixeilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Pierre_Miquelon">
 				<long>
@@ -11074,31 +10858,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Saint Pierre en Miquelon-standaardtijd</standard>
 					<daylight>Saint Pierre en Miquelon-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Pitcairn">
 				<long>
-
 					<standard>Pitcairneilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Ponape">
 				<long>
-
 					<standard>Pohnpei-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Pyongyang">
 				<long>
-
 					<standard>Pyongyang-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Qyzylorda">
 				<long>
@@ -11106,23 +10880,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Qyzylorda-standaardtijd</standard>
 					<daylight draft="contributed">Qyzylorda-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Reunion">
 				<long>
-
 					<standard>Réunionse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Rothera">
 				<long>
-
 					<standard>Rothera-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Sakhalin">
 				<long>
@@ -11130,7 +10897,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Sachalin-standaardtijd</standard>
 					<daylight>Sachalin-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Samara">
 				<long>
@@ -11138,7 +10904,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="contributed">Samara-standaardtijd</standard>
 					<daylight draft="contributed">Samara-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Samoa">
 				<long>
@@ -11146,63 +10911,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Samoaanse standaardtijd</standard>
 					<daylight>Samoaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Seychelles">
 				<long>
-
 					<standard>Seychelse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Singapore">
 				<long>
-
 					<standard>Singaporese standaardtijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Solomon">
 				<long>
-
 					<standard>Salomonseilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="South_Georgia">
 				<long>
-
 					<standard>Zuid-Georgische tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Suriname">
 				<long>
-
 					<standard>Surinaamse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Syowa">
 				<long>
-
 					<standard>Syowa-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Tahiti">
 				<long>
-
 					<standard>Tahitiaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Taipei">
 				<long>
@@ -11210,23 +10953,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Taipei-standaardtijd</standard>
 					<daylight>Taipei-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Tajikistan">
 				<long>
-
 					<standard>Tadzjiekse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Tokelau">
 				<long>
-
 					<standard>Tokelau-eilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Tonga">
 				<long>
@@ -11234,15 +10970,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Tongaanse standaardtijd</standard>
 					<daylight>Tongaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Truk">
 				<long>
-
 					<standard>Chuukse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Turkmenistan">
 				<long>
@@ -11250,15 +10982,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Turkmeense standaardtijd</standard>
 					<daylight>Turkmeense zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Tuvalu">
 				<long>
-
 					<standard>Tuvaluaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Uruguay">
 				<long>
@@ -11266,7 +10994,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Uruguayaanse standaardtijd</standard>
 					<daylight>Uruguayaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Uzbekistan">
 				<long>
@@ -11274,7 +11001,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Oezbeekse standaardtijd</standard>
 					<daylight>Oezbeekse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Vanuatu">
 				<long>
@@ -11282,15 +11008,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Vanuatuaanse standaardtijd</standard>
 					<daylight>Vanuatuaanse zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Venezuela">
 				<long>
-
 					<standard>Venezolaanse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Vladivostok">
 				<long>
@@ -11298,7 +11020,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Vladivostok-standaardtijd</standard>
 					<daylight>Vladivostok-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Volgograd">
 				<long>
@@ -11306,31 +11027,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Wolgograd-standaardtijd</standard>
 					<daylight>Wolgograd-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Vostok">
 				<long>
-
 					<standard>Vostok-tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Wake">
 				<long>
-
 					<standard>Wake-eilandse tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Wallis">
 				<long>
-
 					<standard>Wallis en Futunase tijd</standard>
-
 				</long>
-				
 			</metazone>
 			<metazone type="Yakutsk">
 				<long>
@@ -11338,7 +11049,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Jakoetsk-standaardtijd</standard>
 					<daylight>Jakoetsk-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Yekaterinburg">
 				<long>
@@ -11346,7 +11056,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Jekaterinenburg-standaardtijd</standard>
 					<daylight>Jekaterinenburg-zomertijd</daylight>
 				</long>
-				
 			</metazone>
 			<metazone type="Yukon">
 				<long>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -10822,7 +10822,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und pa</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">hi gu mr</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">gu hi mr</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -7631,7 +7631,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<featureName type="zero">↑↑↑</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrderLocales order="givenFirst">qu und</nameOrderLocales>
+		<nameOrderLocales order="givenFirst">und qu</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -16266,7 +16266,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und so</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve"> </foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -11105,7 +11105,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und ta</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">ja ko zh vi</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ja ko vi zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve"> </foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -9401,7 +9401,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst" draft="contributed">und tk</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst" draft="contributed">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst" draft="contributed"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -10866,7 +10866,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und to</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -11257,7 +11257,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und tr</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zh ko</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ko zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -7704,7 +7704,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und yo</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -7705,7 +7705,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und yo</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
 		<initialPattern type="initialSequence">{0} {1}</initialPattern>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -10014,7 +10014,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und zu</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">zxx</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst"/>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -454,7 +454,8 @@ public class TestPaths extends TestFmwkPlus {
                                     logKnownIssue("cldrbug:9784", "fix TODO's in Attribute validity tests");
                                 }
                             }
-                            if ((elementType == ElementType.PCDATA) == (value.isEmpty())) {
+                            if ((elementType == ElementType.PCDATA) == (value.isEmpty())
+                                && !finalElement.name.equals("nameOrderLocales")) {
                                 errln("PCDATA ≠ emptyValue inconsistency:"
                                     + "\tfile=" + fileName + "/" + file
                                     + "\telementType=" + elementType


### PR DESCRIPTION
CLDR-15739

Modifies DAIP so that it normalizes the locale lists, then runs it.
1. Any zxx is removed
2. Any 'und' is sorted at the front.

Note that Dutch is pulled in because the file was not yet normalized with DAIP

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
4. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
