### PR TITLE
CLDR-15990 generate .xsd from .dtd

### DIFF
--- a/common/dtd/ldml.xsd
+++ b/common/dtd/ldml.xsd
@@ -1,0 +1,8571 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 1991-2022 Unicode, Inc.
+  For terms of use, see http://www.unicode.org/copyright.html
+  SPDX-License-Identifier: Unicode-DFS-2016
+  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="ldml">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="identity"/>
+        <xs:choice>
+          <xs:element ref="alias"/>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="fallback"/>
+            <xs:element minOccurs="0" ref="localeDisplayNames"/>
+            <xs:element minOccurs="0" ref="layout"/>
+            <xs:element minOccurs="0" ref="contextTransforms"/>
+            <xs:element minOccurs="0" ref="characters"/>
+            <xs:element minOccurs="0" ref="delimiters"/>
+            <xs:element minOccurs="0" ref="measurement"/>
+            <xs:element minOccurs="0" ref="dates"/>
+            <xs:element minOccurs="0" ref="numbers"/>
+            <xs:element minOccurs="0" ref="units"/>
+            <xs:element minOccurs="0" ref="listPatterns"/>
+            <xs:element minOccurs="0" ref="collations"/>
+            <xs:element minOccurs="0" ref="posix"/>
+            <xs:element minOccurs="0" ref="characterLabels"/>
+            <xs:element minOccurs="0" ref="segmentations"/>
+            <xs:element minOccurs="0" ref="rbnf"/>
+            <xs:element minOccurs="0" ref="typographicNames"/>
+            <xs:element minOccurs="0" ref="personNames"/>
+            <xs:element minOccurs="0" ref="annotations"/>
+            <xs:element minOccurs="0" ref="metadata"/>
+            <xs:element minOccurs="0" ref="references"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="version"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <xs:element name="identity">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element ref="version"/>
+          <xs:element minOccurs="0" ref="generation"/>
+          <xs:element ref="language"/>
+          <xs:element minOccurs="0" ref="script"/>
+          <xs:element minOccurs="0" ref="territory"/>
+          <xs:element minOccurs="0" ref="variant"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <!-- # These elements are common to almost all elements defined -->
+  <xs:element name="alias">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="source" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="path"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/locale -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/\.\..* -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="special" type="any"/>
+  <xs:element name="version">
+    <xs:complexType>
+      <xs:attribute name="number" use="required"/>
+      <xs:attribute name="cldrVersion" default="42">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="42"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/\$Revision.*\$ -->
+  <!-- @METADATA -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="generation">
+    <xs:complexType>
+      <xs:attribute name="date" use="required"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="language">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/locale -->
+  <!-- @MATCH:literal/long, secondary, short, variant, menu -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="script">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/script -->
+  <!-- @MATCH:literal/secondary, short, stand-alone, variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="territory">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/region -->
+  <!-- @MATCH:literal/short, variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="variant">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/variant -->
+  <!-- @MATCH:literal/secondary, variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <xs:element name="fallback">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="localeDisplayNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="localeDisplayPattern"/>
+          <xs:element minOccurs="0" ref="languages"/>
+          <xs:element minOccurs="0" ref="scripts"/>
+          <xs:element minOccurs="0" ref="territories"/>
+          <xs:element minOccurs="0" ref="subdivisions"/>
+          <xs:element minOccurs="0" ref="variants"/>
+          <xs:element minOccurs="0" ref="keys"/>
+          <xs:element minOccurs="0" ref="types"/>
+          <xs:element minOccurs="0" ref="transformNames"/>
+          <xs:element minOccurs="0" ref="measurementSystemNames"/>
+          <xs:element minOccurs="0" ref="codePatterns"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="localeDisplayPattern">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="localePattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="localeSeparator"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="localeKeyTypePattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="localePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="localeSeparator">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="localeKeyTypePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more language -->
+  <xs:element name="languages">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="language"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more script -->
+  <xs:element name="scripts">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="script"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more territory -->
+  <xs:element name="territories">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="territory"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="subdivisions">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="subdivision"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="subdivision">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/validity/subdivision||literal/AS, AW, AX, BL, CP, CW, GF, GP, GU, HK, IC, MF, MO, MP, MQ, NC, PF, PM, PR, RE, SX, TA, TF, TW, UM, VI, WF, YT, itsd, no50 -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more variant -->
+  <xs:element name="variants">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="variant"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more key -->
+  <xs:element name="keys">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="key"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="key">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/bcp47/anykey||literal/t -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more type -->
+  <xs:element name="types">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="type"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="type">
+    <xs:complexType mixed="true">
+      <xs:attribute name="key" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:bcp47/anykey -->
+  <!-- @MATCH:bcp47/anyvalue -->
+  <!-- @MATCH:literal/short, variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="transformNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="transformName"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="transformName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- # Either 1 alias OR any specials, any order, zero or more measurementSystemName -->
+  <xs:element name="measurementSystemNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="measurementSystemName"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="measurementSystemName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="US"/>
+            <xs:enumeration value="metric"/>
+            <xs:enumeration value="UK"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="codePatterns">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="codePattern"/>
+          <xs:element ref="special"/>
+        </xs:choice>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="codePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/language, script, territory -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <!-- # layout and orientation are script specific, so validSublocales attribute is not required -->
+  <xs:element name="layout">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="orientation"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="inList"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="inText"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="orientation">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="characterOrder"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="lineOrder"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="characters">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left-to-right"/>
+            <xs:enumeration value="right-to-left"/>
+            <xs:enumeration value="top-to-bottom"/>
+            <xs:enumeration value="bottom-to-top"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lines">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left-to-right"/>
+            <xs:enumeration value="right-to-left"/>
+            <xs:enumeration value="top-to-bottom"/>
+            <xs:enumeration value="bottom-to-top"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="characterOrder">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="lineOrder">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="inList">
+    <xs:complexType mixed="true">
+      <xs:attribute name="casing">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="titlecase-words"/>
+            <xs:enumeration value="titlecase-firstword"/>
+            <xs:enumeration value="lowercase-words"/>
+            <xs:enumeration value="mixed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="inText">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="languages"/>
+            <xs:enumeration value="scripts"/>
+            <xs:enumeration value="territories"/>
+            <xs:enumeration value="variants"/>
+            <xs:enumeration value="keys"/>
+            <xs:enumeration value="types"/>
+            <xs:enumeration value="measurementSystemNames"/>
+            <xs:enumeration value="monthWidth"/>
+            <xs:enumeration value="dayWidth"/>
+            <xs:enumeration value="quarterWidth"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="fields"/>
+            <xs:enumeration value="currency"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <xs:element name="contextTransforms">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="contextTransformUsage"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="contextTransformUsage">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="contextTransform"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/calendar-field, currencyName, day-format-except-narrow, day-standalone-except-narrow, era-abbr, era-name, keyValue, languages, month-format-except-narrow, month-standalone-except-narrow, number-spellout, relative, script, typographicNames -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="contextTransform">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="uiListOrMenu"/>
+            <xs:enumeration value="stand-alone"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <xs:element name="characters">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="exemplarCharacters"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="ellipsis"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="moreInformation"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="stopwords"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="indexLabels"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="mapping"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="parseLenients"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="exemplarCharacters">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="auxiliary"/>
+            <xs:enumeration value="standard"/>
+            <xs:enumeration value="punctuation"/>
+            <xs:enumeration value="currencySymbol"/>
+            <xs:enumeration value="index"/>
+            <xs:enumeration value="numbers"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED:currencySymbol -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- # This element can occur anywhere there may be localizable data -->
+  <xs:element name="cp">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="hex" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="ellipsis">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="initial"/>
+            <xs:enumeration value="medial"/>
+            <xs:enumeration value="final"/>
+            <xs:enumeration value="word-initial"/>
+            <xs:enumeration value="word-medial"/>
+            <xs:enumeration value="word-final"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="moreInformation">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="stopwords">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="stopwordList"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="stopwordList">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="indexLabels">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="indexSeparator"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="compressedIndexSeparator"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="indexRangePattern"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="indexLabelBefore"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="indexLabelAfter"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="indexLabel"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="indexSeparator">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="compressedIndexSeparator">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="indexRangePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="indexLabelBefore">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="indexLabelAfter">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="indexLabel">
+    <xs:complexType mixed="true">
+      <xs:attribute name="indexSource"/>
+      <xs:attribute name="priority">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="mapping">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="registry" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="choice" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- use choice instead -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="parseLenients">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="parseLenient"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="scope" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="general"/>
+            <xs:enumeration value="number"/>
+            <xs:enumeration value="date"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="lenient"/>
+            <xs:enumeration value="stricter"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="parseLenient">
+    <xs:complexType mixed="true">
+      <xs:attribute name="sample" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <xs:element name="delimiters">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="quotationStart"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="quotationEnd"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="alternateQuotationStart"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="alternateQuotationEnd"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="quotationStart">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="quotationEnd">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="alternateQuotationStart">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="alternateQuotationEnd">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <xs:element name="measurement">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="measurementSystem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="paperSize"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use measurementData in supplemental instead -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="measurementSystem">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="metric"/>
+            <xs:enumeration value="US"/>
+            <xs:enumeration value="UK"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="choice">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="metric"/>
+            <xs:enumeration value="US"/>
+            <xs:enumeration value="UK"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use measurementSystem in supplemental instead -->
+  <!-- @DEPRECATED -->
+  <!-- use choice instead -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- really required, but needs to be optional to support type also -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="paperSize">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="height"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="width"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use paperSize in supplemental instead -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="height">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="width">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <xs:element name="dates">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="localizedPatternChars"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dateRangePattern"/>
+          <xs:element minOccurs="0" ref="calendars"/>
+          <xs:element minOccurs="0" ref="fields"/>
+          <xs:element minOccurs="0" ref="timeZoneNames"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="localizedPatternChars">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateRangePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use intervalFormats. -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="calendars">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="calendar"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use calendarPreferenceData instead of default element -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="default">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="choice" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="calendar">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="months"/>
+          <xs:element minOccurs="0" ref="monthNames"/>
+          <xs:element minOccurs="0" ref="monthAbbr"/>
+          <xs:element minOccurs="0" ref="monthPatterns"/>
+          <xs:element minOccurs="0" ref="days"/>
+          <xs:element minOccurs="0" ref="dayNames"/>
+          <xs:element minOccurs="0" ref="dayAbbr"/>
+          <xs:element minOccurs="0" ref="quarters"/>
+          <xs:element minOccurs="0" ref="week"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="am"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pm"/>
+          <xs:element minOccurs="0" ref="dayPeriods"/>
+          <xs:element minOccurs="0" ref="eras"/>
+          <xs:element minOccurs="0" ref="cyclicNameSets"/>
+          <xs:element minOccurs="0" ref="dateFormats"/>
+          <xs:element minOccurs="0" ref="timeFormats"/>
+          <xs:element minOccurs="0" ref="dateTimeFormats"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="fields"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use of fields is deprecated here -->
+  <!-- @MATCH:bcp47/ca -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="months">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="monthContext"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthContext">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="monthWidth"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="format"/>
+            <xs:enumeration value="stand-alone"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthWidth">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="month"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbreviated"/>
+            <xs:enumeration value="narrow"/>
+            <xs:enumeration value="wide"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="month">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
+            <xs:enumeration value="10"/>
+            <xs:enumeration value="11"/>
+            <xs:enumeration value="12"/>
+            <xs:enumeration value="13"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="yeartype">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="standard"/>
+            <xs:enumeration value="leap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="monthNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="month"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthAbbr">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="month"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthPatterns">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="monthPatternContext"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthPatternContext">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="monthPatternWidth"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="format"/>
+            <xs:enumeration value="stand-alone"/>
+            <xs:enumeration value="numeric"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthPatternWidth">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="monthPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbreviated"/>
+            <xs:enumeration value="narrow"/>
+            <xs:enumeration value="wide"/>
+            <xs:enumeration value="all"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="monthPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="leap"/>
+            <xs:enumeration value="standardAfterLeap"/>
+            <xs:enumeration value="combined"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="days">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayContext"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dayContext">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayWidth"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="format"/>
+            <xs:enumeration value="stand-alone"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dayWidth">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="day"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbreviated"/>
+            <xs:enumeration value="narrow"/>
+            <xs:enumeration value="short"/>
+            <xs:enumeration value="wide"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="day">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="dayNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="day"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dayAbbr">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="day"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="quarters">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="quarterContext"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="quarterContext">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="quarterWidth"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="format"/>
+            <xs:enumeration value="stand-alone"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="quarterWidth">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="quarter"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbreviated"/>
+            <xs:enumeration value="narrow"/>
+            <xs:enumeration value="wide"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="quarter">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="week">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="minDays"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="firstDay"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="weekendStart"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="weekendEnd"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use supplemental weekData -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="minDays">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="count" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="firstDay">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="day" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use supplemental data -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="weekendStart">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="day" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="time" default="00:00"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use supplemental data -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="weekendEnd">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="day" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="time" default="24:00"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use supplemental data -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="am">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use dayPeriods -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="pm">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use dayPeriods -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dayPeriods">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayPeriodContext"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="dayPeriodContext">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayPeriodWidth"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/format, stand-alone -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="dayPeriodWidth">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayPeriod"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbreviated"/>
+            <xs:enumeration value="narrow"/>
+            <xs:enumeration value="wide"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="dayPeriod">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/afternoon1, afternoon2, am, evening1, evening2, midnight, morning1, morning2, night1, night2, noon, pm -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="eras">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="eraNames"/>
+          <xs:element minOccurs="0" ref="eraAbbr"/>
+          <xs:element minOccurs="0" ref="eraNarrow"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="eraNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="era"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="era">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:range/0~237 -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="eraAbbr">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="era"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="eraNarrow">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="era"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cyclicNameSets">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="cyclicNameSet"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cyclicNameSet">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="cyclicNameContext"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="years"/>
+            <xs:enumeration value="months"/>
+            <xs:enumeration value="days"/>
+            <xs:enumeration value="dayParts"/>
+            <xs:enumeration value="zodiacs"/>
+            <xs:enumeration value="solarTerms"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cyclicNameContext">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="cyclicNameWidth"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="format"/>
+            <xs:enumeration value="stand-alone"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cyclicNameWidth">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="cyclicName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbreviated"/>
+            <xs:enumeration value="narrow"/>
+            <xs:enumeration value="wide"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cyclicName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:range/1~60 -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="dateFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dateFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dateFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="datetimeSkeleton"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="pattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="numbers"/>
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000, 100000000000000, approximately, atLeast, atMost, range, standard -->
+  <!-- TODO: generalize this to be any (M=|d=)?<numberSystem> -->
+  <!-- @MATCH:literal/M=romanlow, d=hanidays, hanidec, hebr, y=jpanyear -->
+  <!-- @VALUE -->
+  <!-- Only used for decimalFormats type="1000..." -->
+  <!-- @MATCH:literal/alphaNextToNumber, noCurrency, variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="datetimeSkeleton">
+    <xs:complexType mixed="true">
+      <xs:attribute name="numbers"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- TODO: generalize this to be any (M=|d=)?<numberSystem> -->
+  <!-- @MATCH:literal/M=romanlow, d=hanidays, hanidec, hebr, y=jpanyear -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="displayName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- only for currencies -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="timeFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="timeFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="timeFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="timeFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="timeFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="datetimeSkeleton"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateTimeFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dateTimeFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="availableFormats"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="appendItems"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="intervalFormats"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateTimeFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dateTimeFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateTimeFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard, atTime -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="availableFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="dateFormatItem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="dateFormatItem">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required"/>
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- TODO rationalize this list -->
+  <!-- @MATCH:literal/Bh, Bhm, Bhms, E, EBhm, EBhms, EEEEd, EHm, EHms, Ed, Ehm, Ehms, Gy, GyM, GyMEEEEd, GyMMM, GyMMMEEEEd, GyMMMEd, GyMMMM, GyMMMMEd, GyMMMMd, GyMMMd, GyMd, H, HHmm, HHmmZ, HHmmss, Hm, HmZ, Hmm, Hms, Hmsv, Hmsvvvv, Hmv, Hmvvvv, M, MEEEEd, MEd, MMM, MMMEEEEd, MMMEd, MMMM, MMMMEEEEd, MMMMEd, MMMMW, MMMMd, MMMMdd, MMMd, MMMdd, MMd, MMdd, Md, Mdd, UM, UMMM, UMMMd, UMd, d, h, hhmm, hhmmss, hm, hms, hmsv, hmsvvvv, hmv, hmvvvv, mmss, ms, y, yM, yMEEEEd, yMEd, yMM, yMMM, yMMMEEEEd, yMMMEd, yMMMM, yMMMMEEEEd, yMMMMEd, yMMMMccccd, yMMMMd, yMMMd, yMMdd, yMd, yQ, yQQQ, yQQQQ, yw, yyyy, yyyyM, yyyyMEEEEd, yyyyMEd, yyyyMM, yyyyMMM, yyyyMMMEEEEd, yyyyMMMEd, yyyyMMMM, yyyyMMMMEd, yyyyMMMMccccd, yyyyMMMMd, yyyyMMMd, yyyyMMdd, yyyyMd, yyyyQQQ, yyyyQQQQ -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="appendItems">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="appendItem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="appendItem">
+    <xs:complexType mixed="true">
+      <xs:attribute name="request" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/Day, Day-Of-Week, Era, Hour, Minute, Month, Quarter, Second, Timezone, Week, Year -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="intervalFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="intervalFormatFallback"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="intervalFormatItem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="intervalFormatFallback">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="intervalFormatItem">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="greatestDifference"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- TODO: check to see if this should be minimized -->
+  <!-- @MATCH:literal/Bh, Bhm, Gy, GyM, GyMEd, GyMMM, GyMMMEd, GyMMMd, GyMd, H, Hm, Hmv, Hv, M, MEd, MMM, MMMEEEEd, MMMEd, MMMM, MMMMEd, MMMMd, MMMd, Md, d, h, hm, hmv, hv, y, yM, yMEd, yMMM, yMMMEEEEd, yMMMEd, yMMMM, yMMMMEEEEd, yMMMMEd, yMMMMd, yMMMd, yMd, GGGGGyM, GGGGGyMEd, GGGGGyMd, GyMMMM, GyMMMMEd, GyMMMMd -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="greatestDifference">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/B, G, H, M, a, d, h, m, y -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="fields">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="field"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="field">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="relative"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="relativeTime"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="relativePeriod"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="era"/>
+            <xs:enumeration value="era-short"/>
+            <xs:enumeration value="era-narrow"/>
+            <xs:enumeration value="year"/>
+            <xs:enumeration value="year-short"/>
+            <xs:enumeration value="year-narrow"/>
+            <xs:enumeration value="quarter"/>
+            <xs:enumeration value="quarter-short"/>
+            <xs:enumeration value="quarter-narrow"/>
+            <xs:enumeration value="month"/>
+            <xs:enumeration value="month-short"/>
+            <xs:enumeration value="month-narrow"/>
+            <xs:enumeration value="week"/>
+            <xs:enumeration value="week-short"/>
+            <xs:enumeration value="week-narrow"/>
+            <xs:enumeration value="weekOfMonth"/>
+            <xs:enumeration value="weekOfMonth-short"/>
+            <xs:enumeration value="weekOfMonth-narrow"/>
+            <xs:enumeration value="day"/>
+            <xs:enumeration value="day-short"/>
+            <xs:enumeration value="day-narrow"/>
+            <xs:enumeration value="dayOfYear"/>
+            <xs:enumeration value="dayOfYear-short"/>
+            <xs:enumeration value="dayOfYear-narrow"/>
+            <xs:enumeration value="weekday"/>
+            <xs:enumeration value="weekday-short"/>
+            <xs:enumeration value="weekday-narrow"/>
+            <xs:enumeration value="weekdayOfMonth"/>
+            <xs:enumeration value="weekdayOfMonth-short"/>
+            <xs:enumeration value="weekdayOfMonth-narrow"/>
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="sun-short"/>
+            <xs:enumeration value="sun-narrow"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="mon-short"/>
+            <xs:enumeration value="mon-narrow"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="tue-short"/>
+            <xs:enumeration value="tue-narrow"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="wed-short"/>
+            <xs:enumeration value="wed-narrow"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="thu-short"/>
+            <xs:enumeration value="thu-narrow"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="fri-short"/>
+            <xs:enumeration value="fri-narrow"/>
+            <xs:enumeration value="sat"/>
+            <xs:enumeration value="sat-short"/>
+            <xs:enumeration value="sat-narrow"/>
+            <xs:enumeration value="dayperiod"/>
+            <xs:enumeration value="dayperiod-short"/>
+            <xs:enumeration value="dayperiod-narrow"/>
+            <xs:enumeration value="hour"/>
+            <xs:enumeration value="hour-short"/>
+            <xs:enumeration value="hour-narrow"/>
+            <xs:enumeration value="minute"/>
+            <xs:enumeration value="minute-short"/>
+            <xs:enumeration value="minute-narrow"/>
+            <xs:enumeration value="second"/>
+            <xs:enumeration value="second-short"/>
+            <xs:enumeration value="second-narrow"/>
+            <xs:enumeration value="zone"/>
+            <xs:enumeration value="zone-short"/>
+            <xs:enumeration value="zone-narrow"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="relative">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- TODO: determine whether to allow 3 -->
+  <!-- @MATCH:range/-2~3 -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="relativeTime">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="relativeTimePattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/future, past -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="relativeTimePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="count" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="relativePeriod">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="timeZoneNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="hourFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="hoursFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="gmtFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="gmtZeroFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="regionFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="fallbackFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="fallbackRegionFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="abbreviationFallback"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="preferenceOrdering"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="singleCountries"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="zone"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="metazone"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="hourFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="hoursFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="gmtFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="gmtZeroFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="regionFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="standard"/>
+            <xs:enumeration value="daylight"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="fallbackFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="fallbackRegionFormat">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="abbreviationFallback">
+    <xs:complexType>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="GMT"/>
+            <xs:enumeration value="standard"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="choice">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="GMT"/>
+            <xs:enumeration value="standard"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- use choice instead -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- really required, but needs to be optional to support type also -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="preferenceOrdering">
+    <xs:complexType>
+      <xs:attribute name="type"/>
+      <xs:attribute name="choice"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use metazones instead -->
+  <!-- @DEPRECATED -->
+  <!-- use choice instead -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- really required, but needs to be optional to support type also -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="singleCountries">
+    <xs:complexType>
+      <xs:attribute name="list" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="zone">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="long"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="short"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="commonlyUsed"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="exemplarCity"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:bcp47/tz -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="long">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="generic"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="standard"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="daylight"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="generic">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="standard">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="daylight">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="short">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="generic"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="standard"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="daylight"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="commonlyUsed">
+    <xs:complexType mixed="true">
+      <xs:attribute name="used">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="exemplarCity">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/formal, secondary -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="metazone">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="long"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="short"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="commonlyUsed"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:metazone -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <xs:element name="numbers">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="defaultNumberingSystem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="otherNumberingSystems"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="minimumGroupingDigits"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="symbols"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="decimalFormats"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="scientificFormats"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="percentFormats"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyFormats"/>
+          <xs:element minOccurs="0" ref="currencies"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="miscPatterns"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="minimalPairs"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="defaultNumberingSystem">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:bcp47/nu -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="otherNumberingSystems">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="native"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="traditional"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="finance"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="native">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="traditional">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="finance">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="minimumGroupingDigits">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="symbols">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="decimal"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="group"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="list"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="percentSign"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="nativeZeroDigit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="patternDigit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="plusSign"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="minusSign"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="approximatelySign"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="exponential"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="superscriptingExponent"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="perMille"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="infinity"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="nan"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyDecimal"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyGroup"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="timeSeparator"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:bcp47/nu -->
+  <xs:element name="decimal">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="group">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="list">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="percentSign">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="nativeZeroDigit">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="patternDigit">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="plusSign">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="minusSign">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="approximatelySign">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="exponential">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="superscriptingExponent">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="perMille">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="infinity">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="nan">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyDecimal">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyGroup">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="timeSeparator">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="decimalFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="decimalFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:bcp47/nu -->
+  <xs:element name="decimalFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="decimalFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="decimalFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="scientificFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="scientificFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:bcp47/nu -->
+  <xs:element name="scientificFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="scientificFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="scientificFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="percentFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="percentFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:bcp47/nu -->
+  <xs:element name="percentFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="percentFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="percentFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyFormats">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencySpacing"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyFormatLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyPatternAppendISO"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:bcp47/nu -->
+  <xs:element name="currencySpacing">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="beforeCurrency"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="afterCurrency"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="beforeCurrency">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyMatch"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="surroundingMatch"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="insertBetween"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="currencyMatch">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="surroundingMatch">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="insertBetween">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="afterCurrency">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyMatch"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="surroundingMatch"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="insertBetween"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="currencyFormatLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyFormat"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="short"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyFormat">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/accounting, standard -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyPatternAppendISO">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="unitPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="count" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="case" type="xs:NMTOKENS"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/ablative, accusative, comitative, dative, ergative, genitive, instrumental, locative, locativecopulative, nominative, oblique, prepositional, sociative, vocative, elative, illative, partitive, terminative, translative -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencies">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="currency"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currency">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:choice minOccurs="0">
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="pattern"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="symbol"/>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="displayName"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="symbol"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" ref="symbol"/>
+              <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+            </xs:sequence>
+          </xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="decimal"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="group"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!--
+    # warning: pattern appears twice in the above. The first is for consistency with all other cases of
+    pattern + displayName; the second is for backwards compatibility
+  -->
+  <!-- @MATCH:validity/currency -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="symbol">
+    <xs:complexType mixed="true">
+      <xs:attribute name="choice">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/formal, narrow, variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="miscPatterns">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="numberSystem"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:bcp47/nu -->
+  <xs:element name="minimalPairs">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="pluralMinimalPairs"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="ordinalMinimalPairs"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="caseMinimalPairs"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="genderMinimalPairs"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="pluralMinimalPairs">
+    <xs:complexType mixed="true">
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/few, many, one, other, two, zero -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="ordinalMinimalPairs">
+    <xs:complexType mixed="true">
+      <xs:attribute name="ordinal" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/few, many, one, other, two, zero -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="caseMinimalPairs">
+    <xs:complexType mixed="true">
+      <xs:attribute name="case" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/ablative, accusative, comitative, dative, ergative, genitive, instrumental, locative, locativecopulative, nominative, oblique, prepositional, sociative, vocative, elative, illative, partitive, terminative, translative -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="genderMinimalPairs">
+    <xs:complexType mixed="true">
+      <xs:attribute name="gender" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/animate, common, feminine, inanimate, masculine, neuter, personal -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <xs:element name="units">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="unit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitLength"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="durationUnit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="unit">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="gender"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="perUnitPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/unit -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="gender">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/animate, common, feminine, inanimate, masculine, neuter, personal -->
+  <!-- @METADATA -->
+  <xs:element name="perUnitPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="unitLength">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="compoundUnit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="unit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="coordinateUnit"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="short"/>
+            <xs:enumeration value="narrow"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="compoundUnit">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="compoundUnitPattern1"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="compoundUnitPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitPrefixPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/regex/10p-?[0-9]{1,2}||regex/1024p[1-8]||literal/per, times, power2, power3 -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="compoundUnitPattern1">
+    <xs:complexType mixed="true">
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="gender" type="xs:NMTOKENS"/>
+      <xs:attribute name="case" type="xs:NMTOKENS"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/animate, common, feminine, inanimate, masculine, neuter, personal -->
+  <!-- @MATCH:literal/ablative, accusative, comitative, dative, ergative, genitive, instrumental, locative, locativecopulative, nominative, oblique, prepositional, sociative, vocative -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="compoundUnitPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="case" type="xs:NMTOKENS"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/ablative, accusative, comitative, dative, ergative, genitive, instrumental, locative, locativecopulative, nominative, oblique, prepositional, sociative, vocative -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="unitPrefixPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="coordinateUnit">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="coordinateUnitPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="coordinateUnitPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="north"/>
+            <xs:enumeration value="east"/>
+            <xs:enumeration value="south"/>
+            <xs:enumeration value="west"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="durationUnit">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="durationUnitPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/hm, hms, ms -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="durationUnitPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="listPatterns">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="listPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="listPattern">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="listPatternPart"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/or, or-narrow, or-short, standard-narrow, standard-short, unit, unit-narrow, unit-short -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="listPatternPart">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="start"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="end"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <xs:element name="collations">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="defaultCollation"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="default"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="collation"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="version" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- should be DEPRECATED, but needs some cleanup first -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="defaultCollation">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="collation">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="base"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+          <xs:element minOccurs="0" ref="settings"/>
+          <xs:element minOccurs="0" ref="suppress_contractions"/>
+          <xs:element minOccurs="0" ref="optimize"/>
+          <xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="cr"/>
+            <xs:element minOccurs="0" ref="rules"/>
+          </xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="visibility">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="internal"/>
+            <xs:enumeration value="external"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/bcp47/co||regex/private-.*||literal/digits-after -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/proposed, short, variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="base">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:element ref="special"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="import">
+    <xs:complexType>
+      <xs:attribute name="source" use="required"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- deprecated, see CLDR ticket #8289 -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="settings">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="strength">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="primary"/>
+            <xs:enumeration value="secondary"/>
+            <xs:enumeration value="tertiary"/>
+            <xs:enumeration value="quaternary"/>
+            <xs:enumeration value="identical"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alternate">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="non-ignorable"/>
+            <xs:enumeration value="shifted"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="backwards">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="normalization">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="caseLevel">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="caseFirst">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="upper"/>
+            <xs:enumeration value="lower"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="hiraganaQuarternary">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="hiraganaQuaternary">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxVariable">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="space"/>
+            <xs:enumeration value="punct"/>
+            <xs:enumeration value="symbol"/>
+            <xs:enumeration value="currency"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="numeric">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="private">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="variableTop"/>
+      <xs:attribute name="reorder" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- deprecated, see CLDR ticket #8289 -->
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="suppress_contractions">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- deprecated, see CLDR ticket #8289 -->
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="optimize">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- deprecated, see CLDR ticket #8289 -->
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cr">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- # Use the cr element instead, with ICU syntax. -->
+  <xs:element name="rules">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:choice>
+            <xs:element ref="reset"/>
+            <xs:element ref="import"/>
+          </xs:choice>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="reset"/>
+            <xs:element ref="import"/>
+            <xs:element ref="p"/>
+            <xs:element ref="pc"/>
+            <xs:element ref="s"/>
+            <xs:element ref="sc"/>
+            <xs:element ref="t"/>
+            <xs:element ref="tc"/>
+            <xs:element ref="q"/>
+            <xs:element ref="qc"/>
+            <xs:element ref="i"/>
+            <xs:element ref="ic"/>
+            <xs:element ref="x"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="reset">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="first_variable"/>
+        <xs:element ref="last_variable"/>
+        <xs:element ref="first_tertiary_ignorable"/>
+        <xs:element ref="last_tertiary_ignorable"/>
+        <xs:element ref="first_secondary_ignorable"/>
+        <xs:element ref="last_secondary_ignorable"/>
+        <xs:element ref="first_primary_ignorable"/>
+        <xs:element ref="last_primary_ignorable"/>
+        <xs:element ref="first_non_ignorable"/>
+        <xs:element ref="last_non_ignorable"/>
+        <xs:element ref="first_trailing"/>
+        <xs:element ref="last_trailing"/>
+      </xs:choice>
+      <xs:attribute name="before" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="first_variable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="last_variable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="first_tertiary_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="last_tertiary_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="first_secondary_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="last_secondary_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="first_primary_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="last_primary_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="first_non_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="last_non_ignorable">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="first_trailing">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="last_trailing">
+    <xs:complexType/>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="pc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="s">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="sc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="t">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="tc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="q">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="qc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="i">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="ic">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="cp"/>
+        <xs:element ref="last_variable"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="x">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="context"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="p"/>
+          <xs:element ref="pc"/>
+          <xs:element ref="s"/>
+          <xs:element ref="sc"/>
+          <xs:element ref="t"/>
+          <xs:element ref="tc"/>
+          <xs:element ref="q"/>
+          <xs:element ref="qc"/>
+          <xs:element ref="i"/>
+          <xs:element ref="ic"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="extend"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="context">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="extend">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cp"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <!-- ######################################################### -->
+  <xs:element name="posix">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="messages"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="messages">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="yesstr"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="nostr"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="yesexpr"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="noexpr"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="yesstr">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="nostr">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="yesexpr">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="noexpr">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="characterLabels">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="characterLabelPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="characterLabel"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="characterLabelPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="count">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/all, category-list, compatibility, enclosed, extended, historic, miscellaneous, other, scripts, strokes, subscript, superscript -->
+  <!-- count only used for certain patterns" -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="characterLabel">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/activities, african_scripts, american_scripts, animal, animals_nature, arrows, body, box_drawing, braille, building, bullets_stars, consonantal_jamo, currency_symbols, dash_connector, digits, dingbats, divination_symbols, downwards_arrows, downwards_upwards_arrows, east_asian_scripts, emoji, european_scripts, female, flag, flags, food_drink, format, format_whitespace, full_width_form_variant, geometric_shapes, half_width_form_variant, han_characters, han_radicals, hanja, hanzi_simplified, hanzi_traditional, heart, historic_scripts, ideographic_desc_characters, japanese_kana, kanbun, kanji, keycap, leftwards_arrows, leftwards_rightwards_arrows, letterlike_symbols, limited_use, male, math_symbols, middle_eastern_scripts, miscellaneous, modern_scripts, modifier, musical_symbols, nature, nonspacing, numbers, objects, other, paired, person, phonetic_alphabet, pictographs, place, plant, punctuation, rightwards_arrows, sign_standard_symbols, small_form_variant, smiley, smileys_people, south_asian_scripts, southeast_asian_scripts, spacing, sport, symbols, technical_symbols, tone_marks, travel, travel_places, upwards_arrows, variant_forms, vocalic_jamo, weather, western_asian_scripts, whitespace -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="segmentations">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="segmentation"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="segmentation">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="variables"/>
+          <xs:element minOccurs="0" ref="segmentRules"/>
+          <xs:element minOccurs="0" ref="exceptions"/>
+          <xs:element minOccurs="0" ref="suppressions"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="validSubLocales"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/GraphemeClusterBreak, LineBreak, SentenceBreak, WordBreak -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="variables">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="variable"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="variable">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:regex/\$[a-zA-Z0-9_]+ -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="segmentRules">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="rule"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rule">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:range/0.0~9999.0 -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="exceptions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="exception"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- use suppressions instead -->
+  <!-- @DEPRECATED -->
+  <xs:element name="exception">
+    <xs:complexType mixed="true">
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="suppressions">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="suppression"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" default="standard" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/standard -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="suppression">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="rbnf">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="rulesetGrouping"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rulesetGrouping">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="ruleset"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/NumberingSystemRules, OrdinalRules, SpelloutRules -->
+  <!-- @METADATA -->
+  <xs:element name="ruleset">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="rbnfrule"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="access">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="public"/>
+            <xs:enumeration value="private"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="allowsParsing">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:regex/(ord-M-)?[\-0-9a-z]+ -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="rbnfrule">
+    <xs:complexType mixed="true">
+      <xs:attribute name="value" use="required"/>
+      <xs:attribute name="radix"/>
+      <xs:attribute name="decexp"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:or/range/-1.0E20~1.0E20||literal/-x, 0, 0.x, NaN, -Inf, Inf, x,x, x.x -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/1,000, 100, 1000, 100000, 20 -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="typographicNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="axisName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="styleName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="featureName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="axisName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ital"/>
+            <xs:enumeration value="opsz"/>
+            <xs:enumeration value="slnt"/>
+            <xs:enumeration value="wdth"/>
+            <xs:enumeration value="wght"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="styleName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ital"/>
+            <xs:enumeration value="opsz"/>
+            <xs:enumeration value="slnt"/>
+            <xs:enumeration value="wdth"/>
+            <xs:enumeration value="wght"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="subtype" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/-12, 0, 1, 100, 112.5, 12, 125, 144, 150, 18, 200, 24, 300, 350, 380, 400, 50, 500, 600, 62.5, 700, 72, 75, 8, 800, 87.5, 900, 950 -->
+  <!-- @MATCH:literal/compressed, demi, extended, heavy, narrow, short, ultra, ultrablack, ultraheavy, wide -->
+  <!-- @METADATA -->
+  <xs:element name="featureName">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="afrc"/>
+            <xs:enumeration value="cpsp"/>
+            <xs:enumeration value="dlig"/>
+            <xs:enumeration value="frac"/>
+            <xs:enumeration value="lnum"/>
+            <xs:enumeration value="onum"/>
+            <xs:enumeration value="ordn"/>
+            <xs:enumeration value="pnum"/>
+            <xs:enumeration value="smcp"/>
+            <xs:enumeration value="tnum"/>
+            <xs:enumeration value="zero"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/short, variant -->
+  <!-- @METADATA -->
+  <xs:element name="personNames">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="nameOrderLocales"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="foreignSpaceReplacement"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="initialPattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="personName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="sampleName"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="nameOrderLocales">
+    <xs:complexType mixed="true">
+      <xs:attribute name="order" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="givenFirst"/>
+            <xs:enumeration value="surnameFirst"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="foreignSpaceReplacement">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="xml:space" default="preserve"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="initialPattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="initial"/>
+            <xs:enumeration value="initialSequence"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="personName">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="namePattern"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="order" type="xs:NMTOKENS"/>
+      <xs:attribute name="length" type="xs:NMTOKENS"/>
+      <xs:attribute name="usage" type="xs:NMTOKENS"/>
+      <xs:attribute name="formality" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/givenFirst, surnameFirst, sorting -->
+  <!-- @MATCH:set/literal/long, medium, short -->
+  <!-- @MATCH:set/literal/referring, addressing, monogram -->
+  <!-- @MATCH:set/literal/formal, informal -->
+  <xs:element name="namePattern">
+    <xs:complexType mixed="true">
+      <xs:attribute name="alt">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="sampleName">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="nameField"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="item" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/givenOnly, givenSurnameOnly, given12Surname, full -->
+  <xs:element name="nameField">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/prefix, given, given-informal, given2, surname, surname-prefix, surname-core, surname2, suffix -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="annotations">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="annotation"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation">
+    <xs:complexType mixed="true">
+      <xs:attribute name="cp" use="required"/>
+      <xs:attribute name="tts"/>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="tts"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <!-- ######################################################### -->
+  <!-- # This element contains metadata for Survey Tool internal use (optimization, etc). -->
+  <xs:element name="metadata">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="casingData"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="casingData">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="casingItem"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+        </xs:sequence>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="casingItem">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="override">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="forceError">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @METADATA -->
+  <xs:element name="references">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="reference"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="reference">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="uri"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="any" mixed="true">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+<!-- @METADATA -->
+<!-- @DEPRECATED -->
+<!-- @DEPRECATED -->
+<!-- @VALUE -->
+<!-- @DEPRECATED -->
+<!-- @MATCH:literal/variant -->
+<!-- @DEPRECATED -->
+<!-- @METADATA -->
+<!-- @DEPRECATED -->
+<!-- @METADATA -->
+<!-- @DEPRECATED -->

