### PR TITLE
CLDR-15255 revert Romanian plurals

### DIFF
--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -99,7 +99,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
         </pluralRules>
         <pluralRules locales="mo ro">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
-            <pluralRule count="few">v != 0 or n = 0 or n % 100 = 2..19 @integer 0, 2~16, 102, 1002, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="few">v != 0 or n = 0 or n != 1 and n % 100 = 1..19 @integer 0, 2~16, 102, 1002, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
             <pluralRule count="other"> @integer 20~35, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
         <pluralRules locales="bs hr sh sr">

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -99,7 +99,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
         </pluralRules>
         <pluralRules locales="mo ro">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
-            <pluralRule count="few">v != 0 or n = 0 or n != 1 and n % 100 = 1..19 @integer 0, 2~16, 102, 1002, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="few">v != 0 or n = 0 or n != 1 and n % 100 = 1..19 @integer 0, 2~16, 101, 1001, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
             <pluralRule count="other"> @integer 20~35, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
         <pluralRules locales="bs hr sh sr">


### PR DESCRIPTION
CLDR-15255

The discussion is complicated: see the comments in https://unicode-org.atlassian.net/browse/CLDR-15255. 

Reverting to before 11578: 

[CLDR-11578: rules for Romanian plural numbersDONE](https://unicode-org.atlassian.net/browse/CLDR-11578) 

That is, [CLDR-11577 fix for Romanian 101, etc. · unicode-org/cldr@aedd789](https://github.com/unicode-org/cldr/commit/aedd789db89d567a2d8555f510aef3577747ae75)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
