### PR TITLE
CLDR-16078 v42: SLE should not be deprecated

### DIFF
--- a/common/validity/currency.xml
+++ b/common/validity/currency.xml
@@ -12,7 +12,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<idValidity>
-		<id type='currency' idStatus='regular'>		<!-- 155 items -->
+		<id type='currency' idStatus='regular'>		<!-- 156 items -->
 			AED AFN ALL AMD ANG AOA ARS AUD AWG AZN
 			BAM BBD BDT BGN BHD BIF BMD BND BOB BRL BSD BTN BWP BYN BZD
 			CAD CDF CHF CLP CNY COP CRC CUC CUP CVE CZK
@@ -31,7 +31,7 @@
 			PAB PEN PGK PHP PKR PLN PYG
 			QAR
 			RON RSD RUB RWF
-			SAR SBD SCR SDG SEK SGD SHP SLL SOS SRD SSP STN SYP SZL
+			SAR SBD SCR SDG SEK SGD SHP SLE SLL SOS SRD SSP STN SYP SZL
 			THB TJS TMT TND TOP TRY TTD TWD TZS
 			UAH UGX USD UYU UZS
 			VES VND VUV
@@ -42,7 +42,7 @@
 		</id>
 		<!-- Deprecated values are those that are not legal tender in some country after 2022.
 			 More detailed usage information needed for some implementations is in supplemental data. -->
-		<id type='currency' idStatus='deprecated'>		<!-- 149 items -->
+		<id type='currency' idStatus='deprecated'>		<!-- 148 items -->
 			ADP AFA ALK AOK AON AOR ARA ARL~M ARP ATS AZM
 			BAD BAN BEC BEF BEL BGL~M BGO BOL BOP BOV BRB~C BRE BRN BRR BRZ BUK BYB BYR
 			CHE CHW CLE~F CNH CNX COU CSD CSK CYP
@@ -58,7 +58,7 @@
 			NIC NLG
 			PEI PES PLZ PTE
 			RHD ROL RUR
-			SDD SDP SIT SKK SLE SRG STD SUR SVC
+			SDD SDP SIT SKK SRG STD SUR SVC
 			TJR TMM TPE TRL
 			UAK UGS USN USS UYI UYP UYW
 			VEB VED VEF VNN

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -124,7 +124,8 @@ public class TestValidity extends TestFmwkPlus {
         "no",
         "escn",
         "gbeng", "gbnir", "gbsct", "gbwls",
-        "itgo", "itpn", "itts", "itud"
+        "itgo", "itpn", "itts", "itud",
+        "SLE"
         );
     static final Set<String> ALLOWED_MISSING = ImmutableSet.of("root", "POSIX", "REVISED", "SAAHO");
     static final Set<String> ALLOWED_REGULAR_TO_SPECIAL = ImmutableSet.of("Zanb", "Zinh", "Zyyy");


### PR DESCRIPTION
re-ran GenerateValidityXml

CLDR-16078

- [X] This PR completes the ticket.