### PR TITLE
CLDR-14951 english date format separators for CH

### DIFF
--- a/common/main/en_CH.xml
+++ b/common/main/en_CH.xml
@@ -11,6 +11,323 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="en"/>
 		<territory type="CH"/>
 	</identity>
+	<dates>
+		<calendars>
+			<calendar type="buddhist">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="chinese">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.r</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="UM">M.U</dateFormatItem>
+						<dateFormatItem id="UMd">dd.MM.U</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.r</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.r</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.r</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="coptic">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="dangi">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.r</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="UM">M.U</dateFormatItem>
+						<dateFormatItem id="UMd">dd.MM.U</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.r</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.r</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.r</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="ethiopic">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="ethiopic-amete-alem">
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="generic">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="gregorian">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">d.M.y G</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="MMdd">dd.MM</dateFormatItem>
+						<dateFormatItem id="yM">MM.y</dateFormatItem>
+						<dateFormatItem id="yMd">dd.MM.y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, dd.MM.y</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="hebrew">
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="indian">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic-civil">
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic-rgsa">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic-tbla">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="islamic-umalqura">
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="japanese">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>M.d.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="persian">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+			<calendar type="roc">
+				<dateFormats>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern>dd.MM.y GGGGG</pattern>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<dateTimeFormats>
+					<availableFormats>
+						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y GGGGG</dateFormatItem>
+					</availableFormats>
+				</dateTimeFormats>
+			</calendar>
+		</calendars>
+	</dates>
 	<numbers>
 		<symbols numberSystem="latn">
 			<group>’</group>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,151 +1,124 @@
 # constructed line for modify_config.txt file
-locale=mn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=hu ja ko mn vi yue zh
-locale=ja ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=hu ja ko vi yue zh
-locale=ko ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=hu ja ko vi yue zh
-locale=zh ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=hu ja ko vi yue zh
-locale=zh_Hant ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=hu ja ko vi yue zh
-locale=zh_Hant_HK ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=hu ja ko vi yue zh
-locale=brx ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko te vi yue zh
-locale=ur ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko te vi yue zh
-locale=af ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=en ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=en_AU ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=en_CA ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=en_GB ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=en_IN ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=ky ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=mi ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=to ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=tt ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=uk ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ja ko vi yue zh
-locale=as ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=doi ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=gu ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=hi ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=hi_Latn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=kn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=kok ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=ks ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=ks_Deva ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=mai ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=ml ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=mni ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=mr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=my ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=ne ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=or ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=pa ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=pcm ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=sa ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=sd ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=sd_Deva ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=si ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=ta ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=te ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=ti ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko te vi yue zh
-locale=am ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ar ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ast ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=az ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=be ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=bg ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=bn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=br ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=bs ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ca ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ceb ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=chr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=cy ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=da ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=el ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=es_419 ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=es_MX ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"][@draft="contributed"]; new_value=ko vi yue zh
-locale=es_US ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=et ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=eu ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=fa ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"][@draft="contributed"]; new_value=ko vi yue zh
-locale=ff ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ff_Adlm ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=fi ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=fil ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=fo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=fr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=fr_CA ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ga ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=gd ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ha ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=he ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=hr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=hy ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=id ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ig ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=jv ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ka ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=kgp ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=kk ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"][@draft="contributed"]; new_value=ko vi yue zh
-locale=lo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=lt ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=lv ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=mk ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ms ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=nl ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=nn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=no ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=pl ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ps ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=pt ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=pt_PT ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=qu ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=ro ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sat ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sc ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sl ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=so ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sq ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sr_Latn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=su ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sv ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=sw ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=tg ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=th ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=tr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=uz ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=wo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=xh ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=yo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=yrl ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=zu ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="surnameFirst"]; new_value=ko vi yue zh
-locale=te ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und
-locale=zh_Hant_HK ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und
-locale=ast ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ast
-locale=br ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und br
-locale=brx ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und brx
-locale=ceb ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ceb
-locale=chr ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und chr
-locale=doi ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und doi
-locale=el ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und el
-locale=ff ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ff
-locale=ff_Adlm ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ff
-locale=fo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und fo
-locale=ha ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ha
-locale=kgp ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und kgp
-locale=ks ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ks
-locale=ks_Deva ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ks
-locale=ky ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ky
-locale=lo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und lo
-locale=mai ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und mai
-locale=mni ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und mni
-locale=ne ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ne
-locale=qu ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und qu
-locale=sa ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und sa
-locale=sat ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und sat
-locale=sd_Deva ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und sd
-locale=sr_Latn ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und sr
-locale=su ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und su
-locale=tg ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und tg
-locale=ti ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und ti
-locale=tt ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und tt
-locale=xh ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und xh
-locale=wo ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und yo
-locale=yrl ; action=add ; new_path=//ldml/personNames/nameOrderLocales[@order="givenFirst"]; new_value=und yrl
+# CLDR-14951 english date format separators for ch and ln
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]  ; new_value=dd.MM.y
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]  ; new_value=d.M.y G
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]  ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]  ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMdd"]  ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yM"]  ; new_value=MM.y 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMd"]  ≣  ; new_value=dd.MM.y 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMEd"]  ; new_value=E, dd.MM.y 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]  ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]  ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]  ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]  ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]  ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]  ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]  ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="buddhist"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]  ; new_value=dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]  ≣  ; new_value=E, dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"] ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="UM"] en ≣  ; new_value=M.U 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="UMd"] ; new_value=dd.MM.U 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"] ; new_value=MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"] ; new_value=dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"] ; new_value=E, dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="coptic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="UM"] en  ; new_value=M.U 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="UMd"]   ; new_value=dd.MM.U 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="dangi"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.r 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]  ≣  ; new_value=E dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"] en ≣  ; new_value=M.d.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="japanese"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="persian"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="roc"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic-amete-alem"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic-amete-alem"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic-amete-alem"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E, dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic-amete-alem"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic-amete-alem"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="ethiopic-amete-alem"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-civil"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-civil"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-civil"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-civil"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-civil"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-civil"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-rgsa"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-tbla"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-umalqura"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-umalqura"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"]   ; new_value=dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-umalqura"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"]   ; new_value=E dd.MM 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-umalqura"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"]   ; new_value=MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-umalqura"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"]   ; new_value=dd.MM.y GGGGG 
+locale=en_CH ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic-umalqura"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"]   ; new_value=E, dd.MM.y GGGGG 


### PR DESCRIPTION
CLDR-14951

Change the en_CH date format separator. 

- This probably changes more calendar than necessary. However, the extra data is harmless.
- I had to change the format of the modify_config.txt lines (just a note for the future)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
