### PR TITLE
CLDR-16045 Remove Australia/India/Vietnam as keywords for non-globe emoji in some langs

### DIFF
--- a/common/annotations/bn.xml
+++ b/common/annotations/bn.xml
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">উদ্বিড়াল</annotation>
 		<annotation cp="🦨">দুর্গন্ধ | স্কাংক</annotation>
 		<annotation cp="🦨" type="tts">স্কাংক</annotation>
-		<annotation cp="🦘">অস্ট্রেলিয়া | ক্যাঙ্গারু | জই | দ্বিগর্ভ | লাফ</annotation>
+		<annotation cp="🦘">ক্যাঙ্গারু | জই | দ্বিগর্ভ | লাফ</annotation>
 		<annotation cp="🦘" type="tts">ক্যাঙ্গারু</annotation>
 		<annotation cp="🦡">বিরক্ত করা | ব্যাজার | হানি ব্যাজার</annotation>
 		<annotation cp="🦡" type="tts">ব্যাজার</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">চেরি ব্লজম</annotation>
 		<annotation cp="💮">ফুল | সাদা ফুল</annotation>
 		<annotation cp="💮" type="tts">সাদা ফুল</annotation>
-		<annotation cp="🪷">পদ্ম | পবিত্রতা | ফুল | বৌদ্ধধর্ম | ভারত | ভিয়েতনাম | হিন্দুধর্ম</annotation>
+		<annotation cp="🪷">পদ্ম | পবিত্রতা | ফুল | বৌদ্ধধর্ম | হিন্দুধর্ম</annotation>
 		<annotation cp="🪷" type="tts">পদ্ম</annotation>
 		<annotation cp="🏵">গাছ | ফিতে দিয়ে তৈরি গোলাপের ব্যাজ</annotation>
 		<annotation cp="🏵" type="tts">ফিতে দিয়ে তৈরি গোলাপের ব্যাজ</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">আড়াআড়ি রাখা তলোয়ার</annotation>
 		<annotation cp="🔫">অস্ত্র | পিস্তল | বন্দুক | রিভলবার | সরঞ্জাম</annotation>
 		<annotation cp="🔫" type="tts">পিস্তল</annotation>
-		<annotation cp="🪃">অস্ট্রেলিয়া | প্রতিক্রিয়া | প্রতিক্ষিপ্ত | বুমের‌্যাঙ</annotation>
+		<annotation cp="🪃">প্রতিক্রিয়া | প্রতিক্ষিপ্ত | বুমের‌্যাঙ</annotation>
 		<annotation cp="🪃" type="tts">বুমের‌্যাঙ</annotation>
 		<annotation cp="🏹">তীর | তীরন্দাজ | ধনুক | ধনুরাশি | রাশিচক্র</annotation>
 		<annotation cp="🏹" type="tts">তীর ধনুক</annotation>

--- a/common/annotations/de.xml
+++ b/common/annotations/de.xml
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">Otter</annotation>
 		<annotation cp="🦨">Skunk | stinken | Stinktier</annotation>
 		<annotation cp="🦨" type="tts">Stinktier</annotation>
-		<annotation cp="🦘">Australien | Hüpfen | Känguru</annotation>
+		<annotation cp="🦘">Hüpfen | Känguru</annotation>
 		<annotation cp="🦘" type="tts">Känguru</annotation>
 		<annotation cp="🦡">Dachs | Dachse</annotation>
 		<annotation cp="🦡" type="tts">Dachs</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">Kirschblüte</annotation>
 		<annotation cp="💮">Blume | Blumenstempel</annotation>
 		<annotation cp="💮" type="tts">Blumenstempel</annotation>
