### PR TITLE
CLDR-16018 fix table

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3394,15 +3394,11 @@ Interpret each languageId as a multimap from a _fieldId_ (language, script, regi
 
 _Examples:_
 
-<!-- HTML: rowspan, colspan -->
-<table><thead>
-<tr><th rowspan="1">Source</th>         <th colspan="4">Fields</th></tr>
-<tr>                                    <th>Language</th>   <th>Script</th> <th>Region</th> <th>Variants</th></tr>
-</thead><tbody>
-<tr><td>en-GB</td>                      <td>{en}</td>       <td>{}</td>     <td>{GB}</td>   <td>{}</td></tr>
-<tr><td>und-GB</td>                     <td>{}</td>         <td>{}</td>     <td>{GB}</td>   <td>{}</td></tr>
-<tr><td>ja-Latn-YU-hepburn-heploc</td>  <td>{ja}</td>       <td>{Latn}</td> <td>{YU}</td>   <td>{hepburn, heploc}</td></tr>
-</tbody></table>
+| Source                    | Language | Script | Region | Variants          |
+|---------------------------|----------|--------|--------|-------------------|
+| en-GB                     | {en}     | {}     | {GB}   | {}                |
+| und-GB                    | {}       | {}     | {GB}   | {}                |
+| ja-Latn-YU-hepburn-heploc | {ja}     | {Latn} | {YU}   | {hepburn, heploc} |
 
 * This can be represented as an abbreviated format: \{L=\{ja}, S=\{Latn}, R=\{YU}, V=\{hepburn, heploc}}, skipping empty sets.
 * “und” is a special language code that is treated as an empty set.


### PR DESCRIPTION
CLDR-16018

Used https://www.tablesgenerator.com/markdown_tables to regenerate and fix the table

1. first paste from HTML spec page into spreadsheet (https://unicode.org/reports/tr35/tr35.html#1-multimap-interpretation)
2. then adjust spreadsheet to have no merged cells (and in this case, fix the misalignment)
3. copy into  https://www.tablesgenerator.com/markdown_tables
4. hit Generate, and copy result into LDML page

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
5. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
6. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
