### PR TITLE
CLDR-15187 Encapsulate locale name constants for mis, mul, root, und, zxx

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
@@ -32,12 +32,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.XMLFileReader;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.web.CLDRProgressIndicator.CLDRProgressTask;
 
 import com.google.common.collect.BiMap;
@@ -265,7 +260,7 @@ public class OutputFileManager {
              * skip "en" and "root", since they should never be changed by the Survey Tool
              */
             sortSet.remove(CLDRLocale.getInstance("en"));
-            sortSet.remove(CLDRLocale.getInstance("root"));
+            sortSet.remove(CLDRLocale.getInstance(LocaleNames.ROOT));
 
             for (CLDRLocale loc : sortSet) {
                 out.write("<li>" + loc.getDisplayName() + "<br/>\n");
@@ -447,7 +442,7 @@ public class OutputFileManager {
     private static void addNameAndParents(Set<String> treatAsNonEmpty, String name) {
         treatAsNonEmpty.add(name);
         String parent = LocaleIDParser.getParent(name);
-        if (!"root".equals(parent)) {
+        if (!LocaleNames.ROOT.equals(parent)) {
             addNameAndParents(treatAsNonEmpty, parent);
         }
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -37,24 +37,10 @@ import org.unicode.cldr.test.CheckForCopy;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.SubmissionLocales;
 import org.unicode.cldr.test.TestCache;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRConfigImpl;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.CoverageInfo;
-import org.unicode.cldr.util.DateTimeFormats;
 import org.unicode.cldr.util.DtdData.IllegalByDtdException;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.PathHeader;
-import org.unicode.cldr.util.SpecialLocales;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.XMLSource;
-import org.unicode.cldr.util.XMLUploader;
-import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.web.BallotBox.InvalidXPathException;
 import org.unicode.cldr.web.BallotBox.VoteNotAcceptedException;
 import org.unicode.cldr.web.CLDRProgressIndicator.CLDRProgressTask;
@@ -1952,7 +1938,7 @@ public class SurveyAjax extends HttpServlet {
     }
 
     private boolean skipLocForImportingVotes(String loc) {
-        if ("und".equals(loc) || "root".equals(loc)) {
+        if (LocaleNames.UND.equals(loc) || LocaleNames.ROOT.equals(loc)) {
             return true; // skip
         }
         return false;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/AddUser.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/AddUser.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LocaleNormalizer;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.web.CookieSession;
@@ -123,7 +124,7 @@ public class AddUser {
     private String getNewUserLocales(String requestLocales) {
         requestLocales = LocaleNormalizer.normalizeQuietly(requestLocales);
         if (requestLocales.isEmpty()) {
-            return "mul";
+            return LocaleNames.MUL;
         }
         return requestLocales;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -27,28 +27,8 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.draft.ScriptMetadata;
 import org.unicode.cldr.draft.ScriptMetadata.Info;
 import org.unicode.cldr.tool.Option.Options;
-import org.unicode.cldr.util.Annotations;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CLDRTool;
-import org.unicode.cldr.util.CLDRURLS;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.CoverageInfo;
-import org.unicode.cldr.util.DtdData;
-import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.FileCopier;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.Timer;
-import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -769,7 +749,7 @@ public class Ldml2JsonConverter {
         boolean isModernTier;
         {
             final Level localeCoverageLevel = sc.getHighestLocaleCoverageLevel("Cldr", filename);
-            isModernTier = (localeCoverageLevel.getLevel() >= Level.MODERN.getLevel()) || filename.equals("root") || filename.equals("und");
+            isModernTier = (localeCoverageLevel.getLevel() >= Level.MODERN.getLevel()) || filename.equals(LocaleNames.ROOT) || filename.equals(LocaleNames.UND);
         }
         return isModernTier;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -27,15 +27,7 @@ import java.util.TreeSet;
 
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.test.DisplayAndInputProcessor.NumericType;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.SimpleFactory;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.TimezoneFormatter;
-import org.unicode.cldr.util.XPathParts;
+import org.unicode.cldr.util.*;
 import org.xml.sax.SAXException;
 
 import com.ibm.icu.dev.test.TestFmwk;
@@ -124,7 +116,7 @@ public class CLDRTest extends TestFmwk {
         // CLDRKey.main(new String[]{"-mde.*"});
         locales = cldrFactory.getAvailable();
         languageLocales = cldrFactory.getAvailableLanguages();
-        resolvedRoot = cldrFactory.make("root", true);
+        resolvedRoot = cldrFactory.make(LocaleNames.ROOT, true);
         /*
          * PrintWriter out = FileUtilities.openUTF8Writer(Utility.GEN_DIRECTORY + "resolved/", "root.xml");
          * CLDRFile temp = (CLDRFile) resolvedRoot.clone();
@@ -242,7 +234,7 @@ public class CLDRTest extends TestFmwk {
         int totalCount = 0;
         UnicodeSet localeMissing = new UnicodeSet();
         for (String locale : locales) {
-            if (locale.equals("root")) continue;
+            if (locale.equals(LocaleNames.ROOT)) continue;
             CLDRFile resolved = cldrFactory.make(locale, false); // FIX LATER
             UnicodeSet exemplars = getFixedExemplarSet(locale, resolved);
             CLDRFile plain = cldrFactory.make(locale, false);
@@ -749,7 +741,7 @@ public class CLDRTest extends TestFmwk {
         int[] warningCount = new int[1];
         for (Iterator<String> it = languageLocales.iterator(); it.hasNext();) {
             String locale = it.next();
-            if (locale.equals("root")) continue;
+            if (locale.equals(LocaleNames.ROOT)) continue;
             // if (!locale.equals("zh_Hant")) continue;
 
             CLDRFile item = cldrFactory.make(locale, true);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
@@ -9,18 +9,10 @@ package org.unicode.cldr.test;
 import java.util.List;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.Status;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.InternalCldrException;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.SpecialLocales;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
-import org.unicode.cldr.util.ValuePathStatus;
-import org.unicode.cldr.util.XMLSource;
 
 /**
  * Checks locale data for coverage.<br>
@@ -81,7 +73,7 @@ public class CheckCoverage extends FactoryCheckCLDR {
         // we test stuff matching specialsToKeep, or code fallback
         // skip anything else
         if (!source.equals(XMLSource.CODE_FALLBACK_ID)
-            && !source.equals("root")
+            && !source.equals(LocaleNames.ROOT)
             && (path.indexOf("metazone") < 0 || value != null && value.length() > 0)) {
             return this; // skip!
         }
@@ -128,7 +120,7 @@ public class CheckCoverage extends FactoryCheckCLDR {
             supplementalData = SupplementalDataInfo.getInstance(cldrFileToCheck.getSupplementalDirectory());
             coverageLevel = CoverageLevel2.getInstance(supplementalData, localeID);
             PluralInfo pluralInfo = supplementalData.getPlurals(PluralType.cardinal, localeID);
-            if (pluralInfo == supplementalData.getPlurals(PluralType.cardinal, "root")
+            if (pluralInfo == supplementalData.getPlurals(PluralType.cardinal, LocaleNames.ROOT)
                    && !SpecialLocales.isScratchLocale(localeID)) {
                 possibleErrors.add(new CheckStatus()
                     .setCause(this).setMainType(CheckStatus.warningType).setSubtype(Subtype.missingPluralInfo)
@@ -139,7 +131,7 @@ public class CheckCoverage extends FactoryCheckCLDR {
 
         if (options != null && options.get(Options.Option.CheckCoverage_skip) != null) return this;
         super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
-        if (localeID.equals("root")) return this;
+        if (localeID.equals(LocaleNames.ROOT)) return this;
 
         requiredLevel = options.getRequiredLevel(localeID);
         if (DEBUG) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -14,11 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.XPathParts;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Field;
 import org.unicode.cldr.util.personname.PersonNameFormatter.FormatParameters;
@@ -58,8 +54,8 @@ public class CheckPlaceHolders extends CheckCLDR {
     static {
         Set<String> valid = new HashSet<>();
         valid.addAll(CLDRConfig.getInstance().getCldrFactory().getAvailable());
-        valid.add("zxx");
-        valid.add("und");
+        valid.add(LocaleNames.ZXX);
+        valid.add(LocaleNames.UND);
         CLDR_LOCALES_FOR_NAME_ORDER = ImmutableSet.copyOf(valid);
     }
 
@@ -156,7 +152,7 @@ public class CheckPlaceHolders extends CheckCLDR {
                                 + " either in givenFirst or in surnameFirst."));
                     }
 
-                    if (!items.contains("und")) {
+                    if (!items.contains(LocaleNames.UND)) {
                         result.add(new CheckStatus().setCause(checkAccessor)
                             .setMainType(CheckStatus.errorType)
                             .setSubtype(Subtype.missingLanguage)
@@ -215,7 +211,7 @@ public class CheckPlaceHolders extends CheckCLDR {
             default:
                 break;
             }
-        } else if (value.equals("zxx")) { // mistaken "we don't use this"
+        } else if (value.equals(LocaleNames.ZXX)) { // mistaken "we don't use this"
             result.add(new CheckStatus().setCause(checkAccessor)
                 .setMainType(CheckStatus.errorType)
                 .setSubtype(Subtype.invalidPlaceHolder)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -544,12 +544,12 @@ public class DisplayAndInputProcessor {
 
     private String normalizeNameOrderLocales(String value) {
         TreeSet<String> result = new TreeSet<>(SPLIT_SPACE.splitToList(value));
-        result.remove("zxx");
-        if (result.remove("und")) { // put und at the front
+        result.remove(LocaleNames.ZXX);
+        if (result.remove(LocaleNames.UND)) { // put und at the front
             if (result.isEmpty()) {
-                return "und";
+                return LocaleNames.UND;
             } else {
-                return "und " + JOIN_SPACE.join(result);
+                return LocaleNames.UND + " " + JOIN_SPACE.join(result);
             }
         }
         return JOIN_SPACE.join(result);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -9,11 +9,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 
@@ -93,7 +89,7 @@ public class ChartLanguageGroups extends Chart {
             .addColumn("Contained", "class='source'", null, "class='target'", true)
             .setBreakSpans(true);
 
-        show(lg, "mul", tablePrinter);
+        show(lg, LocaleNames.MUL, tablePrinter);
         pw.write(tablePrinter.toTable());
     }
 
@@ -163,7 +159,7 @@ public class ChartLanguageGroups extends Chart {
     }
 
     private String getLangName(String langCode) {
-        return langCode.equals("mul") ? "All"
+        return langCode.equals(LocaleNames.MUL) ? "All"
             : langCode.equals("zh") ? "Mandarin Chinese"
                 : ENGLISH.getName(CLDRFile.LANGUAGE_NAME, langCode).replace(" (Other)", "").replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -17,18 +17,8 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.tool.Option.Params;
-import org.unicode.cldr.util.Annotations;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.Annotations.AnnotationSet;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Emoji;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.SimpleXMLSource;
-import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 
 import com.google.common.base.Joiner;
@@ -118,7 +108,7 @@ public class GenerateDerivedAnnotations {
         int processCount = 0;
 
         for (String locale : locales) {
-            if ("root".equals(locale)) {
+            if (LocaleNames.ROOT.equals(locale)) {
                 continue;
             }
             if (!localeMatcher.reset(locale).matches()) {
@@ -206,7 +196,7 @@ public class GenerateDerivedAnnotations {
         }
         Factory factory = Factory.make(CLDRPaths.COMMON_DIRECTORY + "annotationsDerived", ".*");
         for (String locale : locales) {
-            if ("root".equals(locale)) {
+            if (LocaleNames.ROOT.equals(locale)) {
                 continue;
             }
             if (!localeMatcher.reset(locale).matches()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -22,30 +22,13 @@ import java.util.TreeSet;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.draft.ScriptMetadata;
 import org.unicode.cldr.draft.ScriptMetadata.Info;
-import org.unicode.cldr.util.Builder;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Containment;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Iso639Data;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.Iso639Data.Scope;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.SimpleFactory;
-import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData.Type;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
 import com.google.common.base.Joiner;
@@ -241,7 +224,7 @@ public class GenerateMaximalLocales {
         { "swc", "swc_Latn_CD" },
         { "ti", "ti_Ethi_ET" },
         { "ti_Ethi", "ti_Ethi_ET" },
-        { "und", "en_Latn_US" },
+        { LocaleNames.UND, "en_Latn_US" },
         { "und_Adlm", "ff_Adlm_GN" },
         { "und_Adlm_GN", "ff_Adlm_GN" },
         { "und_Arab", "ar_Arab_EG" },
@@ -335,7 +318,7 @@ public class GenerateMaximalLocales {
         { "tk", "Latn" }, // Turkmen (Turkmenistan)
         { "ty", "Latn" }, // Tahitian (French Polynesia)
         { "ja", "Jpan" }, // Special script for japan
-        { "und", "Latn" }, // Ultimate fallback
+        { LocaleNames.UND, "Latn" }, // Ultimate fallback
     };
 
     private static Map<String, String> localeToScriptCache = new TreeMap<>();
@@ -638,7 +621,7 @@ public class GenerateMaximalLocales {
         }
 
         // Specials
-        add(languageToReason, "und", "001", OfficialStatus.unknown, 0);
+        add(languageToReason, LocaleNames.UND, "001", OfficialStatus.unknown, 0);
 
         // for (String language : Iso639Data.getAvailable()) {
         // Scope scope = Iso639Data.getScope(language);
@@ -785,7 +768,7 @@ public class GenerateMaximalLocales {
 
         // first get a mapping to children
         for (String locale : available) {
-            if (locale.equals("root")) {
+            if (locale.equals(LocaleNames.ROOT)) {
                 continue;
             }
             if (ltp.set(locale).getVariants().size() != 0) {
@@ -799,7 +782,7 @@ public class GenerateMaximalLocales {
             if (ltp.getScript().length() != 0) {
                 hasSimpleChildWithScript.add(parent);
             }
-            if (parent.equals("root")) {
+            if (parent.equals(LocaleNames.ROOT)) {
                 continue;
             }
             toSimpleChildren.put(parent, locale);
@@ -922,7 +905,7 @@ public class GenerateMaximalLocales {
          * @param order
          */
         void add(String language, String script, String region, Double order) {
-            if (SHOW_ADD && language.equals("mis")) {
+            if (SHOW_ADD && language.equals(LocaleNames.MIS)) {
                 System.out.println(language + "\t" + script + "\t" + region + "\t" + -order);
             }
             languages.put(language, Row.of(order, script, region));
@@ -1222,7 +1205,7 @@ public class GenerateMaximalLocales {
             Info i = ScriptMetadata.getInfo(script);
             String likelyLanguage = i.likelyLanguage;
             if (LANGUAGE_CODE_TO_STATUS.get(likelyLanguage) == Status.special) {
-                likelyLanguage = "und";
+                likelyLanguage = LocaleNames.UND;
             }
             String originCountry = i.originCountry;
             final String result = likelyLanguage + "_" + script + "_" + originCountry;
@@ -1296,7 +1279,7 @@ public class GenerateMaximalLocales {
         String script = ltp.getScript();
         boolean changed = false;
         if (language.equals("")) {
-            ltp.setLanguage(language = "und");
+            ltp.setLanguage(language = LocaleNames.UND);
             changed = true;
         }
         if (region.equals(UNKNOWN_SCRIPT)) {
@@ -1337,7 +1320,7 @@ public class GenerateMaximalLocales {
                 }
             }
         }
-        if (!language.equals("und") && script.length() != 0 && region.length() != 0) {
+        if (!language.equals(LocaleNames.UND) && script.length() != 0 && region.length() != 0) {
             return languageTag; // it was ok, and we couldn't do anything with it
         }
         return null; // couldn't maximize
@@ -1422,7 +1405,7 @@ public class GenerateMaximalLocales {
 
     private static void add(String key, String value, Map<String, String> toAdd, String kind, LocaleOverride override,
         boolean showAction) {
-        if (SHOW_ADD && key.startsWith("mis")) {
+        if (SHOW_ADD && key.startsWith(LocaleNames.MIS)) {
             int debug = 1;
         }
         if (key.equals(DEBUG_ADD_KEY)) {
@@ -1528,7 +1511,7 @@ public class GenerateMaximalLocales {
         String script = parser.getScript();
         String region = parser.getRegion();
         return "{" + spacing +
-            (lang.equals("und") ? "?" : english.getName(CLDRFile.LANGUAGE_NAME, lang)) + ";" + spacing +
+            (lang.equals(LocaleNames.UND) ? "?" : english.getName(CLDRFile.LANGUAGE_NAME, lang)) + ";" + spacing +
             (script == null || script.equals("") ? "?" : english.getName(CLDRFile.SCRIPT_NAME, script)) + ";" + spacing
             +
             (region == null || region.equals("") ? "?" : english.getName(CLDRFile.TERRITORY_NAME, region)) + spacing
@@ -1565,7 +1548,7 @@ public class GenerateMaximalLocales {
     // private static Map<String, String> getBackMapping(Map<String, String> fluffup) {
     // Relation<String,String> backMap = new Relation(new TreeMap(), TreeSet.class, BEST_LANGUAGE_COMPARATOR);
     // for (String source : fluffup.keySet()) {
-    // if (source.startsWith("und")) {
+    // if (source.startsWith(LocaleNames.UND)) {
     // continue;
     // }
     // String maximized = fluffup.get(source);
@@ -1581,7 +1564,7 @@ public class GenerateMaximalLocales {
     // }
 
     /**
-     * Language tags are presumed to share the first language, except possibly "und". Best is least
+     * Language tags are presumed to share the first language, except possibly LocaleNames.UND. Best is least
      */
     // private static Comparator BEST_LANGUAGE_COMPARATOR = new Comparator<String>() {
     // LanguageTagParser p1 = new LanguageTagParser();
@@ -1597,8 +1580,8 @@ public class GenerateMaximalLocales {
     // // put und at the end
     // int result = lang1.compareTo(lang2);
     // if (result != 0) {
-    // if (lang1.equals("und")) return 1;
-    // if (lang2.equals("und")) return -1;
+    // if (lang1.equals(LocaleNames.UND)) return 1;
+    // if (lang2.equals(LocaleNames.UND)) return -1;
     // return result;
     // }
     //
@@ -1958,7 +1941,7 @@ public class GenerateMaximalLocales {
     // { "si_Sinh", "si_Sinh_LK"},
     // { "ii", "ii_CN"}, // Sichuan Yi (Yi)
     // { "iu", "iu_CA"}, // Inuktitut (Unified Canadian Aboriginal Syllabics)
-    // { "und", "en"}, // English default
+    // { LocaleNames.UND, "en"}, // English default
     // };
 
     static void showDefaultContentDifferencesAndFix(Set<String> defaultLocaleContent) {
@@ -2058,8 +2041,8 @@ public class GenerateMaximalLocales {
             String s1 = ltp1.getLanguage();
             int result = s0.compareTo(s1);
             if (result != 0) {
-                return s0.equals("und") ? 1
-                    : s1.equals("und") ? -1
+                return s0.equals(LocaleNames.UND) ? 1
+                    : s1.equals(LocaleNames.UND) ? -1
                         : result;
             }
             s0 = ltp0.getScript();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -27,37 +27,16 @@ import java.util.stream.Collectors;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.tool.FormattedFileWriter.Anchors;
 import org.unicode.cldr.tool.Option.Options;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.PathValueInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.CoreCoverageInfo;
 import org.unicode.cldr.util.CoreCoverageInfo.CoreItems;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.Counter2;
-import org.unicode.cldr.util.CoverageInfo;
-import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.LanguageTagCanonicalizer;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
 import org.unicode.cldr.util.PathHeader.SurveyToolStatus;
-import org.unicode.cldr.util.PathStarrer;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.RegexLookup;
 import org.unicode.cldr.util.RegexLookup.LookupType;
-import org.unicode.cldr.util.SimpleFactory;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.VettingViewer;
 import org.unicode.cldr.util.VettingViewer.MissingStatus;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
 
@@ -504,8 +483,8 @@ public class ShowLocaleCoverage {
                 continue;
             }
             if (SUPPLEMENTAL_DATA_INFO.getDefaultContentLocales().contains(locale)
-                || locale.equals("root")
-                || locale.equals("und")
+                || locale.equals(LocaleNames.ROOT)
+                || locale.equals(LocaleNames.UND)
                 || locale.equals("supplementalData")) {
                 continue;
             }
@@ -793,7 +772,7 @@ public class ShowLocaleCoverage {
                     if (matcher != null && !matcher.reset(locale).matches()) {
                         continue;
                     }
-                    if (defaultContents.contains(locale) || "root".equals(locale) || "und".equals(locale)) {
+                    if (defaultContents.contains(locale) || LocaleNames.ROOT.equals(locale) || LocaleNames.UND.equals(locale)) {
                         continue;
                     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -16,33 +16,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.tool.Option.Options;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRFile.Status;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.ChainedMap.M4;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.DtdData;
-import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.LanguageTagCanonicalizer;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
 import org.unicode.cldr.util.PathHeader.SurveyToolStatus;
-import org.unicode.cldr.util.PathStarrer;
-import org.unicode.cldr.util.RegexUtilities;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.LengthFirstComparator;
-import org.unicode.cldr.util.XMLFileReader;
-import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -473,8 +456,8 @@ public class ShowStarredCoverage {
         }
 
         private void addLanguage(String key, Source source) {
-            if (key.startsWith("und") || key.startsWith("root")) {
-                languageTags.put("und", source);
+            if (key.startsWith(LocaleNames.UND) || key.startsWith(LocaleNames.ROOT)) {
+                languageTags.put(LocaleNames.UND, source);
                 return;
             }
             ltp.set(key);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SimpleLocaleParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SimpleLocaleParser.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.PatternCache;
 
 /**
@@ -91,7 +92,7 @@ class SimpleLocaleParser {
         if (language == null) {
             language = root.group(8); // marked as “Type: grandfathered” in BCP 47
             if (language == null) {
-                language = "und"; // placeholder for completely private use
+                language = LocaleNames.UND; // placeholder for completely private use
             }
         }
         script = root.group(2);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
@@ -312,7 +312,7 @@ public class CLDRConfig extends Properties {
     }
 
     public CLDRFile getRoot() {
-        return getCLDRFile("root", true);
+        return getCLDRFile(LocaleNames.ROOT, true);
     }
 
     private static final class CollatorRootHelper {
@@ -321,7 +321,7 @@ public class CLDRConfig extends Properties {
         private static final RuleBasedCollator make() {
             RuleBasedCollator colRoot;
 
-            CLDRFile root = getInstance().getCollationFactory().make("root", false);
+            CLDRFile root = getInstance().getCollationFactory().make(LocaleNames.ROOT, false);
             String rules = root.getStringValue("//ldml/collations/collation[@type=\"emoji\"][@visibility=\"external\"]/cr");
             try {
                 colRoot = new RuleBasedCollator(rules);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -27,11 +27,6 @@ import com.ibm.icu.util.ULocale;
 public final class CLDRLocale implements Comparable<CLDRLocale> {
     private static final boolean DEBUG = false;
 
-    /*
-     * The name of the root locale. This is widely assumed to be "root".
-     */
-    private static final String ROOT_NAME = "root";
-
     public interface NameFormatter {
         String getDisplayName(CLDRLocale cldrLocale);
 
@@ -242,12 +237,12 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
     private LocaleIDParser parts = null;
 
     /**
-     * Returns the BCP47 language tag for all except root. For root, returns "root" = ROOT_NAME.
+     * Returns the BCP47 language tag for all except root. For root, returns "root" = LocaleNames.ROOT.
      * @return
      */
     private String toDisplayLanguageTag() {
-        if (getBaseName().equals(ROOT_NAME)) {
-            return ROOT_NAME;
+        if (getBaseName().equals(LocaleNames.ROOT)) {
+            return LocaleNames.ROOT;
         } else {
             return toLanguageTag();
         }
@@ -282,7 +277,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
     private CLDRLocale(String str) {
         str = process(str);
         if (rootMatches(str)) {
-            fullname = ROOT_NAME;
+            fullname = LocaleNames.ROOT;
             parentId = null;
         } else {
             parts = new LocaleIDParser();
@@ -362,10 +357,10 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
             return null;
         }
         /*
-         * Normalize variations of ROOT_NAME before checking stringToLoc.
+         * Normalize variations of LocaleNames.ROOT before checking stringToLoc.
          */
         if (rootMatches(s)) {
-            s = ROOT_NAME;
+            s = LocaleNames.ROOT;
         }
         return stringToLoc.computeIfAbsent(s, k -> new CLDRLocale(k));
     }
@@ -376,15 +371,15 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
      * Also, ignore case, so "RooT" matches.
      *
      * @param s the string
-     * @return true if the string matches ROOT_NAME, else false
+     * @return true if the string matches LocaleNames.ROOT, else false
      */
     private static boolean rootMatches(String s) {
         /*
          * Important:
-         * ULocale.ROOT.getBaseName() is "", the empty string, not ROOT_NAME = "root".
-         * CLDRLocale.ROOT.getBaseName() is ROOT_NAME.
+         * ULocale.ROOT.getBaseName() is "", the empty string, not LocaleNames.ROOT = "root".
+         * CLDRLocale.ROOT.getBaseName() is LocaleNames.ROOT.
          */
-        return s.equals(ULocale.ROOT.getBaseName()) || s.equalsIgnoreCase(ROOT_NAME);
+        return s.equals(ULocale.ROOT.getBaseName()) || s.equalsIgnoreCase(LocaleNames.ROOT);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -72,7 +72,7 @@ public class DayPeriodsCheck {
 
                 // add a couple of strange locales for checking
                 localesToCheck.add(new ULocale("en-Arab"));
-                localesToCheck.add(new ULocale("und"));
+                localesToCheck.add(new ULocale(LocaleNames.UND));
                 for (ULocale locale : localesToCheck) {
                     DayPeriods dayPeriods = DayPeriods.getInstance(locale);
                     if (dayPeriods == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageInfo.java
@@ -91,8 +91,8 @@ public class LanguageInfo {
             foo.cldrDir = languages.contains(language) ? CldrDir.main
                 : CldrDir.seed;
         }
-        getRaw(temp, "und").cldrDir = CldrDir.base;
-        getRaw(temp, "zxx").cldrDir = CldrDir.base;
+        getRaw(temp, LocaleNames.UND).cldrDir = CldrDir.base;
+        getRaw(temp, LocaleNames.ZXX).cldrDir = CldrDir.base;
 
         // finalize and protect
         for (Entry<String, LanguageInfo> entry : temp.entrySet()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleNames.java
@@ -1,0 +1,9 @@
+package org.unicode.cldr.util;
+
+public class LocaleNames {
+    public static final String MIS = "mis";
+    public static final String MUL = "mul";
+    public static final String ROOT = "root";
+    public static final String UND = "und";
+    public static final String ZXX = "zxx";
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -302,7 +302,7 @@ public class StandardCodes {
                 default:
                     for (Iterator<String> it = result.iterator(); it.hasNext();) {
                         String code = it.next();
-                        if (code.equals("root") || code.equals("QO"))
+                        if (code.equals(LocaleNames.ROOT) || code.equals("QO"))
                             continue;
                         List<String> data = getFullData(type, code);
                         if (data.size() < 3) {
@@ -803,7 +803,7 @@ public class StandardCodes {
     }
 
     /**
-     * @param string
+     * @param type
      * @param string2
      * @param string3
      */
@@ -983,7 +983,7 @@ public class StandardCodes {
     static final String registryName = CldrUtility.getProperty("registry", "language-subtag-registry");
 
     public enum LstrType {
-        language("und", "zxx", "mul", "mis", "root"),
+        language(LocaleNames.UND, LocaleNames.ZXX, LocaleNames.MUL, LocaleNames.MIS, LocaleNames.ROOT),
         script("Zzzz", "Zsym", "Zxxx", "Zmth"),
         region("ZZ"),
         variant(),

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -2669,7 +2669,7 @@ public class SupplementalDataInfo {
         org.unicode.cldr.util.Factory factory = CLDRConfig.getInstance().getCldrFactory();
         for (CLDRLocale locale : factory.getAvailableCLDRLocales()) {
             String language = locale.getLanguage();
-            if (language.length() == 0 || language.equals("root")) {
+            if (language.length() == 0 || language.equals(LocaleNames.ROOT)) {
                 continue;
             }
             BasicLanguageData scriptsAndRegions = langToScriptsRegions.get(language);
@@ -3203,7 +3203,7 @@ public class SupplementalDataInfo {
             // System.out.println(type + ", " + locales + ", " + path);
         }
         if (path.size() != 4) {
-            if (locales.equals("root")) return; // we allow root to be empty
+            if (locales.equals(LocaleNames.ROOT)) return; // we allow root to be empty
             throw new IllegalArgumentException(locales + " must have dayPeriodRule elements");
         }
         DayPeriod dayPeriod;
@@ -4028,7 +4028,7 @@ public class SupplementalDataInfo {
     public PluralInfo getPlurals(PluralType type, String locale, boolean allowRoot) {
         Map<String, PluralInfo> infoMap = localeToPluralInfo2.get(type);
         while (locale != null) {
-            if (!allowRoot && locale.equals("root")) {
+            if (!allowRoot && locale.equals(LocaleNames.ROOT)) {
                 break;
             }
             PluralInfo result = infoMap.get(locale);
@@ -4375,7 +4375,7 @@ public class SupplementalDataInfo {
                 if (nextParent == null) {
                     throw new InternalError("SupplementalDataInfo.defaultContentToChild(): No valid parent for "
                         + child);
-                } else if (nextParent == CLDRLocale.ROOT || nextParent == CLDRLocale.getInstance("root")) {
+                } else if (nextParent == CLDRLocale.ROOT || nextParent == CLDRLocale.getInstance(LocaleNames.ROOT)) {
                     throw new InternalError(
                         "SupplementalDataInfo.defaultContentToChild(): Parent is root for default content locale "
                             + child);
@@ -4489,7 +4489,7 @@ public class SupplementalDataInfo {
         Set<String> temp = new HashSet<>();
         for (Entry<String, String> entry : likely.entrySet()) {
             String source = entry.getKey();
-            if (source.startsWith("und")) {
+            if (source.startsWith(LocaleNames.UND)) {
                 continue;
             }
             for (String s : getCombinations(source, ltp, likely, temp)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.Pair;
 
 import com.ibm.icu.dev.test.TestFmwk;
@@ -130,7 +131,7 @@ public class LanguageInfoTest extends TestFmwk {
             matcher.getBestMatch("zh"));
     }
 
-    static final ULocale MUL = new ULocale("mul");
+    static final ULocale MUL = new ULocale(LocaleNames.MUL);
 
     public void testFallbacks() {
         if (logKnownIssue("ICU-21241", "waiting on LocaleMatcherData update")) {
@@ -154,7 +155,7 @@ public class LanguageInfoTest extends TestFmwk {
                 continue;
             }
 
-            // we put "mul" first in the list, to verify that the fallback works enough to be better than the default.
+            // we put LocaleNames.MUL first in the list, to verify that the fallback works enough to be better than the default.
 
             @SuppressWarnings("deprecation")
             final LocaleMatcher matcher = new LocaleMatcher(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -4,12 +4,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.*;
 
 import com.ibm.icu.dev.test.TestFmwk;
 
@@ -61,7 +56,7 @@ public class StandardCodesTest extends TestFmwk {
                 locs = sc.getLocaleCoverageLocales(org,
                     EnumSet.of(Level.MODERATE, Level.MODERN));
                 for (String loc : locs) {
-                    if (loc.equals("*") || loc.equals("mul")) {
+                    if (loc.equals("*") || loc.equals(LocaleNames.MUL)) {
                         // Skip * as wildcard
                         // Skip sandbox locale 'mul'
                         continue;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -6,21 +6,10 @@ import java.util.stream.Collectors;
 
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.MinimizeRegex;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.LocaleIDParser;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
 import com.google.common.base.Joiner;
@@ -48,7 +37,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         // mainLocales has the locales in common/main, which is basically the set in attributeValueValidity.xml $language..
         // We add in additionsToTranslate below the set in attributeValueValidity.xml $languageExceptions
         // (both sets are included in SDI.getCLDRLanguageCodes() but we do not use that until later).
-        Set<String> additionsToTranslate = ImmutableSortedSet.of("zxx", "mul",
+        Set<String> additionsToTranslate = ImmutableSortedSet.of(LocaleNames.ZXX, LocaleNames.MUL,
             "ab", "ace", "ada", "ady", "ain", "ale", "alt", "an", "anp", "arn", "arp", "ars", "atj", "av", "awa", "ay",
             "ba", "ban", "bho", "bi", "bin", "bla", "bug", "byn",
             "cay", "ch", "chk", "chm", "cho", "chp", "chy", "clc", "co", "crg", "crj", "crk", "crl", "crm", "crr", "csw", "cv",
@@ -82,7 +71,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         Map<String, Status> validity = Validity.getInstance().getCodeToStatus(LstrType.language);
         Multimap<Status, String> statusToLang = Multimaps.invertFrom(Multimaps.forMap(validity), TreeMultimap.create());
         Set<String> regular = (Set<String>) statusToLang.get(Status.regular);
-        Set<String> regularPlus = ImmutableSet.<String>builder().addAll(regular).add("und").add("zxx").add("mul").build();
+        Set<String> regularPlus = ImmutableSet.<String>builder().addAll(regular).add(LocaleNames.UND).add(LocaleNames.ZXX).add(LocaleNames.MUL).build();
         Set<String> valid = validity.keySet();
 
         Factory factory = CLDRCONFIG.getCldrFactory();
@@ -90,8 +79,8 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         LanguageTagParser ltp = new LanguageTagParser();
         for (String locale : factory.getAvailableLanguages()) {
             String language = ltp.set(locale).getLanguage();
-            if (language.equals("root")) {
-                language = "und";
+            if (language.equals(LocaleNames.ROOT)) {
+                language = LocaleNames.UND;
             } else if(!StandardCodes.isLocaleAtLeastBasic(language)) {
                 continue;
             }
@@ -105,7 +94,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
 
         assertContains("regularPlus.containsAll(mainLocales)", regularPlus, localesForNames);
 
-        CoverageLevel2 coverageLeveler = CoverageLevel2.getInstance("und");
+        CoverageLevel2 coverageLeveler = CoverageLevel2.getInstance(LocaleNames.UND);
         Multimap<Level, String> levelToLanguage = TreeMultimap.create();
         for (String locale : valid) {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, locale);
@@ -324,7 +313,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                 String locale = originalLevel;
                 while (true) {
                     String parent = LocaleIDParser.getParent(locale);
-                    if (parent == null || parent.equals("root")) {
+                    if (parent == null || parent.equals(LocaleNames.ROOT)) {
                         break;
                     }
                     if (!parent.equals("en_001")) { // en_001 is generated later from en_GB

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckWidths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckWidths.java
@@ -13,6 +13,7 @@ import org.unicode.cldr.test.CheckWidths.UnitWidthUtil;
 import org.unicode.cldr.unittest.TestXMLSource.DummyXMLSource;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.XMLSource;
 
 public class TestCheckWidths extends TestFmwkPlus {
@@ -26,7 +27,7 @@ public class TestCheckWidths extends TestFmwkPlus {
         final String path = "//ldml/numbers/decimalFormats[@numberSystem=\"latn\"]/decimalFormatLength[@type=\"short\"]/decimalFormat[@type=\"standard\"]/pattern[@type=\"1000\"][@count=\"one\"]";
         final String value = "0 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
         xmlSource.putValueAtDPath(path, value);
-        xmlSource.setLocaleID("und");
+        xmlSource.setLocaleID(LocaleNames.UND);
         CLDRFile cldrFileToCheck = new CLDRFile(xmlSource);
         Options options = new Options();
         List<CheckStatus> possibleErrors = new ArrayList<>();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -20,16 +20,7 @@ import org.unicode.cldr.test.CheckPersonNames;
 import org.unicode.cldr.test.CheckPlaceHolders;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.tool.LikelySubtags;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRTransforms;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.PathStarrer;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.XPathParts;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.FallbackFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Field;
@@ -795,7 +786,7 @@ public class TestPersonNameFormatter extends TestFmwk{
     public void TestCheckSampleNames() {
         String[][] tests = {
             // sample-name-component, error
-            {"zxx", "Error: Illegal name field; zxx is only appropriate for NameOrder locales"},
+            {LocaleNames.ZXX, "Error: Illegal name field; zxx is only appropriate for NameOrder locales"},
             {"Fred", ""},
         };
         List<CheckStatus> results = new ArrayList<>();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -28,31 +28,15 @@ import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.tool.PluralMinimalPairs;
 import org.unicode.cldr.tool.PluralRulesFactory;
-import org.unicode.cldr.util.Builder;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
-import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.Iso639Data.Scope;
-import org.unicode.cldr.util.IsoCurrencyParser;
-import org.unicode.cldr.util.LanguageTagCanonicalizer;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.PluralRanges;
-import org.unicode.cldr.util.PreferredAndAllowedHour;
 import org.unicode.cldr.util.PreferredAndAllowedHour.HourStyle;
-import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.CodeType;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData.Type;
 import org.unicode.cldr.util.SupplementalDataInfo.ContainmentStyle;
@@ -66,7 +50,6 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 import org.unicode.cldr.util.SupplementalDataInfo.SampleList;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
 import com.google.common.base.Joiner;
@@ -322,7 +305,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     public void TestPluralSamples2() {
         PluralRulesFactory prf = PluralRulesFactory.getInstance(SUPPLEMENTAL);
         for (String locale : prf.getLocales()) {
-            if (locale.equals("und")) {
+            if (locale.equals(LocaleNames.UND)) {
                 continue;
             }
             if (locale.equals("pl")) {
@@ -700,7 +683,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         toTest.addAll(SUPPLEMENTAL.getDefaultContentLocales());
         LanguageTagParser ltp = new LanguageTagParser();
         main: for (String locale : toTest) {
-            if (locale.startsWith("und") || locale.equals("root")) {
+            if (locale.startsWith(LocaleNames.UND) || locale.equals("root")) {
                 continue;
             }
             Set<String> s = SUPPLEMENTAL.getEquivalentsForLocale(locale);
@@ -1891,9 +1874,9 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             }
         }
         // add special codes we want to see anyway
-        mainLanguages.add("und");
-        mainLanguages.add("mul");
-        mainLanguages.add("zxx");
+        mainLanguages.add(LocaleNames.UND);
+        mainLanguages.add(LocaleNames.MUL);
+        mainLanguages.add(LocaleNames.ZXX);
 
         if (!mainLanguages.containsAll(surveyToolLanguages)) {
             CoverageLevel2 coverageLevel = CoverageLevel2.getInstance(SUPPLEMENTAL, "ja"); // pick "neutral" locale

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -28,34 +28,14 @@ import java.util.regex.Matcher;
 
 import org.unicode.cldr.test.SubmissionLocales;
 import org.unicode.cldr.tool.ConvertLanguageData.InverseComparator;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.CLDRURLS;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.DelegatingIterator;
-import org.unicode.cldr.util.EscapingUtilities;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.NotificationCategory;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.PathHeader;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.PathHeader.PageId;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.PluralSamples;
-import org.unicode.cldr.util.SpecialLocales;
-import org.unicode.cldr.util.StringId;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
-import org.unicode.cldr.util.VettingViewer;
 import org.unicode.cldr.util.VettingViewer.MissingStatus;
 import org.unicode.cldr.util.VettingViewer.VoteStatus;
-import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.util.VoteResolver.Status;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
-import org.unicode.cldr.util.VoterInfoList;
-import org.unicode.cldr.util.XMLUploader;
 import org.unicode.cldr.util.props.ICUPropertyFactory;
 
 import com.google.common.collect.ImmutableMap;
@@ -905,8 +885,8 @@ public class TestUtilities extends TestFmwkPlus {
         assertSpecialLocale("yue_Hans", null); // not readonly, because it is not policy DISCARD
         assertSpecialLocale("en", SpecialLocales.Type.readonly);
         assertSpecialLocale("en_ZZ_PROGRAMMERESE", null); // not defined
-        assertSpecialLocale("und", null);
-        assertSpecialLocale("mul", SpecialLocales.Type.scratch);
+        assertSpecialLocale(LocaleNames.UND, null);
+        assertSpecialLocale(LocaleNames.MUL, SpecialLocales.Type.scratch);
         assertSpecialLocale("mul_ZZ", SpecialLocales.Type.scratch);
         assertSpecialLocale("und_001", null); // not defined
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -16,17 +16,9 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.LanguageTagCanonicalizer;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.TransliteratorUtilities;
-import org.unicode.cldr.util.Units;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
 import com.google.common.base.Objects;
@@ -51,12 +43,12 @@ public class TestValidity extends TestFmwkPlus {
         Object[][] tests = {
             { LstrType.language, Validity.Status.regular, true, "aa", "en" },
             { LstrType.language, null, false, "eng" }, // null means never found under any status
-            { LstrType.language, null, false, "root" },
-            { LstrType.language, Validity.Status.special, true, "mul" },
+            { LstrType.language, null, false, LocaleNames.ROOT },
+            { LstrType.language, Validity.Status.special, true, LocaleNames.MUL },
             { LstrType.language, Validity.Status.deprecated, true, "aju" },
             { LstrType.language, Validity.Status.reserved, true, "qaa", "qfy" },
             { LstrType.language, Validity.Status.private_use, true, "qfz" },
-            { LstrType.language, Validity.Status.unknown, true, "und" },
+            { LstrType.language, Validity.Status.unknown, true, LocaleNames.UND },
 
             { LstrType.script, Validity.Status.reserved, true, "Qaaa", "Qaap"},
             { LstrType.script, Validity.Status.private_use, true, "Qaaq", "Qabx"},
@@ -127,7 +119,7 @@ public class TestValidity extends TestFmwkPlus {
         "itgo", "itpn", "itts", "itud",
         "SLE"
         );
-    static final Set<String> ALLOWED_MISSING = ImmutableSet.of("root", "POSIX", "REVISED", "SAAHO");
+    static final Set<String> ALLOWED_MISSING = ImmutableSet.of(LocaleNames.ROOT, "POSIX", "REVISED", "SAAHO");
     static final Set<String> ALLOWED_REGULAR_TO_SPECIAL = ImmutableSet.of("Zanb", "Zinh", "Zyyy");
 
     public void TestCompatibility() {
@@ -401,7 +393,7 @@ public class TestValidity extends TestFmwkPlus {
             { "eng-840", "en" },
             { "sh_ba", "sr_Latn_BA" },
             { "iw-arab-010", "he_Arab_AQ" },
-            { "und", "und" },
+            { LocaleNames.UND, LocaleNames.UND },
             { "und_us", "und_US" },
             { "und_su", "und_RU" },
         };

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -23,18 +23,10 @@ import org.apache.jena.query.ResultSet;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.rdf.QueryClient;
 import org.unicode.cldr.rdf.TsvWriter;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.Containment;
-import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.Iso639Data;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.Iso639Data.Type;
-import org.unicode.cldr.util.SimpleXMLSource;
-import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 
 import com.google.common.base.Joiner;
@@ -201,7 +193,7 @@ public class GenerateLanguageContainment {
 	}
 	static final QueryHelper QUERY_HELPER = new QueryHelper();
 
-	static final Function<String, String> NAME = code -> code.equals("mul") ? "root" : ENGLISH.getName(code) + " (" + code + ")";
+	static final Function<String, String> NAME = code -> code.equals(LocaleNames.MUL) ? LocaleNames.ROOT : ENGLISH.getName(code) + " (" + code + ")";
 
 	static final Set<String> COLLECTIONS;
 	static {
@@ -265,10 +257,10 @@ public class GenerateLanguageContainment {
 			.put("ira", "bgn") // Iranian <= Western Balochi
 			.put("inc", "trw") // Indo-Aryan <= Torwali
 			.put("jpx", "ja")
-			.put("mul", "art")
-			.put("mul", "euq")
-			.put("mul", "jpx")
-			.put("mul", "tai")
+			.put(LocaleNames.MUL, "art")
+			.put(LocaleNames.MUL, "euq")
+			.put(LocaleNames.MUL, "jpx")
+			.put(LocaleNames.MUL, "tai")
 			.put("ngb", "sg")
 			.put("roa", "cpf")
 			.put("roa", "cpp")
@@ -296,9 +288,9 @@ public class GenerateLanguageContainment {
 			.put("ine", "gmy")
 			.put("ine", "grc")
 			.put("ine", "trw") // inc [Indic] <= trw [Torwali]
-			.put("mul", "crp")
-			.put("mul", "cpp") // Creoles and pidgins, Portuguese-based
-			.put("mul", "und") // anomaly
+			.put(LocaleNames.MUL, "crp")
+			.put(LocaleNames.MUL, "cpp") // Creoles and pidgins, Portuguese-based
+			.put(LocaleNames.MUL, LocaleNames.UND) // anomaly
 			.put("nic", "kcp") // ssa [Nilo-Saharan] <= kcp [Kanga]
 			.put("nic", "kec") // ssa [Nilo-Saharan] <= kec [Keiga]
 			.put("nic", "kgo") // ssa [Nilo-Saharan] <= kgo [Krongo]
@@ -337,7 +329,7 @@ public class GenerateLanguageContainment {
 		Map<Status, Set<String>> table = Validity.getInstance().getStatusToCodes(LstrType.language);
 		TreeMultimap<String, String> _parentToChild = TreeMultimap.create();
 		TreeSet<String> missing = new TreeSet<>(table.get(Status.regular));
-		_parentToChild.put("mul", "und");
+		_parentToChild.put(LocaleNames.MUL, LocaleNames.UND);
 		Set<String> skipping = new LinkedHashSet<>();
 		for (String code : table.get(Status.regular)) {
 			if (ONLY_LIVING) {
@@ -408,7 +400,7 @@ public class GenerateLanguageContainment {
 		System.out.println("Checking " + "he" + "\t" + Containment.getAllDirected(childToParent, "he"));
 
 		try(PrintWriter w = FileUtilities.openUTF8Writer(TsvWriter.getTsvDir(), "RawLanguageContainment.txt")) {
-			print(w, parentToChild, new ArrayList<>(Arrays.asList("mul")));
+			print(w, parentToChild, new ArrayList<>(Arrays.asList(LocaleNames.MUL)));
 		}
 		SimpleXMLSource xmlSource = new SimpleXMLSource("languageGroup");
 		xmlSource.setNonInheriting(true); // should be gotten from DtdType...
@@ -447,7 +439,7 @@ public class GenerateLanguageContainment {
 	}
 
 	private static void printXML(CLDRFile newFile, Multimap<String, String> parentToChild) {
-		printXML(newFile, parentToChild, "mul");
+		printXML(newFile, parentToChild, LocaleNames.MUL);
 	}
 
 	private static void printXML(CLDRFile newFile, Multimap<String, String> parentToChild, String base) {
@@ -455,7 +447,7 @@ public class GenerateLanguageContainment {
 		if (children.isEmpty()) {
 			return;
 		}
-		if (base.equals("und")) {
+		if (base.equals(LocaleNames.UND)) {
 			// skip, no good info
 		} else {
 			newFile.add("//" + DtdType.supplementalData + "/languageGroups/languageGroup[@parent=\"" + base + "\"]",
@@ -520,7 +512,7 @@ public class GenerateLanguageContainment {
 				}
 			}
 			if (chain.size() > 1) {
-				chain.add("mul"); // root
+				chain.add(LocaleNames.MUL); // root
 				itemsFixed.add(chain);
 			}
 		}
@@ -569,11 +561,11 @@ public class GenerateLanguageContainment {
 		//            chain.add(1,"zhx");
 		//        }
 		//        last = chain.get(chain.size()-1);
-		//        if (!"mul".equals(last)) {
-		//            chain.add("mul"); // make sure we have root.
+		//        if (!LocaleNames.MUL.equals(last)) {
+		//            chain.add(LocaleNames.MUL); // make sure we have root.
 		//        }
 		//        if (chain.size() == 2) {
-		//            chain.add(1,"und");
+		//            chain.add(1,LocaleNames.UND);
 		//        }
 		//        return chain;
 	}


### PR DESCRIPTION
-New class LocaleNames has constants MIS, MUL, ROOT, UND, ZXX

CLDR-15187

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
