### PR TITLE
CLDR-15747 Add ability to add an alt path

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAddAlt.js
+++ b/tools/cldr-apps/js/src/esm/cldrAddAlt.js
@@ -1,0 +1,90 @@
+/*
+ * cldrAddAlt: enable adding an "alt" path
+ */
+import * as cldrAjax from "./cldrAjax.js";
+import * as cldrLoad from "./cldrLoad.js";
+import * as cldrStatus from "./cldrStatus.js";
+
+import AddAlt from "../views/AddAlt.vue";
+
+import { createCldrApp } from "../cldrVueRouter";
+
+import { notification } from "ant-design-vue";
+
+function addButton(containerEl, xpstrid) {
+  try {
+    const fragment = document.createDocumentFragment();
+    const addAltWrapper = createCldrApp(AddAlt).mount(fragment);
+    const vueEl = document.createElement("section");
+    containerEl.appendChild(vueEl);
+    vueEl.replaceWith(fragment);
+    addAltWrapper.setXpathStringId(xpstrid);
+  } catch (e) {
+    console.error("Error loading Add Alt vue " + e.message + " / " + e.name);
+    notification.open({
+      message: `${e.name} while loading AddAlt.vue`,
+      description: `${e.message}`,
+      duration: 0,
+    });
+  }
+}
+
+async function getAlts(xpstrid, callbackFunction) {
+  const localeId = cldrStatus.getCurrentLocale();
+  if (!localeId) {
+    return;
+  }
+  const url = cldrAjax.makeApiUrl(
+    "xpath/alt/" + localeId + "/" + xpstrid,
+    null
+  );
+  return await cldrAjax
+    .doFetch(url)
+    .then(cldrAjax.handleFetchErrors)
+    .then((r) => r.json())
+    .then(callbackFunction)
+    .catch((e) => console.error(e));
+}
+
+async function addChosenAlt(xpstrid, alt, callbackFunction) {
+  const localeId = cldrStatus.getCurrentLocale();
+  if (!localeId) {
+    return;
+  }
+  const url = cldrAjax.makeApiUrl("xpath/alt", null);
+  const init = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      alt: alt,
+      localeId: localeId,
+      hexId: xpstrid,
+    }),
+  };
+  try {
+    const response = await cldrAjax.doFetch(url, init);
+    if (response.ok) {
+      callbackFunction(null);
+    } else {
+      const json = await response.json();
+      const message = json.message || "Unknown server response";
+      throw new Error(message);
+    }
+  } catch (e) {
+    console.error(e);
+    window.alert("Error while adding alt: \n\n" + e);
+    callbackFunction(e);
+  }
+}
+
+/**
+ * Reload the page table so it will include the new row
+ */
+function reloadPage() {
+  cldrLoad.reloadV(); // crude
+}
+
+export { addButton, getAlts, addChosenAlt, reloadPage };

--- a/tools/cldr-apps/js/src/esm/cldrInfo.js
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.js
@@ -645,7 +645,8 @@ function updateRowVoteInfoForAllOrgs(theRow, vr, value, item, vdiv) {
             }
           }
         }
