### PR TITLE
CLDR-16105 Inheritance not recognized by PerXPathData

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 import org.unicode.cldr.test.CheckCLDR;
+import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
 import org.unicode.cldr.util.*;
@@ -401,6 +402,8 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         private XMLSource diskData = null;
         private CLDRFile diskFile = null;
 
+        private DisplayAndInputProcessor daip;
+
         /**
          * Per-xpath data. There's one of these per xpath- voting data, etc.
          * Does not contain the actual xpath, at least for now.
@@ -707,8 +710,11 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                         continue;
                     }
                     try {
+                        value = processValue(xpath, value);
                         internalSetVoteForValue(theSubmitter, xpath, value, voteOverride, last_mod);
                         n++;
+                    } catch (VoteNotAcceptedException e) {
+                        logger.severe("VoteNotAcceptedException: " + theSubmitter + ":" + locale + ":" + xpath);
                     } catch (BallotBox.InvalidXPathException e) {
                         logger.severe("InvalidXPathException: Deleting vote for " + theSubmitter + ":" + locale + ":" + xpath);
                         rs.deleteRow();
@@ -1028,6 +1034,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             if (!getPathsForFile().contains(distinguishingXpath)) {
                 throw new BallotBox.InvalidXPathException(distinguishingXpath);
             }
+            value = processValue(distinguishingXpath, value);
             SurveyLog.debug("V4v: " + locale + " " + distinguishingXpath + " : " + user + " voting for '" + value + "'");
             /*
              * this has to do with changing a vote - not counting it.
@@ -1086,6 +1093,39 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             if (newVal != null && !newVal.equals(oldVal)) {
                 xmlsource.notifyListeners(distinguishingXpath);
             }
+        }
+
+        /**
+         * Normalize the value using DAIP including inheritance replacement
+         *
+         * Votes retrieved from the db, uploaded by bulk submission, and imported old votes, may
+         * all have been normalized before, but the normalization criteria and/or the inherited value
+         * may have changed in the meantime.
+         *
+         * DAIP exceptions will not be reported here. For new submissions, DAIP with exception
+         * reporting is assumed to be invoked elsewhere such as VoteAPIHelper.
+         *
+         * @param xpath the path
+         * @param value the value to process
+         * @return the processed value
+         * @throws VoteNotAcceptedException
+         */
+        private String processValue(String xpath, String value) throws VoteNotAcceptedException {
+            if (value != null && !value.isEmpty() && !CldrUtility.INHERITANCE_MARKER.equals(value)) {
+                value = getProcessor().processInput(xpath, value, null);
+                if (value.isEmpty()) {
+                    throw new VoteNotAcceptedException(ErrorCode.E_BAD_VALUE, "Normalization results in empty string.");
+                }
+            }
+            return value;
+        }
+
+        private DisplayAndInputProcessor getProcessor() {
+            if (daip == null) {
+                daip = new DisplayAndInputProcessor(locale, true);
+                daip.enableInheritanceReplacement(getFile(true));
+            }
+            return daip;
         }
 
         /**

--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/unittest/web/data/TestSTFactory.xml
@@ -114,30 +114,32 @@
     <verify status="approved" locale="zh_Hant" xpath="//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator">{1} na {0}</verify>
  -->
 
-  	<!--  testing vote for inherited ↑↑↑ (CldrUtility.INHERITANCE_MARKER) -->
-    <!--  first switch und to AAA -->
+    <!-- Testing vote for inherited ↑↑↑ (CldrUtility.INHERITANCE_MARKER) -->
+    <!-- First make AAA the winning value in the parent locale, so it will be the bailey value in the sublocale. -->
     <vote name="A" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">AAA</vote>
     <vote name="B" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">AAA</vote>
     <vote name="C" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">AAA</vote>
 	<verify status="approved" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >AAA</verify>
 	<!--  <verify status="missing" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >AAA</verify> -->
-	<!--  Now, sublocale vetting. -->
+
+	<!-- Now, in the sublocale, one vote for ↑↑↑, one vote for AAA (bailey) which immediately gets normalized to ↑↑↑ (even
+	     before it gets to the vote resolver), and one vote for CCC (a dissenter). The winning value will be ↑↑↑ (with twice
+	     as many votes as CCC), and then CLDRFile.getStringValue resolves ↑↑↑ to bailey (AAA) -->
 	<vote name="A" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">↑↑↑</vote> <!--  inherited -->
     <vote name="B" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">AAA</vote> <!--  explicit agree -->
     <vote name="C" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">CCC</vote> <!--  (dissenter) -->
-	<verify status="approved" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >AAA</verify> <!-- ↑↑↑ and AAA should be the same, not split.  -->
+	<verify status="approved" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >AAA</verify>
 
-    <!--  now switch und to BBB -->
+    <!-- Now switch to BBB as the winning value in the parent locale, and the bailey value in the sublocale -->
     <vote name="A" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">BBB</vote>
     <vote name="B" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">BBB</vote>
     <vote name="C" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">BBB</vote>
 	<verify status="approved" locale="mul" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >BBB</verify>
 
-	<!-- The following test assumes: that ↑↑↑ (CldrUtility.INHERITANCE_MARKER) participates as such in voting resolution;
-		that ↑↑↑ beats AAA in the tie-breaker based on collation order; and that ↑↑↑ resolves to the Bailey value BBB.
-		Before 2018-8-17, the expected winner was AAA, since AAA beat BBB in the tie-breaker after ↑↑↑ was replaced by BBB.
-		The expected status is "provisional". -->
-	<verify status="provisional" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >BBB</verify> <!-- split vote. ↑↑↑ wins -->
+	<!-- The following test in the sublocale assumes: that BBB is now the bailey value; that bailey is treated the same as
+	     ↑↑↑ (CldrUtility.INHERITANCE_MARKER) in voting resolution; that AAA is not a candidate since it was immediately
+	     changed to ↑↑↑; that ↑↑↑ has more votes (8) than CCC (4). The expected status is "approved" (O=8, N=4; O>N, and O>4) -->
+	<verify status="approved" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >BBB</verify>
 
     <vote name="B" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']">BBB</vote> <!--  explicit agree -->
 	<verify status="approved" locale="mul_AQ" xpath="//ldml/localeDisplayNames/languages/language[@type='ko']" >BBB</verify> <!-- BBB wins. -->


### PR DESCRIPTION
-Normalize Bailey value to INHERITANCE_MARKER in STFactory

-New method STFactory.PerLocaleData.processValue, called by voteForValue and loadVoteValues

-For consistency/encapsulation, use DAIP for the normalization

-Fix one test in TestSTFactory.xml that assumed hard vote would persist when bailey changed

CLDR-16105

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
