### PR TITLE
MERGE WHEN v43 BRANCHED—CLDR-15970 BRS v43 Dependency Fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: "monthly"
     commit-message:
       include: scope
-      prefix: "CLDR-15539 gh:"
+      prefix: "CLDR-15970 gh:"
     assignees:
       - btangmu
       - srl295
@@ -25,7 +25,7 @@ updates:
       interval: "monthly"
     commit-message:
       include: scope
-      prefix: "CLDR-15539 js:"
+      prefix: "CLDR-15970 js:"
     assignees:
       - btangmu
       - srl295
@@ -39,7 +39,7 @@ updates:
       interval: "monthly"
     commit-message:
       include: scope
-      prefix: "CLDR-15539 tr:"
+      prefix: "CLDR-15970 tr:"
     assignees:
       - btangmu
       - srl295
@@ -54,7 +54,7 @@ updates:
       interval: "monthly"
     commit-message:
       include: scope
-      prefix: "CLDR-15539 j:"
+      prefix: "CLDR-15970 j:"
     assignees:
       - btangmu
       - srl295


### PR DESCRIPTION
- update the dependabot target to CLDR-15970

CLDR-15970

- [ ] This PR completes the ticket.