### PR TITLE
CLDR-15992 ar with latn digits: change currency formats to have symbol trailing

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -6282,11 +6282,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>‏¤ #,##0.00;‏-‏¤ #,##0.00</pattern>
+					<pattern>‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>؜¤#,##0.00;(؜¤#,##0.00)</pattern>
+					<pattern>؜#,##0.00¤;(؜#,##0.00¤)</pattern>
 					<pattern alt="alphaNextToNumber">؜#,##0.00 ¤;(؜#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>


### PR DESCRIPTION
CLDR-15992

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

For ar with 'latn' digits, change currency formats to have symbol trailing (displaying on the L):
- For standard formats, change to `<RLM>#,##0.00<NBSP>¤;<RLM>-#,##0.00<NBSP>¤`
- For accounting format, change to `<ALM>#,##0.00¤;(<ALM>#,##0.00¤)`
- Interestingly, the accounting format alt="alphaNextToNumber" was already the same as the above plus NBSP before the currency symbol