-		<annotation cp="🪷">Blume | Buddhismus | Hinduismus | Indien | Lotusblüte | Reinheit | Vietnam</annotation>
+		<annotation cp="🪷">Blume | Buddhismus | Hinduismus | Lotusblüte | Reinheit</annotation>
 		<annotation cp="🪷" type="tts">Lotusblüte</annotation>
 		<annotation cp="🏵">Pflanze | Rosette</annotation>
 		<annotation cp="🏵" type="tts">Rosette</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">gekreuzte Schwerter</annotation>
 		<annotation cp="🔫">Pistole | Revolver | Waffe | Wasserpistole</annotation>
 		<annotation cp="🔫" type="tts">Wasserpistole</annotation>
-		<annotation cp="🪃">Australien | Boomerang | Bumerang</annotation>
+		<annotation cp="🪃">Boomerang | Bumerang</annotation>
 		<annotation cp="🪃" type="tts">Bumerang</annotation>
 		<annotation cp="🏹">Bogen | Pfeil | Pfeil und Bogen</annotation>
 		<annotation cp="🏹" type="tts">Pfeil und Bogen</annotation>

--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -1829,7 +1829,7 @@ annotations.
 		<annotation cp="🦦" type="tts">otter</annotation>
 		<annotation cp="🦨">skunk | stink</annotation>
 		<annotation cp="🦨" type="tts">skunk</annotation>
-		<annotation cp="🦘">Australia | joey | jump | kangaroo | marsupial</annotation>
+		<annotation cp="🦘">joey | jump | kangaroo | marsupial</annotation>
 		<annotation cp="🦘" type="tts">kangaroo</annotation>
 		<annotation cp="🦡">badger | honey badger | pester</annotation>
 		<annotation cp="🦡" type="tts">badger</annotation>
@@ -1957,7 +1957,7 @@ annotations.
 		<annotation cp="🌸" type="tts">cherry blossom</annotation>
 		<annotation cp="💮">flower | white flower</annotation>
 		<annotation cp="💮" type="tts">white flower</annotation>
-		<annotation cp="🪷">Buddhism | flower | Hinduism | India | lotus | purity | Vietnam</annotation> <!-- 1FAB7 -->
+		<annotation cp="🪷">Buddhism | flower | Hinduism | lotus | purity</annotation> <!-- 1FAB7 -->
 		<annotation cp="🪷" type="tts">lotus</annotation>
 		<annotation cp="🏵">plant | rosette</annotation>
 		<annotation cp="🏵" type="tts">rosette</annotation>
@@ -3273,7 +3273,7 @@ annotations.
 		<annotation cp="⚔" type="tts">crossed swords</annotation>
 		<annotation cp="🔫">gun | handgun | pistol | revolver | tool | water | weapon</annotation>
 		<annotation cp="🔫" type="tts">water pistol</annotation>
-		<annotation cp="🪃">australia | boomerang | rebound | repercussion</annotation>
+		<annotation cp="🪃">boomerang | rebound | repercussion</annotation>
 		<annotation cp="🪃" type="tts">boomerang</annotation>
 		<annotation cp="🏹">archer | arrow | bow | bow and arrow | Sagittarius | zodiac</annotation>
 		<annotation cp="🏹" type="tts">bow and arrow</annotation>

--- a/common/annotations/es.xml
+++ b/common/annotations/es.xml
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">nutria</annotation>
 		<annotation cp="🦨">apestar | hedor | mal olor | mofeta | peste | tufo</annotation>
 		<annotation cp="🦨" type="tts">mofeta</annotation>
-		<annotation cp="🦘">australia | canguro | marsupial | salto</annotation>
+		<annotation cp="🦘">canguro | marsupial | salto</annotation>
 		<annotation cp="🦘" type="tts">canguro</annotation>
 		<annotation cp="🦡">ratel | tejón | tejón de la miel | tejón melero</annotation>
 		<annotation cp="🦡" type="tts">tejón</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">flor de cerezo</annotation>
 		<annotation cp="💮">blanca | flor</annotation>
 		<annotation cp="💮" type="tts">flor blanca</annotation>
