### PR TITLE
CLDR-10256 ST: clicking on language should go back to the language

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.js
+++ b/tools/cldr-apps/js/src/esm/cldrGui.js
@@ -118,7 +118,7 @@ function scheduleLoadingWithSessionId() {
   cldrStatus.on("sessionId", () => {
     setTimeout(function () {
       cldrLoad.parseHashAndUpdate(cldrLoad.getHash());
-      cldrMenu.getInitialMenusEtc(cldrStatus.getSessionId());
+      cldrMenu.getInitialMenusEtc();
     }, 100 /* one tenth of a second */);
   });
 }
@@ -236,7 +236,7 @@ const topTitle =
   `
     </div>
     <div id="title-locale-container" class="menu-container">
-      <h1><a href="#locales///" id="title-locale"></a></h1>
+      <h1><a href="#/aa///" id="title-locale"></a></h1>
       <span id="title-dcontent-container"
         ><a
           href="http://cldr.unicode.org/translation/default-content"


### PR DESCRIPTION
-Revise menubuttons.set in cldrMenu.js

-Set textContent instead of innerHTML to avoid vulnerability warnings

-Sanitize locale code to avoid vulnerability warnings

-Remove unused parameters for two cldrMenu functions

CLDR-10256

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
