### PR TITLE
CLDR-15957 rdf: fix logging, speedup query

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Containment.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Containment.java
@@ -214,11 +214,19 @@ public class Containment {
             targets.add(target);
         } else if (size == 1) {
             for (String parent : parents) {
-                getAllDirected(multimap, parent, target, targets);
+                if (parent.equals(lang)) {
+                    System.err.println("ERR: "+ lang + " is its own parent");
+                } else {
+                    getAllDirected(multimap, parent, target, targets);
+                }
             }
         } else {
             for (String parent : parents) {
-                getAllDirected(multimap, parent, (ArrayList<String>) target.clone(), targets);
+                if (parent.equals(lang)) {
+                    System.err.println("ERR: "+ lang + " is its own parent");
+                } else {
+                    getAllDirected(multimap, parent, (ArrayList<String>) target.clone(), targets);
+                }
             }
         }
     }

--- a/tools/cldr-rdf/pom.xml
+++ b/tools/cldr-rdf/pom.xml
@@ -40,6 +40,11 @@
             <version>${jenaVersion}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>2.0.0</version>
+        </dependency>
 
         <!-- project stuff-->
         <dependency>

--- a/tools/cldr-rdf/src/main/resources/org/unicode/cldr/rdf/sparql/wikidata-childToParent.sparql
+++ b/tools/cldr-rdf/src/main/resources/org/unicode/cldr/rdf/sparql/wikidata-childToParent.sparql
@@ -13,14 +13,18 @@ PREFIX bd: <http://www.bigdata.com/rdf#>
 
 
 SELECT DISTINCT ?child ?parent WHERE {
-  ?child p:P279/ps:P279 ?parent.    #child is subclass of parent
   {
+    ?child p:P279/ps:P279 ?parent.    #child is subclass of parent
     ?parent wdt:P31 wd:Q25295. #parent is language family, OR
   } UNION {
+    ?child p:P279/ps:P279 ?parent.    #child is subclass of parent
     ?child wdt:P31 wd:Q25295.  #child is language family, OR
   } UNION {
+    ?child p:P279/ps:P279 ?parent.    #child is subclass of parent
     ?parent wdt:P31 wd:Q34770. #parent is language, OR
   } UNION {
+    ?child p:P279/ps:P279 ?parent.    #child is subclass of parent
     ?child wdt:P31 wd:Q34770.  #child is language
   }
 }
+ORDER BY ?parent ?child


### PR DESCRIPTION
- speedup childToParent query a few orders of magnitude
- also enable JDK 1.4 logging from Jena
(this matches what we do with OpenLiberty)

The actual data update will be a separate PR.

CLDR-15957

- [ ] This PR completes the ticket.