### PR TITLE
CLDR-15414 json: personNames structure, other improvements

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrNode.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrNode.java
@@ -35,15 +35,15 @@ public class CldrNode {
         String[] suppressList = LdmlConvertRules.ATTR_SUPPRESS_LIST;
 
         // let's check if there is anything that can be suppressed
+        // TODO: should hash the parent and pathSegment values so we don't have to linear
+        // search.
         for (int i = 0; i < suppressList.length; i += 3) {
             if (node.name.equals(suppressList[i])) {
                 String key = suppressList[i + 2];
                 String value = node.distinguishingAttributes.get(key);
                 if (value != null && value.equals(suppressList[i + 1])) {
                     node.distinguishingAttributes.remove(key);
-
                 }
-
             }
         }
         return node;
@@ -160,9 +160,11 @@ public class CldrNode {
         Map<String, String> attributesAsValues = new HashMap<>();
         for (String key : distinguishingAttributes.keySet()) {
             String keyStr = LdmlConvertRules.getKeyStr(getParent(), name, key);
+            String keyStrMidStar = LdmlConvertRules.getKeyStr(getParent(), "*", key);
             String keyStr2 = LdmlConvertRules.getKeyStr(name, key);
             if (LdmlConvertRules.ATTR_AS_VALUE_SET.contains(keyStr) || LdmlConvertRules.ATTR_AS_VALUE_SET.contains(keyStr2)) {
-                if (LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStr)) {
+                if (LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStr)
+                     || LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStrMidStar)) {
                     attributesAsValues.put(LdmlConvertRules.ANONYMOUS_KEY,
                         distinguishingAttributes.get(key));
                 } else {
@@ -176,7 +178,9 @@ public class CldrNode {
                 continue;
             }
             String keyStr = LdmlConvertRules.getKeyStr(getParent(), name, key);
-            if (LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStr)) {
+            String keyStrMidStar = LdmlConvertRules.getKeyStr(getParent(), "*", key);
+            if (LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStr) ||
+                LdmlConvertRules.COMPACTABLE_ATTR_AS_VALUE_SET.contains(keyStrMidStar)) {
                 attributesAsValues.put(LdmlConvertRules.ANONYMOUS_KEY,
                     nondistinguishingAttributes.get(key));
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -454,8 +454,11 @@ public class Ldml2JsonConverter {
             final String pathNoDraft = CLDRFile.DRAFT_PATTERN.matcher(path).replaceAll("");
             final String fullPathNoDraft = CLDRFile.DRAFT_PATTERN.matcher(fullPath).replaceAll("");            
 
-            final String transformedPath = transformPath(pathNoDraft, pathPrefix);
-            final String transformedFullPath = transformPath(fullPathNoDraft, pathPrefix);
+            final String pathNoXmlSpace = CLDRFile.XML_SPACE_PATTERN.matcher(pathNoDraft).replaceAll("");
+            final String fullPathNoXmlSpace = CLDRFile.XML_SPACE_PATTERN.matcher(fullPathNoDraft).replaceAll("");
+
+            final String transformedPath = transformPath(pathNoXmlSpace, pathPrefix);
+            final String transformedFullPath = transformPath(fullPathNoXmlSpace, pathPrefix);
 
             if (transformedPath.isEmpty()) {
                 continue; // skip this path
@@ -955,6 +958,25 @@ public class Ldml2JsonConverter {
         writeReadme(outputDir, packageName);
     }
 
+    /**
+     * Write the ## License section
+     */
+    public void writeCopyrightSection(PrintWriter out) {
+        out.println(CldrUtility.getCopyrightMarkdown() + "\n" +
+        "A copy of the license is included as [LICENSE](./LICENSE).");
+    }
+
+    /**
+     * Write the readme fragment from cldr-json-readme.md plus the copyright
+     * @param outf
+     * @throws IOException
+     */
+    private void writeReadmeSection(PrintWriter outf) throws IOException {
+        FileCopier.copy(CldrUtility.getUTF8Data("cldr-json-readme.md"), outf);
+        outf.println();
+        writeCopyrightSection(outf);
+    }
+
     public void writeReadme(String outputDir, String packageName) throws IOException {
         final String basePackageName = getBasePackageName(packageName);
         try (PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/" + packageName, "README.md");) {
@@ -974,12 +996,13 @@ public class Ldml2JsonConverter {
             outf.println();
             outf.println(getNpmBadge(packageName));
             outf.println();
-            FileCopier.copy(CldrUtility.getUTF8Data("cldr-json-readme.md"), outf);
+            writeReadmeSection(outf);
         }
         try (PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/" + packageName, "LICENSE");) {
             FileCopier.copy(CldrUtility.getUTF8Data("unicode-license.txt"), outf);
         }
     }
+
 
     String getBasePackageName(final String packageName) {
         String basePackageName = packageName;
@@ -1243,7 +1266,7 @@ public class Ldml2JsonConverter {
         pkgs.println("Package metadata is available at [`cldr-core`/cldr-packages.json](./cldr-json/cldr-core/cldr-packages.json)");
         pkgs.println();
 
-        FileCopier.copy(CldrUtility.getUTF8Data("cldr-json-readme.md"), pkgs);
+        writeReadmeSection(outf);
         pkgs.close();
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -82,11 +82,7 @@ class LdmlConvertRules {
         "pluralRules:pluralRule:count",
         "languageMatches:languageMatch:desired",
         "styleNames:styleName:subtype",
-        "styleNames:styleName:alt",
-        // person names - TEMPORARY - TODO CLDR-15414
-        "personNames:personName:length",
-        "personNames:personName:formality",
-        "personNames:personName:order"
+        "styleNames:styleName:alt"
         );
 
     /**
@@ -225,7 +221,6 @@ class LdmlConvertRules {
         "grammaticalFeatures:grammaticalDefiniteness:values",
         "grammaticalFeatures:grammaticalCase:values",
         "grammaticalDerivations:deriveCompound:value"
-
     );
 
     /**
@@ -270,7 +265,7 @@ class LdmlConvertRules {
         "decimalFormat", "standard", "type",
         "percentFormat", "standard", "type",
         "scientificFormat", "standard", "type",
-        "pattern", "standard", "type",
+        "pattern", "standard", "type"
     };
 
     /**
@@ -383,7 +378,7 @@ class LdmlConvertRules {
      * These objects values should be output as arrays.
      */
     public static final Pattern VALUE_IS_SPACESEP_ARRAY = PatternCache.get(
-        "(grammaticalCase|grammaticalGender|grammaticalDefiniteness)"
+        "(grammaticalCase|grammaticalGender|grammaticalDefiniteness|nameOrderLocales)"
     );
     public static final Set<String> CHILD_VALUE_IS_SPACESEP_ARRAY = ImmutableSet.of(
         "weekOfPreference",

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -113,6 +113,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
 
     public static final Pattern ALT_PROPOSED_PATTERN = PatternCache.get(".*\\[@alt=\"[^\"]*proposed[^\"]*\"].*");
     public static final Pattern DRAFT_PATTERN = PatternCache.get("\\[@draft=\"([^\"]*)\"\\]");
+    public static final Pattern XML_SPACE_PATTERN = PatternCache.get("\\[@xml:space=\"([^\"]*)\"\\]");
 
     private static boolean LOG_PROGRESS = false;
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
@@ -1397,12 +1397,36 @@ public class CldrUtility {
         return getCopyrightString("");
     }
 
+    private static final class CopyrightHelper {
+        public static final CopyrightHelper INSTANCE = new CopyrightHelper();
+        public final String COPYRIGHT_SHORT = 
+            "Copyright \u00A9 1991-" + Calendar.getInstance().get(Calendar.YEAR) + " Unicode, Inc.";
+    }
+
     public static String getCopyrightString(String linePrefix) {
         // now do the rest
-        return linePrefix + "Copyright \u00A9 1991-" + Calendar.getInstance().get(Calendar.YEAR) + " Unicode, Inc." + CldrUtility.LINE_SEPARATOR
+        return linePrefix + getCopyrightShort() + CldrUtility.LINE_SEPARATOR
             + linePrefix + "For terms of use, see http://www.unicode.org/copyright.html" + CldrUtility.LINE_SEPARATOR
             + linePrefix + CLDRURLS.UNICODE_SPDX_HEADER + CldrUtility.LINE_SEPARATOR
             + linePrefix + "CLDR data files are interpreted according to the LDML specification " + "(http://unicode.org/reports/tr35/)";
+    }
+
+    /**
+     * Returns the '## License' section in markdown.
+     */
+    public static String getCopyrightMarkdown() {
+        return "## License\n" + 
+        "\n" +
+        getCopyrightShort() + "\n" +
+        "[Terms of Use](http://www.unicode.org/copyright.html)\n\n" +
+        CLDRURLS.UNICODE_SPDX_HEADER + "\n";
+    }
+
+    /**
+     * Get the short copyright string, "Copyright © YYYY-YYYY Unicode, Inc."
+     */
+    public static String getCopyrightShort() {
+        return CopyrightHelper.INSTANCE.COPYRIGHT_SHORT;
     }
 
     // TODO Move to collection utilities

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config.txt
@@ -1,12 +1,22 @@
+# Processed by LdmlConfigFileReader
+
+# These are earlier in the file to keep the packageDesc in one place.
 package=localenames ; packageDesc=Translated versions of locale display name elements: languages, scripts, territories, and variants.
+package=person-names ; packageDesc=Personal Name Formatting (tech preview)
+package=numbers ; packageDesc=Data for number formatting.
+package=dates ; packageDesc=Data for date/time formatting, including data for Gregorian calendar.
+package=misc ; packageDesc=Other CLDR data not defined elsewhere
+package=units ; packageDesc=Data for units formatting.
+
+# mapping paths to sections
 section=languages ; path=//cldr/main/[^/]++/localeDisplayNames/languages/.* ; package=localenames
 section=scripts ; path=//cldr/main/[^/]++/localeDisplayNames/scripts/.* ; package=localenames
 section=territories ; path=//cldr/main/[^/]++/localeDisplayNames/territories/.* ; package=localenames
 section=variants ; path=//cldr/main/[^/]++/localeDisplayNames/variants/.* ; package=localenames
 section=transformNames ; path=//cldr/main/[^/]++/localeDisplayNames/transformNames/.* ; package=localenames
-section=measurementSystemNames ; path=//cldr/main/[^/]++/localeDisplayNames/measurementSystemNames/.* ; package=units ; packageDesc=Data for units formatting.
+section=measurementSystemNames ; path=//cldr/main/[^/]++/localeDisplayNames/measurementSystemNames/.* ; package=units
 section=localeDisplayNames ; path=//cldr/main/[^/]++/localeDisplayNames/.* ; package=localenames
-section=contextTransforms ; path=//cldr/main/[^/]++/contextTransforms/.* ; package=misc ; packageDesc=Other CLDR data not defined elsewhere
+section=contextTransforms ; path=//cldr/main/[^/]++/contextTransforms/.* ; package=misc
 section=layout ; path=//cldr/main/[^/]++/layout/.* ; package=misc
 section=characters ; path=//cldr/main/[^/]++/characters/.* ; package=misc
 section=typographic ; path=//cldr/main/[^/]++/typographicNames/.* ; package=misc
@@ -18,7 +28,6 @@ section=ca-coptic ; path=//cldr/main/[^/]++/dates/calendars/coptic/.* ; package=
 section=ca-dangi ; path=//cldr/main/[^/]++/dates/calendars/dangi/.* ; package=cal-dangi ; packageDesc=CLDR data for Dangi calendars.
 section=ca-ethiopic ; path=//cldr/main/[^/]++/dates/calendars/ethiopic/.* ; package=cal-ethiopic ; packageDesc=CLDR data for Ethiopic calendars.
 section=ca-ethiopic-amete-alem ; path=//cldr/main/[^/]++/dates/calendars/ethiopic-amete-alem/.* ; package=cal-ethiopic
-package=dates ; packageDesc=Data for date/time formatting, including data for Gregorian calendar.
 section=ca-generic ; path=//cldr/main/[^/]++/dates/calendars/generic/.* ; package=dates
 section=ca-gregorian ; path=//cldr/main/[^/]++/dates/calendars/gregorian/.* ; package=dates
 section=ca-hebrew ; path=//cldr/main/[^/]++/dates/calendars/hebrew/.* ; package=cal-hebrew ; packageDesc=CLDR data for Hebrew calendars.
@@ -33,17 +42,19 @@ section=ca-persian ; path=//cldr/main/[^/]++/dates/calendars/persian/.* ; packag
 section=ca-roc ; path=//cldr/main/[^/]++/dates/calendars/roc/.* ; package=cal-roc ; packageDesc=CLDR data for ROC calendars.
 section=dateFields ; path=//cldr/main/[^/]++/dates/fields/.* ; package=dates
 section=timeZoneNames ; path=//cldr/main/[^/]++/dates/timeZoneNames/.* ; package=dates
-package=numbers ; packageDesc = Data for number formatting.
 section=currencies ; path=//cldr/main/[^/]++/numbers/currencies/.* ; package=numbers
 section=numbers ; path=//cldr/main/[^/]++/numbers/.* ; package=numbers
 section=units ; path=//cldr/main/[^/]++/units/.* ; package=units
 section=listPatterns ; path=//cldr/main/[^/]++/listPatterns/.* ; package=misc
 section=posix ; path=//cldr/main/[^/]++/posix/.* ; package=misc
+section=personNames ; path=//cldr/main/[^/]++/personNames/.* ; package=person-names
+
+# Depedencies
 dependency=core ; package=dates
 dependency=core ; package=localenames
 dependency=core ; package=numbers
 dependency=core ; package=misc
 dependency=core ; package=units
+dependency=core ; package=person-names
 dependency=numbers ; package=dates
 dependency=dates ; package=cal
-section=personNames ; path=//cldr/main/[^/]++/personNames/.* ; package=person-names ; packageDesc = Personal Name Formatting (tech preview)

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -157,3 +157,12 @@
 # BCP47 (Some other extension)
 < (.*)/(keyword)/(key)\[@extension="([^"]*)"\]\[@name="([^"]*)"\](.*)$
 > $1/$2/$4/$5$6
+
+# PersonNames - name patterns
+< (.*/personName)\[@order="([^"]*)"\]\[@length="([^"]*)"\]\[@usage="([^"]*)"\]\[@formality="([^"]*)"\](.*)/namePattern(.*)$
+> $1/$2/$3/$4/$5$6$7
+
+# PersonNames - sample names
+< (.*/personNames)/(sampleName)\[@item="([^"]*)"\]/nameField\[@type="([^"]*)"\]$
+> $1/$2/$3/$4
+

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/cldr-json-readme.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/cldr-json-readme.md
@@ -9,14 +9,3 @@ For full details, please see <https://github.com/unicode-org/cldr-json>
 
 CLDR does not use Github's issue tracking system to track bugs.  If you find an error in
 the data contained here, please file a new ticket at [Unicode Jira](https://unicode-org.atlassian.net/projects/CLDR/issues)
-
-### Licenses
-
-- Usage of CLDR data and software is governed by the [Unicode Terms of Use](http://www.unicode.org/copyright.html)
-a copy of which is included as [LICENSE](./LICENSE).
-
-### Copyright
-
-Copyright &copy; 1991-2021 Unicode, Inc.
-All rights reserved.
-[Terms of use](http://www.unicode.org/copyright.html)


### PR DESCRIPTION
CLDR-15414

- [X] This PR completes the ticket.


- updated structure for personnames

also:
- drop xml:space from json, everywhere
- reorg how the copyright date is done in json (to avoid a yearly bump)
- improve how packageDesc is handled, so more packages have descriptions