### PR TITLE
CLDR-11228 ST: notify TC of forum responses; notify

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAccount.js
+++ b/tools/cldr-apps/js/src/esm/cldrAccount.js
@@ -1238,7 +1238,7 @@ function getUserActivityUrl() {
 }
 
 function getInterestLocalesUrl() {
-  cldrAjax.makeApiUrl("intlocs", null);
+  return cldrAjax.makeApiUrl("intlocs", null);
 }
 
 function getInterestLocalesPostData(interestLocales) {

--- a/tools/cldr-apps/js/src/esm/cldrForumPanel.js
+++ b/tools/cldr-apps/js/src/esm/cldrForumPanel.js
@@ -31,8 +31,6 @@ let sidewaysShowTimeout = -1;
  * @param {Node} tr
  *
  * TODO: shorten this function (use subroutines)
- *
- * Formerly known as cldrSurvey.showForumStuff
  */
 function loadInfo(frag, forumDivClone, tr) {
   let isOneLocale = false;
@@ -316,8 +314,6 @@ function getUsersValue(theRow) {
 /**
  * Update the forum posts in the Info Panel
  *
- * This includes the version of the Info Panel displayed in the Dashboard "Fix" window
- *
  * @param tr the table-row element with which the forum posts are associated,
  *		and whose info is shown in the Info Panel; or null, to get the
  *		tr from surveyCurrentId
@@ -335,10 +331,6 @@ function updatePosts(tr) {
     }
   }
   if (!tr || !tr.forumDiv || !tr.forumDiv.url) {
-    /*
-     * This is normal for updatePosts(null) called by success handler
-     * for submitPost, from Dashboard, since Fix window is no longer open
-     */
     return;
   }
   let ourUrl = tr.forumDiv.url + "&what=forum_fetch";
@@ -358,13 +350,13 @@ function updatePosts(tr) {
     try {
       if (json && json.ret && json.ret.length > 0) {
         const posts = json.ret;
-        const content = cldrForum.parseContent(posts, "info");
+        let content = cldrForum.parseContent(posts, "info");
         /*
          * Reality check: the json should refer to the same path as tr, which in practice
          * always matches cldrStatus.getCurrentId(). If not, log a warning and substitute "Please reload"
          * for the content.
          */
-        let xpstrid = posts[0].xpath;
+        const xpstrid = posts[0].xpath;
         if (xpstrid !== tr.xpstrid || xpstrid !== cldrStatus.getCurrentId()) {
           console.log(
             "Warning: xpath strid mismatch in updatePosts loadHandler:"
@@ -377,12 +369,6 @@ function updatePosts(tr) {
         }
         /*
          * Update the element whose class is 'forumDiv'.
-         * Note: When updatePosts is called by the mouseover event handler for
-         * the "Show n posts" button set up by havePosts, a clone of tr.forumDiv is created
-         * (for mysterious reasons) by that event handler, and we could pass forumDivClone
-         * as a parameter to updatePosts, then do forumDivClone.appendChild(content)
-         * here, which is essentially how it formerly worked. However, that wouldn't work when
-         * we're called by the success handler for submitPost. This works in all cases.
          */
         $(".forumDiv").first().html(content);
       }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
@@ -172,7 +172,7 @@ public class SurveyForum {
         return num;
     }
 
-    private void gatherInterestedUsers(String forum, Set<Integer> cc_emails, Set<Integer> bcc_emails) {
+    private void gatherUsersInterestedInLocale(String forum, Set<Integer> cc_emails, Set<Integer> bcc_emails) {
         try {
             Connection conn = null;
             PreparedStatement pIntUsers = null;
@@ -213,7 +213,9 @@ public class SurveyForum {
      *
      * Called by doPostInternal
      */
-    private void emailNotify(UserRegistry.User user, CLDRLocale locale, int base_xpath, String subj, String text, Integer postId) {
+    private void emailNotify(PostInfo postInfo, int postId) {
+        User user = postInfo.getUser();
+        CLDRLocale locale = postInfo.getLocale();
         String forum = localeToForum(locale);
         ElapsedTimer et = new ElapsedTimer("Sending email to " + forum);
         // Do email-
@@ -221,19 +223,44 @@ public class SurveyForum {
         Set<Integer> bcc_emails = new HashSet<>();
 
         // Collect list of users to send to.
-        gatherInterestedUsers(forum, cc_emails, bcc_emails);
+        gatherUsersInterestedInLocale(forum, cc_emails, bcc_emails);
+        gatherUsersInterestedInThread(postInfo, user, cc_emails);
 
-        String subject = "CLDR forum post (" + locale.getDisplayName() + " - " + locale + "): " + subj;
+        String subject = "CLDR forum post (" + locale.getDisplayName() + " - " + locale + "): " + postInfo.getSubj();
 
         String body = "Do not reply to this message, instead go to <"
             + CLDRConfig.getInstance().absoluteUrls().forSpecial(CLDRURLS.Special.Forum, locale, (String) null, Integer.toString(postId))
 
             + ">\n====\n\n"
-            + text;
+            + postInfo.getText();
 
-        logger.fine(et + ": Forum notify: u#" + user.id + " x" + base_xpath + " queueing cc:" + cc_emails.size() + " and bcc:" + bcc_emails.size());
+        logger.fine(et + ": Forum notify: u#" + user.id + " x" + postInfo.getPath() + " queueing cc:" + cc_emails.size() + " and bcc:" + bcc_emails.size());
 
-        MailSender.getInstance().queue(user.id, cc_emails, bcc_emails, HTMLUnsafe(subject), HTMLUnsafe(body), locale, base_xpath, postId);
+        MailSender.getInstance().queue(user.id, cc_emails, bcc_emails, HTMLUnsafe(subject), HTMLUnsafe(body), locale, postInfo.getPath(), postId);
+    }
+
+    /**
+     * Add users interested in this particular thread
+     *
+     * If this is a reply, add the user who started the thread, if they are not the current poster,
+     * and they are a TC member
+     *
+     * @param postInfo the new post
+     * @param currentUser the poster of the new post
+     * @param cc_emails the set of emails to which we may add
+     */
+    private void gatherUsersInterestedInThread(PostInfo postInfo, User currentUser, Set<Integer> cc_emails) {
+        if (postInfo.getReplyTo() < 0) {
+            return; // not a reply
+        }
+        final int rootPosterId = getUserId(postInfo.getRoot());
+        if (rootPosterId == currentUser.id) {
+            return; // don't notify the poster of their own action
+        }
+        UserRegistry.User rootPoster = sm.reg.getInfo(rootPosterId);
+        if (UserRegistry.userIsTC(rootPoster)) {
+            cc_emails.add(rootPosterId);
+        }
     }
 
     /**
@@ -241,17 +268,16 @@ public class SurveyForum {
      * This was already checked on the client, but don't trust the client too much.
      * Check on server as well, at least to prevent someone closing a post who shouldn't be allowed to.
      *
-     * @param user the current user
-     * @param postType the PostType
-     * @param replyTo the post id of the parent, or NO_PARENT
+     * @param postInfo the PostInfo
      * @return true or false
-     *
-     * @throws SurveyException
      */
-    private boolean userCanUsePostType(User user, PostType postType, int replyTo) throws SurveyException {
+    private boolean userCanUsePostType(PostInfo postInfo) {
         if (SurveyMain.isPhaseReadonly()) {
             return false;
         }
+        int replyTo = postInfo.getReplyTo();
+        PostType postType = postInfo.getType();
+        User user = postInfo.getUser();
         if (postType == PostType.DISCUSS && replyTo == NO_PARENT && !UserRegistry.userIsTC(user)) {
             return false; // only TC can initiate Discuss; others can reply
         }
@@ -261,50 +287,36 @@ public class SurveyForum {
         if (replyTo == NO_PARENT) {
             return false; // first post can't begin as closed
         }
-        if (getFirstPosterInThread(replyTo) == user.id) {
+        if (getUserId(postInfo.getRoot()) == user.id) {
             return true;
         }
-        if (UserRegistry.userIsTC(user)) {
-            return true;
-        }
-        return false;
+        return UserRegistry.userIsTC(user);
     }
 
     /**
-     * Get the user id of the first poster in the thread containing this post
+     * Get the user id of the poster of this post
      *
-     * @param postId
+     * @param postId the post id
      * @return the user id, or UserRegistry.NO_USER
-     *
-     * @throws SurveyException
      */
-    private int getFirstPosterInThread(int postId) throws SurveyException {
+    private int getUserId(int postId) {
         int posterId = UserRegistry.NO_USER;
         Connection conn = null;
         PreparedStatement pList = null;
         try {
             conn = sm.dbUtils.getAConnection();
             if (conn != null) {
-                pList = DBUtils.prepareStatement(conn, "pList", "SELECT parent,poster FROM " + DBUtils.Table.FORUM_POSTS
+                pList = DBUtils.prepareStatement(conn, "pList", "SELECT poster FROM " + DBUtils.Table.FORUM_POSTS
                     + " WHERE id=?");
-                for (;;) {
-                    pList.setInt(1, postId);
-                    ResultSet rs = pList.executeQuery();
-                    int parentId = NO_PARENT;
-                    while (rs.next()) {
-                        parentId = rs.getInt(1);
-                        posterId = rs.getInt(2);
-                    }
-                    if (parentId == NO_PARENT) {
-                        break;
-                    }
-                    postId = parentId;
+                pList.setInt(1, postId);
+                ResultSet rs = pList.executeQuery();
+                while (rs.next()) {
+                    posterId = rs.getInt(1);
                 }
             }
         } catch (SQLException se) {
-            String complaint = "SurveyForum: Couldn't get parent for post - " + DBUtils.unchainSqlException(se);
+            String complaint = "SurveyForum: Couldn't get poster for post - " + DBUtils.unchainSqlException(se);
             SurveyLog.logException(logger, se, complaint);
-            throw new SurveyException(ErrorCode.E_INTERNAL, complaint);
         } finally {
             DBUtils.close(pList, conn);
         }
@@ -998,19 +1010,17 @@ public class SurveyForum {
      */
     private Integer doPostInternal(PostInfo postInfo) throws SurveyException {
         if (!postInfo.isValid()) {
-            SurveyLog.errln("Invalid postInfo in SurveyForum.doPostInternal");
+            logger.severe("Invalid postInfo in SurveyForum.doPostInternal");
             return 0;
         }
-        PostType postType = postInfo.getType();
-        User user = postInfo.getUser();
-        if (!userCanUsePostType(user, postType, postInfo.getReplyTo())) {
-            SurveyLog.errln("Post not allowed in SurveyForum.doPostInternal");
+        if (!userCanUsePostType(postInfo)) {
+            logger.severe("Post not allowed in SurveyForum.doPostInternal");
             return 0;
         }
         int postId = savePostToDb(postInfo);
 
         if (postInfo.getSendEmail()) {
-            emailNotify(user, postInfo.getLocale(), postInfo.getPath(), postInfo.getSubj(), postInfo.getText(), postId);
+            emailNotify(postInfo, postId);
         }
         return postId;
     }


### PR DESCRIPTION
-New method SurveyForum.gatherUsersInterestedInThread

-Rename gatherInterestedUsers to gatherUsersInterestedInLocale

-Parameter PostInfo in emailNotify, used for gatherUsersInterestedInThread, also reduces parameters

-Simplify and speed up by replacing getFirstPosterInThread with getUserId(postInfo.getRoot())

-Use logger.severe instead of deprecated SurveyLog.errln

-Fix bug in cldrAccount.js, needed return in getInterestLocalesUrl

-Fix bug in cldrForumPanel.js, in exceptional case content is not const

-Comments

CLDR-11228

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
