### PR TITLE
CLDR-15921 v42 BRS LikelySubtags

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -80,6 +80,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Ahom; ?; ? } => { Ahom; Ahom; India }-->
 		<likelySubtag from="ajg" to="ajg_Latn_ZZ"/>
 		<!--{ Aja (Benin); ?; ? } => { Aja (Benin); Latin; Unknown Region }-->
+		<likelySubtag from="ajt" to="ajt_Arab_TN"/>
+		<!--{ Judeo-Tunisian Arabic; ?; ? } => { Judeo-Tunisian Arabic; Arabic; Tunisia }-->
 		<likelySubtag from="ak" to="ak_Latn_GH"/>
 		<!--{ Akan; ?; ? } => { Akan; Latin; Ghana }-->
 		<likelySubtag from="akk" to="akk_Xsux_IQ"/>
@@ -341,7 +343,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="bkv" to="bkv_Latn_ZZ"/>
 		<!--{ Bekwarra; ?; ? } => { Bekwarra; Latin; Unknown Region }-->
 		<likelySubtag from="bla" to="bla_Latn_CA"/>
-		<!--{ Siksika; ?; ? } => { Siksika; Latin; Canada }-->
+		<!--{ Siksiká; ?; ? } => { Siksiká; Latin; Canada }-->
 		<likelySubtag from="blg" to="blg_Latn_MY"/>
 		<!--{ Balau; ?; ? } => { Balau; Latin; Malaysia }-->
 		<likelySubtag from="blt" to="blt_Tavt_VN"/>
@@ -1411,7 +1413,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="lag" to="lag_Latn_TZ"/>
 		<!--{ Langi; ?; ? } => { Langi; Latin; Tanzania }-->
 		<likelySubtag from="lah" to="lah_Arab_PK"/>
-		<!--{ Lahnda; ?; ? } => { Lahnda; Arabic; Pakistan }-->
+		<!--{ Western Panjabi; ?; ? } => { Western Panjabi; Arabic; Pakistan }-->
 		<likelySubtag from="laj" to="laj_Latn_UG"/>
 		<!--{ Lango (Uganda); ?; ? } => { Lango (Uganda); Latin; Uganda }-->
 		<likelySubtag from="las" to="las_Latn_ZZ"/>
@@ -2037,7 +2039,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="ppo" to="ppo_Latn_ZZ"/>
 		<!--{ Folopa; ?; ? } => { Folopa; Latin; Unknown Region }-->
 		<likelySubtag from="pqm" to="pqm_Latn_CA"/>
-		<!--{ Malecite; ?; ? } => { Malecite; Latin; Canada }-->
+		<!--{ Maliseet-Passamaquoddy; ?; ? } => { Maliseet-Passamaquoddy; Latin; Canada }-->
 		<likelySubtag from="pra" to="pra_Khar_PK"/>
 		<!--{ Prakrit languages; ?; ? } => { Prakrit languages; Kharoshthi; Pakistan }-->
 		<likelySubtag from="prd" to="prd_Arab_IR"/>
@@ -2240,6 +2242,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Samoan; ?; ? } => { Samoan; Latin; Samoa }-->
 		<likelySubtag from="sma" to="sma_Latn_SE"/>
 		<!--{ Southern Sami; ?; ? } => { Southern Sami; Latin; Sweden }-->
+		<likelySubtag from="smd" to="smd_Latn_AO"/>
+		<!--{ Sama; ?; ? } => { Sama; Latin; Angola }-->
 		<likelySubtag from="smj" to="smj_Latn_SE"/>
 		<!--{ Lule Sami; ?; ? } => { Lule Sami; Latin; Sweden }-->
 		<likelySubtag from="smn" to="smn_Latn_FI"/>
@@ -2252,6 +2256,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Skolt Sami; ?; ? } => { Skolt Sami; Latin; Finland }-->
 		<likelySubtag from="sn" to="sn_Latn_ZW"/>
 		<!--{ Shona; ?; ? } => { Shona; Latin; Zimbabwe }-->
+		<likelySubtag from="snb" to="snb_Latn_MY"/>
+		<!--{ Sebuyau; ?; ? } => { Sebuyau; Latin; Malaysia }-->
 		<likelySubtag from="snc" to="snc_Latn_ZZ"/>
 		<!--{ Sinaugoro; ?; ? } => { Sinaugoro; Latin; Unknown Region }-->
 		<likelySubtag from="snk" to="snk_Latn_ML"/>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1799,16 +1799,17 @@ For terms of use, see http://www.unicode.org/copyright.html
             <zoneAlias type="Asia/Kashgar" replacement="Asia/Urumqi" reason="deprecated"/>
         </alias>
 		<defaultContent locales="
