### PR TITLE
CLDR-15932 issues from prod test: copy empty annotation parents, fix en_AU/oc_ES/sw_KE

### DIFF
--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -7938,9 +7938,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} fluid ounces</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fluid ounces</displayName>
+				<unitPattern count="one">{0} Imp. fluid ounce</unitPattern>
+				<unitPattern count="other">{0} Imp. fluid ounces</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>tablespoons</displayName>
@@ -8989,9 +8989,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>tbsp</displayName>
@@ -10035,14 +10035,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0}fl oz</unitPattern>
+				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>Imp. fl oz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp fl oz</displayName>
+				<unitPattern count="one">{0}fl oz Im</unitPattern>
+				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>↑↑↑</displayName>

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -3803,7 +3803,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="EGP">
 				<displayName draft="unconfirmed">libra egipcia</displayName>
 				<displayName count="other" draft="unconfirmed">libres egipcies</displayName>
-				<symbol draft="unconfirmed">↑↑↑</symbol>
+				<symbol draft="unconfirmed">EGP</symbol>
 				<symbol alt="narrow" draft="unconfirmed">EGP</symbol>
 			</currency>
 			<currency type="ERN">
@@ -4210,7 +4210,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="RON">
 				<displayName draft="unconfirmed">leu ruman</displayName>
 				<displayName count="other" draft="unconfirmed">leus rumans</displayName>
-				<symbol draft="unconfirmed">↑↑↑</symbol>
+				<symbol draft="unconfirmed">RON</symbol>
 				<symbol alt="narrow" draft="unconfirmed">L</symbol>
 			</currency>
 			<currency type="RSD">

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -534,8 +534,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hani">↑↑↑</script>
 			<script type="Hans">Kilichorahisishwa</script>
 			<script type="Hans" alt="stand-alone">Kihan Kilichorahisishwa</script>
-			<script type="Hant">Kawaida</script>
-			<script type="Hant" alt="stand-alone">Kihan cha Kawaida</script>
 			<script type="Hebr">↑↑↑</script>
 			<script type="Hira">Kihiragana</script>
 			<script type="Hrkt">Silabi za Kijapani</script>
@@ -584,7 +582,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="014">Afrika Mashariki</territory>
 			<territory type="015">Afrika Kaskazini</territory>
 			<territory type="017">↑↑↑</territory>
-			<territory type="018">Afrika Kusini</territory>
 			<territory type="019">↑↑↑</territory>
 			<territory type="021">↑↑↑</territory>
 			<territory type="029">↑↑↑</territory>
@@ -604,7 +601,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="154">Ulaya Kaskazini</territory>
 			<territory type="155">Ulaya Magharibi</territory>
 			<territory type="202">Kusini mwa Jangwa la Sahara</territory>
-			<territory type="419">Amerika Kusini</territory>
 			<territory type="AC">↑↑↑</territory>
 			<territory type="AD">↑↑↑</territory>
 			<territory type="AE">↑↑↑</territory>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -222,6 +222,7 @@ public class GenerateProductionData {
             }
             boolean isMainDir = factory != null && sourceFile.getName().contentEquals("main");
             boolean isRbnfDir = factory != null && sourceFile.getName().contentEquals("rbnf");
+            boolean isAnnotationsDir = factory != null && sourceFile.getName().startsWith("annotations");
 
             Set<String> emptyLocales = new HashSet<>();
             final Stats stats2 = new Stats();
@@ -253,8 +254,8 @@ public class GenerateProductionData {
             stats2.showNonZero("\tTOTAL:\t");
             // if there are empty ldml files, AND we aren't in /main/,
             // then remove any without children
-            if (!emptyLocales.isEmpty() && !sourceFile.getName().equals("main")) {
-                Set<String> childless = getChildless(emptyLocales, factory.getAvailable());
+            if (!emptyLocales.isEmpty() && !isMainDir) {
+                Set<String> childless = getChildless(emptyLocales, factory.getAvailable(), isAnnotationsDir);
                 if (!childless.isEmpty()) {
                     if (VERBOSE) System.out.println("\t" + destinationFile + "\tRemoving empty locales:" + childless);
                     childless.stream().forEach(locale -> new File(destinationFile, locale + ".xml").delete());
@@ -551,13 +552,19 @@ public class GenerateProductionData {
         return result;
     }
 
-    private static Set<String> getChildless(Set<String> emptyLocales, Set<String> available) {
+    private static Set<String> getChildless(Set<String> emptyLocales, Set<String> available, boolean isAnnotationsDir) {
         // first build the parent2child map
         Multimap<String,String> parent2child = HashMultimap.create();
         for (String locale : available) {
             String parent = LocaleIDParser.getParent(locale);
             if (parent != null) {
                 parent2child.put(parent, locale);
+            }
+            if (isAnnotationsDir) {
+                String simpleParent = LocaleIDParser.getParent(locale, true);
+                if (simpleParent != null && (parent == null || simpleParent != parent)) {
+                    parent2child.put(simpleParent, locale);
+                }
             }
         }
 


### PR DESCRIPTION
CLDR-15932

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Fix issues from running tests on the production version of the data (BRS task):
1. `en_AU` fluid ounces: There was a display name collision because `en_AU` was inheriting from `en_001` the plain name "fluid ounce" for `volume-fluid-ounce-imperial`, but also defined the plain name "fluid ounce" for `volume-fluid-ounce` (i.e. the US fluid ounce). Although `en_AU` is mostly metric (more so than `en_GB`), per https://www.legislation.gov.au/Details/F2012C00400 the fluid ounce they do use is the US one, i.e. 0.0000295735296 cubic meters. So changed the display names for `volume-fluid-ounce-imperial` to explicitly use "Imperial".
2. `oc_ES` missing currency symbols: There were two cases in which `oc_ES` was overriding a narrow currency symbol inherited from `os`, while inheriting (with ↑↑↑) what `os` used for the standard currency symbol, which was just the ISO 4217 code inherited from root. But when the ↑↑↑ entry is deleted for production data, there is an error for alt entry without the non-alt entry. So just explicitly specified the ISO 4217 code as the standard currency symbol.
3. `sw_KE` display name collisions,  delete problem entries to inherit from `sw`:
    * For Hant, `sw_KE` was using something akin to "common" (which conflicted with the name for Zyyy) instead of "simplified".
    * For 018 Southern Africa, name was colliding with ZA South Africa
    * For 419 Latin American, name was colliding with 005 South America
4. GenerateProductionData fix: The unit test TestCLDRFile/TestFileIds tests that for annotation files, not only is the true parent present, but also the "simple" parent (i.e. from subtag stripping) is present, if different. And for that reason we added an empty annotations/ff.xml file. However GenerateProductionData did not copy empty files that had no children, resulting in the following error on production data: `Error: (TestCLDRFile.java:743) Missing simple parent (ff) for ff_Adlm  in common/annotations; likely=ff_Adlm`. So the solution is to update GenerateProductionData so that for annotation files, it ensures that empty files are copied if they are either the true or simple (truncation) parent of a file with content.