### PR TITLE
CLDR-16102 Fix supplemental version unicodeVersion attribute to be 15.0.0

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -15,7 +15,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST version cldrVersion CDATA #FIXED "42" >
     <!--@MATCH:version-->
     <!--@VALUE-->
-<!ATTLIST version unicodeVersion CDATA #FIXED "14.0.0" >
+<!ATTLIST version unicodeVersion CDATA #FIXED "15.0.0" >
     <!--@MATCH:version-->
     <!--@VALUE-->
 


### PR DESCRIPTION
CLDR-16102

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Fix supplemental version unicodeVersion attribute (FIXED in dtd) to be 15.0.0 to correctly reflect CLDR 42 Unicode version (on maint/maint-42 branch, already fixed on main branch)