-			aa_ET ab_GE af_ZA agq_CM ak_GH am_ET an_ES ann_NG ar_001 arn_CL as_IN asa_TZ ast_ES
-			az_Arab_IR az_Cyrl_AZ az_Latn az_Latn_AZ
-			ba_RU bal_Arab bal_Arab_PK bal_Latn_PK bas_CM be_BY bem_ZM bez_TZ bg_BG bgc_IN bgn_PK bho_IN
-			blt_VN bm_ML bm_Nkoo_ML bn_BD bo_CN br_FR brx_IN bs_Cyrl_BA bs_Latn bs_Latn_BA
-			bss_CM byn_ER
+			aa_ET ab_GE af_ZA agq_CM ak_GH am_ET an_ES ann_NG ar_001 arn_CL as_IN asa_TZ
+			ast_ES az_Arab_IR az_Cyrl_AZ az_Latn az_Latn_AZ
+			ba_RU bal_Arab bal_Arab_PK bal_Latn_PK bas_CM be_BY bem_ZM bez_TZ bg_BG bgc_IN
+			bgn_PK bho_IN blt_VN bm_ML bm_Nkoo_ML bn_BD bo_CN br_FR brx_IN bs_Cyrl_BA
+			bs_Latn bs_Latn_BA bss_CM byn_ER
 			ca_ES cad_US cch_NG ccp_BD ce_RU ceb_PH cgg_UG chr_US cic_US ckb_IQ co_FR cs_CZ
 			cu_RU cv_RU cy_GB
 			da_DK dav_KE de_DE dje_NE doi_IN dsb_DE dua_CM dv_MV dyo_SN dz_BT
 			ebu_KE ee_GH el_GR en_Dsrt_US en_US eo_001 es_ES et_EE eu_ES ewo_CM
-			fa_IR ff_Adlm_GN ff_Latn ff_Latn_SN fi_FI fil_PH fo_FO fr_FR frr_DE fur_IT fy_NL
+			fa_IR ff_Adlm_GN ff_Latn ff_Latn_SN fi_FI fil_PH fo_FO fr_FR frr_DE fur_IT
+			fy_NL
 			ga_IE gaa_GH gd_GB gez_ET gl_ES gn_PY gsw_CH gu_IN guz_KE gv_IM
 			ha_Arab_NG ha_NG haw_US he_IL hi_IN hi_Latn_IN hnj_Hmnp hnj_Hmnp_US hr_HR
 			hsb_DE hu_HU hy_AM
@@ -1821,7 +1822,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			luy_KE lv_LV
 			mai_IN mas_KE mdf_RU mer_KE mfe_MU mg_MG mgh_MZ mgo_CM mi_NZ mk_MK ml_IN mn_MN
 			mn_Mong_CN mni_Beng mni_Beng_IN mni_Mtei_IN moh_CA mr_IN ms_Arab_MY ms_MY mt_MT
-			mua_CM mus_US my_MM shn_MM myv_RU mzn_IR
+			mua_CM mus_US my_MM myv_RU mzn_IR
 			naq_NA nb nb_NO nd_ZW nds_DE ne_NP nl_NL nmg_CM nn_NO nnh_CM nqo_GN nr_ZA
 			nso_ZA nus_SS nv_US ny_MW nyn_UG
 			oc_FR om_ET or_IN os_GE osa_US
@@ -1830,7 +1831,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			raj_IN rhg_Rohg rhg_Rohg_MM rm_CH rn_BI ro_RO rof_TZ ru_RU rw_RW rwk_TZ
 			sa_IN sah_RU saq_KE sat_Deva_IN sat_Olck sat_Olck_IN sbp_TZ sc_IT scn_IT
 			sd_Arab sd_Arab_PK sd_Deva_IN sdh_IR se_NO seh_MZ ses_ML sg_CF shi_Latn_MA
-			shi_Tfng shi_Tfng_MA si_LK sid_ET sk_SK sl_SI sma_SE smj_SE smn_FI sms_FI sn_ZW
+			shi_Tfng shi_Tfng_MA shn_MM si_LK sid_ET sk_SK sl_SI sma_SE smj_SE smn_FI sms_FI sn_ZW
 			so_SO sq_AL sr_Cyrl sr_Cyrl_RS sr_Latn_RS ss_ZA ssy_ER st_ZA su_Latn su_Latn_ID
 			sv_SE sw_TZ syr_IQ szl_PL
 			ta_IN te_IN teo_UG tg_TJ th_TH ti_ET tig_ER tk_TM tn_ZA to_TO tok_001 tpi_PG tr_TR

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.util.DtdData.ValueStatus;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.LanguageInfo;
 import org.unicode.cldr.util.Organization;
+import org.unicode.cldr.util.StackTracker;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -201,10 +202,11 @@ public class TestAttributeValues extends TestFmwk {
                 }
             } catch (Throwable e) {
                 if(r == null) throw e;
-                throw (IllegalArgumentException) new IllegalArgumentException(" at " + r.getLocation()).initCause(e);
+                throw (IllegalArgumentException) new IllegalArgumentException(" at " + r.getLocation(), e);
             }
         } catch (Exception e) {
-            errln("Exception occured in " + fullFile + " after parsing " + lastElement);
+            e.printStackTrace(this.getErrorLogPrintWriter());
+            errln("Exception occured in " + fullFile + " after parsing " + lastElement + " - " + e);
         }
         pathChecker.elementCount.addAndGet(_elementCount);
         pathChecker.attributeCount.addAndGet(_attributeCount);


### PR DESCRIPTION
CLDR-15921 likely subtags

- [ ] This PR completes the ticket.

Still some manual reverts here, all of the following are missing:

Missing from defaultcontent when generating
~- `shn_MM`~ **Edit** This wasn't missing, just in the wrong place.
- `tok_001`
- `os_GE` (vs `os_RU`)

Missing from likelysubtags when generating
- `oc_ES`
- `sd_IN`
- `tok`
- `rhg_Arab_MM`
- `und_Cpmn_CY`

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
