### PR TITLE
CLDR-15034 kbd: remove backspace element and after

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -244,16 +244,14 @@ When explicitly specified, attributes can contain escaped characters. This speci
 
 The _UnicodeSet_ notation is described in [UTS #35 section 5.3.3](tr35.md#Unicode_Sets) and allows for comprehensive character matching, including by character range, properties, names, or codepoints. Currently, the following attributes allow _UnicodeSet_ notation:
 
-* `from`, `before`, `after` on the `<transform>` element
-* `from`, `before`, `after` on the `<reorder>` element
-* `from`, `before`, `after` on the `<backspace>` element
+* `from` or `before` on the `<transform>` element
+* `from` or `before`on the `<reorder>` element
 * `chars` on the [`<repertoire>`](#test-element-repertoire) test element.
 
 The `\u{...}` notation, a subset of hex notation, is described in [UTS #18 section 1.1](https://www.unicode.org/reports/tr18/#Hex_notation). It can refer to one or multiple individual codepoints. Currently, the following attributes allow the `\u{...}` notation:
 
 * `to`, `longPress`, `multiTap`, `hint` on the `<map>` element
 * `to` on the `<transform>` element
-* `to` on the `<backspace>` element
 
 Characters of general category of Combining Mark (M), Control characters (Cc), Format characters (Cf), and whitespace other than space should be encoded using one of the notation above as appropriate.
 
@@ -304,7 +302,7 @@ This is the top level element. All other elements defined below are under this e
 >
 > Parents: _none_
 >
-> Children: [backspaces](#Element_backspaces), [displays](#Element_displays), [import](#Element_import), [info](#Element_info), [keys](#Element_keys), [layers](#Element_layers), [locales](#Element_locales), [names](#Element_names), [reorders](#Element_reorders), [settings](#Element_settings), [_special_](tr35.md#special), [transforms](#Element_transforms), [version](#Element_version), [vkeys](#Element_vkeys)
+> Children: [displays](#Element_displays), [import](#Element_import), [info](#Element_info), [keys](#Element_keys), [layers](#Element_layers), [locales](#Element_locales), [names](#Element_names), [reorders](#Element_reorders), [settings](#Element_settings), [_special_](tr35.md#special), [transforms](#Element_transforms), [version](#Element_version), [vkeys](#Element_vkeys)
 >
 > Occurrence: required, single
 >
@@ -935,7 +933,7 @@ After loading, the above example will be the equivalent of the following.
 
 > <small>
 >
-> Parents: [backspaces](#Element_backspaces), [displays](#Element_displays), [keyboard](#Element_keyboard), [keys](#Element_keys), [layers](#Element_layers), [names](#Element_names), [reorders](#Element_reorders), [transforms](#Element_transforms), [vkeys](#Element_vkeys)
+> Parents: [displays](#Element_displays), [keyboard](#Element_keyboard), [keys](#Element_keys), [layers](#Element_layers), [names](#Element_names), [reorders](#Element_reorders), [transforms](#Element_transforms), [vkeys](#Element_vkeys)
 >
 > Children: _none_
 >
@@ -962,15 +960,14 @@ Elements are considered to have three attributes that make them unique: the tag 
 | `map`        | `keyMap`     | `@iso`                       |
 | `flicks`     | `keyMap`     | `@iso`                       |
 | `flick`      | `flicks`     | `@directions`                |
-| `display`    | `displays` | `@to`                        |
+| `display`    | `displays`   | `@to`                        |
 | `layer`      | `keyboard`   | `@modifier`                  |
 | `row`        | `layer`      | `@keys`                      |
 | `switch`     | `layer`      | `@iso`                       |
 | `vkeys`      | `layer`      | `@iso`                       |
 | `transforms` | `keyboard`   | `@type`                      |
-| `transform`  | `keyboard`   | `@before`, `@from`, `@after` |
-| `reorder`    | `reorders`   | `@before`, `@from`, `@after` |
-| `backspace`  | `backspaces` | `@before`, `@from`, `@after` |
+| `transform`  | `keyboard`   | `@before`, `@from`           |
+| `reorder`    | `reorders`   | `@before`, `@from`           |
 
 In order to help identify mistakes, it is an error if a file contains two elements that override each other. All element overrides must come as a result of an `<include>` element either for the element overridden or the element overriding.
 
@@ -1527,7 +1524,6 @@ The reorder transform consists of `<reorder>` elements encapsulated in a `<reord
 ```xml
 <reorder from="{combination of characters}"
    [before="{look-behind required match}"]
-   [after="{look-ahead required match}"]
    [order="{list of weights}"]
    [tertiary="{list of weights}"]
    [tertiaryBase="{list of true/false}"]
@@ -1650,7 +1646,7 @@ We want all of these sequences to end up ordered as the first. To do this, we us
 
 The first reorder is the default ordering for the _sakot_ which allows for it to be placed anywhere in a sequence, but moves any non-consonants that may immediately follow it, back before it in the sequence. The next two rules give the orders for the top vowel component and tone marks respectively. The next three rules give the _sakot_ and _wa_ characters a primary order that places them before the _o_. Notice particularly the final reorder rule where the _sakot_+_wa_ is split by the tone mark. This rule is necessary in case someone types into the middle of previously normalized text.
 
-`<reorder>` elements are priority ordered based first on the length of string their `@from` attribute matches and then the sum of the lengths of the strings their `@before` and `@after` attributes match.
+`<reorder>` elements are priority ordered based first on the length of string their `@from` attribute matches and then the sum of the lengths of the strings their `@before` attributes match.
 
 If a layout has two `<reorders>` elements, e.g. from importing one and specifying the second, then `<reorder>` elements are merged. The @from string in a `<reorder>` element describes a set of strings that it matches. This also holds for the `@before` attribute. The intersection of two `<reorder>` elements consists of the intersections of their `@from` and `@before` string sets. It is illegal for the intersection between any two `<reorder>` elements in the same `<reorders>` element to be non empty, although implementors are encouraged to have pity on layout authors when reporting such errors, since they can be hard to track down.
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1646,7 +1646,7 @@ We want all of these sequences to end up ordered as the first. To do this, we us
 
 The first reorder is the default ordering for the _sakot_ which allows for it to be placed anywhere in a sequence, but moves any non-consonants that may immediately follow it, back before it in the sequence. The next two rules give the orders for the top vowel component and tone marks respectively. The next three rules give the _sakot_ and _wa_ characters a primary order that places them before the _o_. Notice particularly the final reorder rule where the _sakot_+_wa_ is split by the tone mark. This rule is necessary in case someone types into the middle of previously normalized text.
 
-`<reorder>` elements are priority ordered based first on the length of string their `@from` attribute matches and then the sum of the lengths of the strings their `@before` attributes match.
+`<reorder>` elements are priority ordered based first on the length of string their `@from` attribute matches and then the sum of the lengths of the strings their `@before` attribute matches.
 
 If a layout has two `<reorders>` elements, e.g. from importing one and specifying the second, then `<reorder>` elements are merged. The @from string in a `<reorder>` element describes a set of strings that it matches. This also holds for the `@before` attribute. The intersection of two `<reorder>` elements consists of the intersections of their `@from` and `@before` string sets. It is illegal for the intersection between any two `<reorder>` elements in the same `<reorders>` element to be non empty, although implementors are encouraged to have pity on layout authors when reporting such errors, since they can be hard to track down.
 


### PR DESCRIPTION
- more instances of the <backspace> element and `after=` in the docs to remove

CLDR-15034

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
ALLOW_MULTI_COMMITS=true