-		<annotation cp="🪷">budismo | flor | hinduismo | India | loto | pureza | Vietnam</annotation>
+		<annotation cp="🪷">budismo | flor | hinduismo | loto | pureza</annotation>
 		<annotation cp="🪷" type="tts">loto</annotation>
 		<annotation cp="🏵">flor | planta | roseta</annotation>
 		<annotation cp="🏵" type="tts">roseta</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">espadas cruzadas</annotation>
 		<annotation cp="🔫">agua | juguete | pistola | pistola de agua | verano</annotation>
 		<annotation cp="🔫" type="tts">pistola de agua</annotation>
-		<annotation cp="🪃">Australia | boomerang | bumerán | rebotar</annotation>
+		<annotation cp="🪃">boomerang | bumerán | rebotar</annotation>
 		<annotation cp="🪃" type="tts">bumerán</annotation>
 		<annotation cp="🏹">arco | arco y flecha | arquero | flecha | sagitario | zodiaco</annotation>
 		<annotation cp="🏹" type="tts">arco y flecha</annotation>

--- a/common/annotations/es_419.xml
+++ b/common/annotations/es_419.xml
@@ -1946,7 +1946,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">↑↑↑</annotation>
 		<annotation cp="💮">flor | flor blanca | sello</annotation>
 		<annotation cp="💮" type="tts">↑↑↑</annotation>
-		<annotation cp="🪷">budismo | flor | hinduismo | India | lotus | pureza | Vietnam</annotation>
+		<annotation cp="🪷">budismo | flor | hinduismo | lotus | pureza</annotation>
 		<annotation cp="🪷" type="tts">lotus</annotation>
 		<annotation cp="🏵">↑↑↑</annotation>
 		<annotation cp="🏵" type="tts">↑↑↑</annotation>

--- a/common/annotations/es_MX.xml
+++ b/common/annotations/es_MX.xml
@@ -1818,7 +1818,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦦" type="tts">↑↑↑</annotation>
 		<annotation cp="🦨">zorrillo</annotation>
 		<annotation cp="🦨" type="tts">zorrillo</annotation>
-		<annotation cp="🦘">Australia | canguro | marsupial | saltar</annotation>
+		<annotation cp="🦘">canguro | marsupial | saltar</annotation>
 		<annotation cp="🦘" type="tts">canguro</annotation>
 		<annotation cp="🦡">tejón | tejón de la miel</annotation>
 		<annotation cp="🦡" type="tts">tejón</annotation>
@@ -1944,7 +1944,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🌸" type="tts">↑↑↑</annotation>
 		<annotation cp="💮">↑↑↑</annotation>
 		<annotation cp="💮" type="tts">↑↑↑</annotation>
-		<annotation cp="🪷">budismo | flor | hinduismo | India | loto | lotus | pureza | Vietnam</annotation>
+		<annotation cp="🪷">budismo | flor | hinduismo | loto | lotus | pureza</annotation>
 		<annotation cp="🪷" type="tts">loto</annotation>
 		<annotation cp="🏵">↑↑↑</annotation>
 		<annotation cp="🏵" type="tts">↑↑↑</annotation>
@@ -2896,7 +2896,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👗" type="tts">↑↑↑</annotation>
 		<annotation cp="👘">↑↑↑</annotation>
 		<annotation cp="👘" type="tts">↑↑↑</annotation>
-		<annotation cp="🥻">India | prenda | ropa | sari | vestido</annotation>
+		<annotation cp="🥻">prenda | ropa | sari | vestido</annotation>
 		<annotation cp="🥻" type="tts">↑↑↑</annotation>
 		<annotation cp="🩱">traje de baño | traje de baño de una pieza</annotation>
 		<annotation cp="🩱" type="tts">↑↑↑</annotation>

