### PR TITLE
CLDR-15368 TABLE_USES_NEW_API=true and page/auto

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -27,7 +27,7 @@ const ROW_ID_PREFIX = "row_"; // formerly "r@"
 
 const CLDR_TABLE_DEBUG = false;
 
-const TABLE_USES_NEW_API = false;
+const TABLE_USES_NEW_API = true;
 
 /*
  * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
@@ -376,8 +376,14 @@ function getSingleRowUrl(tr, theRow) {
 
 function getPageUrl(curLocale, curPage, curId) {
   if (TABLE_USES_NEW_API) {
+    let p = null;
+    if (curId && !curPage) {
+      p = new URLSearchParams();
+      p.append("xpstrid", curId);
+      curPage = "auto";
+    }
     const api = "voting/" + curLocale + "/page/" + curPage;
-    return cldrAjax.makeApiUrl(api, null);
+    return cldrAjax.makeApiUrl(api, p);
   }
   return (
     cldrStatus.getContextPath() +

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -112,8 +112,20 @@ public class VoteAPI {
         @Parameter(example = "Languages_K_N",
             schema = @Schema(type = SchemaType.STRING)) @PathParam("page") String page,
 
+        @QueryParam("xpstrid") @Schema(description = "Xpath string ID if page is auto")
+            @DefaultValue("") String xpstrid,
+
         @HeaderParam(Auth.SESSION_HEADER) String session) {
-        return VoteAPIHelper.handleGetOnePage(loc, session, page);
+
+        /*
+         * The optional xpstrid query parameter enables requests like
+         *    /cldr-apps/api/voting/fr/page/auto?xpstrid=2703e9d07ab2ef3a
+         * so that a URL like
+         *    https://cldr-smoke.unicode.org/cldr-apps/v#/zh_Hant//2703e9d07ab2ef3a
+         * can be used instead of
+         *    https://cldr-smoke.unicode.org/cldr-apps/v#/zh_Hant/Alphabetic_Information/2703e9d07ab2ef3a
+         */
+        return VoteAPIHelper.handleGetOnePage(loc, session, page, xpstrid);
     }
 
     public static final class RowResponse {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -76,10 +76,29 @@ public class VoteAPIHelper {
         return handleGetRows(args);
     }
 
-    static Response handleGetOnePage(String loc, String session, String page) {
+    static Response handleGetOnePage(String loc, String session, String page, String xpstrid) {
         ArgsForGet args = new ArgsForGet(loc, session);
-        args.page = page;
+        if ("auto".equals(page) && xpstrid != null && !xpstrid.isEmpty()) {
+            args.page = getPageFromXpathStringId(xpstrid);
+        } else {
+            args.page = page;
+        }
         return handleGetRows(args);
+    }
+
+    private static String getPageFromXpathStringId(String xpstrid) {
+        try {
+            String xpath = CookieSession.sm.xpt.getByStringID(xpstrid);
+            if (xpath != null) {
+                PathHeader ph = CookieSession.sm.getSTFactory().getPathHeader(xpath);
+                if (ph != null) {
+                    return ph.getPageId().name();
+                }
+            }
+        } catch (Throwable t) {
+            return null;
+        }
+        return null;
     }
 
     private static Response handleGetRows(ArgsForGet args) {


### PR DESCRIPTION
-Turn on the api, and fix a bug that occured with Jump to Original links

-Front end: set TABLE_USES_NEW_API = true; enhance getPageUrl

-Back end: new getPageFromXpathStringId reproduces old behavior when page name is absent

CLDR-15368

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
