### PR TITLE
CLDR-16036 BRS v42: Update ICU4J libs to release-72-rc before CLDR 42 beta2

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -12,7 +12,7 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 42</h3>
-    <p>Last updated: 2022-Sep-12</p>
+    <p>Last updated: 2022-Sep-22</p>
 
     <!--<p><b>Note:</b> CLDR 42 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 42, intended for those wishing to do pre-release testing.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>72.0.1-SNAPSHOT-cldr-2022-09-12</icu4j.version>
+		<icu4j.version>72.1-SNAPSHOT-release-72-rc</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-16036

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Now that ICU release-72-rc is tagged, update ICU4J libs in CLDR to that version before CLDR 42 beta2