### PR TITLE
CLDR-16089 Remove periods from ordinal number formatters in languages that don't have this convention

### DIFF
--- a/common/rbnf/ar.xml
+++ b/common/rbnf/ar.xml
@@ -296,7 +296,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         <rulesetGrouping type="OrdinalRules">
             <ruleset type="digits-ordinal">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=.;</rbnfrule>
+                <rbnfrule value="0">=#,##0=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>

--- a/common/rbnf/el.xml
+++ b/common/rbnf/el.xml
@@ -206,7 +206,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-cardinal-neuter← δισεκατομμυριοστός[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-cardinal-neuter← τρισεκατομμυριοστός[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-cardinal-neuter← τετράκις εκατομμυριοστός[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-feminine">
                 <rbnfrule value="-x">μείον →→;</rbnfrule>
@@ -257,7 +257,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-cardinal-neuter← δισεκατομμυριοστή[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-cardinal-neuter← τρισεκατομμυριοστή[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-cardinal-neuter← τετράκις εκατομμυριοστή[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-neuter">
                 <rbnfrule value="-x">μείον →→;</rbnfrule>
@@ -307,7 +307,13 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-cardinal-neuter← δισεκατομμυριοστό[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-cardinal-neuter← τρισεκατομμυριοστό[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-cardinal-neuter← τετράκις εκατομμυριοστό[ →→];</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+        </rulesetGrouping>
+        <rulesetGrouping type="OrdinalRules">
+            <ruleset type="digits-ordinal">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>

--- a/common/rbnf/en.xml
+++ b/common/rbnf/en.xml
@@ -167,7 +167,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-numbering← billion→%%th→;</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-numbering← trillion→%%th→;</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-numbering← quadrillion→%%th→;</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;</rbnfrule>
             </ruleset>
             <ruleset type="and-o" access="private">
                 <rbnfrule value="0">th;</rbnfrule>
@@ -193,7 +193,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-numbering-verbose← billion→%%commas-o→;</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-numbering-verbose← trillion→%%commas-o→;</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-numbering-verbose← quadrillion→%%commas-o→;</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">

--- a/common/rbnf/en_IN.xml
+++ b/common/rbnf/en_IN.xml
@@ -167,7 +167,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-numbering← billion→%%th→;</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-numbering← trillion→%%th→;</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-numbering← quadrillion→%%th→;</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;</rbnfrule>
             </ruleset>
             <ruleset type="and-o" access="private">
                 <rbnfrule value="0">th;</rbnfrule>
@@ -193,13 +193,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-numbering-verbose← billion→%%commas-o→;</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-numbering-verbose← trillion→%%commas-o→;</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-numbering-verbose← quadrillion→%%commas-o→;</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
-            </ruleset>
-        </rulesetGrouping>
-        <rulesetGrouping type="OrdinalRules">
-            <ruleset type="digits-ordinal">
-                <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>

--- a/common/rbnf/he.xml
+++ b/common/rbnf/he.xml
@@ -334,5 +334,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="11">=%spellout-numbering=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
+        <rulesetGrouping type="OrdinalRules">
+            <ruleset type="digits-ordinal">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=;</rbnfrule>
+            </ruleset>
+        </rulesetGrouping>
     </rbnf>
 </ldml>

--- a/common/rbnf/nl.xml
+++ b/common/rbnf/nl.xml
@@ -113,7 +113,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000">←%spellout-cardinal←­miljard→%%ord-ste→;</rbnfrule>
                 <rbnfrule value="1000000000000">←%spellout-cardinal←­biljoen→%%ord-ste→;</rbnfrule>
                 <rbnfrule value="1000000000000000">←%spellout-cardinal←­biljard→%%ord-ste→;</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=.;</rbnfrule>
+                <rbnfrule value="1000000000000000000">=#,##0=e;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">

--- a/common/rbnf/ru.xml
+++ b/common/rbnf/ru.xml
@@ -848,7 +848,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячный;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-й;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-neuter">
                 <rbnfrule value="-x">минус →→;</rbnfrule>
@@ -900,7 +900,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячное;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-е;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-feminine">
                 <rbnfrule value="-x">минус →→;</rbnfrule>
@@ -952,7 +952,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячная;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-я;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-plural">
                 <rbnfrule value="-x">минус →→;</rbnfrule>
@@ -1004,7 +1004,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячные;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-e;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-masculine-genitive">
                 <rbnfrule value="-x">минус →→;</rbnfrule>
@@ -1056,7 +1056,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячного;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-го;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-neuter-genitive">
                 <rbnfrule value="0">=%spellout-ordinal-masculine-genitive=;</rbnfrule>
@@ -1111,7 +1111,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячной;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-й;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-plural-genitive">
                 <rbnfrule value="-x">минус →→;</rbnfrule>
@@ -1163,7 +1163,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячных;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-х;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-masculine-dative">
                 <rbnfrule value="-x">минус →→;</rbnfrule>
@@ -1215,7 +1215,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячному;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-му;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-neuter-dative">
                 <rbnfrule value="0">=%spellout-ordinal-masculine-dative=;</rbnfrule>
@@ -1282,7 +1282,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячную;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-ю;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-plural-accusative">
                 <rbnfrule value="0">=%spellout-ordinal-plural=;</rbnfrule>
@@ -1337,7 +1337,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячном;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-м;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-neuter-locative">
                 <rbnfrule value="0">=%spellout-ordinal-masculine-locative=;</rbnfrule>
@@ -1398,7 +1398,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячным;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-м;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-ordinal-neuter-ablative">
                 <rbnfrule value="0">=%spellout-ordinal-masculine-ablative=;</rbnfrule>
@@ -1456,13 +1456,13 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2001" radix="1000">←%%thousandsprefixseparate←тысячи[ →→];</rbnfrule>
                 <rbnfrule value="5000" radix="1000">←%%thousandsprefixconjoined←тысячными;</rbnfrule>
                 <rbnfrule value="5001" radix="1000">←%%thousandsprefixseparate←тысяч[ →→];</rbnfrule>
-                <rbnfrule value="21001">=0=.;</rbnfrule>
+                <rbnfrule value="21001">=0=-ми;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <ruleset type="digits-ordinal">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=.;</rbnfrule>
+                <rbnfrule value="0">=#,##0=;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal-masculine">
                 <rbnfrule value="-x">−→→;</rbnfrule>

--- a/common/rbnf/uk.xml
+++ b/common/rbnf/uk.xml
@@ -129,5 +129,11 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
+        <rulesetGrouping type="OrdinalRules">
+            <ruleset type="digits-ordinal">
+                <rbnfrule value="-x">−→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=;</rbnfrule>
+            </ruleset>
+        </rulesetGrouping>
     </rbnf>
 </ldml>


### PR DESCRIPTION
CLDR-16089

- [x] This PR completes the ticket.