### PR TITLE
CLDR-15034 kbd: spec: NFC as  the preferred form

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -477,9 +477,10 @@ _Attribute:_ `author`
 _Attribute:_ `normalization`
 
 > The `normalization` attribute describes the intended normalization form of the keyboard layout output. The valid values are `NFC`, `NFD` or `other`.
+>
 > An example use case is aiding a user to choose among the two same layouts with one outputting characters in the normalization form C and one in the normalization form D.
 >
-> All keyboards in the CLDR repository will be in `NFC` form.  However, users and implementations may produce and consume other normalization forms.
+> All keyboards in the CLDR repository will be in `NFC` or `NFD` forms.  However, users and implementations may produce and consume other normalization forms or mixed output, use the `other` value to indicate this case.
 >
 > When using `NFC` or `NFD`, tooling should verify that all possible keystrokes, gestures, and transforms on the keyboard only produce the specified normalization form, producing warnings if not.
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -478,6 +478,10 @@ _Attribute:_ `normalization`
 
 > The `normalization` attribute describes the intended normalization form of the keyboard layout output. The valid values are `NFC`, `NFD` or `other`.
 > An example use case is aiding a user to choose among the two same layouts with one outputting characters in the normalization form C and one in the normalization form D.
+>
+> All keyboards in the CLDR repository will be in `NFC` form.  However, users and implementations may produce and consume other normalization forms.
+>
+> Tooling should verify that all possible keystrokes and gestures on the keyboard only produce the specified normalization form.
 
 _Attribute:_ `layout`
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -481,7 +481,7 @@ _Attribute:_ `normalization`
 >
 > All keyboards in the CLDR repository will be in `NFC` form.  However, users and implementations may produce and consume other normalization forms.
 >
-> Tooling should verify that all possible keystrokes and gestures on the keyboard only produce the specified normalization form.
+> When using `NFC` or `NFD`, tooling should verify that all possible keystrokes, gestures, and transforms on the keyboard only produce the specified normalization form, producing warnings if not.
 
 _Attribute:_ `layout`
 


### PR DESCRIPTION
CLDR-15034

Summary:   `<info normalization=…>` already has the possible values `NFC`, `NFD`, and `other`. 

This notes that `NFC` is required for CLDR's repository, and that tooling would validate for `NFC` or `NFD` values.

If `other` is provided (this is like the 'mixed' @miloush  mentioned) then tooling would not be expected to check the output of the keyboard.

ALLOW_MANY_COMMITS=true
ALLOW_MULTI_COMMITS=true