### PR TITLE
CLDR-14734 Info Panel Visibility

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAccount.js
+++ b/tools/cldr-apps/js/src/esm/cldrAccount.js
@@ -4,7 +4,6 @@
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
 import * as cldrGui from "./cldrGui.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
@@ -195,8 +194,6 @@ function listSingleUser(email) {
 }
 
 function reallyLoad() {
-  cldrGui.hideRightPanel();
-  cldrInfo.showNothing();
   const xhrArgs = {
     url: getUrl(),
     handleAs: "json",

--- a/tools/cldr-apps/js/src/esm/cldrAdmin.js
+++ b/tools/cldr-apps/js/src/esm/cldrAdmin.js
@@ -5,7 +5,6 @@ import * as cldrAccount from "./cldrAccount.js";
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
 import * as cldrEvent from "./cldrEvent.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
@@ -20,8 +19,6 @@ let exceptionNames = {};
 
 // called as special.load
 function load() {
-  cldrInfo.showNothing();
-
   const ourDiv = document.createElement("div");
   const surveyUser = cldrStatus.getSurveyUser();
   const hasPermission = surveyUser && surveyUser.userlevelName === "ADMIN";

--- a/tools/cldr-apps/js/src/esm/cldrCreateLogin.js
+++ b/tools/cldr-apps/js/src/esm/cldrCreateLogin.js
@@ -2,15 +2,12 @@
  * cldrCreateLogin: encapsulate the "Create and Login" part of the Admin Panel.
  */
 import * as cldrAjax from "./cldrAjax.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
 
 // called as special.load
 function load() {
-  cldrInfo.showNothing();
-
   const ourDiv = document.createElement("div");
   ourDiv.setAttribute("id", "createLoginDiv");
   ourDiv.innerHTML = getHtml();

--- a/tools/cldr-apps/js/src/esm/cldrErrorSubtypes.js
+++ b/tools/cldr-apps/js/src/esm/cldrErrorSubtypes.js
@@ -2,7 +2,6 @@
  * cldrErrorSubtypes: encapsulate functions for the "Error Subtypes" page of Survey Tool
  */
 import * as cldrAjax from "./cldrAjax.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
@@ -24,7 +23,6 @@ const mainId = "errorSubtypes";
 
 // called as special.load
 function load() {
-  cldrInfo.showNothing();
   const xhrArgs = {
     url: getUrl(),
     handleAs: "json",

--- a/tools/cldr-apps/js/src/esm/cldrEvent.js
+++ b/tools/cldr-apps/js/src/esm/cldrEvent.js
@@ -416,6 +416,8 @@ function unpackMenuSideBar(json) {
     toggleOverlay();
     const url = $(this).data("url");
     if (url === "dashboard") {
+      // Note: setCurrentSpecial("general") is dubious here; it doesn't cause
+      // the "general" page to be loaded; it doesn't hide whatever else was displayed.
       cldrStatus.setCurrentSpecial("general");
       cldrGui.insertDashboard();
     } else {
@@ -557,84 +559,6 @@ function interceptPulldownLink(event) {
 
   event.preventDefault();
   event.stopPropagation();
-}
-
-/**
- * Add some label with a tooltip to every icon
- *
- * Called only from review.js -- not yet used for !USE_DOJO
- */
-function labelizeIcon() {
-  var icons = [
-    {
-      selector: ".d-dr-approved",
-      type: "success",
-      text: "Approved",
-      title: 'The "Proposed" (winning) value will be in the release.',
-    },
-    {
-      selector: ".d-dr-contributed",
-      type: "success",
-      text: "Contributed",
-      title:
-        'The "Proposed" (winning) value will be in the release (with a slightly lower status).',
-    },
-    {
-      selector: ".d-dr-provisional",
-      type: "warning",
-      text: "Provisional",
-      title:
-        'There is a "Proposed" (winning) value, but it doesn\'t have enough votes.',
-    },
-    {
-      selector: ".d-dr-unconfirmed",
-      type: "warning",
-      text: "Unconfirmed",
-      title:
-        'There is a "Proposed" (winning) value, but it doesn\'t have enough votes.',
-    },
-    {
-      selector: ".d-dr-inherited-provisional",
-      type: "inherited-provisional",
-      text: "Inherited and Provisional",
-      title: 'The "Proposed" (winning) value is inherited and provisional.',
-    },
-    {
-      selector: ".d-dr-inherited-unconfirmed",
-      type: "inherited-unconfirmed",
-      text: "Inherited and Unconfirmed",
-      title: 'The "Proposed" (winning) value is inherited and unconfirmed.',
-    },
-    {
-      selector: ".d-dr-missing",
-      type: "warning",
-      text: "Missing",
-      title: "There is no winning value. The inherited value will be used.",
-    },
-    {
-      selector: ".i-star",
-      type: "primary",
-      text: "Baseline",
-      title:
-        "The baseline value, which was approved in the last release, plus latest XML fixes by the Technical Committee, if any.",
-    },
-  ];
-
-  $.each(icons, function (index, element) {
-    $(element.selector).each(function () {
-      if ($(this).next(".label").length !== 0) {
-        $(this).next().remove();
-      }
-      $(this).after(
-        '<div class="label label-' +
-          element.type +
-          ' label-icon">' +
-          element.text +
-          "</div>"
-      );
-      $(this).next().tooltip({ title: element.title });
-    });
-  });
 }
 
 /**

--- a/tools/cldr-apps/js/src/esm/cldrGenericVue.js
+++ b/tools/cldr-apps/js/src/esm/cldrGenericVue.js
@@ -2,7 +2,6 @@
  * cldrGenericVue: encapsulate functions for the any other special pages of Survey Tool
  * which route through Vue
  */
-import * as cldrGui from "./cldrGui.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrRetry from "./cldrRetry.js";
 import * as cldrSurvey from "./cldrSurvey.js";
@@ -24,9 +23,6 @@ function loadHandler(json, specialPage) {
   }
 
   const app = document.createElement("div");
-
-  // make right hand sidebar empty. TODO: better way to do this?
-  cldrGui.hideRightPanel();
   cldrSurvey.hideLoader();
   cldrLoad.flipToOtherDiv(app);
 

--- a/tools/cldr-apps/js/src/esm/cldrGui.js
+++ b/tools/cldr-apps/js/src/esm/cldrGui.js
@@ -4,6 +4,7 @@
 import * as cldrDrag from "./cldrDrag.js";
 import * as cldrEvent from "./cldrEvent.js";
 import * as cldrForum from "./cldrForum.js";
+import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrMenu from "./cldrMenu.js";
 import * as cldrProgress from "./cldrProgress.js";
@@ -24,7 +25,6 @@ const runGuiId = "st-run-gui";
 let mainHeaderWrapper = null;
 let dashboardWidgetWrapper = null;
 
-let rightPanelVisible = true;
 let dashboardVisible = false;
 
 /**
@@ -56,6 +56,7 @@ function run() {
     setOnClicks();
     window.addEventListener("resize", handleResize);
     cldrProgress.insertWidget("CompletionSpan");
+    cldrInfo.initialize("ItemInfoContainer", "MainContentPane", "open-right");
   } catch (e) {
     return Promise.reject(e);
   }
@@ -174,10 +175,6 @@ function setOnClicks() {
   for (let i = 0; i < els.length; i++) {
     els[i].onclick = () => insertDashboard();
   }
-  els = document.getElementsByClassName("toggle-right");
-  for (let i = 0; i < els.length; i++) {
-    els[i].onclick = () => toggleRightPanel();
-  }
 }
 
 const leftSidebar =
@@ -270,7 +267,7 @@ const topTitle =
       <span id="CompletionSpan"></span>
       <span>
         <button class="cldr-nav-btn btn-primary open-dash" type="button">Open Dashboard</button>
-        <button class="cldr-nav-btn btn-primary toggle-right" type="button">Toggle Info Panel</button>
+        <button class="cldr-nav-btn btn-primary open-right" type="button">Open Info Panel</button>
       </span>
     </nav>
   </header>
@@ -290,7 +287,6 @@ const sideBySide = `
       <section id="DashboardSection"></section>
     </div>
     <div id="ItemInfoContainer" class="sidebyside-column sidebyside-narrow">
-      <section id="itemInfo" class="sidebyside-scrollable"></section>
     </div>
   </main>
 `;
@@ -415,50 +411,6 @@ function updateWithStatus() {
 }
 
 /**
- * Show or hide the right panel
- */
-function toggleRightPanel() {
-  rightPanelVisible ? hideRightPanel() : showRightPanel();
-}
-
-/**
- * Show the right panel
- */
-function showRightPanel() {
-  if (rightPanelVisible) {
-    return;
-  }
-  const main = document.getElementById("MainContentPane");
-  const info = document.getElementById("ItemInfoContainer");
-  if (main && info) {
-    main.style.width = "75%";
-    info.style.width = "25%";
-    info.style.display = "flex";
-    rightPanelVisible = true;
-  }
-}
-
-/**
- * Hide the right panel
- *
- * Called by toggleRightPanel, and also for Reports.
- * Otherwise, for the Date/Time, Zones, Numbers reports (especially Zones), the panel may invisibly prevent
- * clicking on the "view" buttons.
- */
-function hideRightPanel() {
-  if (!rightPanelVisible) {
-    return;
-  }
-  const main = document.getElementById("MainContentPane");
-  const info = document.getElementById("ItemInfoContainer");
-  if (main && info) {
-    main.style.width = "100%";
-    info.style.display = "none";
-    rightPanelVisible = false;
-  }
-}
-
-/**
  * The user's coverage level has changed. Inform all widgets we know about that need
  * updating to reflect the change.
  *
@@ -573,13 +525,11 @@ function refreshCounterVetting() {
 export {
   dashboardIsVisible,
   hideDashboard,
-  hideRightPanel,
   insertDashboard,
   refreshCounterVetting,
   run,
   setToptitleVisibility,
   showDashboard,
-  showRightPanel,
   updateDashboardRow,
   updateWidgetsWithCoverage,
   updateWithStatus,

--- a/tools/cldr-apps/js/src/esm/cldrLocales.js
+++ b/tools/cldr-apps/js/src/esm/cldrLocales.js
@@ -2,12 +2,10 @@
  * cldrLocales: encapsulate functions concerning locales for Survey Tool
  */
 import * as cldrEvent from "./cldrEvent.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrMenu from "./cldrMenu.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
-import * as cldrText from "./cldrText.js";
 
 // called as special.load
 function load() {
@@ -28,10 +26,13 @@ function load() {
   cldrEvent.filterAllLocale(); // filter for init data
   cldrEvent.forceSidebar();
   cldrStatus.setCurrentLocale(null);
-  cldrStatus.setCurrentSpecial("locales"); // TODO: always redundant? it's already "locales"
-  const message = cldrText.get("localesInitialGuidance");
-  cldrInfo.showMessage(message);
-  $("#itemInfo").html("");
+
+  // When clicking on the locale name in the header of the main Page view,
+  // the OtherSection div may be non-empty and needs to be hidden here
+  const otherSection = document.getElementById("OtherSection");
+  if (otherSection) {
+    otherSection.style.display = "none";
+  }
 }
 
 // called as special.parseHash

--- a/tools/cldr-apps/js/src/esm/cldrMenu.js
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.js
@@ -455,7 +455,7 @@ function updateTitleAndSection(menuMap) {
   const curSpecial = cldrStatus.getCurrentSpecial();
   const titlePageContainer = document.getElementById("title-page-container");
 
-  if (curSpecial != null && curSpecial != "") {
+  if (curSpecial) {
     const specialId = "special_" + curSpecial;
     $("#section-current").html(cldrText.get(specialId));
     cldrDom.setDisplayed(titlePageContainer, false);
@@ -473,9 +473,6 @@ function updateTitleAndSection(menuMap) {
       cldrStatus.setCurrentSection(mySection.id);
       $("#section-current").html(mySection.name);
       cldrDom.setDisplayed(titlePageContainer, false); // will fix title later
-    } else {
-      $("#section-current").html(cldrText.get("section_general"));
-      cldrDom.setDisplayed(titlePageContainer, false);
     }
   }
 }

--- a/tools/cldr-apps/js/src/esm/cldrRecentActivity.js
+++ b/tools/cldr-apps/js/src/esm/cldrRecentActivity.js
@@ -11,13 +11,12 @@
  */
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
-import * as cldrGui from "./cldrGui.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrRetry from "./cldrRetry.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
 import * as cldrText from "./cldrText.js";
-import * as cldrUserListExport from "../esm/cldrUserListExport";
+import * as cldrUserListExport from "./cldrUserListExport.js";
 
 /**
  * The id of the user in question; not necessarily the current user
@@ -48,7 +47,6 @@ function pleaseLogIn() {
 function loadWithJson(json) {
   cldrSurvey.hideLoader();
   cldrLoad.setLoading(false);
-  cldrGui.hideRightPanel();
   const frag = cldrDom.construct(getHtml(json));
 
   // Add a button for recent activity download

--- a/tools/cldr-apps/js/src/esm/cldrReport.js
+++ b/tools/cldr-apps/js/src/esm/cldrReport.js
@@ -3,7 +3,6 @@
  */
 import * as cldrClient from "./cldrClient.js";
 import * as cldrDom from "./cldrDom.js";
-import * as cldrGui from "./cldrGui.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrSurvey from "./cldrSurvey.js";
 import * as cldrText from "./cldrText.js";
@@ -33,7 +32,6 @@ function reportLoadHandler(html, report) {
     lastrr.unmount();
   }
   lastrr = rr;
-  cldrGui.hideRightPanel();
 }
 
 function reportName(report) {

--- a/tools/cldr-apps/js/src/esm/cldrReportDates.js
+++ b/tools/cldr-apps/js/src/esm/cldrReportDates.js
@@ -3,18 +3,14 @@
  */
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrReport from "./cldrReport.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
-import * as cldrText from "./cldrText.js";
 
 // called as special.load
 function load() {
   cldrSurvey.showLoader(null);
-  const message = cldrText.get("reportGuidance");
-  cldrInfo.showMessage(message);
   const url = getUrl();
   cldrSurvey.hideLoader();
   const xhrArgs = {

--- a/tools/cldr-apps/js/src/esm/cldrReportNumbers.js
+++ b/tools/cldr-apps/js/src/esm/cldrReportNumbers.js
@@ -3,18 +3,14 @@
  */
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrReport from "./cldrReport.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
-import * as cldrText from "./cldrText.js";
 
 // called as special.load
 function load() {
   cldrSurvey.showLoader(null);
-  const message = cldrText.get("reportGuidance");
-  cldrInfo.showMessage(message);
   const url = getUrl();
   cldrSurvey.hideLoader();
   const xhrArgs = {

--- a/tools/cldr-apps/js/src/esm/cldrReportZones.js
+++ b/tools/cldr-apps/js/src/esm/cldrReportZones.js
@@ -3,18 +3,14 @@
  */
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrReport from "./cldrReport.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
-import * as cldrText from "./cldrText.js";
 
 // called as special.load
 function load() {
   cldrSurvey.showLoader(null);
-  const message = cldrText.get("reportGuidance");
-  cldrInfo.showMessage(message);
   const url = getUrl();
   cldrSurvey.hideLoader();
   const xhrArgs = {

--- a/tools/cldr-apps/js/src/esm/cldrRetry.js
+++ b/tools/cldr-apps/js/src/esm/cldrRetry.js
@@ -3,7 +3,6 @@
  */
 import * as cldrEvent from "./cldrEvent.js";
 import * as cldrGenericVue from "./cldrGenericVue.js";
-import * as cldrInfo from "./cldrInfo.js";
 import * as cldrLoad from "./cldrLoad.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
@@ -50,7 +49,6 @@ function handleDisconnect(why, json, word, what) {
 
 // called as special.load
 function load() {
-  cldrInfo.showNothing();
   cldrEvent.hideOverlayAndSidebar();
   if (!errInfo.location) {
     window.location.href = "/cldr-apps/v";

--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -52,8 +52,6 @@ const strings = {
   "i-override_desc":
     "You have voted on this item with a lower vote count (shown in parenthesis).",
 
-  itemInfoBlank: "This area shows further details about the selected item.",
-
   draftStatus: "Status: ${0}",
   confirmed: "Confirmed",
   approved: "Approved",
@@ -173,13 +171,12 @@ const strings = {
   winningStatus_disputed: "Disputed",
   winningStatus_msg: "${1} ${0} Value ",
 
-  reportGuidance: " ",
   dataPageInitialGuidance:
     "Please consult the <a target='_blank' href='http://cldr.unicode.org/translation/getting-started/guide'>Instructions <span class='glyphicon glyphicon-share'></span></a> page.<br/><br/>Briefly, for each row:<br/><ol><li>Click on a cell in the 'Code' column.</li><li>Read the details that appear in the right panel (widen your window to see it).</li><li> Hover over the English and the Winning value to see examples.</li><li>To vote:<ol><li>for an existing item in the Winning or Others column, click on the <input type='radio'/> for that item.</li><li>for a new value, click on the button in the \"Add\" column. A new editing box will open. Enter the new value and hit RETURN.</li><li>for no value (abstain, or retract a vote), click on the  <input type='radio'/> in the Abstain column.</li></ol></li></ol>",
   generalPageInitialGuidance:
     "This area will show details of items as you work with the Survey Tool.",
-  localesInitialGuidance:
-    "Choose a locale to get started.  <ul><li><span class='locked'>locked</span> locales may not be modified by anyone,</li><li><span class='canmodify'>hand icon</span> indicates editing allowed by you</li><li><span class='name_var'>Locales with (Variants)</span> may have specific differences to note.</li></ul><p>Don't see your locale? See: <a href='http://cldr.unicode.org/index/bug-reports#New_Locales'>Adding New Locales</a></p>",
+  generalSpecialGuidance:
+    "Please hover over the sidebar to choose a section to begin entering data. If you have not already done so, please read the <a target='_blank' href='http://www.unicode.org/cldr/survey_tool.html'>Instructions</a>, particularly the Guide and the Walkthrough. You can also use the Dashboard to see all the errors, warnings, and missing items in one place.",
 
   loginGuidance: "You may not make any changes, you are not logged in.",
   readonlyGuidance: "You may not make changes to this locale.",
@@ -277,8 +274,8 @@ const strings = {
     "${count} old winning votes were automatically imported",
   "v-title_desc":
     "This area shows the date before which votes are considered “old”.",
+
   section_forum: "Forum",
-  section_general: "General Info",
   section_subpages: "Subpages",
 
   searchNoResults: "No results found.",
@@ -453,8 +450,7 @@ const strings = {
   special_flagged: "Flagged Items",
   special_forum: "Forum Posts",
   special_forum_participation: "Forum Participation",
-  special_general:
-    "Please hover over the sidebar to choose a section to begin entering data. If you have not already done so, please read the <a target='_blank' href='http://www.unicode.org/cldr/survey_tool.html'>Instructions</a>, particularly the Guide and the Walkthrough. You can also use the Dashboard to see all the errors, warnings, and missing items in one place.",
+  special_general: "General Info",
   special_list_emails: "List Email Addresses",
   special_list_users: "List Users",
   special_locales: "Locale List",

--- a/tools/cldr-apps/js/src/views/GeneralInfo.vue
+++ b/tools/cldr-apps/js/src/views/GeneralInfo.vue
@@ -49,8 +49,7 @@ export default {
       this.betaNote = null;
     }
 
-    // setup specialGeneral
-    this.specialGeneral = cldrText.get("special_general");
+    this.specialGeneral = cldrText.get("generalSpecialGuidance");
   },
   methods: {
     insertDashboard() {

--- a/tools/cldr-apps/js/src/views/InfoPanel.vue
+++ b/tools/cldr-apps/js/src/views/InfoPanel.vue
@@ -1,0 +1,56 @@
+<template>
+  <section id="InfoPanelSection">
+    <header class="sidebyside-column-top">
+      <button
+        class="cldr-nav-btn info-panel-closebox"
+        title="Close"
+        @click="closeInfoPanel"
+      >
+        X
+      </button>
+      <span class="i-am-info-panel">Info Panel</span>
+    </header>
+  </section>
+</template>
+
+<script>
+import * as cldrInfo from "../esm/cldrInfo.js";
+
+export default {
+  methods: {
+    closeInfoPanel() {
+      cldrInfo.closePanel();
+    },
+  },
+};
+</script>
+
+<style scoped>
+#InfoPanelSection {
+  border-top: 1px solid #cfeaf8;
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  font-size: small;
+  overflow: hidden;
+}
+
+header {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 1ex 0;
+  background-color: white;
+  background-image: linear-gradient(white, #e7f7ff);
+}
+
+.info-panel-closebox {
+  margin-left: 1ex;
+}
+
+.i-am-info-panel {
+  font-weight: bold;
+  margin-right: 1ex;
+}
+</style>

--- a/tools/cldr-apps/js/test/TestCldrProgress.js
+++ b/tools/cldr-apps/js/test/TestCldrProgress.js
@@ -2,6 +2,8 @@ import * as cldrProgress from "../src/esm/cldrProgress.js";
 
 const assert = chai.assert;
 
+export const TestCldrProgress = "ok";
+
 describe("cldrProgress.friendlyPercent", function () {
   it("should return a number", function () {
     const fp = cldrProgress.friendlyPercent(0, 0);

--- a/tools/cldr-apps/src/main/webapp/css/redesign.css
+++ b/tools/cldr-apps/src/main/webapp/css/redesign.css
@@ -448,7 +448,7 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 }
 
 
-.sidebar-chooser, #review-link  {
+.sidebar-chooser  {
 	cursor:pointer;
 }
 


### PR DESCRIPTION
-Give the Info Panel a title bar with a close box

-Rename button from Toggle Info Panel to Open Info Panel

-Hide button when panel is visible

-Remember whether the panel should be visible for the Page table view

-Use new InfoPanel.vue for the title bar, non-Vue (for now) for content

-Automatically close panel by default for specials

-Automatically open panel for specials that call showMessage

-Move some Info Panel code from cldrGui.js to cldrInfo.js

-Refactor for encapsulation, simplicity, shorter functions, use subroutines

-Fix inconsistent naming: change section_general to generalSpecialGuidance; change special_general to section_general

-Remove dead code

-Fix unit test TestCldrProgress, was missing export ok

-Comments

CLDR-14734

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
