### PR TITLE
CLDR-16141 use multiplication sign instead of X

### DIFF
--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -13,7 +13,7 @@
           title="Close"
           @click="closeDashboard"
         >
-          X
+          ✕
         </button>
         <span
           class="i-am-dashboard"

--- a/tools/cldr-apps/js/src/views/InfoPanel.vue
+++ b/tools/cldr-apps/js/src/views/InfoPanel.vue
@@ -6,7 +6,7 @@
         title="Close"
         @click="closeInfoPanel"
       >
-        X
+        ✕
       </button>
       <span class="i-am-info-panel">Info Panel</span>
     </header>


### PR DESCRIPTION
CLDR-16141

- two spots, use ✕ instead of X

Followup to CLDR-13837



- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
