### PR TITLE
CLDR-15949 In unitPreferencesTest.txt, change metric-ton to tonne for ICU tests

### DIFF
--- a/common/testData/units/unitPreferencesTest.txt
+++ b/common/testData/units/unitPreferencesTest.txt
@@ -257,8 +257,8 @@ length;	visiblty;	GB;	905256 / 625;	1448.4096;	meter;	4752;	4752.0;	foot
 length;	visiblty;	GB;	381 / 1250;	0.3048;	meter;	1;	1.0;	foot
 length;	visiblty;	GB;	3429 / 12500;	0.27432;	meter;	9 / 10;	0.9;	foot
 
-mass;	default;	001;	1100;	1100.0;	kilogram;	11 / 10;	1.1;	metric-ton
-mass;	default;	001;	1000;	1000.0;	kilogram;	1;	1.0;	metric-ton
+mass;	default;	001;	1100;	1100.0;	kilogram;	11 / 10;	1.1;	tonne
+mass;	default;	001;	1000;	1000.0;	kilogram;	1;	1.0;	tonne
 mass;	default;	001;	900;	900.0;	kilogram;	900;	900.0;	kilogram
 mass;	default;	001;	1;	1.0;	kilogram;	1;	1.0;	kilogram
 mass;	default;	001;	9 / 10;	0.9;	kilogram;	900;	900.0;	gram


### PR DESCRIPTION
CLDR-15949

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

CLDR-14421 renamed the unit "metric-ton" to "tonne" but did not update the unitPreferencesTest.txt file used for ICU tests; this PR updates "metric-ton" in that file to "tonne"