### PR TITLE
CLDR-15970 deps: update Node.js to LTS v16

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -296,8 +296,8 @@
 					</execution>
 				</executions>
 				<configuration>
-					<nodeVersion>v14.17.5</nodeVersion>
-					<npmVersion>6.14.14</npmVersion>
+					<nodeVersion>v16.17.1</nodeVersion>
+					<npmVersion>8.15.0</npmVersion>
 					<!-- run in project sourcedir -->
 					<workingDirectory>${project.basedir}/js</workingDirectory>
 				</configuration>


### PR DESCRIPTION
CLDR-15970

Node v16 is the current LTS version.

- [ ] This PR completes the ticket.