--- a/common/dtd/ldmlBCP47.xsd
+++ b/common/dtd/ldmlBCP47.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 1991-2022 Unicode, Inc.
+  For terms of use, see http://www.unicode.org/copyright.html
+  SPDX-License-Identifier: Unicode-DFS-2016
+  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="ldmlBCP47">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="version"/>
+        <xs:element minOccurs="0" ref="generation"/>
+        <xs:element minOccurs="0" ref="cldrVersion"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="keyword"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="attribute"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="version">
+    <xs:complexType>
+      <xs:attribute name="number" use="required"/>
+      <xs:attribute name="cldrVersion" default="42">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="42"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @MATCH:regex/\$Revision.*\$ -->
+  <!-- @METADATA -->
+  <!-- @MATCH:version -->
+  <!-- @VALUE -->
+  <xs:element name="generation">
+    <xs:complexType>
+      <xs:attribute name="date" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cldrVersion">
+    <xs:complexType>
+      <xs:attribute name="version" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="keyword">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="key"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="key">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="type"/>
+      </xs:sequence>
+      <xs:attribute name="extension" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="description"/>
+      <xs:attribute name="deprecated" default="false">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="preferred" type="xs:NMTOKEN"/>
+      <xs:attribute name="alias" type="xs:NMTOKEN"/>
+      <xs:attribute name="valueType">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="single"/>
+            <xs:enumeration value="multiple"/>
+            <xs:enumeration value="incremental"/>
+            <xs:enumeration value="any"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="since"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:regex/[a-z0-9]{2} -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:version -->
+  <!-- @METADATA -->
+  <xs:element name="type">
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="description" use="required"/>
+      <xs:attribute name="deprecated" default="false">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="preferred" type="xs:NMTOKEN"/>
+      <xs:attribute name="alias"/>
+      <xs:attribute name="since"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:bcp47/anyvalue -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:version -->
+  <!-- @METADATA -->
+  <xs:element name="attribute">
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="description" use="required"/>
+      <xs:attribute name="deprecated" default="false">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="preferred" type="xs:NMTOKEN"/>
+      <xs:attribute name="since"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+<!-- @VALUE -->
+<!-- @VALUE -->
+<!-- @VALUE -->
+<!-- @METADATA -->

