### PR TITLE
CLDR-16086 Headers are hidden in new web site color scheme (#2455)

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/bytype-index.css
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/bytype-index.css
@@ -20,14 +20,14 @@ h1 {
 
 .pathHeader {
 	font-weight: bold;
-	background-color: #000099;
+	background-color: #CCCCCC;
 	font-size: 120%;
 	color: white
 }
 
 .path {
 	font-weight: bold;
-	background-color: #ddddFF
+	background-color: #EEEEEE
 }
 
 .head {


### PR DESCRIPTION
(cherry picked from commit b3948345c4f0b0fbd46733906506a830ba58fd81)

CLDR-16086

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

-Fix in bytype-index.css

Just cherry-picks the CSS change in #2455 (which accidentally went into main branch) to maint/maint-42 branch.