### PR TITLE
CLDR-15937 zh word new erroneously added

### DIFF
--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -9047,7 +9047,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="BGN">
 				<displayName>保加利亚列弗</displayName>
-				<displayName count="other">保加利亚新列弗</displayName>
+				<displayName count="other">保加利亚列弗</displayName>
 				<symbol>BGN</symbol>
 			</currency>
 			<currency type="BGO">


### PR DESCRIPTION
CLDR-15937

- [X] This PR completes the ticket.

Note: the change now makes the translation *almost* identical to currency BGO, which uses "保加利亚列弗 (1879–1952)", i.e. the same currency name but with the year interval added.