### PR TITLE
CLDR-15286 Document new dateTimeFormat "atTime" variant and when to use it

### DIFF
--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -562,12 +562,28 @@ Time formats use the specific non-location format (z or zzzz) for the time zone 
 Date/Time formats have the following form:
 ```xml
     <dateTimeFormats>
+        <dateTimeFormatLength type="full">
+            <dateTimeFormat>
+                <pattern>{1}, {0}</pattern>
+            </dateTimeFormat>
+            <dateTimeFormat type="atTime">
+                <pattern>{1} 'at' {0}</pattern>
+            </dateTimeFormat>
+        </dateTimeFormatLength>
         <dateTimeFormatLength type="long">
             <dateTimeFormat>
+                <pattern>{1}, {0}</pattern>
+            </dateTimeFormat>
+            <dateTimeFormat type="atTime">
                 <pattern>{1} 'at' {0}</pattern>
             </dateTimeFormat>
         </dateTimeFormatLength>
         <dateTimeFormatLength type="medium">
+            <dateTimeFormat>
+                <pattern>{1}, {0}</pattern>
+            </dateTimeFormat>
+        </dateTimeFormatLength>
+        <dateTimeFormatLength type="short">
             <dateTimeFormat>
                 <pattern>{1}, {0}</pattern>
             </dateTimeFormat>
@@ -624,11 +640,13 @@ These formats allow for date and time formats to be composed in various ways.
 <!ELEMENT dateTimeFormatLength (alias | (default*, dateTimeFormat*, special*))>
 <!ATTLIST dateTimeFormatLength type ( full | long | medium | short ) #IMPLIED >
 <!ELEMENT dateTimeFormat (alias | (pattern*, displayName*, special*))>
+<!ATTLIST dateTimeFormat type NMTOKEN "standard" >
+    <!--@MATCH:literal/standard, atTime-->
 ```
 
 The `dateTimeFormat` element works like the dateFormats and timeFormats, except that the pattern is of the form "{1} {0}", where {0} is replaced by the time format, and {1} is replaced by the date format, with results such as "8/27/06 7:31 AM". Except for the substitution markers {0} and {1}, text in the dateTimeFormat is interpreted as part of a date/time pattern, and is subject to the same rules described in [Date Format Patterns](#Date_Format_Patterns). This includes the need to enclose ASCII letters in single quotes if they are intended to represent literal text.
 
-When combining a standard date pattern with a standard time pattern, the type of dateTimeFormat used to combine them is determined by the type of the date pattern. For example:
+When combining a standard date pattern with a standard time pattern, start with the `dateTimeFormatLength` whose `type` matches the type of the *date* pattern, and then use one of the `dateTimeFormat`s for that `dateTimeFormatLength` (as described after the following table). For example:
 
 ###### Table: <a name="Date_Time_Combination_Examples" href="#Date_Time_Combination_Examples">Date-Time Combination Examples</a>
 
@@ -636,6 +654,15 @@ When combining a standard date pattern with a standard time pattern, the type of
 | ----------------------- | ------------------------- | ------- |
 | full date + short time  | full, e.g. "{1} 'at' {0}" | Wednesday, September 18, 2013 at 4:30 PM |
 | medium date + long time | medium, e.g. "{1}, {0}"   | Sep 18, 2013, 4:30:00 PM PDT |
+
+For each `dateTimeFormatLength`, there is a standard `dateTimeFormat`. In addition to the placeholders {0} and {1}, this should not have characters other than space and punctuation; it should impose no grammatical context that might require specific grammatical forms for the date and/or time. For English, this might be “{1}, {0}”.
+
+In addition, especially for the full and long `dateTimeFormatLength`s, there may be a `dateTimeFormat` with `type="atTime"`. This is used to indicate an event at a specific time, and may impose specific grammatical requirements on the formats for date and/or time. For English, this might be “{1} 'at' {0}”.
+
+The default guidelines for choosing which `dateTimeFormat` to use for a given `dateTimeFormatLength` are as follows:
+* If an interval is being formatted, use the standard combining pattern to produce e.g. “March 15, 3:00 – 5:00 PM” or “March 15, 9:00 AM – March 16, 5:00 PM”.
+* If a single date or relative date is being combined with a single time, by default use the atTime pattern (if available) to produce an event time: “March 15 at 3:00 PM” or “tomorrow at 3:00 PM”.  However, at least in the case of combining a single date and time, APIs should also offer a “current time” option of using the standard combining pattern to produce a format more suitable for indicating  the current time: “March 15, 3:00 PM”.
+* For all other uses of these patterns, use the standard pattern.
 
 #### 2.6.2 <a name="availableFormats_appendItems" href="#availableFormats_appendItems">Elements availableFormats, appendItems</a>
 


### PR DESCRIPTION
CLDR-15286

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Document new dateTimeFormat "atTime" variant and when to use it.

Note in this PR I am not adding the corresponding entry in the Mods section of tr35 because it would conflict with a prior PR. I will updated the Mods section for this addition as part of another spec PR.