### PR TITLE
CLDR-13542 revert change from apostrophe grouping for Swiss locales

### DIFF
--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -4657,7 +4657,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimumGroupingDigits>↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 			<percentSign>↑↑↑</percentSign>
 			<plusSign>↑↑↑</plusSign>
 			<minusSign>↑↑↑</minusSign>

--- a/common/main/de_LI.xml
+++ b/common/main/de_LI.xml
@@ -31,7 +31,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 		</symbols>
 		<percentFormats numberSystem="latn">
 			<percentFormatLength>

--- a/common/main/en_CH.xml
+++ b/common/main/en_CH.xml
@@ -13,7 +13,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</identity>
 	<numbers>
 		<symbols numberSystem="latn">
-			<group>’</group>
+			<group>'</group>
 			<superscriptingExponent>·</superscriptingExponent>
 		</symbols>
 		<currencyFormats numberSystem="latn">

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -1923,7 +1923,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 			<list>;</list>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>

--- a/common/main/it_CH.xml
+++ b/common/main/it_CH.xml
@@ -173,7 +173,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -2537,7 +2537,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 			<list draft="contributed">;</list>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -64,13 +64,10 @@ public class DisplayAndInputProcessor {
             "[:Default_Ignorable_Code_Point:]" +
             "[:patternwhitespace:]" +
             "[:Me:][:Mn:]]" // add non-spacing marks
-    ).freeze();
+        ).freeze();
 
     public static final Pattern NUMBER_FORMAT_XPATH = Pattern
         .compile("//ldml/numbers/.*Format\\[@type=\"standard\"]/pattern.*");
-
-    public static final Pattern NUMBER_SEPARATOR_PATTERN = Pattern
-        .compile("//ldml/numbers/symbols.*/(decimal|group)");
 
     private static final Pattern APOSTROPHE_SKIP_PATHS = PatternCache.get("//ldml/("
         + "localeDisplayNames/languages/language\\[@type=\"mic\"].*|"
@@ -335,10 +332,7 @@ public class DisplayAndInputProcessor {
                 }
             }
         }
-        // Fix up any apostrophes in number symbols
-        if (NUMBER_SEPARATOR_PATTERN.matcher(path).matches()) {
-            value = value.replace('\'', '\u2019');
-        }
+
         // Fix up any apostrophes as appropriate (Don't do so for things like date patterns...
         if (!APOSTROPHE_SKIP_PATHS.matcher(path).matches()) {
             value = normalizeApostrophes(value);
@@ -518,10 +512,7 @@ public class DisplayAndInputProcessor {
             if (!APOSTROPHE_SKIP_PATHS.matcher(path).matches()) {
                 value = normalizeApostrophes(value);
             }
-            // Fix up any apostrophes in number symbols
-            if (NUMBER_SEPARATOR_PATTERN.matcher(path).matches()) {
-                value = value.replace('\'', '\u2019');
-            }
+
             // Fix up hyphens, replacing with N-dash as appropriate
             if (INTERVAL_FORMAT_PATHS.matcher(path).matches()) {
                 value = normalizeIntervalHyphensAndSpaces(value); // This may also adjust spaces around en dash
@@ -924,7 +915,7 @@ public class DisplayAndInputProcessor {
 
     public static String fixAdlamNasalization(String fromString) {
         return ADLAM_MISNASALIZED.matcher(fromString)
-        .replaceAll("$1"+ADLAM_NASALIZATION+"$2");  // replace quote with 𞥋
+            .replaceAll("$1"+ADLAM_NASALIZATION+"$2");  // replace quote with 𞥋
     }
 
     static Pattern REMOVE_QUOTE1 = PatternCache.get("(\\s)(\\\\[-\\}\\]\\&])()");
@@ -1123,7 +1114,7 @@ public class DisplayAndInputProcessor {
 
         // Further whitespace adjustments per CLDR-14032
         if ((scriptCode.equals("Latn") || scriptCode.equals("Cyrl") || scriptCode.equals("Grek")) &&
-                HOUR_FORMAT_XPATHS.matcher(path).matches()) {
+            HOUR_FORMAT_XPATHS.matcher(path).matches()) {
             String test = AMPM_SPACE_BEFORE.matcher(value).replaceAll("$1$2"); // value without a+
             if (value.length() - test.length() != 4) { // exclude patterns with aaaa
                 value = AMPM_SPACE_BEFORE.matcher(value).replaceAll("$1\u202F$3");


### PR DESCRIPTION
CLDR-13542

This has the effect of reverting https://unicode-org.atlassian.net/browse/CLDR-9865, as in https://github.com/unicode-org/cldr/commit/abb5ba2f0b8b8d3fc3dc16c9ecd4abcbba0bf2dc#diff-873bba593c30f754801f660191b8b500L60

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
