### PR TITLE
CLDR-15956 BCP47 u-extension specification for measurement unit prefe…

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -830,6 +830,16 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
         <tr><td>"uksystem"</td>
             <td>UK System of measurement: feet, pints, etc.; pints are 20oz</td></tr>
 
+<tr><td colspan="4"><b>A <a name="MeasurementUnitPreferenceOverride" id="MeasurementUnitPreferenceOverride" href="#MeasurementUnitPreferenceOverride">Measurement Unit Preference Override</a> defines an override for measurement unit preference. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="mu" in bcp47/<a href="https://github.com/unicode-org/cldr/tree/main/common/bcp47/measure.xml" target="_blank">measure.xml</a></b>.</td></tr>
+<tr><td rowspan="3">"mu"</td>
+    <td rowspan="3">Measurement unit override</td>
+            <td>"celsius"</td>
+            <td>Celsius as temparature unit</td></tr>
+        <tr><td>"kelvin"</td>
+            <td>Kelvin as temparature unit</td></tr>
+        <tr><td>"fahrenhe"</td>
+            <td>Fahrenheit as temparature unit</td></tr>
+
 <tr><td colspan="4"><b>A <a name="UnicodeNumberSystemIdentifier" id="UnicodeNumberSystemIdentifier" href="#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> defines a type of number system. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/tree/main/common/bcp47/number.xml" target="_blank">number.xml</a>.</b></td></tr>
 <tr><td rowspan="7">"nu"<br>(numbers)</td>
     <td rowspan="7">Numbering system</td>


### PR DESCRIPTION
…rence override (mu)

As a part of BRS42, added mu to u-extension table in LDML.

CLDR-15956

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
