### PR TITLE
CLDR-15368 Switch WHAT_GETROW/WHAT_SUBMIT to api, corrections, clean up

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -27,8 +27,6 @@ const ROW_ID_PREFIX = "row_"; // formerly "r@"
 
 const CLDR_TABLE_DEBUG = false;
 
-const TABLE_USES_NEW_API = true;
-
 /*
  * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.
  * It must match NO_WINNING_VALUE in the server Java code.
@@ -350,53 +348,25 @@ function singleRowErrHandler(err, tr, onFailure) {
 }
 
 function getSingleRowUrl(tr, theRow) {
-  if (TABLE_USES_NEW_API) {
-    const loc = cldrStatus.getCurrentLocale();
-    const api = "voting/" + loc + "/row/" + theRow.xpstrid;
-    let p = null;
-    if (cldrGui.dashboardIsVisible()) {
-      p = new URLSearchParams();
-      p.append("dashboard", "true");
-    }
-    return cldrAjax.makeApiUrl(api, p);
-  }
-  const p = new URLSearchParams();
-  p.append("what", "getrow"); // cf. WHAT_GETROW in SurveyAjax.java
-  p.append("_", cldrStatus.getCurrentLocale());
-  p.append("xpath", theRow.xpathId);
-  p.append("fhash", tr.rowHash);
-  p.append("automatic", "t");
+  const loc = cldrStatus.getCurrentLocale();
+  const api = "voting/" + loc + "/row/" + theRow.xpstrid;
+  let p = null;
   if (cldrGui.dashboardIsVisible()) {
+    p = new URLSearchParams();
     p.append("dashboard", "true");
   }
-  p.append("s", cldrStatus.getSessionId());
-  p.append("cacheKill", cldrSurvey.cacheBuster());
-  return cldrAjax.makeUrl(p);
+  return cldrAjax.makeApiUrl(api, p);
 }
 
 function getPageUrl(curLocale, curPage, curId) {
-  if (TABLE_USES_NEW_API) {
-    let p = null;
-    if (curId && !curPage) {
-      p = new URLSearchParams();
-      p.append("xpstrid", curId);
-      curPage = "auto";
-    }
-    const api = "voting/" + curLocale + "/page/" + curPage;
-    return cldrAjax.makeApiUrl(api, p);
+  let p = null;
+  if (curId && !curPage) {
+    p = new URLSearchParams();
+    p.append("xpstrid", curId);
+    curPage = "auto";
   }
-  return (
-    cldrStatus.getContextPath() +
-    "/SurveyAjax?what=getrow&_=" +
-    curLocale +
-    "&x=" +
-    curPage +
-    "&strid=" +
-    curId +
-    "&s=" +
-    cldrStatus.getSessionId() +
-    cldrSurvey.cacheKill()
-  );
+  const api = "voting/" + curLocale + "/page/" + curPage;
+  return cldrAjax.makeApiUrl(api, p);
 }
 
 /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -262,26 +262,35 @@ public class VoteAPI {
     }
 
     final static public class VoteResponse {
-        @Schema(description = "true if voting succeeded.")
+        @Schema(description = "True if voting succeeded.")
         public boolean didVote;
         @Schema(description = "If set, some other reason why the submission failed.")
         public String didNotSubmit;
-        @Schema(description = "VoteResolver info about the voting results")
-        public VoteResolver<String> submitResult;
         @Schema(description = "If not ALLOW_*, gives reason why the voting was not allowed.")
         public StatusAction statusAction = null;
-        @Schema()
-        public boolean dataEmpty;
-        @Schema(description = "Tests which were run.")
-        public String testsRun;
         @Schema(description = "Results of status checks.")
-        public CheckStatusSummary[] results;
+        public CheckStatusSummary[] testResults;
+        @Schema(description = "True if testResults include warnings.")
+        public boolean testWarnings;
+        @Schema(description = "True if testResults include errors.")
+        public boolean testErrors;
 
-        void setResults(List<CheckStatus> results) {
-            this.results = new CheckStatusSummary[results.size()];
-            for (int i = 0; i < results.size(); i++) {
-                this.results[i] = new CheckStatusSummary(results.get(i));
+        void setTestResults(List<CheckStatus> testResults) {
+            this.testResults = new CheckStatusSummary[testResults.size()];
+            this.testWarnings = has(testResults, CheckStatus.warningType);
+            this.testErrors = has(testResults, CheckStatus.errorType);
+            for (int i = 0; i < testResults.size(); i++) {
+                this.testResults[i] = new CheckStatusSummary(testResults.get(i));
             }
+        }
+
+        private static boolean has(List<CheckStatus> result, CheckStatus.Type type) {
+            for (CheckStatus s : result) {
+                if (s.getType().equals(type)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 


### PR DESCRIPTION
-Remove TABLE_USES_NEW_API and VOTE_USES_NEW_API, now effectively permanently true

-Recognize DAIP reduction to empty string, as it was recognized for WHAT_SUBMIT

-New method VoteAPIHelper.normalizedToZeroLengthError

-Use the string value of json.didNotSubmit when present

-Use boolean json.didVote instead of json.submitResult, which was treated as boolean anyway

-Imitate old json more closely, including testErrors, testWarnings, testResults

-Remove unused json.dataEmpty, json.testsRun

-Fix duplicate cldrRetry.handleDisconnect in cldrVote.js

-Do not assign to unused variable span in cldrVote.js

-Comments

CLDR-15368

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
