### PR TITLE
CLDR-16057 test: improve TestCurrency message on ISO 4217

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1423,7 +1423,9 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             isoCurrenciesToCountries.keySet());
         missing.removeAll(modernCurrencyCodes.keySet());
         if (missing.size() != 0) {
-            errln("Missing codes compared to ISO: " + missing.toString());
+            errln("Codes in ISO 4217 but not current tender in CLDR " +
+                "(may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): " +
+                missing.toString());
         }
 
         for (String currency : modernCurrencyCodes.keySet()) {


### PR DESCRIPTION
CLDR-16057

- [X] This PR completes the ticket.

Note that this is for v43, and also it will fail until e5a71a8a2dc008c8d9c731168212f2eca3eed357 (#2375) is cherry picked to main