### PR TITLE
CLDR-16002 json: update 'modern' logic

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -761,8 +761,8 @@ public class Ldml2JsonConverter {
     private boolean localeIsModernTier(String filename) {
         boolean isModernTier;
         {
-            final Level localeCoverageLevel = sc.getLocaleCoverageLevel("Cldr", filename);
-            isModernTier = localeCoverageLevel == Level.MODERN || filename.equals("root") || filename.equals("und");
+            final Level localeCoverageLevel = sc.getHighestLocaleCoverageLevel("Cldr", filename);
+            isModernTier = (localeCoverageLevel.getLevel() >= Level.MODERN.getLevel()) || filename.equals("root") || filename.equals("und");
         }
         return isModernTier;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -392,6 +392,25 @@ public class StandardCodes {
         return getLocaleTypes().get(org);
     }
 
+    /**
+     * returns the highest level in the hierarchy, not including root.
+     */
+    public Level getHighestLocaleCoverageLevel(String organization, String locale) {
+        // first get parent
+        final String parentId = LocaleIDParser.getParent(locale);
+        Level parentLevel = Level.UNDETERMINED;
+        if (parentId != null && !parentId.equals("root")) {
+            parentLevel = getHighestLocaleCoverageLevel(organization, parentId); // recurse
+        }
+        final Level ourLevel = getLocaleCoverageLevel(organization, locale);
+        if (parentLevel.getLevel() > ourLevel.getLevel()) {
+            // if parentLevel is higher
+            return parentLevel;
+        } else {
+            return ourLevel;
+        }
+    }
+
     public Level getLocaleCoverageLevel(String organization, String desiredLocale) {
         return getLocaleCoverageLevel(Organization.fromString(organization), desiredLocale);
     }


### PR DESCRIPTION
- update logic for 'modern' vs 'full'
- new StandardCodes.getHighestLocaleCoverageLevel() which checks parent locales (but not root)

CLDR-16002

- [ ] This PR completes the ticket.

Yes, this is on maint-42