### PR TITLE
CLDR-14276 update ckb single character + add locale tags

### DIFF
--- a/common/main/ckb.xml
+++ b/common/main/ckb.xml
@@ -11,6 +11,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="ckb"/>
 	</identity>
 	<localeDisplayNames>
+		<localeDisplayPattern>
+			<localePattern>{0} ({1})</localePattern>
+			<localeSeparator>{0}، {1}</localeSeparator>
+			<localeKeyTypePattern>{0}: {1}</localeKeyTypePattern>
+		</localeDisplayPattern>
 		<languages>
 			<language type="aa">ئەفار</language>
 			<language type="ab">ئەبخازی</language>
@@ -807,10 +812,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</orientation>
 	</layout>
 	<characters>
-		<exemplarCharacters>[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ھ ە و ۆ ی ێ]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[\u200E\u200F \u064B \u064C \u064D \u064E \u064F \u0650 \u0651 \u0652 ء آ أ ؤ إ ة ث ذ ص ض ط ظ ك ه ى ي]</exemplarCharacters>
-		<exemplarCharacters type="index" draft="unconfirmed">[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ھ ە و ۆ ی ێ]</exemplarCharacters>
+		<exemplarCharacters>[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ه ە و ۆ ی ێ]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[\u200E\u200F \u064B \u064C \u064D \u064E \u064F \u0650 \u0651 \u0652 ء آ أ ؤ إ ة ث ذ ص ض ط ظ ك ھ ى ي]</exemplarCharacters>
+		<exemplarCharacters type="index" draft="unconfirmed">[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ه ە و ۆ ی ێ]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\u200E\u200F \- ‑ , ٫ ٬ . % ٪ ‰ ؉ + 0٠ 1١ 2٢ 3٣ 4٤ 5٥ 6٦ 7٧ 8٨ 9٩]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[\- ‐ ‑ – — ، ؛ \: ! ؟ . … ' &quot; « » ( ) \[ \]]</exemplarCharacters>
 		<moreInformation draft="unconfirmed">؟</moreInformation>
 		<parseLenients scope="date" level="lenient">
 			<parseLenient sample="-" draft="unconfirmed">↑↑↑</parseLenient>
@@ -1371,6 +1377,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<appendItem request="Timezone">{0} {1}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="MEd">
 							<greatestDifference id="d" draft="unconfirmed">E، M/d – E، M/d</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E، M/d – E، M/d</greatestDifference>
@@ -1535,6 +1542,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">کاتی هەرێمی</displayName>
 			</field>
 		</fields>
+		<timeZoneNames>
+			<hourFormat>+HH:mm;-HH:mm</hourFormat>
+			<gmtFormat>گرینیچ {0}</gmtFormat>
+			<gmtZeroFormat>گرینیچ</gmtZeroFormat>
+			<regionFormat>بەکاتی {0}</regionFormat>
+			<regionFormat type="daylight">کاتی {0} هاوینە</regionFormat>
+			<regionFormat type="standard">کاتی {0} فەرمی</regionFormat>
+			<fallbackFormat>{1} ({0})</fallbackFormat>
+		</timeZoneNames>
 	</dates>
 	<numbers>
 		<defaultNumberingSystem>arab</defaultNumberingSystem>


### PR DESCRIPTION
[CLDR-14276](https://unicode-org.atlassian.net/browse/CLDR-14276)

- [x] This PR completes the ticket. I have addressed all bits mentioned in this [comment](https://unicode-org.atlassian.net/browse/CLDR-14276?focusedCommentId=165044) by @DavidLRowe 

Related (closed) PR was #823 by @jwtiyar. Note for @jwtiyar: the characters you have mentioned in the #823 only h-doucheshme needed replacing. David's suggestions is the bulk of this PR.

[CLDR-14276]: https://unicode-org.atlassian.net/browse/CLDR-14276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