-      } else {
+      }
+      if (!topVoter) {
         // just find someone in the right org..
         for (var voter in item.votes) {
           if (item.votes[voter].org == org) {

--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -7,6 +7,7 @@
  * 		updateRow
  * 		refreshSingleRow
  */
+import * as cldrAddAlt from "./cldrAddAlt.js";
 import * as cldrAjax from "./cldrAjax.js";
 import * as cldrCoverage from "./cldrCoverage.js";
 import * as cldrDom from "./cldrDom.js";
@@ -776,6 +777,9 @@ function updateRowEnglishComparisonCell(tr, theRow, cell) {
     cell.appendChild(infos);
   }
   cldrInfo.listen(null, tr, cell, null);
+  if (cldrStatus.getPermissions()?.userIsTC) {
+    cldrAddAlt.addButton(cell, theRow.xpstrid);
+  }
   cell.isSetup = true;
 }
 

--- a/tools/cldr-apps/js/src/views/AddAlt.vue
+++ b/tools/cldr-apps/js/src/views/AddAlt.vue
@@ -1,0 +1,114 @@
+<template>
+  <section>
+    <button
+      v-if="!altMenu && !success"
+      title="Add an alt path"
+      @click="getMenu"
+    >
+      +alt
+    </button>
+    <div v-if="altMenu && altMenu.length">
+      <label for="chosenAlt">alt=</label>
+      <select
+        id="chosenAlt"
+        name="chosenAlt"
+        v-model="chosenAlt"
+        title="Choose an alt attribute"
+      >
+        <option disabled value="">Please Select</option>
+        <option :key="alt" v-for="alt in altMenu">{{ alt }}</option>
+      </select>
+    </div>
+    <div>
+      <span v-if="chosenAlt">
+        <button title="Add alt path now" @click="reallyAdd">Add</button>
+        &nbsp;
+      </span>
+      <span v-if="chosenAlt || errMessage">
+        <button title="Do not add alt path" @click="reset">Cancel</button>
+      </span>
+    </div>
+    <div v-if="errMessage">
+      {{ errMessage }}
+    </div>
+    <div v-if="success">
+      SUCCESS
+      <button @click="clickLoad">Load</button>
+    </div>
+  </section>
+</template>
+
+<script>
+import * as cldrAddAlt from "../esm/cldrAddAlt.js";
+
+export default {
+  data() {
+    return {
+      xpstrid: null,
+      altMenu: null,
+      chosenAlt: "",
+      errMessage: null,
+      success: false,
+    };
+  },
+
+  methods: {
+    setXpathStringId(xpstrid) {
+      this.xpstrid = xpstrid;
+    },
+
+    getMenu() {
+      if (this.xpstrid) {
+        cldrAddAlt.getAlts(this.xpstrid, this.setAlts /* callback */);
+      }
+    },
+
+    // callback
+    setAlts(json) {
+      this.altMenu = json.alt;
+    },
+
+    reallyAdd() {
+      if (this.xpstrid && this.chosenAlt) {
+        cldrAddAlt.addChosenAlt(
+          this.xpstrid,
+          this.chosenAlt,
+          this.showResult /* callback */
+        );
+      }
+    },
+
+    showResult(errMessage) {
+      this.reset();
+      this.errMessage = errMessage; // null or empty for success
+      if (!errMessage) {
+        this.success = true;
+      }
+    },
+
+    clickLoad() {
+      this.reset();
+      cldrAddAlt.reloadPage();
+    },
+
+    reset() {
+      this.altMenu = null;
+      this.chosenAlt = "";
+      this.errMessage = null;
+      this.success = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+button,
+select {
+  margin-top: 1ex;
+}
+
+section {
+  clear: both;
+  float: right;
+}
+</style>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -261,8 +261,11 @@ public class VoteAPI {
         if (mySession == null) {
             return Auth.noSessionResponse();
         }
-
-        return VoteAPIHelper.handleVote(loc, xpstrid, request, mySession);
+        final String xp = CookieSession.sm.xpt.getByStringID(xpstrid);
+        if (xp == null) {
+            return Response.status(Response.Status.NOT_FOUND).build(); // no XPath found
+        }
+        return VoteAPIHelper.handleVote(loc, xp, request.value, request.voteLevelChanged, mySession, true /* forbiddenIsOk */);
     }
 
     final static public class VoteResponse {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -320,7 +320,15 @@ public class VoteAPIHelper {
         return ro.getNotifications();
     }
 
-    static Response handleVote(String loc, String xpstrid, VoteRequest request, final CookieSession mySession) {
+    // forbiddenIsOk is true when called from VoteAPI for the main, original usage of this method; when true, it means
+    // that even if we get statusAction.isForbidden, we'll return an OK (200) response, with json.didVote false.
+    //
+    // forbiddenIsOk is false when called from XPathAlt for the special purpose of adding a new path, so that
+    // XPathAlt will get something other than OK (200) in case of failure.
+    //
+    // This method needs refactoring into smaller subroutines, with the lower-level details separated from
+    // the HTTP response concerns, so that VoteAPI and XPathAlt can share code without the awkwardness of forbiddenIsOk.
+    static Response handleVote(String loc, String xp, String value, int voteLevelChanged, final CookieSession mySession, boolean forbiddenIsOk) {
         VoteResponse r = new VoteResponse();
         mySession.userDidAction();
         CLDRLocale locale = CLDRLocale.getInstance(loc);
@@ -329,15 +337,11 @@ public class VoteAPIHelper {
         }
         loc = locale.getBaseName(); // sanitized
         final SurveyMain sm = CookieSession.sm;
-        final String xp = sm.xpt.getByStringID(xpstrid);
-        if (xp == null) {
-            return Response.status(Status.NOT_FOUND).build(); // no XPath found
-        }
         CheckCLDR.Options options = DataPage.getOptions(mySession, locale);
         final STFactory stf = sm.getSTFactory();
         synchronized (mySession) {
             try {
-                final String origValue = request.value;
+                final String origValue = value;
                 final Exception[] exceptionList = new Exception[1];
                 final CLDRFile cldrFile = stf.make(loc, true, true);
                 final String val = processValue(locale, xp, exceptionList, origValue, cldrFile);
@@ -357,6 +361,7 @@ public class VoteAPIHelper {
                 if (r.statusAction == null) {
                     r.statusAction = calculateShowRowAction(cldrFile, xp, val, dataRow);
                 }
+
                 if (!r.statusAction.isForbidden()) {
                     CandidateInfo ci = calculateCandidateItem(result, val, dataRow);
                     // Now, recalculate the statusAction for accepting the new item
@@ -366,10 +371,8 @@ public class VoteAPIHelper {
                     if (!r.statusAction.isForbidden()) {
                         try {
                             final BallotBox<UserRegistry.User> ballotBox = stf.ballotBoxForLocale(locale);
-                            if (request.voteLevelChanged == 0) { // treat 0 as null
-                                request.voteLevelChanged = null;
-                            }
-                            ballotBox.voteForValue(mySession.user, xp, val, request.voteLevelChanged);
+                            Integer withVote = (voteLevelChanged == 0) ? null : voteLevelChanged;
+                            ballotBox.voteForValue(mySession.user, xp, val, withVote);
                             r.didVote = true;
                         } catch (VoteNotAcceptedException e) {
                             if (e.getErrCode() == ErrorCode.E_PERMANENT_VOTE_NO_FORUM) {
@@ -384,6 +387,12 @@ public class VoteAPIHelper {
                 SurveyLog.logException(logger, t, "Processing submission " + locale + ":" + xp);
                 return (new STError(t).build());
             }
+        }
+        if (!forbiddenIsOk && r.statusAction.isForbidden()) {
+            return Response
+                .status(Response.Status.NOT_ACCEPTABLE)
+                .entity(new STError("Status action is forbidden: " + r.statusAction))
+                .build();
         }
         return Response.ok(r).build();
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAlt.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAlt.java
@@ -1,0 +1,268 @@
+package org.unicode.cldr.web.api;
+
+import static org.unicode.cldr.web.CookieSession.sm;
+
+import java.util.*;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.unicode.cldr.icu.LDMLConstants;
+import org.unicode.cldr.util.*;
+import org.unicode.cldr.web.CookieSession;
+import org.unicode.cldr.web.UserRegistry;
+
+@Path("/xpath/alt")
+@Tag(name = "xpath", description = "APIs for XPath info")
+public class XPathAlt {
+
+    @GET
+    @Path("/{localeId}/{hexId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Fetch alt values from locale and XPath Hex ID",
+        description = "Looks up the alt values that could be added for a specific XPath Hex ID."
+    )
+    @APIResponses(
+        value = {
+            @APIResponse(
+                responseCode = "404",
+                description = "XPath Hex ID not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = STError.class))
+            ),
+            @APIResponse(
+                responseCode = "200",
+                description = "Array of possible alt values",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = AltSetResponse.class)
+                )
+            ),
+        }
+    )
+    public Response getAltByHex(
+        @Parameter(required = true, example = "aa", schema = @Schema(type = SchemaType.STRING)) @PathParam(
+            "localeId"
+        ) String localeId,
+        @Parameter(
+            required = true,
+            example = "6154e7673c3829ce",
+            schema = @Schema(type = SchemaType.STRING)
+        ) @PathParam("hexId") String hexId
+    ) {
+        CLDRLocale locale = CLDRLocale.getInstance(localeId);
+        if (locale == null) {
+            return badLocale(localeId);
+        }
+        String xpath = getXPathByHex(hexId);
+        if (xpath == null) {
+            return badPath(hexId);
+        }
+        Set<String> set = getSet(locale, xpath);
+        return Response.ok(new AltSetResponse(hexId, set)).build();
+    }
+
+    private String getXPathByHex(String hexId) {
+        String xpath = null;
+        try {
+            xpath = sm.xpt.getByStringID(hexId);
+        } catch (RuntimeException e) {
+            /*
+             * Don't report the exception. This happens when it simply wasn't found.
+             * Possibly getByStringID, or some version of it, should not throw an exception.
+             */
+        }
+        return xpath;
+    }
+
+    @Schema(description = "Response for XPath alt set query")
+    public static final class AltSetResponse {
+
+        @Schema(description = "Hex ID of XPath.")
+        public final String hexId;
+
+        @Schema(description = "Array of possible alt attributes.")
+        public final String[] alt;
+
+        public AltSetResponse(String hexId, Set<String> set) {
+            this.hexId = hexId;
+            this.alt = (set == null) ? new String[0] : set.toArray(new String[0]);
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Add alt path", description = "Create a new alt path in the given locale")
+    @APIResponses(
+        value = {
+            @APIResponse(
+                responseCode = "404",
+                description = "XPath Hex ID not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = STError.class))
+            ),
+            @APIResponse(
+                responseCode = "200",
+                description = "Alt path was added",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = AddAltPathRequest.class)
+                )
+            ),
+        }
+    )
+    public Response putByHex(@HeaderParam(Auth.SESSION_HEADER) String sessionString, AddAltPathRequest request) {
+        CookieSession session;
+        try {
+            session = Auth.getSession(sessionString);
+            if (session == null) {
+                return Auth.noSessionResponse();
+            }
+            if (!UserRegistry.userIsTC(session.user)) {
+                return Response.status(403, "Forbidden").build();
+            }
+            session.userDidAction();
+        } catch (Exception e) {
+            return Response.status(500, "An exception occurred").entity(e).build();
+        }
+        CLDRLocale locale = CLDRLocale.getInstance(request.localeId);
+        if (locale == null) {
+            return badLocale(request.localeId);
+        }
+        String xpath = getXPathByHex(request.hexId);
+        if (xpath == null) {
+            return badPath(request.hexId);
+        }
+        Set<String> set = getSet(locale, xpath);
+        if (set == null || !set.contains(request.alt)) {
+            return noAlt(request.hexId, request.alt);
+        }
+        return addPath(locale, xpath, request.alt, session);
+    }
+
+    private Response addPath(CLDRLocale locale, String xpath, String alt, CookieSession session) {
+        CLDRFile cldrFile = getFile(locale);
+        if (cldrFile == null) {
+            return badFile(locale);
+        }
+        try {
+            XPathParts xpp = XPathParts.getFrozenInstance(xpath).cloneAsThawed();
+            xpp.addAttribute(LDMLConstants.ALT, alt);
+            String newXpath = xpp.toString();
+            if (cldrFile.isHere(newXpath)) { // compare STFactory.getPathsForFile()
+                return alreadyExists(newXpath);
+            }
+            String newValue = "?"; // should be CldrUtility.INHERITANCE_MARKER, but that can give StatusAction.FORBID_NULL
+            Response r = VoteAPIHelper.handleVote(
+                locale.getBaseName(),
+                newXpath,
+                newValue,
+                1/* one vote */,
+                session,
+                false/* forbiddenIsOk */
+            );
+            int status = r.getStatus();
+            if (status != 200) {
+                return badHandleVote(newXpath, status);
+            }
+        } catch (Exception e) {
+            return Response.status(500, "An exception occurred").entity(e).build();
+        }
+        return Response.ok().build();
+    }
+
+    public static class AddAltPathRequest {
+
+        @Schema(description = "Locale ID")
+        public String localeId;
+
+        @Schema(description = "XPath Hex ID")
+        public String hexId;
+
+        @Schema(description = "New alt value")
+        public String alt;
+    }
+
+    private Set<String> getSet(CLDRLocale locale, String xpath) {
+        DtdData dtdData = DtdData.getInstance(DtdType.fromPath(xpath), CLDRConfig.getInstance().getCldrBaseDirectory());
+        XPathParts xpp = XPathParts.getFrozenInstance(xpath);
+        String el = xpp.getElement(-1);
+        DtdData.Element element = dtdData.getElementFromName().get(el);
+        DtdData.Attribute attribute = element.getAttributeNamed(LDMLConstants.ALT);
+        Set<String> set = (attribute == null) ? null : attribute.getMatchLiterals();
+        if (set != null && !set.isEmpty()) {
+            set = removePathsAlreadyPresent(set, locale, xpath);
+        }
+        return set;
+    }
+
+    private Set<String> removePathsAlreadyPresent(Set<String> origSet, CLDRLocale locale, String origXpath) {
+        CLDRFile cldrFile = getFile(locale);
+        if (cldrFile == null) {
+            return null;
+        }
+        Set<String> set = new TreeSet<>();
+        for (String alt : origSet) {
+            XPathParts xpp = XPathParts.getFrozenInstance(origXpath).cloneAsThawed();
+            xpp.addAttribute(LDMLConstants.ALT, alt);
+            String newXpath = xpp.toString();
+            if (!cldrFile.isHere(newXpath)) { // compare STFactory.getPathsForFile()
+                set.add(alt);
+            }
+        }
+        return set;
+    }
+
+    private CLDRFile getFile(CLDRLocale locale) {
+        return sm.getSTFactory().make(locale.getBaseName(), true);
+    }
+
+    private Response badLocale(String localeId) {
+        return Response
+            .status(Response.Status.NOT_FOUND)
+            .entity(new STError("Locale ID " + localeId + " not found"))
+            .build();
+    }
+
+    private Response badPath(String hexId) {
+        return Response
+            .status(Response.Status.NOT_FOUND)
+            .entity(new STError("XPath Hex ID " + hexId + " not found"))
+            .build();
+    }
+
+    private Response noAlt(String hexId, String alt) {
+        return Response
+            .status(Response.Status.NOT_FOUND)
+            .entity(new STError("XPath Hex ID " + hexId + " alt value " + alt + " not found"))
+            .build();
+    }
+
+    private Response badFile(CLDRLocale locale) {
+        return Response
+            .status(Response.Status.NOT_FOUND)
+            .entity(new STError("Cannot add alt path: null CLDRFile for locale " + locale.getBaseName()))
+            .build();
+    }
+
+    private Response alreadyExists(String newXpath) {
+        return Response
+            .status(Response.Status.NOT_ACCEPTABLE)
+            .entity(new STError("Alt path already exists: " + newXpath))
+            .build();
+    }
+
+    private Response badHandleVote(String newXpath, int status) {
+        return Response
+            .status(status)
+            .entity(new STError("Cannot add alt path: handleVote failed for " + newXpath))
+            .build();
+    }
+}


### PR DESCRIPTION
-New cldrAddAlt.js, AddAlt.vue, XPathAlt.java

-Call cldrAddAlt from cldrTable for the comparison cell, only if TC

-New api/xpath/alt/localeId/hexId GET gets array of alt attribute values for specified xpath

-New api/xpath/alt POST adds new alt attribute value for specified xpath

-Revise VoteAPIHelper.handleVote so it can also be called from XPathAlt

-New STFactory.PerLocaleData.makeSureInPathsForFile

-Fix bug in cldrInfo.js, try harder to get topVoter

-Comments

CLDR-15747

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