--- a/common/annotations/es_US.xml
+++ b/common/annotations/es_US.xml
@@ -1944,7 +1944,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🌸" type="tts">↑↑↑</annotation>
 		<annotation cp="💮">flor | flor blanca</annotation>
 		<annotation cp="💮" type="tts">↑↑↑</annotation>
-		<annotation cp="🪷">budismo | flor | flor de loto | hinduismo | India | pureza | Vietnam</annotation>
+		<annotation cp="🪷">budismo | flor | flor de loto | hinduismo | pureza</annotation>
 		<annotation cp="🪷" type="tts">flor de loto</annotation>
 		<annotation cp="🏵">↑↑↑</annotation>
 		<annotation cp="🏵" type="tts">↑↑↑</annotation>

--- a/common/annotations/fr.xml
+++ b/common/annotations/fr.xml
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">loutre</annotation>
 		<annotation cp="🦨">animal | mouffette | odeur | puer | putois</annotation>
 		<annotation cp="🦨" type="tts">mouffette</annotation>
-		<annotation cp="🦘">Australie | joey | kangourou | marsupial | saut</annotation>
+		<annotation cp="🦘">joey | kangourou | marsupial | saut</annotation>
 		<annotation cp="🦘" type="tts">kangourou</annotation>
 		<annotation cp="🦡">animal | blaireau | ratel</annotation>
 		<annotation cp="🦡" type="tts">blaireau</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">fleur de cerisier</annotation>
 		<annotation cp="💮">fleur | fleur blanche</annotation>
 		<annotation cp="💮" type="tts">fleur blanche</annotation>
-		<annotation cp="🪷">bouddhisme | fleur | hindouisme | Inde | lotus | pureté | Viêt Nam</annotation>
+		<annotation cp="🪷">bouddhisme | fleur | hindouisme | lotus | pureté</annotation>
 		<annotation cp="🪷" type="tts">lotus</annotation>
 		<annotation cp="🏵">plante | rosette</annotation>
 		<annotation cp="🏵" type="tts">rosette</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">épées croisées</annotation>
 		<annotation cp="🔫">arme | arme à feu | pistolet | pistolet à eau | revolver</annotation>
 		<annotation cp="🔫" type="tts">pistolet à eau</annotation>
-		<annotation cp="🪃">australie | boomerang | répercussion</annotation>
+		<annotation cp="🪃">boomerang | répercussion</annotation>
 		<annotation cp="🪃" type="tts">boomerang</annotation>
 		<annotation cp="🏹">arc | arc et flèche | archer | flèche | Sagittaire</annotation>
 		<annotation cp="🏹" type="tts">arc et flèche</annotation>

--- a/common/annotations/fr_CA.xml
+++ b/common/annotations/fr_CA.xml
@@ -1818,7 +1818,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦦" type="tts">↑↑↑</annotation>
 		<annotation cp="🦨">animal | bête puante | mouffette | odeur | puer | putois</annotation>
 		<annotation cp="🦨" type="tts">↑↑↑</annotation>
-		<annotation cp="🦘">Australie | bébé kangourou | kangourou | marsupial | saut</annotation>
+		<annotation cp="🦘">bébé kangourou | kangourou | marsupial | saut</annotation>
 		<annotation cp="🦘" type="tts">↑↑↑</annotation>
 		<annotation cp="🦡">blaireau | ratel</annotation>
 		<annotation cp="🦡" type="tts">↑↑↑</annotation>
@@ -3260,7 +3260,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="⚔" type="tts">↑↑↑</annotation>
 		<annotation cp="🔫">arme | arme à feu | pistolet | pistolet à eau | revolver</annotation>
 		<annotation cp="🔫" type="tts">pistolet à eau</annotation>
-		<annotation cp="🪃">australie | boomerang | outil | répercussion | retour</annotation>
+		<annotation cp="🪃">boomerang | outil | répercussion | retour</annotation>
 		<annotation cp="🪃" type="tts">boomerang</annotation>
 		<annotation cp="🏹">arc | arc et flèche | flèche | sagittaire | zodiaque</annotation>
 		<annotation cp="🏹" type="tts">↑↑↑</annotation>

