### PR TITLE
CLDR-15865 v42: SLL transition: cherry pick from CLDR-15900 (#2375)

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -957,7 +957,7 @@ The printed version of ISO-4217:2001
         </region>
         <region iso3166="SL">
             <currency iso4217="SLE" from="2022-07-01"/>
-            <currency iso4217="SLL" from="1964-08-04" to="2022-10-01"/>
+            <currency iso4217="SLL" from="1964-08-04" to="2023-03-31"/>
             <currency iso4217="GBP" from="1808-11-30" to="1966-02-04"/>
         </region>
         <region iso3166="SM">


### PR DESCRIPTION
CLDR-15900 v42: SLL extended transition period (#2375)

- per ISO 4217 amendment 173 quoting directive from the Bank of Sierra Leone dated 2022-09-15
- https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-173.pdf

(cherry picked from commit e5a71a8a2dc008c8d9c731168212f2eca3eed357)

- Note: this may still fail tests in a year, still investigating.

CLDR-15865