### PR TITLE
CLDR-10384 Use display names for Organization menus

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAccount.js
+++ b/tools/cldr-apps/js/src/esm/cldrAccount.js
@@ -4,6 +4,7 @@
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrDom from "./cldrDom.js";
 import * as cldrLoad from "./cldrLoad.js";
+import * as cldrOrganizations from "./cldrOrganizations.js";
 import * as cldrStatus from "./cldrStatus.js";
 import * as cldrSurvey from "./cldrSurvey.js";
 import * as cldrText from "./cldrText.js";
@@ -12,8 +13,8 @@ import * as cldrUserLevels from "./cldrUserLevels.js";
 const CLDR_ACCOUNT_DEBUG = false;
 const SHOW_GRAVATAR = !CLDR_ACCOUNT_DEBUG;
 
-const WHAT_USER_LIST = "user_list"; // cf. org.unicode.cldr.web.SurveyAjax.WHAT_USER_LIST
-const LIST_JUST = "justu"; // cf. org.unicode.cldr.web.UserList.LIST_JUST
+const WHAT_USER_LIST = "user_list"; // cf. SurveyAjax.WHAT_USER_LIST
+const LIST_JUST = "justu"; // cf. UserList.LIST_JUST
 
 // cf. UserList.java and SurveyMain.java for these constants
 const LIST_ACTION_SETLEVEL = "set_userlevel_";
@@ -29,7 +30,6 @@ const LIST_MAILUSER_CONFIRM = "mailthem_c";
 const LIST_MAILUSER_CONFIRM_CODE = "confirm";
 const PREF_SHOWLOCKED = "p_showlocked";
 const PREF_JUSTORG = "p_justorg";
-const GET_ORGS = "get_orgs";
 
 const userListTableId = "userListTable";
 
