### PR TITLE
CLDR-15034 tr35-keyboards: add hex constant for ABNT2 key

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2021,8 +2021,8 @@ In the following chart, “CLDR Name” indicates the value used with the `from`
 | BACKSLASH | D13            | 0xDC            |
 | RBRACKET  | D12            | 0xDD            |
 | QUOTE     | C11            | 0xDE            |
-| LESS-THAN | B00            | 0xE2            | 102nd key on European layouts, right of left shift. |
-| ABNT2     | B11            | -               | Extra key, left of right-shift |
+| LESS-THAN | B00            | 0xE2            | 102nd key on European layouts, right of left shift.                  |
+| ABNT2     | B11            | 0xC1            | Extra key, left of right-shift, Brazilian Portuguese ABNT2 keyboards |
 
 Footnotes:
 


### PR DESCRIPTION
Constant sourced from Windows DDK kbd.h (VK_ABNT_C1).

CLDR-15034

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
