### PR TITLE
CLDR-16091 Type error in Annotations.java which is harmless but prevents code compiling.

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Annotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Annotations.java
@@ -608,8 +608,7 @@ public class Annotations {
             throw new IllegalArgumentException("Cannot find source annotation directory for locale " + locale);
         } else if (dirs.size() != 1) {
             throw new IllegalArgumentException(
-                "Did not find exactly one source directory for locale " + locale + " - " +
-                 String.join(" ", dirs.toArray(new String[0])));
+                "Did not find exactly one source directory for locale " + locale + " - " + dirs);
         }
         final File theDir = dirs.get(0);
         return theDir;


### PR DESCRIPTION
CLDR-16091

In Annotations.java it currently does:

```
            throw new IllegalArgumentException(
                "Did not find exactly one source directory for locale " + locale + " - " +
                 String.join(" ", dirs.toArray(new String[0])));
        }
```

Except dirs is a List<File>.

This code should just add dirs to the string and let toString() do the rest.

- [x] This PR completes the ticket.