### PR TITLE
CLDR-15958 json: fix currency generation

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/JsonConverter.java
@@ -147,7 +147,10 @@ public class JsonConverter {
             if (possibleAttributeKeys != null) {
                 for (final String attribute : possibleAttributeKeys) {
                     if (isDistinguishing(dtdType, element, attribute)) {
-                        if (attribute.equals("alt")) continue; // TODO fix
+                        if (attribute.equals("alt")) {
+                            // TODO fix
+                            System.err.println("Warning: Unhandled ALT: " + parts.toString());
+                        }
                         String attributeValue = parts.getAttributeValue(i, attribute);
                         out.addElement("_" + attribute);
                         if (attributeValue == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -450,8 +450,12 @@ public class Ldml2JsonConverter {
                 continue;
             }
 
-            String transformedPath = transformPath(path, pathPrefix);
-            String transformedFullPath = transformPath(fullPath, pathPrefix);
+            // discard draft before transforming
+            final String pathNoDraft = CLDRFile.DRAFT_PATTERN.matcher(path).replaceAll("");
+            final String fullPathNoDraft = CLDRFile.DRAFT_PATTERN.matcher(fullPath).replaceAll("");            
+
+            final String transformedPath = transformPath(pathNoDraft, pathPrefix);
+            final String transformedFullPath = transformPath(fullPathNoDraft, pathPrefix);
 
             if (transformedPath.isEmpty()) {
                 continue; // skip this path

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -112,6 +112,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     private static final boolean DEBUG = false;
 
     public static final Pattern ALT_PROPOSED_PATTERN = PatternCache.get(".*\\[@alt=\"[^\"]*proposed[^\"]*\"].*");
+    public static final Pattern DRAFT_PATTERN = PatternCache.get("\\[@draft=\"([^\"]*)\"\\]");
 
     private static boolean LOG_PROGRESS = false;
 
@@ -1496,8 +1497,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             "abbreviationFallback",
             "default", "mapping", "measurementSystem", "preferenceOrdering" }));
 
-        static final Pattern draftPattern = PatternCache.get("\\[@draft=\"([^\"]*)\"\\]");
-        Matcher draftMatcher = draftPattern.matcher("");
+        Matcher draftMatcher = DRAFT_PATTERN.matcher("");
 
         /**
          * Adds a parsed XPath to the CLDRFile.

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -66,13 +66,17 @@
 < (.*)/(characterLabels)/(characterLabelPattern)(.*)$
 > $1/characterLabelPatterns/$3$4
 
+# add currency with alt
+< (.*/numbers/currencyFormats\[@numberSystem="([^"]*)"\])/currencyFormatLength/currencyFormat\[@type="(accounting|standard)"]/pattern\[@type="standard"\]\[@alt="([^"]*)"\]$
+> $1/$3-$4
+
+# add currency without alt
+< (.*/numbers/currencyFormats\[@numberSystem="([^"]*)"\])/currencyFormatLength/currencyFormat\[@type="(accounting|standard)"]/pattern\[@type="standard"\]$
+> $1/$3
+
 # add type=standard
 < (.*/numbers/(decimal|scientific|percent|currency)Formats\[@numberSystem="([^"]*)"\])/(decimal|scientific|percent|currency)FormatLength/(decimal|scientific|percent|currency)Format\[@type="standard"]/pattern.*$
 > $1/standard
-
-#
-< (.*/numbers/currencyFormats\[@numberSystem="([^"]*)"\])/currencyFormatLength/currencyFormat\[@type="accounting"]/pattern.*$
-> $1/accounting
 
 # Add "type" attribute with value "standard" if there is no "type" in "decimalFormatLength".
 < (.*/numbers/(decimal|scientific|percent)Formats\[@numberSystem="([^"]*)"\]/(decimal|scientific|percent)FormatLength)/(.*)$


### PR DESCRIPTION
- due to CLDR-14336

CLDR-15958

- [ ] This PR completes the ticket.

With this fix, English JSON data is, for example,

```json
{
          "standard": "¤#,##0.00",
          "standard-alphaNextToNumber": "¤ #,##0.00",
          "standard-noCurrency": "#,##0.00",
          "accounting": "¤#,##0.00;(¤#,##0.00)",
          "accounting-alphaNextToNumber": "¤ #,##0.00;(¤ #,##0.00)",
          "accounting-noCurrency": "#,##0.00;(#,##0.00)"
}
```