### PR TITLE
CLDR-15933 Remove unnecessary & incorrect legacy alias added for key "mu"

### DIFF
--- a/common/bcp47/measure.xml
+++ b/common/bcp47/measure.xml
@@ -13,7 +13,7 @@
 			<type name="uksystem" description="UK System of measurement: feet, pints, etc.; pints are 20oz"
 				alias="imperial" since="28" />
 		</key>
-		<key name="mu" alias="measurement-unit" since="42" description="Allows setting overrides for measurement units. Currently limited to quantity=temperature, and no provision for usage or size.">
+		<key name="mu" since="42" description="Allows setting overrides for measurement units. Currently limited to quantity=temperature, and no provision for usage or size.">
 			<type name="celsius" description="temperature unit is Celsius" since="42" />
 			<type name="kelvin" description="temperature unit is Kelvin" since="42" />
 			<type name="fahrenhe" description="temperature unit is Fahrenheit" since="42" />


### PR DESCRIPTION
CLDR-15933

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

The bcp47 alias added in #2303 for new key "mu" is unnecessary (don't need aliases for new keys), and is malformed.