### PR TITLE
CLDR-15976 Remove some occurrences of ZERO WIDTH SPACE

### DIFF
--- a/common/annotations/fr.xml
+++ b/common/annotations/fr.xml
@@ -297,8 +297,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⇓" type="tts" draft="contributed">flèche double vers le bas</annotation>
 		<annotation cp="⇔" draft="contributed">flèche double vers la gauche et la droite</annotation>
 		<annotation cp="⇔" type="tts" draft="contributed">flèche double vers la gauche et la droite</annotation>
-		<annotation cp="⇎" draft="contributed">double flèche gauche​-droite barrée</annotation>
-		<annotation cp="⇎" type="tts" draft="contributed">double flèche gauche​-droite barrée</annotation>
+		<annotation cp="⇎" draft="contributed">double flèche gauche-droite barrée</annotation>
+		<annotation cp="⇎" type="tts" draft="contributed">double flèche gauche-droite barrée</annotation>
 		<annotation cp="⇖" draft="contributed">flèche double vers le nord-ouest</annotation>
 		<annotation cp="⇖" type="tts" draft="contributed">flèche double vers le nord-ouest</annotation>
 		<annotation cp="⇗" draft="contributed">flèche double vers le nord-est</annotation>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -7280,7 +7280,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pluralMinimalPairs count="other">{0} dage</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Tag den {0}. vej til højre.</ordinalMinimalPairs>
 			<caseMinimalPairs case="genitive">Med {0} mellemrum</caseMinimalPairs>
-			<caseMinimalPairs case="nominative">Jeg tror, ​​at {0} er nok.</caseMinimalPairs>
+			<caseMinimalPairs case="nominative">Jeg tror, at {0} er nok.</caseMinimalPairs>
 			<genderMinimalPairs gender="common">En {0}</genderMinimalPairs>
 			<genderMinimalPairs gender="neuter">Et {0}</genderMinimalPairs>
 		</minimalPairs>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -968,7 +968,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">République du Congo</territory>
 			<territory type="CH">Suisse</territory>
 			<territory type="CI">Côte d’Ivoire</territory>
-			<territory type="CI" alt="variant">​​République de Côte d’Ivoire</territory>
+			<territory type="CI" alt="variant">République de Côte d’Ivoire</territory>
 			<territory type="CK">Îles Cook</territory>
 			<territory type="CL">Chili</territory>
 			<territory type="CM">Cameroun</territory>


### PR DESCRIPTION
-Add feature to DAIP to remove ZWS from only two locales for now: da and fr

-Apply the resulting changes to 3 xml files

-Comments

CLDR-15976

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
