### PR TITLE
CLDR-14421 fix XML problem in unitIdComponents

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -372,7 +372,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT unitIdComponent EMPTY >
 <!ATTLIST unitIdComponent type NMTOKEN #REQUIRED >
-    <!--@MATCH:literal/prefix, suffix, special-->
+    <!--@MATCH:literal/prefix, suffix, power, and, per-->
 <!ATTLIST unitIdComponent values NMTOKENS #REQUIRED >
     <!--@MATCH:set/regex/[a-z]+ -->
     <!--@VALUE-->

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -374,7 +374,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST unitIdComponent type NMTOKEN #REQUIRED >
     <!--@MATCH:literal/prefix, suffix, power, and, per-->
 <!ATTLIST unitIdComponent values NMTOKENS #REQUIRED >
-    <!--@MATCH:set/regex/[a-z]+ -->
+    <!--@MATCH:set/regex/[a-z]+[0-9]* -->
     <!--@VALUE-->
 
 <!ELEMENT unitConstants ( unitConstant* ) >

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -8,15 +8,13 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 <supplementalData>
     <version number="$Revision$"/>
-    <!--  
     <unitIdComponents>
     	<unitIdComponent type="prefix" values="arc british dessert fluid light nautical xxx x curr"/>
-		<unitIdComponent type="suffix" values="force imperial luminosity mass metric person radius scandinavian troy unit us"/> 
-		<unitIdComponent type="power" values="square cubic pow2 pow3 pow4 pow5 pow6 pow7 pow8 pow8 pow10 pow11 pow12 pow13 pow14 pow15"/>
+		<unitIdComponent type="suffix" values="force imperial luminosity mass metric person radius scandinavian troy unit us"/>
+		<unitIdComponent type="power" values="square cubic pow2 pow3 pow4 pow5 pow6 pow7 pow8 pow9 pow10 pow11 pow12 pow13 pow14 pow15"/>
 		<unitIdComponent type="and" values="and"/>
 		<unitIdComponent type="per" values="per"/>
     </unitIdComponents>
-    -->
     <unitConstants>
         <unitConstant constant="lb_to_kg" value="0.45359237"/>
         <unitConstant constant="ft_to_m" value="0.3048"/>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -509,6 +509,7 @@
 //supplementalData/unitPreferenceData/unitPreferences[@category="%A"][@usage="%A"][@scope="%A"]/unitPreference[@regions="%A"][@alt="%A"]			; Supplemental ; Units ; $1/$2/$3 ; $4-$5 ; HIDE
 
 
+//supplementalData/unitIdComponents/unitIdComponent[@type="%A"]/_values	; Supplemental ; Units ; IdComponent ; $1-values ; HIDE
 //supplementalData/unitConstants/unitConstant[@constant="%A"]/_value	; Supplemental ; Units ; Constant ; $1-value ; HIDE
 //supplementalData/unitConstants/unitConstant[@constant="%A"]/_status	; Supplemental ; Units ; Constant ; $1-status ; HIDE
 //supplementalData/unitQuantities/unitQuantity[@baseUnit="%A"]/_quantity	; Supplemental ; Units ; Quantity ; $1-value ; HIDE


### PR DESCRIPTION
The problem was a hidden NBSP.
Also, hide the display of information in TestUnits under the flags. This drastically reduces the number of warnings for the normal case.

CLDR-14421

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