--- a/common/dtd/ldmlSupplemental.xsd
+++ b/common/dtd/ldmlSupplemental.xsd
@@ -1,0 +1,2887 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 1991-2022 Unicode, Inc.
+  For terms of use, see http://www.unicode.org/copyright.html
+  SPDX-License-Identifier: Unicode-DFS-2016
+  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="supplementalData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="version"/>
+        <xs:element minOccurs="0" ref="generation"/>
+        <xs:element minOccurs="0" ref="cldrVersion"/>
+        <xs:element minOccurs="0" ref="currencyData"/>
+        <xs:element minOccurs="0" ref="territoryContainment"/>
+        <xs:element minOccurs="0" ref="subdivisionContainment"/>
+        <xs:element minOccurs="0" ref="languageData"/>
+        <xs:element minOccurs="0" ref="territoryInfo"/>
+        <xs:element minOccurs="0" ref="postalCodeData"/>
+        <xs:element minOccurs="0" ref="calendarData"/>
+        <xs:element minOccurs="0" ref="calendarPreferenceData"/>
+        <xs:element minOccurs="0" ref="weekData"/>
+        <xs:element minOccurs="0" ref="timeData"/>
+        <xs:element minOccurs="0" ref="measurementData"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitConstants"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitQuantities"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="convertUnits"/>
+        <xs:element minOccurs="0" ref="unitPreferenceData"/>
+        <xs:element minOccurs="0" ref="timezoneData"/>
+        <xs:element minOccurs="0" ref="characters"/>
+        <xs:element minOccurs="0" ref="transforms"/>
+        <xs:element minOccurs="0" ref="metadata"/>
+        <xs:element minOccurs="0" ref="codeMappings"/>
+        <xs:element minOccurs="0" ref="parentLocales"/>
+        <xs:element minOccurs="0" ref="personNamesDefaults"/>
+        <xs:element minOccurs="0" ref="likelySubtags"/>
+        <xs:element minOccurs="0" ref="metazoneInfo"/>
+        <xs:element minOccurs="0" ref="plurals"/>
+        <xs:element minOccurs="0" ref="telephoneCodeData"/>
+        <xs:element minOccurs="0" ref="numberingSystems"/>
+        <xs:element minOccurs="0" ref="bcp47KeywordMappings"/>
+        <xs:element minOccurs="0" ref="gender"/>
+        <xs:element minOccurs="0" ref="references"/>
+        <xs:element minOccurs="0" ref="languageMatching"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayPeriodRuleSet"/>
+        <xs:element minOccurs="0" ref="metaZones"/>
+        <xs:element minOccurs="0" ref="primaryZones"/>
+        <xs:element minOccurs="0" ref="windowsZones"/>
+        <xs:element minOccurs="0" ref="coverageLevels"/>
+        <xs:element minOccurs="0" ref="idValidity"/>
+        <xs:element minOccurs="0" ref="rgScope"/>
+        <xs:element minOccurs="0" ref="languageGroups"/>
+        <xs:element minOccurs="0" ref="grammaticalData"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="version">
+    <xs:complexType>
+      <xs:attribute name="number" use="required"/>
+      <xs:attribute name="cldrVersion" default="42">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="42"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="unicodeVersion" default="14.0.0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="14.0.0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @MATCH:version -->
+  <!-- @VALUE -->
+  <!-- @MATCH:version -->
+  <!-- @VALUE -->
+  <xs:element name="generation">
+    <xs:complexType>
+      <xs:attribute name="date" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="cldrVersion">
+    <xs:complexType>
+      <xs:attribute name="version" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="fractions"/>
+        <xs:element maxOccurs="unbounded" ref="region"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="fractions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="info"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="info">
+    <xs:complexType>
+      <xs:attribute name="iso4217" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="digits" type="xs:NMTOKEN"/>
+      <xs:attribute name="rounding" type="xs:NMTOKEN"/>
+      <xs:attribute name="cashDigits" type="xs:NMTOKEN"/>
+      <xs:attribute name="cashRounding" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/validity/currency||literal/DEFAULT -->
+  <!-- @MATCH:range/0~5 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0~5 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0~100 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/0, 5, 50 -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="region">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="currency"/>
+      </xs:sequence>
+      <xs:attribute name="iso3166" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/region -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currency">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="alternate"/>
+      </xs:sequence>
+      <xs:attribute name="before" type="xs:NMTOKEN"/>
+      <xs:attribute name="from" type="xs:NMTOKEN"/>
+      <xs:attribute name="to" type="xs:NMTOKEN"/>
+      <xs:attribute name="iso4217" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="digits" type="xs:NMTOKEN"/>
+      <xs:attribute name="rounding" type="xs:NMTOKEN"/>
+      <xs:attribute name="cashRounding" type="xs:NMTOKEN"/>
+      <xs:attribute name="tender">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use from and to instead. -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:time/yyyy-MM-dd -->
+  <!-- @MATCH:time/yyyy-MM-dd -->
+  <!-- @MATCH:validity/currency -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="alternate">
+    <xs:complexType>
+      <xs:attribute name="iso4217" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- use from and to instead. -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="territoryContainment">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="group"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="contains" type="xs:NMTOKENS"/>
+      <xs:attribute name="grouping">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="status">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="grouping"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/region -->
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <xs:element name="subdivisionContainment">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="subgroup"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subgroup">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="subtype" type="xs:NMTOKEN"/>
+      <xs:attribute name="contains" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/validity/region||validity/subdivision -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:set/or/validity/subdivision||literal/itca, itnu, itor, itsd, itss, no01, no02, no03, no04, no05, no06, no07, no08, no09, no10, no11, no12, no14, no15, no18, no19, no20, no21, no22, no50 -->
+  <!-- @VALUE -->
+  <xs:element name="languageData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="language"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="language">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="scripts" type="xs:NMTOKENS"/>
+      <xs:attribute name="territories" type="xs:NMTOKENS"/>
+      <xs:attribute name="variants" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/language -->
+  <!-- @MATCH:set/validity/script -->
+  <!-- @VALUE -->
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/secondary, variant -->
+  <xs:element name="territoryInfo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="territory"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="territory">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languagePopulation"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="gdp" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="literacyPercent" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="population" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/region -->
+  <!-- @MATCH:range/0~100000000000000 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0.0~100.0 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0~10000000000 -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="languagePopulation">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="literacyPercent" type="xs:NMTOKEN"/>
+      <xs:attribute name="writingPercent" type="xs:NMTOKEN"/>
+      <xs:attribute name="populationPercent" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="officialStatus">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="de_facto_official"/>
+            <xs:enumeration value="official"/>
+            <xs:enumeration value="official_regional"/>
+            <xs:enumeration value="official_minority"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/locale -->
+  <!-- @MATCH:range/0~100 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0~100 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0.0~100.0 -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="postalCodeData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="postCodeRegex"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="postCodeRegex">
+    <xs:complexType mixed="true">
+      <xs:attribute name="territoryId" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="calendarData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="calendar"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="calendar">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="calendarSystem"/>
+        <xs:element minOccurs="0" ref="eras"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="territories" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:bcp47/ca -->
+  <!-- use ordering attribute in calendarPreference element instead. -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="calendarSystem">
+    <xs:complexType>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="solar"/>
+            <xs:enumeration value="lunar"/>
+            <xs:enumeration value="lunisolar"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <xs:element name="eras">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="era"/>
+      </xs:sequence>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="era">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="start"/>
+      <xs:attribute name="end"/>
+      <xs:attribute name="named">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:range/0~250 -->
+  <!-- @MATCH:time/yyyy-MM-dd -->
+  <!-- @VALUE -->
+  <!-- @MATCH:time/yyyy-MM-dd -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="calendarPreferenceData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="calendarPreference"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="calendarPreference">
+    <xs:complexType>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="ordering" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @MATCH:set/bcp47/ca -->
+  <!-- @VALUE -->
+  <xs:element name="weekData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="minDays"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="firstDay"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="weekendStart"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="weekendEnd"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="weekOfPreference"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="minDays">
+    <xs:complexType>
+      <xs:attribute name="count" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="firstDay">
+    <xs:complexType>
+      <xs:attribute name="day" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="weekendStart">
+    <xs:complexType>
+      <xs:attribute name="day" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="weekendEnd">
+    <xs:complexType>
+      <xs:attribute name="day" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="sun"/>
+            <xs:enumeration value="mon"/>
+            <xs:enumeration value="tue"/>
+            <xs:enumeration value="wed"/>
+            <xs:enumeration value="thu"/>
+            <xs:enumeration value="fri"/>
+            <xs:enumeration value="sat"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="weekOfPreference">
+    <xs:complexType>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="ordering" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @MATCH:set/literal/weekOfDate, weekOfInterval, weekOfMonth, weekOfYear -->
+  <!-- @VALUE -->
+  <xs:element name="timeData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hours"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="hours">
+    <xs:complexType>
+      <xs:attribute name="allowed" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="preferred" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="regions" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/H, h, K, k, hB, hb -->
+  <!-- @MATCH:literal/H, h -->
+  <!-- @MATCH:set/or/validity/region||validity/locale -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="measurementData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="measurementSystem"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="paperSize"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="measurementSystem">
+    <xs:complexType>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="metric"/>
+            <xs:enumeration value="US"/>
+            <xs:enumeration value="UK"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="category">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="temperature"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="paperSize">
+    <xs:complexType>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="A4"/>
+            <xs:enumeration value="US-Letter"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="territories" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="unitConstants">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitConstant"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="unitConstant">
+    <xs:complexType>
+      <xs:attribute name="constant" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="value" use="required"/>
+      <xs:attribute name="status" type="xs:NMTOKEN"/>
+      <xs:attribute name="description"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[A-Za-z][_A-Za-z0-9]* -->
+  <!-- @MATCH:regex/[-+*/\._ 0-9a-zA-Z]+ -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/approximate, exact -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <xs:element name="unitQuantities">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitQuantity"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="unitQuantity">
+    <xs:complexType>
+      <xs:attribute name="baseUnit" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="quantity" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="status" type="xs:NMTOKEN"/>
+      <xs:attribute name="description"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @MATCH:regex/[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/simple -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <xs:element name="convertUnits">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="convertUnit"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="convertUnit">
+    <xs:complexType>
+      <xs:attribute name="source" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="baseUnit" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="factor"/>
+      <xs:attribute name="offset"/>
+      <xs:attribute name="systems" type="xs:NMTOKENS"/>
+      <xs:attribute name="description"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/(100-)?[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @MATCH:regex/[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/[-+*/\._ 0-9a-zA-Z]+ -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/[-+*/\._ 0-9a-zA-Z]+ -->
+  <!-- @VALUE -->
+  <!-- @MATCH:set/literal/ussystem, uksystem, metric, si, other -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <xs:element name="unitPreferenceData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitPreferences"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="unitPreferences">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitPreference"/>
+      </xs:sequence>
+      <xs:attribute name="category" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="usage" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="scope">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="small"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[a-z]+([-][a-z]+)* -->
+  <!-- @MATCH:regex/[a-z]+([-][a-z]+)* -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="unitPreference">
+    <xs:complexType mixed="true">
+      <xs:attribute name="regions" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="geq" type="xs:NMTOKEN"/>
+      <xs:attribute name="skeleton"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:set/validity/region -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/informal, variant -->
+  <xs:element name="timezoneData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mapTimezones"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="zoneFormatting"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="mapTimezones">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mapZone"/>
+      </xs:sequence>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="otherVersion"/>
+      <xs:attribute name="typeVersion"/>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/metazones -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @MATCH:regex/[0-9]{4}[a-z]+ -->
+  <!-- @METADATA -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <xs:element name="mapZone">
+    <xs:complexType>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="other" use="required"/>
+      <xs:attribute name="territory"/>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/bcp47/tz -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:validity/region -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <xs:element name="zoneFormatting">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="zoneItem"/>
+      </xs:sequence>
+      <xs:attribute name="multizone" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="tzidVersion"/>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="zoneItem">
+    <xs:complexType>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="territory" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="aliases"/>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="characters">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="character-fallback"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="character-fallback">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="character"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="character">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="substitute"/>
+      </xs:sequence>
+      <xs:attribute name="value" use="required"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="substitute">
+    <xs:complexType mixed="true">
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard"/>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="transforms">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="transform"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="transform">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="comment"/>
+        <xs:element ref="tRule"/>
+      </xs:choice>
+      <xs:attribute name="source"/>
+      <xs:attribute name="target"/>
+      <xs:attribute name="variant"/>
+      <xs:attribute name="direction" default="both">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="forward"/>
+            <xs:enumeration value="backward"/>
+            <xs:enumeration value="both"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alias"/>
+      <xs:attribute name="backwardAlias"/>
+      <xs:attribute name="visibility" default="external">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="internal"/>
+            <xs:enumeration value="external"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any/TODO -->
+  <!-- @MATCH:any/TODO -->
+  <!-- @MATCH:any/TODO -->
+  <!-- @MATCH:any/TODO -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any/TODO -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="comment" type="xs:string"/>
+  <!-- @ORDERED -->
+  <!-- @METADATA -->
+  <xs:element name="tRule" type="xs:string"/>
+  <!-- @ORDERED -->
+  <xs:element name="metadata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="attributeOrder"/>
+        <xs:element minOccurs="0" ref="elementOrder"/>
+        <xs:element minOccurs="0" ref="serialElements"/>
+        <xs:element minOccurs="0" ref="suppress"/>
+        <xs:element minOccurs="0" ref="validity"/>
+        <xs:element minOccurs="0" ref="alias"/>
+        <xs:element minOccurs="0" ref="deprecated"/>
+        <xs:element minOccurs="0" ref="distinguishing"/>
+        <xs:element minOccurs="0" ref="blocking"/>
+        <xs:element minOccurs="0" ref="coverageAdditions"/>
+        <xs:element minOccurs="0" ref="skipDefaultLocale"/>
+        <xs:element minOccurs="0" ref="defaultContent"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="attributeOrder">
+    <xs:complexType mixed="true">
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="elementOrder">
+    <xs:complexType mixed="true">
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="serialElements">
+    <xs:complexType mixed="true">
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="suppress">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="attributes"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="attributes">
+    <xs:complexType>
+      <xs:attribute name="element" type="xs:NMTOKENS"/>
+      <xs:attribute name="attribute" type="xs:NMTOKENS"/>
+      <xs:attribute name="attributeValue"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="validity">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="variable"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="attributeValues"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="variable">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="id" use="required"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="attributeValues">
+    <xs:complexType mixed="true">
+      <xs:attribute name="dtds" type="xs:NMTOKEN"/>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="elements" type="xs:NMTOKENS"/>
+      <xs:attribute name="attributes" type="xs:NMTOKENS"/>
+      <xs:attribute name="order" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <xs:element name="alias">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languageAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="scriptAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="territoryAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="subdivisionAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="variantAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="zoneAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="unitAlias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="usageAlias"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="languageAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="overlong"/>
+            <xs:enumeration value="macrolanguage"/>
+            <xs:enumeration value="legacy"/>
+            <xs:enumeration value="bibliographic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/validity/locale||literal/aa_saaho, aar, abk, afr, aka, alb, amh, ara, arg, arm, art_lojban, asm, ava, ave, aym, aze, bak, bam, baq, bel, ben, bih, bis, bod, bos, bre, bul, bur, cat, ces, cha, che, chi, chu, chv, cor, cos, cre, cym, cze, dan, deu, div, dut, dzo, ell, eng, epo, est, eus, ewe, fao, fas, fij, fin, fra, fre, fry, ful, geo, ger, gla, gle, glg, glv, gre, grn, guj, hat, hau, hbs, heb, her, hin, hmo, hrv, hun, hye, i_ami, i_bnn, i_hak, i_klingon, i_lux, i_navajo, i_pwn, i_tao, i_tay, i_tsu, ibo, ice, ido, iii, iku, ile, ina, ind, ipk, isl, ita, jav, jpn, kal, kan, kas, kat, kau, kaz, khm, kik, kin, kir, kom, kon, kor, kua, kur, lao, lat, lav, lim, lin, lit, ltz, lub, lug, mac, mah, mal, mao, mar, may, mkd, mlg, mlt, mol, mon, mri, msa, mya, nau, nav, nbl, nde, ndo, nep, nld, nno, no_bokmal, no_nynorsk, no_bok, no_nyn, nob, nor, nya, oci, oji, ori, orm, oss, pan, per, pli, pol, por, pus, que, roh, ron, rum, run, rus, sag, san, scc, scr, sgn_BE_FR, sgn_BE_NL, sgn_CH_DE, sin, slk, slo, slv, sme, smo, sna, snd, som, sot, spa, sqi, srd, srp, ssw, sun, swa, swe, tah, tam, tat, tel, tgk, tgl, tha, tib, tir, ton, tsn, tso, tuk, tur, twi, uig, ukr, urd, uzb, ven, vie, vol, wel, wln, wol, xho, yid, yor, zh_guoyu, zh_hakka, zh_min_nan, zh_xiang, zha, zho, zul, cel_gaulish, i_default, i_enochian, i_mingo, und_aaland, und_bokmal, und_hakka, und_lojban, und_nynorsk, und_saaho, und_xiang, zh_min, en_GB_oed, zh_cmn, zh_cmn_Hans, zh_cmn_Hant, zh_gan, zh_wuu, zh_yue -->
+  <!-- @MATCH:or/validity/locale||literal/en_x_i_default, nan_x_zh_min, see_x_i_mingo, und_x_i_enochian, xtg_x_cel_gaulish -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="scriptAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="overlong"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/script -->
+  <!-- @MATCH:validity/script -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="territoryAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="overlong"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/or/validity/region||regex/[0-9]{3}|[A-Z]{3}||literal/CT, DY, FQ, HV, JT, MI, NH, NQ, PC, PU, PZ, RH, UK, VD, WK -->
+  <!-- @MATCH:set/validity/region -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="subdivisionAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="overlong"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/subdivision -->
+  <!-- @MATCH:set/or/validity/region||validity/subdivision||literal/cnmn, cz663, no50 -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="variantAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="overlong"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/validity/variant||literal/aaland, polytoni -->
+  <!-- @MATCH:or/validity/variant||validity/region||literal/hy, hyw -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="zoneAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="replacement" use="required"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+            <xs:enumeration value="overlong"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:or/bcp47/tz||literal/SystemV/AST4, SystemV/AST4ADT, SystemV/CST6, SystemV/CST6CDT, SystemV/EST5, SystemV/EST5EDT, SystemV/HST10, SystemV/MST7, SystemV/MST7MDT, SystemV/PST8, SystemV/PST8PDT, SystemV/YST9, SystemV/YST9YDT -->
+  <!-- @MATCH:bcp47/tz -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="unitAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/short-unit/deprecated -->
+  <!-- @MATCH:regex/[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="usageAlias">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="replacement" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="reason">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="deprecated"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @MATCH:regex/[A-Za-z][-A-Za-z0-9]* -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="deprecated">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="deprecatedItems"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="deprecatedItems">
+    <xs:complexType>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="standard"/>
+            <xs:enumeration value="supplemental"/>
+            <xs:enumeration value="ldml"/>
+            <xs:enumeration value="supplementalData"/>
+            <xs:enumeration value="ldmlBCP47"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="elements" type="xs:NMTOKENS"/>
+      <xs:attribute name="attributes" type="xs:NMTOKENS"/>
+      <xs:attribute name="values"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="distinguishing">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="distinguishingItems"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="distinguishingItems">
+    <xs:complexType>
+      <xs:attribute name="exclude">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="elements" type="xs:NMTOKENS"/>
+      <xs:attribute name="attributes" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="blocking">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="blockingItems"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="blockingItems">
+    <xs:complexType>
+      <xs:attribute name="elements" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="coverageAdditions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languageCoverage"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="scriptCoverage"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="territoryCoverage"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyCoverage"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="timezoneCoverage"/>
+      </xs:sequence>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="languageCoverage">
+    <xs:complexType>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="scriptCoverage">
+    <xs:complexType>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="territoryCoverage">
+    <xs:complexType>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyCoverage">
+    <xs:complexType>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="timezoneCoverage">
+    <xs:complexType>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="values"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- would be NMTOKENS, but needs to allow / -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="skipDefaultLocale">
+    <xs:complexType>
+      <xs:attribute name="services" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="defaultContent">
+    <xs:complexType>
+      <xs:attribute name="locales" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @VALUE -->
+  <xs:element name="codeMappings">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languageCodes"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="territoryCodes"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="currencyCodes"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="languageCodes">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="alpha3" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="territoryCodes">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="numeric" type="xs:NMTOKEN"/>
+      <xs:attribute name="alpha3" type="xs:NMTOKEN"/>
+      <xs:attribute name="fips10" type="xs:NMTOKEN"/>
+      <xs:attribute name="internet" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/region -->
+  <!-- @MATCH:range/1~999 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/[A-Z]{3} -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/[A-Z]{2} -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="currencyCodes">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="numeric" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/currency -->
+  <!-- @MATCH:range/1~999 -->
+  <!-- @VALUE -->
+  <!-- # Parent locales -->
+  <xs:element name="parentLocales">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="parentLocale"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="parentLocale">
+    <xs:complexType>
+      <xs:attribute name="parent" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/locale -->
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @VALUE -->
+  <xs:element name="personNamesDefaults">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="alias"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="nameOrderLocalesDefault"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="nameOrderLocalesDefault">
+    <xs:complexType mixed="true">
+      <xs:attribute name="order" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="givenFirst"/>
+            <xs:enumeration value="surnameFirst"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="likelySubtags">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="likelySubtag"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="likelySubtag">
+    <xs:complexType>
+      <xs:attribute name="from" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="to" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/locale -->
+  <!-- @MATCH:validity/locale -->
+  <!-- @VALUE -->
+  <xs:element name="metazoneInfo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="timezone"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="timezone">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="usesMetazone"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:bcp47/tz -->
+  <xs:element name="usesMetazone">
+    <xs:complexType>
+      <xs:attribute name="from"/>
+      <xs:attribute name="to"/>
+      <xs:attribute name="mzone" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:time/yyyy-MM-dd HH:mm -->
+  <!-- @MATCH:time/yyyy-MM-dd HH:mm -->
+  <!-- @MATCH:metazone -->
+  <!-- @VALUE -->
+  <xs:element name="plurals">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pluralRules"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pluralRanges"/>
+      </xs:sequence>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ordinal"/>
+            <xs:enumeration value="cardinal"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- default is cardinal -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="pluralRules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pluralRule"/>
+      </xs:sequence>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="pluralRule">
+    <xs:complexType mixed="true">
+      <xs:attribute name="count" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- 'other' is implicitly everything else -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="pluralRanges">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pluralRange"/>
+      </xs:sequence>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="pluralRange">
+    <xs:complexType>
+      <xs:attribute name="start">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="end">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="result" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- if missing, means *all* -->
+  <!-- if missing, means *all* -->
+  <!-- if a whole rule is missing, means *other* -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="telephoneCodeData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="codesByTerritory"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="codesByTerritory">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="telephoneCountryCode"/>
+      </xs:sequence>
+      <xs:attribute name="territory" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <xs:element name="telephoneCountryCode">
+    <xs:complexType>
+      <xs:attribute name="code" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="from" type="xs:NMTOKEN"/>
+      <xs:attribute name="to" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <!-- @DEPRECATED -->
+  <xs:element name="numberingSystems">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="numberingSystem"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="numberingSystem">
+    <xs:complexType>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="numeric"/>
+            <xs:enumeration value="algorithmic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="radix" type="xs:NMTOKEN"/>
+      <xs:attribute name="digits"/>
+      <xs:attribute name="rules"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @MATCH:bcp47/nu -->
+  <!-- @VALUE -->
+  <!-- @MATCH:unicodeset/[\p{Nd}[\u3007\u4E00\u4E03\u4E09\u4E5D\u4E8C\u4E94\u516B\u516D\u56DB][\U00011F50-\U00011F59\U0001E4F0-\U0001E4F9]] -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <xs:element name="bcp47KeywordMappings">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="mapKeys"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mapTypes"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="mapKeys">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="keyMap"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <xs:element name="keyMap">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="bcp47" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <xs:element name="mapTypes">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="typeMap"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <xs:element name="typeMap">
+    <xs:complexType>
+      <xs:attribute name="type" use="required"/>
+      <xs:attribute name="bcp47" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @DEPRECATED -->
+  <!-- @DEPRECATED -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- # Gender List support -->
+  <xs:element name="gender">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="personList"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="personList">
+    <xs:complexType>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="neutral"/>
+            <xs:enumeration value="mixedNeutral"/>
+            <xs:enumeration value="maleTaints"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @VALUE -->
+  <xs:element name="references">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="reference"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="reference">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="uri"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="standard">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED:true, false -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:literal/variant -->
+  <xs:element name="languageMatching">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languageMatches"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="languageMatches">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="paradigmLocales"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="matchVariable"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languageMatch"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/written, written_new -->
+  <xs:element name="paradigmLocales">
+    <xs:complexType>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @VALUE -->
+  <xs:element name="matchVariable">
+    <xs:complexType>
+      <xs:attribute name="id" use="required"/>
+      <xs:attribute name="value" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/\$[a-zA-Z0-9_]+ -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="languageMatch">
+    <xs:complexType>
+      <xs:attribute name="desired" use="required"/>
+      <xs:attribute name="supported" use="required"/>
+      <xs:attribute name="percent" type="xs:NMTOKEN"/>
+      <xs:attribute name="distance" type="xs:NMTOKEN"/>
+      <xs:attribute name="oneway">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any/TODO -->
+  <!-- @MATCH:any/TODO -->
+  <!-- @MATCH:range/0~100 -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0~100 -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- # Day Periods -->
+  <xs:element name="dayPeriodRuleSet">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayPeriodRules"/>
+      </xs:sequence>
+      <xs:attribute name="type" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/selection -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="dayPeriodRules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="dayPeriodRule"/>
+      </xs:sequence>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <!-- @METADATA -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <xs:element name="dayPeriodRule">
+    <xs:complexType>
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="at" type="xs:NMTOKEN"/>
+      <xs:attribute name="after" type="xs:NMTOKEN"/>
+      <xs:attribute name="before" type="xs:NMTOKEN"/>
+      <xs:attribute name="from" type="xs:NMTOKEN"/>
+      <xs:attribute name="to" type="xs:NMTOKEN"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="references"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/afternoon1, afternoon2, am, evening1, evening2, midnight, morning1, morning2, night1, night2, noon, pm -->
+  <!-- @MATCH:time/HH:mm -->
+  <!-- @VALUE -->
+  <!-- @MATCH:time/HH:mm -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @MATCH:time/HH:mm -->
+  <!-- @VALUE -->
+  <!-- @MATCH:time/HH:mm -->
+  <!-- @VALUE -->
+  <!-- @MATCH:time/HH:mm -->
+  <!-- @VALUE -->
+  <!-- @DEPRECATED -->
+  <!-- @METADATA -->
+  <!-- @METADATA -->
+  <xs:element name="metaZones">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="metazoneInfo"/>
+        <xs:element minOccurs="0" ref="mapTimezones"/>
+        <xs:element minOccurs="0" ref="metazoneIds"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="metazoneIds">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="metazoneId"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="metazoneId">
+    <xs:complexType>
+      <xs:attribute name="shortId" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="longId"/>
+      <xs:attribute name="deprecated" default="false">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="preferred" type="xs:NMTOKEN"/>
+      <xs:attribute name="since" default="40"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[a-z][a-z][a-z][a-z] -->
+  <!-- @MATCH:metazone -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:metazone -->
+  <!-- @VALUE -->
+  <!-- @MATCH:version -->
+  <!-- @METADATA -->
+  <xs:element name="primaryZones">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="primaryZone"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="primaryZone">
+    <xs:complexType mixed="true">
+      <xs:attribute name="iso3166" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/region -->
+  <!-- # Time Zones -->
+  <xs:element name="windowsZones">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="mapTimezones"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- # Coverage levels -->
+  <xs:element name="coverageLevels">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="approvalRequirements"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="coverageVariable"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="coverageLevel"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pathMatch"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- @METADATA -->
+  <xs:element name="approvalRequirements">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="approvalRequirement"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="approvalRequirement">
+    <xs:complexType>
+      <xs:attribute name="votes" use="required"/>
+      <xs:attribute name="locales" use="required"/>
+      <xs:attribute name="paths" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <xs:element name="coverageVariable">
+    <xs:complexType>
+      <xs:attribute name="key" use="required"/>
+      <xs:attribute name="value" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="coverageLevel">
+    <xs:complexType>
+      <xs:attribute name="inLanguage"/>
+      <xs:attribute name="inScript"/>
+      <xs:attribute name="inTerritory"/>
+      <xs:attribute name="value" use="required"/>
+      <xs:attribute name="match" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:validity/script -->
+  <!-- @MATCH:any -->
+  <!-- @MATCH:literal/basic, core, minimal, moderate, modern, posix -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <xs:element name="pathMatch">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:NMTOKENS"/>
+      <xs:attribute name="match" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="idValidity">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="id"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="idStatus" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/currency, language, region, script, subdivision, unit, variant -->
+  <!-- @MATCH:literal/deprecated, macroregion, private_use, regular, reserved, special, unknown -->
+  <xs:element name="rgScope">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="rgPath"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rgPath">
+    <xs:complexType>
+      <xs:attribute name="path" use="required"/>
+      <xs:attribute name="draft">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="approved"/>
+            <xs:enumeration value="contributed"/>
+            <xs:enumeration value="provisional"/>
+            <xs:enumeration value="unconfirmed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <xs:element name="languageGroups">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="languageGroup"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="languageGroup">
+    <xs:complexType mixed="true">
+      <xs:attribute name="parent" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/language -->
+  <!-- # Grammatical Features -->
+  <xs:element name="grammaticalData">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="grammaticalFeatures"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="grammaticalDerivations"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="grammaticalFeatures">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="grammaticalCase"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="grammaticalGender"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="grammaticalDefiniteness"/>
+      </xs:sequence>
+      <xs:attribute name="targets" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/nominal -->
+  <!-- @MATCH:set/validity/language -->
+  <xs:element name="grammaticalCase">
+    <xs:complexType>
+      <xs:attribute name="scope" type="xs:NMTOKENS"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/units -->
+  <!-- @MATCH:set/literal/abessive, ablative, accusative, adessive, allative, causal, comitative, dative, delative, elative, ergative, essive, genitive, illative, inessive, instrumental, locative, locativecopulative, nominative, oblique, partitive, prepositional, sociative, sublative, superessive, terminative, translative, vocative -->
+  <!-- @VALUE -->
+  <xs:element name="grammaticalGender">
+    <xs:complexType>
+      <xs:attribute name="scope" type="xs:NMTOKENS"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/units -->
+  <!-- @MATCH:set/literal/animate, common, feminine, inanimate, masculine, neuter, personal -->
+  <!-- @VALUE -->
+  <xs:element name="grammaticalDefiniteness">
+    <xs:complexType>
+      <xs:attribute name="scope" type="xs:NMTOKENS"/>
+      <xs:attribute name="values" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/units -->
+  <!-- @MATCH:set/literal/definite, indefinite, unspecified, construct -->
+  <!-- @VALUE -->
+  <xs:element name="grammaticalDerivations">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="deriveCompound"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="deriveComponent"/>
+      </xs:sequence>
+      <xs:attribute name="locales" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/validity/locale -->
+  <xs:element name="deriveCompound">
+    <xs:complexType>
+      <xs:attribute name="feature" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="structure" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="value" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:set/literal/gender -->
+  <!-- @MATCH:set/literal/per, times, power, prefix -->
+  <!-- TODO: add @MATCH function for locale's gender categories and use here -->
+  <!-- @MATCH:set/literal/0, 1 -->
+  <!-- @VALUE -->
+  <xs:element name="deriveComponent">
+    <xs:complexType>
+      <xs:attribute name="feature" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="structure" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="value0" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="value1" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+<!-- @MATCH:set/literal/plural, case -->
+<!-- @MATCH:set/literal/per, times, power, prefix -->
+<!-- TODO: add @MATCH function for locale's plural/case categories and use here -->
+<!-- @MATCH:set/literal/compound, zero, one, two, few, many, other, accusative, nominative -->
+<!-- @VALUE -->
+<!-- TODO: add @MATCH function for locale's plural/case categories and use here -->
+<!-- @MATCH:set/literal/compound, zero, one, two, few, many, other, accusative, nominative -->
+<!-- @VALUE -->

--- a/common/dtd/xml.xsd
+++ b/common/dtd/xml.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace">
+  <xs:import schemaLocation="ldml.xsd"/>
+  <xs:attribute name="space">
+    <xs:simpleType>
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="default"/>
+        <xs:enumeration value="preserve"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:schema>

--- a/keyboards/dtd/ldmlKeyboard.xsd
+++ b/keyboards/dtd/ldmlKeyboard.xsd
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 1991-2022 Unicode, Inc.
+  For terms of use, see http://www.unicode.org/copyright.html
+  SPDX-License-Identifier: Unicode-DFS-2016
+  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<!--
+  Important Note:
+
+  The CLDR Keyboard Workgroup is currently developing major changes to the
+  CLDR keyboard specification.
+
+  This DTD is a work in progress.
+
+  Please see CLDR-15034 for the latest information.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="keyboard">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" ref="locales"/>
+        <xs:element minOccurs="0" ref="version"/>
+        <xs:element minOccurs="0" ref="info"/>
+        <xs:element ref="names"/>
+        <xs:element minOccurs="0" ref="settings"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="vkeyMaps"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayMap"/>
+        <xs:element minOccurs="0" ref="keys"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="layerMaps"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="transforms"/>
+        <xs:element minOccurs="0" ref="reorders"/>
+        <xs:element minOccurs="0" ref="backspaces"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="locale" use="required"/>
+      <xs:attribute name="conformsTo" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="techpreview"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/bcp47 -->
+  <!-- @MATCH:any -->
+  <!-- @METADATA -->
+  <xs:element name="import">
+    <xs:complexType>
+      <xs:attribute name="path" use="required"/>
+      <xs:attribute name="base">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="cldr"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="locales">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="locale"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="locale">
+    <xs:complexType>
+      <xs:attribute name="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:validity/bcp47 -->
+  <!-- @VALUE -->
+  <xs:element name="version">
+    <xs:complexType>
+      <xs:attribute name="number"/>
+      <xs:attribute name="cldrVersion" default="techpreview">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="techpreview"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @MATCH:version -->
+  <!-- @METADATA -->
+  <xs:element name="info">
+    <xs:complexType>
+      <xs:attribute name="author"/>
+      <xs:attribute name="normalization"/>
+      <xs:attribute name="layout"/>
+      <xs:attribute name="indicator"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:literal/NFC, NFD, other -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="names">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element maxOccurs="unbounded" ref="name"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="name">
+    <xs:complexType>
+      <xs:attribute name="value" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="special" type="any"/>
+  <xs:element name="settings">
+    <xs:complexType>
+      <xs:attribute name="fallback">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="omit"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="transformFailure">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="omit"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="transformPartial">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="hide"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="vkeyMaps">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="vkeyMap"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="vkeyMap">
+    <xs:complexType>
+      <xs:attribute name="from" use="required"/>
+      <xs:attribute name="to" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="displayMap">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="display"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="displayOptions"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="display">
+    <xs:complexType>
+      <xs:attribute name="to" use="required"/>
+      <xs:attribute name="display" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="displayOptions">
+    <xs:complexType>
+      <xs:attribute name="baseCharacter"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="keys">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="key"/>
+          <xs:element ref="flicks"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="key">
+    <xs:complexType>
+      <xs:attribute name="id" use="required"/>
+      <xs:attribute name="flicks" type="xs:NMTOKEN"/>
+      <xs:attribute name="gap">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="to"/>
+      <xs:attribute name="longPress"/>
+      <xs:attribute name="longPressDefault"/>
+      <xs:attribute name="multitap"/>
+      <xs:attribute name="switch" type="xs:NMTOKEN"/>
+      <xs:attribute name="transform">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="no"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="width"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @MATCH:range/0.01~100.0 -->
+  <!-- @VALUE -->
+  <xs:element name="flicks">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="flick"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
+  <xs:element name="flick">
+    <xs:complexType>
+      <xs:attribute name="directions" use="required" type="xs:NMTOKENS"/>
+      <xs:attribute name="to" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="layerMaps">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="layerMap"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="form" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="hardware"/>
+            <xs:enumeration value="touch"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="minDeviceWidthMM"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:range/1~999 -->
+  <xs:element name="layerMap">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="row"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NMTOKEN"/>
+      <xs:attribute name="modifier" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <xs:element name="row">
+    <xs:complexType>
+      <xs:attribute name="keys" use="required" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <xs:element name="transforms">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="transform"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:literal/simple, final -->
+  <xs:element name="transform">
+    <xs:complexType>
+      <xs:attribute name="before"/>
+      <xs:attribute name="from" use="required"/>
+      <xs:attribute name="to" use="required"/>
+      <xs:attribute name="error">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="fail"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- @MATCH:any -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="reorders">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="reorder"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="reorder">
+    <xs:complexType>
+      <xs:attribute name="before"/>
+      <xs:attribute name="from" use="required"/>
+      <xs:attribute name="order"/>
+      <xs:attribute name="tertiary"/>
+      <xs:attribute name="tertiary_base"/>
+      <xs:attribute name="prebase"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <!-- @VALUE -->
+  <xs:element name="backspaces">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="import"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="backspace"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="backspace">
+    <xs:complexType>
+      <xs:attribute name="before"/>
+      <xs:attribute name="from" use="required"/>
+      <xs:attribute name="to"/>
+      <xs:attribute name="error">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="fail"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="any" mixed="true">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+<!-- @VALUE -->
+<!-- @VALUE -->

--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -56,6 +56,12 @@
 			<groupId>com.google.myanmartools</groupId>
 			<artifactId>myanmar-tools</artifactId>
 		</dependency>
+
+		<!-- for XSD generation -->
+		<dependency>
+			<groupId>org.relaxng</groupId>
+			<artifactId>trang</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdType.java
@@ -88,4 +88,8 @@ public enum DtdType {
         + " -->\n"
         + "<" + this + ">\n";
     }
+
+    public String getXsdPath() {
+        return dtdPath.replaceAll("\\.dtd$", ".xsd");
+    }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLValidator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLValidator.java
@@ -14,6 +14,7 @@ package org.unicode.cldr.util;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -23,6 +24,8 @@ import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -34,20 +37,24 @@ import org.xml.sax.SAXParseException;
 
 @CLDRTool(alias = "validate", description = "Check XML files for validity")
 public class XMLValidator {
+    private static final String SCHEMA = "--schema=";
     public boolean quiet = false;
     public boolean parseonly = false;
     public boolean justCheckBom = false;
+    public final File withSchema;
 
-    public XMLValidator(boolean quiet, boolean parseonly, boolean justCheckBom) {
+    public XMLValidator(boolean quiet, boolean parseonly, boolean justCheckBom, File withSchema) {
         this.quiet = quiet;
         this.parseonly = parseonly;
         this.justCheckBom = justCheckBom;
+        this.withSchema = withSchema;
     }
 
     public static void main(String[] args) throws IOException {
         boolean quiet = false;
         boolean parseonly = false;
         boolean justCheckBom = false;
+        File withSchema = null;
         if (args.length == 0) {
             System.out.println("No files specified. Validation failed. Use --help for help.");
             return;
@@ -63,6 +70,11 @@ public class XMLValidator {
                 parseonly = true;
             } else if (args[i].equals("--justCheckBom")) {
                 justCheckBom = true;
+            } else if (args[i].startsWith(SCHEMA)) {
+                withSchema = new File(args[i].substring(SCHEMA.length()));
+                if (!withSchema.canRead()) {
+                    throw new FileNotFoundException("Could not read schema " + withSchema.getAbsolutePath());
+                }
             } else {
                 File f = new File(args[i]);
                 if (f.isDirectory()) {
@@ -83,7 +95,7 @@ public class XMLValidator {
         if(!quiet) {
             System.err.println("# " + toCheck.size() + " file(s) to check");
         }
-        int failCount = new XMLValidator(quiet, parseonly, justCheckBom).check(toCheck);
+        int failCount = new XMLValidator(quiet, parseonly, justCheckBom, withSchema).check(toCheck);
         if(failCount != 0) {
             System.err.println("# FAIL: " + failCount + " of " + toCheck.size() + " file(s) had errors.");
             System.exit(1);
@@ -198,12 +210,22 @@ public class XMLValidator {
         }
     }
 
-    Document parse(InputSource docSrc, String filename) {
+    Document parse(InputSource docSrc, String filename) throws SAXException {
         DocumentBuilderFactory dfactory = DocumentBuilderFactory.newInstance();
         // Always set namespaces on
         if (!parseonly) {
             dfactory.setNamespaceAware(true);
             dfactory.setValidating(true);
+        }
+
+        if (withSchema != null) {
+            // assumes validating
+            dfactory.setNamespaceAware(true);
+            dfactory.setValidating(true);
+
+            SchemaFactory sfac = SchemaFactory.newDefaultInstance();
+            Schema schema = sfac.newSchema(withSchema);
+            dfactory.setSchema(schema);
         }
         // Set other attributes here as needed
         // applyAttributes(dfactory, attributes);

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -168,6 +168,14 @@
 				<artifactId>mybatis</artifactId>
 				<version>3.5.6</version>
 			</dependency>
+
+
+			<!-- XSD generation -->
+			<dependency>
+				<groupId>org.relaxng</groupId>
+				<artifactId>trang</artifactId>
+				<version>20220510</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
CLDR-15990

⚠️ **Not v42 See important note at end**

Generates and adds XML Schema as part of GenerateDtd
Does not currently alter the XSD from the autoconverted form, but in the future *could* use the DtdData annotations to create a better .xsd file

- use the jing-trang library
- add an option --schema= to XMLValidator to use the schema


- [ ] This PR completes the ticket.

-----

Note: this is not for v42.  It is on the keyboard branch in response to an idea that had been brought up in Keyboard-SC. If this is included in keyboard branch (and as part of the Keyboard work) that doesn't mean that it must go into CLDR. But brought here for review in case it's a good idea.

Also note that Keyman in https://github.com/keymanapp/keyman/pull/7184 is using an auto generated XSD because it is difficult to find DTD validators in JavaScript, but XSD is usable.