--- a/common/annotations/hi.xml
+++ b/common/annotations/hi.xml
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">ऊदबिलाव</annotation>
 		<annotation cp="🦨">स्कंक</annotation>
 		<annotation cp="🦨" type="tts">स्कंक</annotation>
-		<annotation cp="🦘">ऑस्ट्रेलिया | कंगारू | कंगारू का बच्चा | कूद | धानी</annotation>
+		<annotation cp="🦘">कंगारू | कंगारू का बच्चा | कूद | धानी</annotation>
 		<annotation cp="🦘" type="tts">कंगारू</annotation>
 		<annotation cp="🦡">पेस्टर | बिज्जू | हनी बैजर</annotation>
 		<annotation cp="🦡" type="tts">बिज्जू</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">चैरी ब्लॉसम</annotation>
 		<annotation cp="💮">छाप | फूल | फूल की छाप | बहुत अच्छे काम की छाप</annotation>
 		<annotation cp="💮" type="tts">फूल की छाप</annotation>
-		<annotation cp="🪷">कमल | पवित्रता | फूल | बौद्ध धर्म | भारत | वियतनाम | हिंदू धर्म</annotation>
+		<annotation cp="🪷">कमल | पवित्रता | फूल | बौद्ध धर्म | हिंदू धर्म</annotation>
 		<annotation cp="🪷" type="tts">कमल</annotation>
 		<annotation cp="🏵">पुष्प | पुष्प, रिबन का पुष्प | रिबन का पुष्प</annotation>
 		<annotation cp="🏵" type="tts">पुष्प, रिबन का पुष्प</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">क्रॉस बनाती तलवारें</annotation>
 		<annotation cp="🔫">औज़ार | पानी की पिस्तौल | बंदूक | रिवॉल्वर | हथियार</annotation>
 		<annotation cp="🔫" type="tts">पानी की पिस्तौल</annotation>
-		<annotation cp="🪃">ऑस्ट्रेलिया | प्रतिध्वनि | बूमरैग | बूमरैंग | रीबाउंड</annotation>
+		<annotation cp="🪃">प्रतिध्वनि | बूमरैग | बूमरैंग | रीबाउंड</annotation>
 		<annotation cp="🪃" type="tts">बूमरैंग</annotation>
 		<annotation cp="🏹">टूल | तीर और कमान | धनुष | बाण | राशि</annotation>
 		<annotation cp="🏹" type="tts">तीर और कमान</annotation>

--- a/common/annotations/hi_Latn.xml
+++ b/common/annotations/hi_Latn.xml
@@ -1813,7 +1813,7 @@ annotations.
 		<annotation cp="🦦" type="tts">otter</annotation>
 		<annotation cp="🦨">skunk | stink</annotation>
 		<annotation cp="🦨" type="tts">skunk</annotation>
-		<annotation cp="🦘">Australia | joey | jump | kangaroo | marsupial</annotation>
+		<annotation cp="🦘">joey | jump | kangaroo | marsupial</annotation>
 		<annotation cp="🦘" type="tts">kangaroo</annotation>
 		<annotation cp="🦡">badger | honey badger | pester</annotation>
 		<annotation cp="🦡" type="tts">badger</annotation>
@@ -1939,7 +1939,7 @@ annotations.
 		<annotation cp="🌸" type="tts">cherry blossom</annotation>
 		<annotation cp="💮">flower | white flower</annotation>
 		<annotation cp="💮" type="tts">white flower</annotation>
-		<annotation cp="🪷">Buddhism | flower | Hinduism | India | lotus | purity | Vietnam</annotation> <!-- 1FAB7 -->
+		<annotation cp="🪷">Buddhism | flower | Hinduism | lotus | purity</annotation> <!-- 1FAB7 -->
 		<annotation cp="🪷" type="tts">lotus</annotation>
 		<annotation cp="🏵">plant | rosette</annotation>
 		<annotation cp="🏵" type="tts">rosette</annotation>