@@ -75,7 +75,7 @@ const bulkActionChangeButtonDiv =
   "</div>\n";
 
 const infoType = {
-  // this MUST agree with org.unicode.cldr.web.UserRegistry.InfoType
+  // this MUST agree with UserRegistry.InfoType
   INFO_EMAIL: "E-mail",
   INFO_NAME: "Name",
   INFO_PASSWORD: "Password",
@@ -99,7 +99,7 @@ let isJustMe = false;
 let justUser = null;
 
 let showLockedUsers = false;
-let orgList = null;
+let orgs = null;
 let levelList = null;
 let shownUsers = null;
 let justOrg = null;
@@ -194,6 +194,21 @@ function listSingleUser(email) {
 }
 
 function reallyLoad() {
+  getOrgsAndLevels().then(reallyReallyLoad);
+}
+
+async function getOrgsAndLevels() {
+  orgs = await cldrOrganizations.get();
+  if (!orgs) {
+    throw new Error("Organization names not received from server");
+  }
+  levelList = await cldrUserLevels.getLevelList();
+  if (!levelList) {
+    throw new Error("User levels not received from server");
+  }
+}
+
+function reallyReallyLoad() {
   const xhrArgs = {
     url: getUrl(),
     handleAs: "json",
@@ -208,9 +223,6 @@ function loadHandler(json) {
   if (json.err) {
     ourDiv.innerHTML = json.err;
   } else {
-    if (json.orgList) {
-      orgList = json.orgList;
-    }
     shownUsers = json.shownUsers;
     if (
       justUser &&
@@ -218,11 +230,6 @@ function loadHandler(json) {
       getSelectedAction(shownUsers[0]) === "change_INFO_EMAIL"
     ) {
       justUser = shownUsers[0].email;
-    }
-    if (json.userPerms.levels) {
-      // Note for future improvement: levelList could be derived instead from cldrUserLevels.getLevelList,
-      // then the back end would no longer need to include it in UserList
-      levelList = json.userPerms.levels;
     }
     ourDiv.innerHTML = getHtml(json);
   }
@@ -246,7 +253,7 @@ function getHtml(json) {
   if (isJustMe) {
     html += "<h2>My Account</h2>\n";
   } else {
-    const org = json.org ? json.org : "ALL";
+    const org = json.org ? orgs.shortToDisplay[json.org] : "ALL";
     html += "<h2>Users for " + org + "</h2>\n";
   }
   html += getEmailNotification(json);
@@ -256,7 +263,7 @@ function getHtml(json) {
       html += " " + participatingUsersButton;
     }
     html += "</p>\n";
-    if (orgList && !justUser) {
+    if (orgs && !justUser && cldrStatus.getPermissions()?.userIsAdmin) {
       html += getOrgFilterMenu();
     }
   }
@@ -279,31 +286,44 @@ function getHtml(json) {
 }
 
 function getTable(json) {
-  shownUsers = json.shownUsers;
-  // Note: this assignment to levelList is redundant except for the unit test;
-  // a future revision of the unit test could supply a mock levelList separately
-  levelList = json.userPerms.levels;
+  shownUsers = json.shownUsers; // redundant except for unit test
   byEmail = {};
   let html = getTableStart();
-  let oldOrg = "";
-  for (let i in shownUsers) {
-    const u = {
-      data: shownUsers[i],
-    };
-    byEmail[u.data.email] = u;
-    if (oldOrg !== u.data.org) {
-      html +=
-        "<tr class='heading'><th class='partsection' colspan='6'><a name='" +
-        u.data.org +
-        "'><h4>" +
-        u.data.org +
-        "</h4></a></th></tr>\n";
-      oldOrg = u.data.org;
+  for (let org of getSortedOrgsToShow()) {
+    const orgDisplayName = orgs.shortToDisplay[org];
+    html +=
+      "<tr class='heading'><th class='partsection' colspan='6'><a name='" +
+      org +
+      "'><h4>" +
+      orgDisplayName +
+      "</h4></a></th></tr>\n";
+    for (let userData of shownUsers) {
+      if (org === userData.org) {
+        const u = {
+          data: userData,
+        };
+        byEmail[userData.email] = u;
+        html += getUserTableRow(u, json);
+      }
     }
-    html += getUserTableRow(u, json);
   }
   html += getTableEnd(json);
   return html;
+}
+
+function getSortedOrgsToShow() {
+  const sortedOrgs = [];
+  const orgsFound = {};
+  for (let userData of shownUsers) {
+    orgsFound[userData.org] = true;
+  }
+  for (let displayName of orgs.sortedDisplayNames) {
+    const shortName = orgs.displayToShort[displayName];
+    if (orgsFound[shortName]) {
+      sortedOrgs.push(shortName);
+    }
+  }
+  return sortedOrgs;
 }
 
 function getTableStart() {
@@ -950,10 +970,18 @@ function getOrgFilterMenu() {
     "<label class='menutop-active'>Filter Organization " +
     "<select id='filterOrgSelect' class='menutop-other'>\n" +
     "<option value='all'>Show All</option>\n";
-  orgList.forEach(function (org) {
-    const sel = org === justOrg ? " selected='selected'" : "";
-    html += "<option value='" + org + "'" + sel + ">" + org + "</option>\n";
-  });
+  for (let displayName of orgs.sortedDisplayNames) {
+    const shortName = orgs.displayToShort[displayName];
+    const sel = shortName === justOrg ? " selected='selected'" : "";
+    html +=
+      "<option value='" +
+      shortName +
+      "'" +
+      sel +
+      ">" +
+      displayName +
+      "</option>\n";
+  }
   html += "</select>\n";
   html += "</label>\n";
   return html;
@@ -1181,9 +1209,6 @@ function getUrl() {
   const allowCache = false;
   const p = new URLSearchParams();
   p.append("what", WHAT_USER_LIST);
-  if (needOrgList()) {
-    p.append(GET_ORGS, true);
-  }
   p.append(PREF_SHOWLOCKED, showLockedUsers);
   if (justOrg) {
     p.append(PREF_JUSTORG, justOrg);
@@ -1196,15 +1221,6 @@ function getUrl() {
     p.append("cacheKill", cldrSurvey.cacheBuster());
   }
   return cldrAjax.makeUrl(p);
-}
-
-function needOrgList() {
-  if (orgList) {
-    return false; // already got orgList
-  }
-  // Only Admin needs orgList
-  const perm = cldrStatus.getPermissions();
-  return perm && perm.userIsAdmin;
 }
 
 function getLoginUrl(email, password) {
@@ -1344,22 +1360,16 @@ function setActionMenuOnChange() {
   }
 }
 
-/**
- * Get the list of organizations
- *
- * @returns an array of strings, or null
- *
- * This only works if the user is admin and the #account page has already been opened,
- * as is the case for AddUser.vue
- */
-function getOrgList() {
-  return orgList;
+function setMockLevels(list) {
+  levelList = list;
+}
+
+function setMockOrgs(o) {
+  orgs = o;
 }
 
 export {
   createUser,
-  filterOrg,
-  getOrgList,
   load,
   loadListUsers,
   zoomUser,
@@ -1368,4 +1378,6 @@ export {
    */
   getHtml,
   getTable,
+  setMockLevels,
+  setMockOrgs,
 };

--- a/tools/cldr-apps/js/src/esm/cldrOrganizations.js
+++ b/tools/cldr-apps/js/src/esm/cldrOrganizations.js
@@ -1,0 +1,54 @@
+/*
+ * cldrOrganizations: handle Organization names
+ */
+import * as cldrAjax from "./cldrAjax.js";
+
+let orgs = null;
+
+/**
+ * Get a complete list of organizations, with their short names and display names
+ *
+ * Short and display names are like "wikimedia" and "Wikimedia Foundation", respectively
+ *
+ * @returns the object with these elements:
+ *          displayToShort - the map from display names to short names
+ *          shortToDisplay - the map from short names to display names
+ *          sortedDisplayNames - the sorted array of display names
+ */
+async function get() {
+  if (orgs) {
+    return orgs;
+  }
+  const url = cldrAjax.makeApiUrl("organizations", null);
+  return await cldrAjax
+    .doFetch(url)
+    .then(cldrAjax.handleFetchErrors)
+    .then((r) => r.json())
+    .then(loadOrgs)
+    .catch((e) => console.error(`Error: ${e} ...`));
+}
+
+function loadOrgs(json) {
+  if (!json.map) {
+    console.error("Organization list not received from server");
+    return null;
+  }
+  const shortToDisplay = json.map;
+  const displayToShort = {};
+  for (let shortName in shortToDisplay) {
+    displayToShort[shortToDisplay[shortName]] = shortName;
+  }
+  const sortedDisplayNames = Object.keys(displayToShort).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  orgs = { displayToShort, shortToDisplay, sortedDisplayNames };
+  return orgs;
+}
+
+export {
+  get,
+  /*
+   * The following is meant to be accessible for unit testing only, to set mock data:
+   */
+  loadOrgs,
+};

--- a/tools/cldr-apps/js/src/esm/cldrUserLevels.js
+++ b/tools/cldr-apps/js/src/esm/cldrUserLevels.js
@@ -69,12 +69,12 @@ function check(list) {
 }
 
 function canVoteInNonOrgLocales(number, list) {
-  const name = list[number].name;
+  const name = list[number]?.name;
   return match(name, ADMIN) || match(name, TC) || match(name, GUEST);
 }
 
 function match(a, b) {
-  return a.toLowerCase() === b.toLowerCase();
+  return a && b && a.toLowerCase() === b.toLowerCase();
 }
 
 async function getLevelList() {

--- a/tools/cldr-apps/js/test/TestCldrAccount.js
+++ b/tools/cldr-apps/js/test/TestCldrAccount.js
@@ -1,6 +1,7 @@
 import * as cldrTest from "./TestCldrTest.js";
 
 import * as cldrAccount from "../src/esm/cldrAccount.js";
+import * as cldrOrganizations from "../src/esm/cldrOrganizations.js";
 
 export const TestCldrAccount = "ok";
 
@@ -11,63 +12,19 @@ const json = {
   isBusted: "0",
   what: "user_list",
   err: "",
-  org: "SurveyTool",
+  org: "surveytool",
   preset_do: "",
   SurveyOK: "1",
   preset_fromint: -1,
   userPerms: {
     canCreateUsers: true,
-    levels: {
-      0: {
-        string: "0: (ADMIN)",
-        isManagerFor: true,
-        name: "admin",
-        canCreateOrSetLevelTo: true,
-      },
-      1: {
-        string: "1: (TC)",
-        isManagerFor: true,
-        name: "tc",
-        canCreateOrSetLevelTo: true,
-      },
-      2: {
-        string: "2: (MANAGER)",
-        isManagerFor: true,
-        name: "manager",
-        canCreateOrSetLevelTo: true,
-      },
-      5: {
-        string: "5: (VETTER)",
-        isManagerFor: true,
-        name: "vetter",
-        canCreateOrSetLevelTo: true,
-      },
-      8: {
-        string: "8: (ANONYMOUS)",
-        isManagerFor: true,
-        name: "anonymous",
-        canCreateOrSetLevelTo: true,
-      },
-      999: {
-        string: "999: (LOCKED)",
-        isManagerFor: true,
-        name: "locked",
-        canCreateOrSetLevelTo: true,
-      },
-      10: {
-        string: "10: (GUEST)",
-        isManagerFor: true,
-        name: "guest",
-        canCreateOrSetLevelTo: true,
-      },
-    },
     canModifyUsers: true,
   },
   shownUsers: [
     {
       voteCountMenu: [4, 100],
       votecount: 100,
-      org: "SurveyTool",
+      org: "surveytool",
       lastlogin: "2021-02-04 17:12:04.0",
       userCanDeleteUser: false,
       userlevelName: "admin",
@@ -86,6 +43,108 @@ const json = {
   uptime: "",
   isSetup: "1",
 };
+
+const levelsJson = {
+  0: {
+    string: "0: (ADMIN)",
+    isManagerFor: true,
+    name: "admin",
+    canCreateOrSetLevelTo: true,
+  },
+  1: {
+    string: "1: (TC)",
+    isManagerFor: true,
+    name: "tc",
+    canCreateOrSetLevelTo: true,
+  },
+  2: {
+    string: "2: (MANAGER)",
+    isManagerFor: true,
+    name: "manager",
+    canCreateOrSetLevelTo: true,
+  },
+  5: {
+    string: "5: (VETTER)",
+    isManagerFor: true,
+    name: "vetter",
+    canCreateOrSetLevelTo: true,
+  },
+  8: {
+    string: "8: (ANONYMOUS)",
+    isManagerFor: true,
+    name: "anonymous",
+    canCreateOrSetLevelTo: true,
+  },
+  999: {
+    string: "999: (LOCKED)",
+    isManagerFor: true,
+    name: "locked",
+    canCreateOrSetLevelTo: true,
+  },
+  10: {
+    string: "10: (GUEST)",
+    isManagerFor: true,
+    name: "guest",
+    canCreateOrSetLevelTo: true,
+  },
+};
+
+const orgsJson = {
+  map: {
+    adlam: "Winden Jangen Adlam",
+    adobe: "Adobe",
+    afghan_csa: "Afghan CSA",
+    afghan_mcit: "Afghan MCIT",
+    afrigen: "Afrigen",
+    apple: "Apple",
+    bangladesh: "Bangladesh",
+    bangor_univ: "Bangor Univ.",
+    bhutan: "Bhutan DDC",
+    breton: "Office of Breton Lang",
+    cherokee: "Cherokee Nation",
+    cldr: "Cldr",
+    gaeilge: "Foras na Gaeilge",
+    georgia_isi: "Georgia ISI",
+    gnome: "Gnome Foundation",
+    google: "Google",
+    ibm: "IBM",
+    india: "India MIT",
+    iran_hci: "Iran HCI",
+    kendra: "Kendra (Nepal)",
+    kotoistus: "Kotoistus (Finnish IT Ctr)",
+    kunsill_malti: "Il-Kunsill Nazzjonali tal-Ilsien Malti",
+    lakota_lc: "Lakota LC",
+    lao_dpt: "Lao Posts/Telecom??",
+    longnow: "The Long Now Foundation",
+    meta: "Meta",
+    microsoft: "Microsoft",
+    mozilla: "Mozilla",
+    netflix: "Netflix",
+    nyiakeng_puachue_hmong: "Nyiakeng Puachue Hmong",
+    openinstitute: "Open Inst (Cambodia)",
+    openoffice_org: "Open Office",
+    oracle: "Oracle",
+    pakistan: "Pakistan",
+    rodakych: "Rodakych",
+    rohingyazuban: "Rohingya Language Council",
+    rumantscha: "Lia Rumantscha",
+    sardware: "Sardware",
+    sil: "SIL",
+    special: "High Coverage and Generated",
+    srilanka: "Sri Lanka ICTA",
+    surveytool: "Survey Tool",
+    unaffiliated: "Unaffiliated",
+    venetian: "VeC - Lengua Veneta",
+    welsh_lc: "Welsh LC",
+    wikimedia: "Wikimedia Foundation",
+    wod_nko: "WOD N’ko",
+    yahoo: "Yahoo",
+  },
+};
+
+cldrAccount.setMockLevels(levelsJson);
+const orgs = cldrOrganizations.loadOrgs(orgsJson);
+cldrAccount.setMockOrgs(orgs);
 
 describe("cldrAccount.getTable", function () {
   const html = cldrAccount.getTable(json);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -41,8 +41,6 @@ public class UserList {
     private static final String PREF_SHOWLOCKED = "p_showlocked";
     private static final String PREF_JUSTORG = "p_justorg";
 
-    private static final String GET_ORGS = "get_orgs";
-
     private final boolean isValid;
     private final HttpServletRequest request;
     private final User me;
@@ -114,9 +112,6 @@ public class UserList {
         r.put("org", forOrg);
         r.put("userPerms", userPerms);
         r.put("canShowLocked", canShowLocked);
-        if ("true".equals(request.getParameter(GET_ORGS))) {
-            r.put("orgList", UserRegistry.getOrgList());
-        }
         listUsers(r);
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/AddUser.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/AddUser.java
@@ -1,10 +1,6 @@
 package org.unicode.cldr.web.api;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -46,8 +42,8 @@ public class AddUser {
                 description = "Forbidden"),
         })
     public Response addUser(
-        @QueryParam("s") @Schema(required = true, description = "Session String") String sessionString,
-        AddUserRequest request) {
+        AddUserRequest request,
+        @HeaderParam(Auth.SESSION_HEADER) String sessionString) {
         try {
             CookieSession session = Auth.getSession(sessionString);
             if (session == null) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/OrgList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/OrgList.java
@@ -12,7 +12,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.unicode.cldr.web.UserRegistry;
+import org.unicode.cldr.util.Organization;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 @Path("/organizations")
 @Tag(name = "organizations", description = "Get the list of Survey Tool organizations")
@@ -21,33 +24,38 @@ public class OrgList {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-        summary = "Get Organization List",
+        summary = "Get Organization Map",
         description = "This handles a request for the list of organizations")
     @APIResponses(
         value = {
             @APIResponse(
                 responseCode = "200",
-                description = "Results of OrgList request",
+                description = "Results of Organization request",
                 content = @Content(mediaType = "application/json",
-                    schema = @Schema(implementation = OrgListResponse.class))),
+                    schema = @Schema(implementation = OrgMapResponse.class))),
         })
     public Response getOrgs() {
         try {
-            OrgListResponse response = new OrgListResponse();
+            OrgMapResponse response = new OrgMapResponse();
             return Response.ok(response, MediaType.APPLICATION_JSON).build();
         } catch (Exception e) {
             return Response.status(500, "An exception occurred").entity(e).build();
         }
     }
 
-    @Schema(description = "Response for OrgList query")
-    public final class OrgListResponse {
+    @Schema(description = "Response for organizations query")
+    public static final class OrgMapResponse {
 
-        @Schema(description = "List of organization names")
-        public String[] list;
+        @Schema(description = "Map from short names to display names")
+        public Map<String,String> map;
 
-        public OrgListResponse() {
-            list = UserRegistry.getOrgList();
+        public OrgMapResponse() {
+            map = new TreeMap<>();
+            for (Organization o: Organization.values()) {
+                if (o.visibleOnFrontEnd()) {
+                    map.put(o.name(), o.getDisplayName());
+                }
+            }
         }
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Organization.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Organization.java
@@ -67,7 +67,7 @@ public enum Organization {
 
     /**
      * Get a list of the TC Organizations
-     * @return
+     * @return the set
      */
     public static Set<Organization> getTCOrgs() {
         return TC_ORGS;
@@ -75,7 +75,7 @@ public enum Organization {
 
     /**
      * Is this organization a TC Org?
-     * @return
+     * @return true if it is TC
      */
     public boolean isTCOrg() {
         return getTCOrgs().contains(this);
@@ -109,7 +109,7 @@ public enum Organization {
         return displayName;
     }
 
-    static Map<String, Organization> OrganizationNameMap;
+    static final Map<String, Organization> OrganizationNameMap;
     static {
         OrganizationNameMap = new HashMap<>();
         for (Organization x : values()) {
@@ -125,7 +125,7 @@ public enum Organization {
      * @param displayName Preferred display name for the organization
      * @param names Alternate aliases for this organization
      */
-    private Organization(String displayName, String... names) {
+    Organization(String displayName, String... names) {
         this.displayName = displayName;
         this.names = names;
     }
@@ -142,5 +142,9 @@ public enum Organization {
             }
         }
         return localeSet;
+    }
+
+    public boolean visibleOnFrontEnd() {
+        return this != Organization.special;
     }
 }


### PR DESCRIPTION
-New cldrOrganizations.js encapsulates org names on front end

-Sort org display names alphabetically on front end with localeCompare

-List Users and Add User menus are alphabetically sorted by org display name

-List Users sections are alphabetically sorted by org display name

-Fix form-validation problems in AddUser.vue, wait until levels and orgs are loaded

-Fix AddUser.vue, clear errors and warnings when Add Another User

-In cldrAccount.js always get orgs; even for a single org, need short/display mapping

-In cldrAccount.js new setMockLevels, setMockOrgs for unit testing without json from server

-In AddUser.java, use Auth.SESSION_HEADER not query param s

-In OrgList.java, respond with both short and display org names

-In OrgList.java, do not share Organization.special (High Coverage and Generated) with the front end

-In UserList.java, do not include org list in json, no longer needed

-Comments

CLDR-10384

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
