### PR TITLE
CLDR-15974 json: fix to PACKAGES.md

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1266,7 +1266,7 @@ public class Ldml2JsonConverter {
         pkgs.println("Package metadata is available at [`cldr-core`/cldr-packages.json](./cldr-json/cldr-core/cldr-packages.json)");
         pkgs.println();
 
-        writeReadmeSection(outf);
+        writeReadmeSection(pkgs);
         pkgs.close();
     }
 


### PR DESCRIPTION
PACKAGES.md's readme section was inadvertently written to cldr-packages.json, after that file was closed.

Missed commiting this in a hardware restore, this was already used to create cldr-json

CLDR-15974

- [ ] This PR completes the ticket.