@@ -3255,7 +3255,7 @@ annotations.
 		<annotation cp="⚔" type="tts">crossed swords</annotation>
 		<annotation cp="🔫">gun | handgun | paani ki pistol | pistol | revolver | tool | water | weapon</annotation>
 		<annotation cp="🔫" type="tts">paani ki pistol</annotation>
-		<annotation cp="🪃">australia | boomerang | rebound | repercussion</annotation>
+		<annotation cp="🪃">boomerang | rebound | repercussion</annotation>
 		<annotation cp="🪃" type="tts">boomerang</annotation>
 		<annotation cp="🏹">archer | arrow | bow | Sagittarius | teer aur kamaan | zodiac</annotation>
 		<annotation cp="🏹" type="tts">teer aur kamaan</annotation>

--- a/common/annotations/ur.xml
+++ b/common/annotations/ur.xml
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">اود بلاؤ</annotation>
 		<annotation cp="🦨">بدبودار | سکنک</annotation>
 		<annotation cp="🦨" type="tts">سکنک</annotation>
-		<annotation cp="🦘">آسٹریلیا | چھلانگ | کینگرو | مارسوپئیل | ننھا کینگرو</annotation>
+		<annotation cp="🦘">چھلانگ | کینگرو | مارسوپئیل | ننھا کینگرو</annotation>
 		<annotation cp="🦘" type="tts">کینگرو</annotation>
 		<annotation cp="🦡">افریقی بجو | بجو | پریشان کرنا</annotation>
 		<annotation cp="🦡" type="tts">بجو</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">چیری بلاسم</annotation>
 		<annotation cp="💮">پھول | سفید پھول</annotation>
 		<annotation cp="💮" type="tts">سفید پھول</annotation>
-		<annotation cp="🪷">بدھ مت | بھارت | پھول | طہارت | کنول | ہندو مت | ویتنام</annotation>
+		<annotation cp="🪷">بدھ مت | پھول | طہارت | کنول | ہندو مت</annotation>
 		<annotation cp="🪷" type="tts">کنول</annotation>
 		<annotation cp="🏵">پھول | پودا | گلاب کا نقش</annotation>
 		<annotation cp="🏵" type="tts">گلاب کا نقش</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">کراس کی شکل بناتی تلواریں</annotation>
 		<annotation cp="🔫">پانی کی پستول | پستول | ہتھیار</annotation>
 		<annotation cp="🔫" type="tts">پستول</annotation>
-		<annotation cp="🪃">آسٹریلیا | بازگشت | بومرینگ | پلٹاؤ</annotation>
+		<annotation cp="🪃">بازگشت | بومرینگ | پلٹاؤ</annotation>
 		<annotation cp="🪃" type="tts">بومرینگ</annotation>
 		<annotation cp="🏹">تیر | تیر اور کمان | جنگ | کمان | ہتھیار</annotation>
 		<annotation cp="🏹" type="tts">تیر اور کمان</annotation>

--- a/common/annotations/zh.xml
+++ b/common/annotations/zh.xml
@@ -1809,7 +1809,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🐻" type="tts">熊</annotation>
 		<annotation cp="🐻‍❄">北极 | 北极熊 | 熊 | 白色</annotation>
 		<annotation cp="🐻‍❄" type="tts">北极熊</annotation>
-		<annotation cp="🐨">澳大利亚 | 考拉</annotation>
+		<annotation cp="🐨">考拉</annotation>
 		<annotation cp="🐨" type="tts">考拉</annotation>
 		<annotation cp="🐼">头 | 熊猫 | 胖达 | 脸</annotation>
 		<annotation cp="🐼" type="tts">熊猫</annotation>
