### PR TITLE
CLDR-15955 Add constraints for unit IDs

### DIFF
--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -788,27 +788,40 @@ The parentLocales data is supplemental data, but is described in detail in the [
 
 The unit conversion data ([units.xml](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml)) provides the data for converting all of the cldr unit identifiers to base units, and back. That allows conversion between any two convertible units, such as two units of length. For any two convertible units (such as acre and dunum) the first can be converted to the base unit (square-meter), then that base unit can be converted to the second unit.
 
-Many of the elements allow for a common @description attribute, to disambiguate the main attribute value or to explain the choice of other values. For example:
-```xml
-<unitConstant constant="glucose_molar_mass" value="180.1557"
-  description="derivation from the mean atomic weights according to STANDARD ATOMIC WEIGHTS 2019 on https://ciaaw.org/atomic-weights.htm"/>
+### Unit Parsing Data
+
+<!ELEMENT unitIdComponents ( unitIdComponent* ) >
+
+<!ELEMENT unitIdComponent EMPTY >
+<!ATTLIST unitIdComponent type NMTOKEN #REQUIRED >
+<!ATTLIST unitIdComponent values NMTOKENS #REQUIRED >
+
+These elements provide support for parsing unit identifiers, as described in [Unit Elements](tr35-general.md#Unit_Elements). 
+Each of the values has tokens with specific functions, identified by the type. 
+For example the following values can be suffixes in a simple_unit identifier such as `quart-imperial`.
+
 ```
+<unitIdComponent type="suffix" values="force imperial luminosity mass metric person radius scandinavian troy unit us"/>
+````
+
+### Constants
+
 
 ```xml
 <!ELEMENT unitConstants ( unitConstant* ) >
 
 <!ELEMENT unitConstant EMPTY >
-
 <!ATTLIST unitConstant constant NMTOKEN #REQUIRED >
-
 <!ATTLIST unitConstant value CDATA #REQUIRED >
-
 <!ATTLIST unitConstant status NMTOKEN #IMPLIED >
-
 <!ATTLIST unitConstant description CDATA #IMPLIED >
 ```
 
-### Constants
+Many of the elements allow for a common @description attribute, to disambiguate the main attribute value or to explain the choice of other values. For example:
+```xml
+<unitConstant constant="glucose_molar_mass" value="180.1557"
+  description="derivation from the mean atomic weights according to STANDARD ATOMIC WEIGHTS 2019 on https://ciaaw.org/atomic-weights.htm"/>
+```
 
 The data uses a small set of constants for readability, such as:
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3669,6 +3669,12 @@ Proposed Update for CLDR Version 42.
    * Added a new subsection to  specify the interaction of the unit Preferences data with the locale keys mu, ms, and rg, and the base locale.
 * Plurals
    * In [Plural rules syntax](tr35-numbers.html#Plural_rules_syntax), allow sample values to have positive and negative signs.
+* Units of measurement
+   * [Unit Preferences](tr35-info.md#Unit_Preferences)
+      * Added a new subsection to  specify the interaction of the unit Preferences data with the locale keys mu, ms, and rg, and the base locale.
+   * [Unit Elements](tr35-general.md#Unit_Elements), [Unit_Conversion](tr35-info.md#Unit_Conversion)
+       * For simpler and cleaner parsing, add a new element (unitIdComponent) and restructured the EBNF for parsing unit identifiers.
+       * As part of this work, the identifier metric-ton was deprecated in favor of tonne. As usual, the older identifier remains for compatibility, and is aliased to the new one. 
 
 Note that small changes such as typos and link fixes are not listed above. Modifications in previous versions are listed in those respective versions. Click on **Previous Version** in the header until you get to the desired version.
 


### PR DESCRIPTION
CLDR-15955

Note that this deviates somewhat from the ticket: simple_unit is now above prefixed_unit, since the names and structure make more sense that way.

(Also, the table in the ticket got gummed up because of the presence of | characters in the text. The sheet https://docs.google.com/spreadsheets/d/1QpVPnIgJdYWZil2sr_L4P3z6O_AsT3sKZhP_SOyTVqQ/edit#gid=1228405746 has a cleaned up version.)

I considered changing the table structure to markdown, but refrained because that would make it harder to review. 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
