### PR TITLE
CLDR-15994 BRS v42: Update ICU4J libs before alpha3

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>72.0.1-SNAPSHOT-cldr-2022-08-17</icu4j.version>
+		<icu4j.version>72.0.1-SNAPSHOT-cldr-2022-09-07</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-15994

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Update ICU4J libs in CLDR to ICU4J as of 2022-09-07, through the following ICU fixes:
- 00003dcbf2... ICU-21957 Update TODO ticket reference: CLDR-13044 (done) ---> ICU-21420 (open).
- 6e3a923056... ICU-22116 Update CI job for ICU4J to use Java 8 instead of Java 7
- baa104b50b... ICU-21957 Clean-up of TODO and logKnownIssue entries (BRS task):
