### PR TITLE
CLDR-11228 forum; follow-up simplification

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrForum.js
+++ b/tools/cldr-apps/js/src/esm/cldrForum.js
@@ -28,12 +28,6 @@ const FORUM_DEBUG = false;
  */
 const SHOW_AGREE_AND_DECLINE = false;
 
-function forumDebug(s) {
-  if (FORUM_DEBUG) {
-    console.log(s);
-  }
-}
-
 /**
  * The locale, like "fr_CA", for which to show Forum posts.
  * This module has persistent data for only one locale at a time, except that sublocales may be
@@ -789,49 +783,9 @@ function addThreadSubjectSpan(topicInfo, rootPost) {
  * @param postDivs the map from post id to DOM elements
  */
 function appendPostDivsToTopicDivs(posts, topicDivs, postDivs) {
-  const SIMPLE_REPLY_STYLE = true;
-  const USE_HORIZONTAL_RULE = false;
   for (let i = posts.length - 1; i >= 0; i--) {
     const post = posts[i];
-    if (post.parent === -1) {
-      // this post is the root of its thread, not a reply
-      topicDivs[post.threadId].appendChild(postDivs[post.id]);
-    } else {
-      // this is a reply
-      if (SIMPLE_REPLY_STYLE) {
-        if (USE_HORIZONTAL_RULE) {
-          const horizontalRule = forumCreateChunk("", "hr", "postRule");
-          topicDivs[post.threadId].appendChild(horizontalRule);
-        }
-        topicDivs[post.threadId].appendChild(postDivs[post.id]);
-      } else {
-        if (postDivs[post.root]) {
-          if (!postDivs[post.root].replies) {
-            // add the "replies" area
-            forumDebug("Adding replies area to " + post.root);
-            postDivs[post.root].replies = forumCreateChunk(
-              "",
-              "div",
-              "postReplies"
-            );
-            postDivs[post.root].appendChild(postDivs[post.root].replies);
-          }
-          // add to new location
-          postDivs[post.root].replies.appendChild(postDivs[post.id]);
-        } else {
-          // The root of this post was deleted.
-          forumDebug(
-            "The root of post #" +
-              post.id +
-              " is " +
-              post.root +
-              " but it was deleted or not visible"
-          );
-          // link it in somewhere
-          topicDivs[post.threadId].appendChild(postDivs[post.id]);
-        }
-      }
-    }
+    topicDivs[post.threadId].appendChild(postDivs[post.id]);
   }
 }
 


### PR DESCRIPTION
-Simplify cldrForum.appendPostDivsToTopicDivs to facilitate modernization

-Boolean constants SIMPLE_REPLY_STYLE and USE_HORIZONTAL_RULE were left over from very old changes, enabling reversion to obsolete behavior

CLDR-11228

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
