### PR TITLE
CLDR-16135 Cleanup for sample names

### DIFF
--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -11353,7 +11353,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="surname-prefix">ван дэн</nameField>
 			<nameField type="surname-core">Вольф</nameField>
 			<nameField type="surname2">Бэкер-Шмідт</nameField>
-			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -11711,7 +11711,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="surname-prefix">φαν ντεν</nameField>
 			<nameField type="surname-core">Δεληγιάννης</nameField>
 			<nameField type="surname2">Δημητρίου Αργυρακάκης</nameField>
-			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9454,16 +9454,16 @@ annotations.
 			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>
 		<sampleName item="foreignG">
-			<nameField type="given">Zendaya</nameField>
+			<nameField type="given">Sinbad</nameField>
 		</sampleName>
 		<sampleName item="foreignGS">
-			<nameField type="given">Irene</nameField>
-			<nameField type="surname">Adler</nameField>
+			<nameField type="given">Käthe</nameField>
+			<nameField type="surname">Müller</nameField>
 		</sampleName>
 		<sampleName item="foreignGGS">
-			<nameField type="given">John</nameField>
+			<nameField type="given">Zäzilia</nameField>
 			<nameField type="given2">Hamish</nameField>
-			<nameField type="surname">Watson</nameField>
+			<nameField type="surname">Stöber</nameField>
 		</sampleName>
 		<sampleName item="foreignFull">
 			<nameField type="prefix">Prof. Dr.</nameField>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -13538,7 +13538,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="surname-prefix">בן</nameField>
 			<nameField type="surname-core">ארי</nameField>
 			<nameField type="surname2">מזרחי</nameField>
-			<nameField type="suffix">Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -11777,7 +11777,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="surname-prefix">ван ден</nameField>
 			<nameField type="surname-core">Вольф</nameField>
 			<nameField type="surname2">Бэкер Шмит</nameField>
-			<nameField type="suffix">Анагаах ухааны доктор, Ph.D</nameField>
+			<nameField type="suffix">Анагаах ухааны доктор</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -9087,7 +9087,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<nameField type="surname-prefix">भान डेन</nameField>
 			<nameField type="surname-core">वाग्ले</nameField>
 			<nameField type="surname2">विकास शर्मा</nameField>
-			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -9079,10 +9079,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<nameField type="given">اډا کورنیلیا</nameField>
 			<nameField type="given-informal">نیلي</nameField>
 			<nameField type="given2">ایوا سوفیا</nameField>
-			<nameField type="surname-prefix">van den</nameField>
 			<nameField type="surname-core">لیوه</nameField>
 			<nameField type="surname2">بیکر شمیت</nameField>
-			<nameField type="suffix">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -11613,7 +11613,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</sampleName>
 		<sampleName item="nativeGGS">
 			<nameField type="given">大文</nameField>
-			<nameField type="given2">John</nameField>
+			<nameField type="given2">明德</nameField>
 			<nameField type="surname">陈</nameField>
 		</sampleName>
 		<sampleName item="foreignFull">

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -203,9 +203,14 @@ public class CheckPlaceHolders extends CheckCLDR {
                 break;
             case surname:
                 // can't have surname2 unless we have surname
-                String modPath = pathParts.cloneAsThawed().setAttribute(-1, "type", Field.surname2.toString()).toString();
+                final XPathParts thawedPathParts = pathParts.cloneAsThawed();
+                String modPath = thawedPathParts.setAttribute(-1, "type", Field.surname2.toString()).toString();
                 String surname2Value = checkAccessor.getStringValue(modPath);
-                if (surname2Value != null && !surname2Value.equals("∅∅∅")) {
+                String modPathcore = thawedPathParts.setAttribute(-1, "type", "surname-core").toString();
+                String surnameCoreValue = checkAccessor.getStringValue(modPathcore);
+                if (surname2Value != null
+                    && !surname2Value.equals("∅∅∅")
+                    && (surnameCoreValue == null || surnameCoreValue.equals("∅∅∅"))) {
                     result.add(new CheckStatus().setCause(checkAccessor)
                         .setMainType(CheckStatus.errorType)
                         .setSubtype(Subtype.invalidPlaceHolder)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -330,10 +330,10 @@ public class TestPersonNameFormatter extends TestFmwk{
         String[][] tests = {
             {
                 "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"long\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
-                "〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Wolf M.D. Ph.D.〗〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia César Martín von Brühl MD DDS〗"
+                "〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Wolf M.D. Ph.D.〗〖Sinbad〗〖Käthe Müller〗〖Zäzilia Hamish Stöber〗〖Ada Cornelia César Martín von Brühl MD DDS〗"
             },{
                 "//ldml/personNames/personName[@order=\"surnameFirst\"][@length=\"long\"][@usage=\"monogram\"][@formality=\"informal\"]/namePattern",
-                "〖Z〗〖AI〗〖WJ〗〖WN〗〖Z〗〖AI〗〖WJ〗〖VN〗"
+                "〖Z〗〖AI〗〖WJ〗〖WN〗〖S〗〖MK〗〖SZ〗〖VN〗"
             },{
                 "//ldml/personNames/nameOrderLocales[@order=\"givenFirst\"]",
                 "〖und = «any other»〗〖en = English〗"
@@ -437,7 +437,7 @@ public class TestPersonNameFormatter extends TestFmwk{
         String value2 = enWritable.getStringValue(path); // check that English is as expected
         assertEquals(path, "{given} {given2} {surname} {suffix}", value2);
 
-        String expected = "〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Wolf M.D. Ph.D.〗〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia César Martín von Brühl MD DDS〗";
+        String expected = "〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Wolf M.D. Ph.D.〗〖Sinbad〗〖Käthe Müller〗〖Zäzilia Hamish Stöber〗〖Ada Cornelia César Martín von Brühl MD DDS〗";
         String value = enWritable.getStringValue(path);
 
         checkExampleGenerator(exampleGenerator, path, value, expected);
@@ -451,7 +451,7 @@ public class TestPersonNameFormatter extends TestFmwk{
         enWritable.add(namePath, "IRENE");
         exampleGenerator.updateCache(namePath);
 
-        String expected2 =  "〖Zendaya〗〖IRENE Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Wolf M.D. Ph.D.〗〖Zendaya〗〖Irene Adler〗〖John Hamish Watson〗〖Ada Cornelia César Martín von Brühl MD DDS〗";
+        String expected2 =  "〖Zendaya〗〖IRENE Adler〗〖John Hamish Watson〗〖Ada Cornelia Eva Sophia Wolf M.D. Ph.D.〗〖Sinbad〗〖Käthe Müller〗〖Zäzilia Hamish Stöber〗〖Ada Cornelia César Martín von Brühl MD DDS〗";
         checkExampleGenerator(exampleGenerator, path, value, expected2);
     }
 


### PR DESCRIPTION
CLDR-16135

This cleans up the last part of the previous PR, and also enables the script check.

There was a small change in CheckPlaceHolders to allow surname2 if either the surname or surname-core is present (since we treat those as equivalent if there is no surname-prefix).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
