### PR TITLE
CLDR-6396 Seed and common; fix TestCLDRLocaleCoverage, TestReadAllDTDs

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -1,14 +1,7 @@
 package org.unicode.cldr.unittest;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.unicode.cldr.test.CoverageLevel2;
@@ -213,6 +206,8 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
     }
 
     private boolean assertContains(String title, Collection<String> set, Collection<String> subset) {
+        set = removeBelowBasic(set);
+        subset = removeBelowBasic(subset);
         boolean result = set.containsAll(subset);
         if (!result) {
             Set<String> temp = new LinkedHashSet<>(subset);
@@ -224,6 +219,16 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             errln(title + ": Missing:\t" + temp.size() + "\n\t" + Joiner.on("\n\t").join(temp2));
         }
         return result;
+    }
+
+    private Collection<String> removeBelowBasic(Collection<String> set) {
+        Collection<String> set2 = new TreeSet<>();
+        for (String locale: set) {
+            if (StandardCodes.isLocaleAtLeastBasic(locale)) {
+                set2.add(locale);
+            }
+        }
+        return set2;
     }
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -93,8 +93,6 @@ public class TestCLDRFile {
         "common/supplemental",
         "common/validity",
 
-        // Test a couple of others:
-        "seed/main",
         "exemplars/main",
     })
     public void TestReadAllDTDs(final String subdir) {


### PR DESCRIPTION
-Fix TestCLDRLocaleCoverage/TestLanguageNameCoverage, skip non-basic locales

-Fix TestReadAllDTDs, do not test seed/main

CLDR-6396

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
