### PR TITLE
CLDR-16029 doc: update Latest Proposed Update link (maint-41)

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -11,7 +11,7 @@
 <tr><td>Previous Version</td><td><a href="https://www.unicode.org/reports/tr35/tr35-65/tr35.html">https://www.unicode.org/reports/tr35/tr35-65/tr35.html</a></td></tr>
 <tr><td>Latest Version</td><td><a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a></td></tr>
 <tr><td>Corrigenda</td><td><a href="https://cldr.unicode.org/index/corrigenda">https://cldr.unicode.org/index/corrigenda</a></td></tr>
-<tr><td>Latest Proposed Update</td><td><a href="https://unicode-org.github.io/cldr/ldml/tr35.html">https://unicode-org.github.io/cldr/ldml/tr35.html</a></td></tr>
+<tr><td>Latest Proposed Update</td><td><a href="https://www.unicode.org/reports/tr35/proposed.html">https://www.unicode.org/reports/tr35/proposed.html</a></td></tr>
 <tr><td>Namespace</td><td><a href="https://unicode.org/cldr/">https://unicode.org/cldr/</a></td></tr>
 <tr><td>DTDs</td><td><a href="https://www.unicode.org/cldr/dtd/41/">https://www.unicode.org/cldr/dtd/41/</a></td></tr>
 <tr><td>Revision</td><td><a href="#Modifications">66</a></td></tr>


### PR DESCRIPTION
- Latest proposed update link should always be: https://www.unicode.org/reports/tr35/proposed.html
- This URL will redirect to the appropriate spot depending on project phase

(cherry picked from commit d33f209bfeaae80bee6c1e8a224bd4b5de2421e6) #2370 

CLDR-16029

- [X] This PR completes the ticket.
- [x] Need to merge the tr-archive stuff
