### PR TITLE
CLDR-15054 No Changed notification if oldValue=INHERITANCE_MARKER and value=bailey

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -488,11 +488,10 @@ public class VettingViewer<T> {
             if (skipForLimitedSubmission(path, errorStatus, oldValue)) {
                 return;
             }
-            if (!onlyRecordErrors && choices.contains(NotificationCategory.changedOldValue)) {
-                if (oldValue != null && !oldValue.equals(value)) {
-                    problems.add(NotificationCategory.changedOldValue);
-                    vc.problemCounter.increment(NotificationCategory.changedOldValue);
-                }
+            if (!onlyRecordErrors && choices.contains(NotificationCategory.changedOldValue) &&
+                    changedFromBaseline(path, value, oldValue, sourceFile)) {
+                problems.add(NotificationCategory.changedOldValue);
+                vc.problemCounter.increment(NotificationCategory.changedOldValue);
             }
             VoteStatus voteStatus = userVoteStatus.getStatusForUsersOrganization(sourceFile, path, organization);
             boolean itemsOkIfVoted = (voteStatus == VoteStatus.ok);
@@ -511,6 +510,19 @@ public class VettingViewer<T> {
                 R2<SectionId, PageId> group = Row.of(ph.getSectionId(), ph.getPageId());
                 sorted.put(group, new WritingInfo(ph, problems, htmlMessage, firstSubtype()));
             }
+        }
+
+        private boolean changedFromBaseline(String path, String value, String oldValue, CLDRFile sourceFile) {
+            if (oldValue != null && !oldValue.equals(value)) {
+                if (CldrUtility.INHERITANCE_MARKER.equals(oldValue)) {
+                    String baileyValue = sourceFile.getBaileyValue(path, null, null);
+                    if (baileyValue != null && baileyValue.equals(value)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         private Subtype firstSubtype() {


### PR DESCRIPTION
-Skip NotificationCategory.changedOldValue due to obsolete hard/soft distinction

CLDR-15054

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
