### PR TITLE
CLDR-15368 Enable API to replace WHAT_GETROW

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.js
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.js
@@ -370,12 +370,12 @@ function updateRowVoteInfo(tr, theRow) {
     console.error("theRow is null or undefined in updateRowVoteInfo");
     return;
   }
-  var vr = theRow.voteResolver;
+  const vr = theRow.votingResults;
   tr.voteDiv = document.createElement("div");
   tr.voteDiv.className = "voteDiv";
   const surveyUser = cldrStatus.getSurveyUser();
   if (theRow.voteVhash && theRow.voteVhash !== "" && surveyUser) {
-    var voteForItem = theRow.items[theRow.voteVhash];
+    const voteForItem = theRow.items[theRow.voteVhash];
     if (
       voteForItem &&
       voteForItem.votes &&
@@ -421,14 +421,11 @@ function updateRowVoteInfo(tr, theRow) {
    * The value_vote array has an even number of elements,
    * like [value0, vote0, value1, vote1, value2, vote2, ...].
    */
-  var n = 0;
+  let n = 0;
   while (n < vr.value_vote.length) {
-    var value = vr.value_vote[n++];
-    var vote = vr.value_vote[n++];
-    if (
-      value == null /* TODO: impossible? */ ||
-      value === cldrTable.NO_WINNING_VALUE
-    ) {
+    const value = vr.value_vote[n++];
+    const vote = parseInt(vr.value_vote[n++]);
+    if (value === cldrTable.NO_WINNING_VALUE) {
       continue;
     }
     var item = tr.rawValueToItem[value]; // backlink to specific item in hash

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.js
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.js
@@ -734,7 +734,7 @@ function testsToHtml(tests) {
       "' title='" +
       testItem.type +
       ": " +
-      (testItem.cause || { class: "Unknown" }).class +
+      (testItem.cause || "Unknown") +
       "." +
       testItem.subtype +
       "'>";

--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -158,8 +158,7 @@ function insertRowsIntoTbody(theTable, reuseTable) {
   const theRows = theTable.json.page.rows;
   const toAdd = theTable.toAdd;
   const parRow = document.getElementById("proto-parrow");
-  const sortMode = theTable.json.displaySets.default; // always "ph" (path header)
-  const theSort = theTable.json.displaySets[sortMode];
+  const theSort = theTable.json.displaySets.ph; // path header
   const partitions = theSort.partitions;
   const rowList = theSort.rows;
   const partitionList = Object.keys(partitions);
@@ -353,8 +352,7 @@ function singleRowErrHandler(err, tr, onFailure) {
 function getSingleRowUrl(tr, theRow) {
   if (TABLE_USES_NEW_API) {
     const loc = cldrStatus.getCurrentLocale();
-    const xpath = theRow.xpathId;
-    const api = "voting/" + loc + "/row/" + xpath;
+    const api = "voting/" + loc + "/row/" + theRow.xpstrid;
     let p = null;
     if (cldrGui.dashboardIsVisible()) {
       p = new URLSearchParams();
@@ -454,7 +452,7 @@ function reallyUpdateRow(tr, theRow) {
   /*
    * Update the vote info.
    */
-  if (theRow.voteResolver) {
+  if (theRow.votingResults) {
     cldrInfo.updateRowVoteInfo(tr, theRow);
   } else {
     tr.voteDiv = null;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -2344,11 +2344,11 @@ public class SurveyAjax extends HttpServlet {
 
         final String candVal = val;
 
-        DataPage section = DataPage.make(null /* pageId */, null /* ctx */, mySession,
+        DataPage page = DataPage.make(null /* pageId */, null /* ctx */, mySession,
             locale, xp, null /* matcher */);
-        section.setUserForVotelist(mySession.user);
+        page.setUserForVotelist(mySession.user);
 
-        DataRow pvi = section.getDataRow(xp);
+        DataRow pvi = page.getDataRow(xp);
         CheckCLDR.StatusAction showRowAction = pvi.getStatusAction();
         if (CldrUtility.INHERITANCE_MARKER.equals(val)) {
             if (pvi.wouldInheritNull()) {
@@ -2546,7 +2546,7 @@ public class SurveyAjax extends HttpServlet {
             SupplementalDataInfo sdi = ctx.sm.getSupplementalDataInfo();
             CLDRLocale dcParent = sdi.getBaseFromDefaultContent(locale);
             if (dcParent != null) {
-                new JSONWriter(out).object().key("section")
+                new JSONWriter(out).object().key("page")
                     .value(new JSONObject().put("nocontent", "Default Content, see " + dcParent.getBaseName())).endObject();
                 return; // short circuit.
             }
@@ -2586,8 +2586,7 @@ public class SurveyAjax extends HttpServlet {
                     // Requested a single path, not a page. Don't need path header.
                     pageId = page.getPageId();
                 } else {
-                    dsets.put("default", PathHeaderSort.name);
-                    dsets.put(PathHeaderSort.name, page.createDisplaySet(new PathHeaderSort(), null));
+                    dsets.put(PathHeaderSort.name, page.createDisplaySet(new PathHeaderSort()));
                 }
 
                 if (pageId != null) {
@@ -2835,10 +2834,10 @@ public class SurveyAjax extends HttpServlet {
                     checkResult.clear();
                     cc.check(base, checkResult, val0);
 
-                    DataPage section = DataPage.make(null, null, cs, loc, base, null);
-                    section.setUserForVotelist(cs.user);
+                    DataPage page = DataPage.make(null, null, cs, loc, base, null);
+                    page.setUserForVotelist(cs.user);
 
-                    DataPage.DataRow pvi = section.getDataRow(base);
+                    DataPage.DataRow pvi = page.getDataRow(base);
                     CheckCLDR.StatusAction showRowAction = pvi.getStatusAction(CheckCLDR.InputMethod.BULK);
 
                     if (CheckForCopy.sameAsCode(val0, x, cldrUnresolved, baseFile)) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
@@ -655,6 +655,8 @@ public class XPathTable {
      * xpath to long
      * @param xpath a string identifying a path, for example "//ldml/numbers/symbols[@numberSystem="sund"]/infinity"
      * @return a long integer, which is a hash of xpath; for example 2795888612892500012 (decimal) = 6d37a14eec91cee6 (hex)
+     *
+     * CAUTION: this is NOT the same as getByXpath, which is generally a much smaller integer!
      */
     public static final long getStringID(String xpath) {
         return StringId.getId(xpath);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -1,14 +1,10 @@
 package org.unicode.cldr.web.api;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.io.PrintWriter;
+import java.util.*;
 import java.util.logging.Logger;
 
+import javax.json.bind.spi.JsonbProvider;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -18,53 +14,43 @@ import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.test.CheckForCopy;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.PatternPlaceholders;
 import org.unicode.cldr.util.PathHeader.PageId;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.web.BallotBox;
+import org.unicode.cldr.web.*;
 import org.unicode.cldr.web.BallotBox.VoteNotAcceptedException;
-import org.unicode.cldr.web.CookieSession;
-import org.unicode.cldr.web.DataPage;
 import org.unicode.cldr.web.DataPage.DataRow;
 import org.unicode.cldr.web.DataPage.DataRow.CandidateItem;
-import org.unicode.cldr.web.STFactory;
 import org.unicode.cldr.web.SurveyException.ErrorCode;
-import org.unicode.cldr.web.SurveyLog;
-import org.unicode.cldr.web.SurveyMain;
-import org.unicode.cldr.web.UserRegistry;
 import org.unicode.cldr.web.UserRegistry.User;
-import org.unicode.cldr.web.XPathMatcher;
-import org.unicode.cldr.web.XPathTable;
 import org.unicode.cldr.web.api.VoteAPI.RowResponse;
 import org.unicode.cldr.web.api.VoteAPI.RowResponse.Row.Candidate;
 import org.unicode.cldr.web.api.VoteAPI.VoteResponse;
 
 /**
  * Note: The functions in this class needed to be separated from VoteAPI because of static init problems.
- *
- * As of 2022-04-07, this class hasn't been used yet, except for testing in conjunction
- * with CldrRows.vue and CldrRow.vue. This is intended to be a modernized replacement
- * for SurveyAjax.getRow (WHAT_GETROW). It isn't ready to be used since it doesn't produce
- * json compatible with the front end. References:
- * https://unicode-org.atlassian.net/browse/CLDR-15368
- * https://unicode-org.atlassian.net/browse/CLDR-15403
  */
 public class VoteAPIHelper {
-    public static final class VoteEntry {
-        public Object userid;
-        public int votes;
-        public Integer override;
+    private static final boolean DEBUG_SERIALIZATION = false;
 
-        public VoteEntry(int id, int votes, Integer override) {
-            this.userid = id;
-            this.votes = votes;
-            this.override = override;
+    public static final class VoteEntry {
+        public final String email;
+        public final VoteResolver.Level level;
+        public final String name;
+        public final String org;
+        public final Integer overridedVotes;
+        public final String userid;
+        public final int votes;
+
+        public VoteEntry(User u, Integer override) {
+            this.email = u.email.replace("@", " (at) ");
+            this.level = u.getLevel();
+            this.org = u.getOrganization().toString();
+            this.overridedVotes = override;
+            this.name = u.name;
+            this.userid = Integer.toString(u.id);
+            this.votes = u.getVoteCount();
         }
     }
 
@@ -131,23 +117,28 @@ public class VoteAPIHelper {
             }
             final DataPage pageData = DataPage.make(pageId, null, mySession, locale, xp, matcher);
             pageData.setUserForVotelist(mySession.user);
+            r.page = new RowResponse.Page();
 
             // don't return default content
             CLDRLocale dcParent = SupplementalDataInfo.getInstance().getBaseFromDefaultContent(locale);
             if (dcParent != null) {
                 r.dcParent = dcParent.getBaseName();
+                r.page.nocontent = true;
             } else {
-                r.isReadOnly = STFactory.isReadOnlyLocale(locale);
+                r.canModify = UserRegistry.userCanModifyLocale(mySession.user, locale);
                 r.localeDisplayName = locale.getDisplayName();
-                r.rows = calculateRows(pageData.getAll());
+                r.page.nocontent = false;
+                Collection<DataRow> dataRows = pageData.getAll();
+                r.page.rows = makePageRows(dataRows);
+                if (args.page != null) {
+                    r.displaySets = makeDisplaySets(dataRows);
+                }
             }
             if (args.getDashboard) {
-                /*
-                 * TODO: implement single-path dashboard in this modern-api context
-                 * See existing implementation in SurveyAjax.java, Dashboard.java
-                 * Reference: https://unicode-org.atlassian.net/browse/CLDR-15368
-                 */
-                return new STError(ErrorCode.E_INTERNAL, "handleGetRows: single-path dashboard not implemented yet").build();
+                r.notifications = getOnePathDash(XPathTable.xpathToBaseXpath(xp), locale, mySession);
+            }
+            if (DEBUG_SERIALIZATION) {
+                debugSerialization(r, args);
             }
             return Response.ok(r).build();
         } catch (Throwable t) {
@@ -157,75 +148,138 @@ public class VoteAPIHelper {
         }
     }
 
-    private static RowResponse.Row[] calculateRows(Collection<DataRow> all) {
-        List<RowResponse.Row> list = new LinkedList<>();
-        for (final DataRow r : all) {
-            list.add(calculateRow(r));
+    private static void debugSerialization(RowResponse r, ArgsForGet args) {
+        try {
+            JsonbProvider.provider().create().build().toJson(r, new PrintWriter(System.out));
+        } catch (Throwable t) {
+            t.printStackTrace();
+            SurveyLog.logException(logger, t, "DEBUG_SERIALIZATION: " + args.localeId + " / " + args.xpstrid);
         }
-        return list.toArray(new RowResponse.Row[0]);
+    }
+
+    private static RowResponse.DisplaySets makeDisplaySets(Collection<DataRow> dataRows) {
+        final RowResponse.DisplaySets displaySets = new RowResponse.DisplaySets();
+        final SortMode sortMode = new PathHeaderSort();
+        displaySets.ph = sortMode.createDisplaySet(null, dataRows);
+        return displaySets;
+    }
+
+    private static Map<String, RowResponse.Row> makePageRows(Collection<DataRow> all) {
+        final Map<String, RowResponse.Row> rows = new HashMap<>();
+        for (final DataRow r : all) {
+            rows.put(r.fieldHash(), calculateRow(r));
+        }
+        return rows;
     }
 
     private static RowResponse.Row calculateRow(final DataRow r) {
-        RowResponse.Row row = new RowResponse.Row();
-        // from DataPage.DataRow.toJSONString()
-
-        // TODO: ourVote
+        final RowResponse.Row row = new RowResponse.Row();
+        final VoteResolver<String> resolver = r.getResolver();
         final String xpath = r.getXpath();
-        row.xpstrid = XPathTable.getStringIDString(xpath);
+        final PatternPlaceholders placeholders = PatternPlaceholders.getInstance();
 
+        row.canFlagOnLosing = resolver.canFlagOnLosing();
+        row.confirmStatus = r.getConfirmStatus();
+        row.coverageValue = r.getCoverageValue();
         row.code = r.getCode();
-        row.resolver = r.getResolver();
-        row.dir = r.getDirectionality(); // TODO: should not be needed, but there are some override situations.
+        row.dir = r.getDirectionality(); // should not be needed, but there are some override situations.
         row.displayExample = r.getDisplayExample();
         row.displayName = r.getDisplayName();
         row.extraAttributes = r.getNonDistinguishingAttributes();
-        row.hasVoted = r.userHasVoted();
-        row.inheritedLocale = r.getInheritedLocaleName();
-        // NB: "winningValue" is in the resolver info.
-        row.inheritedXpath = r.getInheritedXPath();
         row.flagged = r.isFlagged();
-        row.statusAction = r.getStatusAction();
-        row.voteResolver = r.getResolver();
+        row.hasVoted = r.userHasVoted();
         row.helpHtml = r.getHelpHTML();
-        row.rdf = r.getRDFURI();
-
+        row.inheritedLocale = r.getInheritedLocaleName();
+        row.inheritedValue = r.getInheritedValue();
+        row.inheritedXpid = r.getInheritedXPath();
         row.items = calculateItems(r);
-        PatternPlaceholders placeholders = PatternPlaceholders.getInstance();
-        row.placeholderStatus = placeholders.getStatus(xpath);
         row.placeholderInfo = placeholders.get(xpath);
+        row.placeholderStatus = placeholders.getStatus(xpath);
+        row.rdf = r.getRDFURI();
+        row.rowFlagged = r.isFlagged();
+        row.statusAction = r.getStatusAction();
+        row.voteVhash = r.getVoteVHash();
+        row.votingResults = getVotingResults(resolver);
+        row.winningValue = r.getWinningValue();
+        row.winningVhash = r.getWinningVHash();
+        row.xpath = xpath;
+        row.xpathId = CookieSession.sm.xpt.getByXpath(xpath);
+        row.xpstrid = XPathTable.getStringIDString(xpath);
         return row;
     }
 
-    private static Candidate[] calculateItems(final DataRow r) {
-        // Add candidate items
-        List<RowResponse.Row.Candidate> items = new LinkedList<>();
-        for (final CandidateItem i : r.items.values()) {
-            RowResponse.Row.Candidate c = calculateItem(i);
-            items.add(c);
+    /**
+     * Convert the given back-end VoteResolver into a front-end VotingResults
+     *
+     * @param resolver the back-end VoteResolver
+     * @return the VotingResults
+     */
+    private static RowResponse.Row.VotingResults getVotingResults(VoteResolver<String> resolver) {
+        final RowResponse.Row.VotingResults results = new RowResponse.Row.VotingResults();
+        final EnumSet<Organization> conflictedOrgs = resolver.getConflictedOrganizations();
+        final List<String> valueToVoteA = new ArrayList<>();
+        final Map<String, Long> valueToVote = resolver.getResolvedVoteCounts();
+        for (Map.Entry<String, Long> e : valueToVote.entrySet()) {
+            valueToVoteA.add(e.getKey());
+            valueToVoteA.add(String.valueOf(e.getValue()));
         }
-        return items.toArray(new Candidate[0]);
+        results.nameTime = resolver.getNameTime();
+        results.requiredVotes = resolver.getRequiredVotes();
+        results.value_vote = valueToVoteA.toArray(new String[0]);
+        results.valueIsLocked = resolver.isValueLocked();
+        results.orgs = new HashMap<>();
+        for (Organization o : Organization.values()) {
+            final String orgVote = resolver.getOrgVote(o);
+            if (orgVote != null) {
+                final RowResponse.Row.OrgValueVotes org = new RowResponse.Row.OrgValueVotes();
+                org.conflicted = conflictedOrgs.contains(o);
+                org.orgVote = orgVote;
+                org.status = resolver.getStatusForOrganization(o).name();
+                org.votes = resolver.getOrgToVotes(o);
+                results.orgs.put(o.name(), org);
+            }
+        }
+        return results;
+    }
+
+    private static Map<String, Candidate> calculateItems(final DataRow r) {
+        final Map<String, Candidate> items = new HashMap<>();
+        for (final CandidateItem i : r.items.values()) {
+            items.put(i.getValueHash(), calculateItem(i));
+        }
+        return items;
     }
 
     private static RowResponse.Row.Candidate calculateItem(final CandidateItem i) {
-        // from DataPage.DataRow.CandidateItem.toJSONString()
-        // Ideally this would go into RowResponse.Row.Candidate but can't due to
-        // static initialization problems.
         RowResponse.Row.Candidate c = new RowResponse.Row.Candidate();
-        c.value = i.getValue();
-        c.displayValue = i.getProcessedValue();
         c.example = i.getExample();
+        c.history = i.getHistory();
         c.isBaselineValue = i.isBaselineValue();
-        // TODO: pass underlying values to FE. Don't pass CSS class.
-        //    c.pClass = i.getPClass();
-        // TODO: c.tests = i.tests
+        c.pClass = i.getPClass(); // it might be better to pass underlying values (not CSS class) to FE
+        c.rawValue = i.getValue();
+        c.tests = getConvertedTests(i.getTests());
+        c.value = i.getProcessedValue();
+        c.valueHash = i.getValueHash();
         c.votes = calculateVotes(i.getVotes(), i.getOverrides());
         return c;
     }
 
-    private static VoteEntry[] calculateVotes(Set<User> votes, Map<User, Integer> overrides) {
-        if (votes == null) return new VoteEntry[0];
-        List<VoteEntry> entries = new ArrayList<>(votes.size());
-        for (final User u : votes) {
+    private static List<VoteAPI.CheckStatusSummary> getConvertedTests(List<CheckStatus> tests) {
+        List<VoteAPI.CheckStatusSummary> newTests = new ArrayList<>();
+        if (tests != null) {
+            for (CheckStatus test : tests) {
+                newTests.add(new VoteAPI.CheckStatusSummary(test));
+            }
+        }
+        return newTests;
+    }
+
+    private static Map<String, VoteEntry> calculateVotes(Set<User> users, Map<User, Integer> overrides) {
+        if (users == null) {
+            return null;
+        }
+        Map<String, VoteEntry> votes = new HashMap<>(users.size());
+        for (final User u : users) {
             if (UserRegistry.userIsLocked(u)) {
                 continue;
             }
@@ -233,9 +287,16 @@ public class VoteAPIHelper {
             if (overrides != null) {
                 override = overrides.get(u);
             }
-            entries.add(new VoteEntry(u.id, u.getVoteCount(), override));
+            VoteEntry voteEntry = new VoteEntry(u, override);
+            votes.put(voteEntry.userid, voteEntry);
         }
-        return entries.toArray(new VoteEntry[0]);
+        return votes;
+    }
+
+    private static Dashboard.ReviewNotification[] getOnePathDash(String baseXp, CLDRLocale locale, CookieSession mySession) {
+        Level coverageLevel = Level.get(mySession.getEffectiveCoverageLevel(locale.toString()));
+        Dashboard.ReviewOutput ro = new Dashboard().get(locale, mySession.user, coverageLevel, baseXp);
+        return ro.getNotifications();
     }
 
     static Response handleVote(String loc, String xpstrid, VoteRequest request, final CookieSession mySession) {
@@ -266,9 +327,11 @@ public class VoteAPIHelper {
                 r.setResults(result);
                 r.testsRun = cc.toString();
                 // Create a DataPage for this single XPath.
-                DataPage section = DataPage.make(null, null, mySession, locale, xp, null);
-                section.setUserForVotelist(mySession.user);
-                DataRow pvi = section.getDataRow(xp);
+                // NOTE: tests may be run twice, since we call both runTests and DataPage.make!
+                // -- If so, this should be corrected before we actually use this code!
+                DataPage page = DataPage.make(null, null, mySession, locale, xp, null);
+                page.setUserForVotelist(mySession.user);
+                DataRow pvi = page.getDataRow(xp);
                 // First, calculate the status for showing
                 r.statusAction = calculateShowRowAction(locale, stf, xp, val, pvi);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -376,15 +376,6 @@ public class PathHeader implements Comparable<PathHeader> {
         "\\[@alt=\"([^\"]*+)\"]")
         .matcher("");
 
-    static final Collator alphabetic = CLDRConfig.getInstance().getCollatorRoot();
-
-//    static final RuleBasedCollator alphabetic = (RuleBasedCollator) Collator
-//            .getInstance(ULocale.ENGLISH);
-//    static {
-//        alphabetic.setNumericCollation(true);
-//        alphabetic.freeze();
-//    }
-
     static final SupplementalDataInfo supplementalDataInfo = SupplementalDataInfo.getInstance();
     static final Map<String, String> metazoneToContinent = supplementalDataInfo
         .getMetazoneToContinentMap();
@@ -2116,9 +2107,22 @@ public class PathHeader implements Comparable<PathHeader> {
 
     private static final List<String> COUNTS = Arrays.asList("displayName", "zero", "one", "two", "few", "many", "other", "per");
 
+    private static Collator alphabetic;
+
     private static int alphabeticCompare(String aa, String bb) {
-        // A frozen Collator is thread-safe.
+        if (alphabetic == null) {
+            initializeAlphabetic();
+         }
         return alphabetic.compare(aa, bb);
+    }
+
+    private static synchronized void initializeAlphabetic() {
+        // Lazy initialization: don't call CLDRConfig.getInstance() too early or we'll get
+        // "CLDRConfig.getInstance() was called prior to SurveyTool setup" when called from
+        // com.ibm.ws.microprofile.openapi.impl.core.jackson.ModelResolver._addEnumProps
+        if (alphabetic == null) {
+            alphabetic = CLDRConfig.getInstance().getCollatorRoot();
+        }
     }
 
     public enum BaseUrl {


### PR DESCRIPTION
-Enable Survey Tool to work correctly with TABLE_USES_NEW_API = true

-Keep TABLE_USES_NEW_API = false for now pending further testing

-Make VoteAPI produce json more like DataSection.getRow

-Supply numerous data items that were missing from VoteAPI json

-Remove duplicate VoteResolver in VoteAPI

-Distinguish front-end votingResults from back-end voteResolver

-Lazy initialization of PathHeader alphabetic collator to avoid CLDRConfig conflict

-A few front end changes, no need for displaySets.default; fix getSingleRowUrl; simplify testItem.cause

-Comments

CLDR-15368

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->