@@ -1819,7 +1819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦦" type="tts">水獭</annotation>
 		<annotation cp="🦨">熏 | 臭 | 臭鼬 | 鼬</annotation>
 		<annotation cp="🦨" type="tts">臭鼬</annotation>
-		<annotation cp="🦘">小袋鼠 | 有袋类动物 | 澳大利亚 | 袋鼠 | 跳</annotation>
+		<annotation cp="🦘">小袋鼠 | 有袋类动物 | 袋鼠 | 跳</annotation>
 		<annotation cp="🦘" type="tts">袋鼠</annotation>
 		<annotation cp="🦡">獾 | 纠缠 | 蜜獾</annotation>
 		<annotation cp="🦡" type="tts">獾</annotation>
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🌸" type="tts">樱花</annotation>
 		<annotation cp="💮">白花 | 花</annotation>
 		<annotation cp="💮" type="tts">白花</annotation>
-		<annotation cp="🪷">佛教 | 印度 | 印度教 | 纯洁 | 花 | 莲花 | 越南</annotation>
+		<annotation cp="🪷">佛教 | 印度教 | 纯洁 | 花 | 莲花</annotation>
 		<annotation cp="🪷" type="tts">莲花</annotation>
 		<annotation cp="🏵">圆形花饰 | 花</annotation>
 		<annotation cp="🏵" type="tts">圆形花饰</annotation>
@@ -2897,7 +2897,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👗" type="tts">连衣裙</annotation>
 		<annotation cp="👘">和服 | 日本</annotation>
 		<annotation cp="👘" type="tts">和服</annotation>
-		<annotation cp="🥻">印度 | 披肩 | 纱丽 | 衣服</annotation>
+		<annotation cp="🥻">披肩 | 纱丽 | 衣服</annotation>
 		<annotation cp="🥻" type="tts">纱丽</annotation>
 		<annotation cp="🩱">一片式 | 泳衣 | 泳装 | 游泳 | 连体泳衣</annotation>
 		<annotation cp="🩱" type="tts">连体泳衣</annotation>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⚔" type="tts">交叉放置的剑</annotation>
 		<annotation cp="🔫">工具 | 左轮 | 手枪 | 枪 | 武器 | 水枪</annotation>
 		<annotation cp="🔫" type="tts">水枪</annotation>
-		<annotation cp="🪃">反弹 | 回弹 | 回旋镖 | 澳大利亚</annotation>
+		<annotation cp="🪃">反弹 | 回弹 | 回旋镖</annotation>
 		<annotation cp="🪃" type="tts">回旋镖</annotation>
 		<annotation cp="🏹">射手 | 射箭 | 弓 | 弓和箭 | 箭</annotation>
 		<annotation cp="🏹" type="tts">弓和箭</annotation>
@@ -3487,7 +3487,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🛐" type="tts">宗教场所</annotation>
 		<annotation cp="⚛">原子符号 | 无神论 | 物质</annotation>
 		<annotation cp="⚛" type="tts">原子符号</annotation>
-		<annotation cp="🕉">印度 | 奥姆 | 宗教</annotation>
+		<annotation cp="🕉">奥姆 | 宗教</annotation>
 		<annotation cp="🕉" type="tts">奥姆</annotation>
 		<annotation cp="✡">六芒星 | 大卫之星 | 宗教 | 犹太</annotation>
 		<annotation cp="✡" type="tts">六芒星</annotation>


### PR DESCRIPTION
CLDR-16045

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

Remove (the equivalents of) Australia, India, Vietnam from annotations for non-globe emoji in selected languages (based on the region names we have in the language). This is just the preliminary manual change for CLDR 42 beta2, a more comprehensive removal using a tool will follow under a different ticket.

Note: besides the emoji we discussed (lotus blossom, kangaroo, boomerang) this was also relevant for some other emoji in some languages:
- sari had a keyword of India in some
- koala bear had a keyword of Australia in some
- om sign had a keyword of India in zh