### PR TITLE
CLDR-15902 ar currency patterns add RLM/ALMs for improved layout

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -6268,7 +6268,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>#,##0.00 ¤</pattern>
+					<pattern>‏#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -6282,12 +6282,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>¤ #,##0.00</pattern>
+					<pattern>‏¤ #,##0.00;‏-‏¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern>؜¤#,##0.00;(؜¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">؜#,##0.00 ¤;(؜#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>


### PR DESCRIPTION
CLDR-15902

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

For currency patterns in ar:
- For standard currency patterns for 'arab' and 'latn' digits, add RLMs as shown in [Arabic currency formats](https://docs.google.com/document/d/1D3q1BlICcpQi_GWZXyudP-KlVMNMb3l2ZJAGELF1VI4/edit#)
- For accounting currency patterns for 'latn' digits, add ALM at the beginning of the positive pattern, and also lust after the initial paren of the negative currency pattern.