### PR TITLE
CLDR-16077 Portuguese spellout-ordinal-masculine for trillion is feminine instead of masculine

### DIFF
--- a/common/rbnf/pt.xml
+++ b/common/rbnf/pt.xml
@@ -151,7 +151,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2000">←%spellout-cardinal-masculine← milésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000000">←%spellout-cardinal-masculine← milionésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000000000">←%spellout-cardinal-masculine← bilionésimo[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← trilionésima[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%spellout-cardinal-masculine← trilionésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-cardinal-masculine← quadrilionésimo[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=º;</rbnfrule>
             </ruleset>


### PR DESCRIPTION
CLDR-16077

Apparently due to a copy and paste typo, trillions was misspelled in Brazilian Portuguese. The pt_PT locale is not affected by this issue.

- [x] This PR completes the ticket.