### PR TITLE
CLDR-14878 fix(build): fix action

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.git-ref }}
-          repo: ${{ github.event.inputs.repo }}
+          repository: ${{ github.event.inputs.repo }}
           lfs: false
       - name: Calculate Tag Name
         id: tagname


### PR DESCRIPTION
had `repo` instead of `repository` for the checkout action

CLDR-14878

