### PR TITLE
CLDR-13717 cs list patterns, use NBSP for second space in {0} a {1}

### DIFF
--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -19567,8 +19567,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern>
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">{0} a {1}</listPatternPart>
-			<listPatternPart type="2">{0} a {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -19597,14 +19597,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">{0} a {1}</listPatternPart>
-			<listPatternPart type="2">{0} a {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">{0} a {1}</listPatternPart>
-			<listPatternPart type="2">{0} a {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
@@ -19615,7 +19615,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="unit-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>


### PR DESCRIPTION
CLDR-13717

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

In cs list patterns, use NBSP for second space in {0} a {1} to prevent lines that end with a 1-letter word (not permitted in cs).