### PR TITLE
CLDR-15966 ja-JP numbers ≤ 99999999999999999999

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1421,7 +1421,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT pattern ( #PCDATA ) >
 <!ATTLIST pattern type NMTOKEN "standard" >
-    <!--@MATCH:literal/1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000, 100000000000000, approximately, atLeast, atMost, range, standard-->
+    <!--@MATCH:literal/1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000, 100000000000000, 1000000000000000, 10000000000000000, 100000000000000000, 1000000000000000000, 10000000000000000000, approximately, atLeast, atMost, range, standard-->
 <!ATTLIST pattern numbers CDATA #IMPLIED >
     <!-- TODO: generalize this to be any (M=|d=)?<numberSystem> -->
     <!--@MATCH:literal/M=romanlow, d=hanidays, hanidec, hebr, y=jpanyear-->

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -7284,6 +7284,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000000000" count="other">0兆</pattern>
 					<pattern type="10000000000000" count="other">00兆</pattern>
 					<pattern type="100000000000000" count="other">000兆</pattern>
+					<pattern type="1000000000000000" count="other">0000兆</pattern>
+					<pattern type="10000000000000000" count="other">0京</pattern>
+					<pattern type="100000000000000000" count="other">00京</pattern>
+					<pattern type="1000000000000000000" count="other">000京</pattern>
+					<pattern type="10000000000000000000" count="other">0000京</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
@@ -7300,6 +7305,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000000000" count="other">0兆</pattern>
 					<pattern type="10000000000000" count="other">00兆</pattern>
 					<pattern type="100000000000000" count="other">000兆</pattern>
+					<pattern type="1000000000000000" count="other">0000兆</pattern>
+					<pattern type="10000000000000000" count="other">0京</pattern>
+					<pattern type="100000000000000000" count="other">00京</pattern>
+					<pattern type="1000000000000000000" count="other">000京</pattern>
+					<pattern type="10000000000000000000" count="other">0000京</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -7355,6 +7365,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00兆</pattern>
 					<pattern type="100000000000000" count="other">¤000兆</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000兆</pattern>
+					<pattern type="1000000000000000" count="other">¤0000兆</pattern>
+					<pattern type="1000000000000000" count="other" alt="alphaNextToNumber">¤ 0000兆</pattern>
+					<pattern type="10000000000000000" count="other">¤0京</pattern>
+					<pattern type="10000000000000000" count="other" alt="alphaNextToNumber">¤ 0京</pattern>
+					<pattern type="100000000000000000" count="other">¤00京</pattern>
+					<pattern type="100000000000000000" count="other" alt="alphaNextToNumber">¤ 00京</pattern>
+					<pattern type="1000000000000000000" count="other">¤000京</pattern>
+					<pattern type="1000000000000000000" count="other" alt="alphaNextToNumber">¤ 000京</pattern>
+					<pattern type="10000000000000000000" count="other">¤0000京</pattern>
+					<pattern type="10000000000000000000" count="other" alt="alphaNextToNumber">¤ 0000京</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>


### PR DESCRIPTION
Previously, the maximum supported number was:
999999999999999

Adds support for numbers up to:
99999999999999999999

CLDR-15966

- [x] This PR completes the ticket.