### PR TITLE
CLDR-15575 json: don\"t double escape double quotes

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1734,9 +1734,8 @@ public class Ldml2JsonConverter {
     private static final Pattern escapePattern = PatternCache.get("\\\\(?!u)");
 
     /**
-     * Escape \ and " in value string.
+     * Escape \ in value string.
      * \ should be replaced by \\, except in case of \u1234
-     * " should be replaced by \"
      * In following code, \\\\ represent one \, because java compiler and
      * regular expression compiler each do one round of escape.
      *
@@ -1747,7 +1746,7 @@ public class Ldml2JsonConverter {
     private String escapeValue(String value) {
         Matcher match = escapePattern.matcher(value);
         String ret = match.replaceAll("\\\\\\\\");
-        return ret.replace("\"", "\\\"").replace("\n", " ").replace("\t", " ");
+        return ret.replace("\n", " ").replace("\t", " ");
     }
 
     /**


### PR DESCRIPTION
JSON output already escapes " to \", double escaping produced \\\"

CLDR-15575

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
