### PR TITLE
CLDR-16140 re-enable non-grammar locales, limited data driven-test

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -68,6 +68,11 @@ public final class SubmissionLocales {
      */
     public static final Set<String> TC_ORG_LOCALES;
 
+    /**
+     * Set to true iff ONLY grammar locales should be limited submission
+     * {@link GrammarInfo#getGrammarLocales()}
+     */
+    public static final boolean ONLY_GRAMMAR_LOCALES = false;
 
     /**
      * Update this in each limited release.
@@ -75,12 +80,14 @@ public final class SubmissionLocales {
     public static final Set<String> LOCALES_FOR_LIMITED;
     static {
         Set<String> temp = new HashSet<>(CLDR_OR_HIGH_LEVEL_LOCALES);
-        temp.retainAll(GrammarInfo.getGrammarLocales());
+        if (ONLY_GRAMMAR_LOCALES) {
+            temp.retainAll(GrammarInfo.getGrammarLocales());
+        }
         LOCALES_FOR_LIMITED = ImmutableSortedSet.copyOf(temp);
 
         Set<String> temp2 = new HashSet<>(CLDR_LOCALES);
         temp2.removeAll(SPECIAL_ORG_LOCALES);
-        TC_ORG_LOCALES = ImmutableSortedSet.copyOf(temp);
+        TC_ORG_LOCALES = ImmutableSortedSet.copyOf(temp2);
     }
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
@@ -1,0 +1,47 @@
+package org.unicode.cldr.test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvFileSource;
+
+public class TestSubmissionLocales {
+    @ParameterizedTest
+    @CsvFileSource(resources = "/org/unicode/cldr/test/TestSubmissionLocales.csv", numLinesToSkip = 1)
+    // Note: the header line is skipped, need to manually verify that the arguments
+    // are in sync w/ the CSV
+    void TestSubmissionDataDriven(String allowed, String locale,
+        String error, String missing, String xpath) {
+        assumeTrue(CheckCLDR.LIMITED_SUBMISSION, () -> "Skipping if not LIMITED_SUBMISSION");
+        assumeFalse(allowed.charAt(0) == '#'); // skip 'comment' lines
+        final boolean isAllowed = allowed.equals("allowed");
+        final boolean isError = error.equals("error");
+        final boolean isMissing = missing.equals("missing");
+        assertEquals(isAllowed, SubmissionLocales.allowEvenIfLimited(locale, xpath, isError, isMissing),
+            () -> String.format("%s %s:%s", allowed, locale, xpath));
+    }
+
+    @Test
+    void TestSubmissionLocale() {
+        assumeTrue(CheckCLDR.LIMITED_SUBMISSION, () -> "Skipping if not LIMITED_SUBMISSION");
+        assertAll("zh assertions",
+            ()->assertTrue(SubmissionLocales.CLDR_LOCALES.contains("zh"), "Expected zh to be a CLDR_LOCALE"),
+            ()->assertTrue(SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES.contains("zh"), "Expected zh to be a CLDR_OR_HIGH_LEVEL_LOCALE"),
+            ()->assertTrue(SubmissionLocales.TC_ORG_LOCALES.contains("zh"), "Expected zh to be TC_ORG_LOCALES"),
+            ()->assertFalse(SubmissionLocales.ALLOW_ALL_PATHS_BASIC.contains("zh"), "Expected zh to NOT be ALLOW_ALL_PATHS_BASIC"),
+            ()->assertTrue(SubmissionLocales.LOCALES_FOR_LIMITED.contains("zh"), "Expected zh to be LOCALES_FOR_LIMITED"),
+            ()->assertTrue(SubmissionLocales.LOCALES_ALLOWED_IN_LIMITED.contains("zh"), "Expected zh to be LOCALES_ALLOWED_IN_LIMITED"),
+            ()->assertTrue(SubmissionLocales.LOCALES_FOR_LIMITED.contains("zh"), "Expected zh to be LOCALES_FOR_LIMITED")
+        );
+    }
+
+    static public final boolean bool(final String s) {
+        return Boolean.parseBoolean(s);
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -987,31 +987,6 @@ public class TestCheckCLDR extends TestFmwk {
         }
     }
 
-    /**
-     * These are paths that are allowed if missing (from allowed locales)
-     * Needs to be changed for each Limited Submission cycle. Is ignored for full submission cycles.
-     */
-    final Set<String> sampleNewPaths = ImmutableSet.of(
-//        "//ldml/annotations/annotation[@cp=\\\"🐻‍❄\\\"][@type=\\\"tts\\\"]",
-//        "//ldml/annotations/annotation[@cp=\\\"√\\\"][@type=\\\"tts\\\"]",
-//        "//ldml/units/unitLength[@type=\\\"short\\\"]/compoundUnit[@type=\\\"10p-1\\\"]/unitPrefixPattern",
-//        "//ldml/localeDisplayNames/languages/language[@type=\\\"fa_AF\\\"]",
-//        "//ldml/units/unitLength[@type=\\\"long\\\"]/compoundUnit[@type=\\\"power2\\\"]/compoundUnitPattern1"
-        );
-
-    /**
-     * These are paths that are allowed whether missing or not (from allowed locales)
-     * Needs to be changed for each Limited Submission cycle. Is ignored for full submission cycles.
-     */
-    final Set<String> SAMPLE_EXCEPTIONAL_PATHS = ImmutableSet.of(
-        "//ldml/personNames/nameOrderLocales[@order=\"givenFirst\"]",
-        "//ldml/personNames/nameOrderLocales[@order=\"surnameFirst\"]",
-        "//ldml/localeDisplayNames/territories/territory[@type=\"TR\"]",
-        "//ldml/localeDisplayNames/territories/territory[@type=\"TR\"][@alt=\"variant\"]"
-        );
-
-    final String sampleDisallowedInLimitedSubmission = "//ldml/localeDisplayNames/territories/territory[@type=\"SY\"]";
-
     final String UNIT_PATH = "//ldml/units/unitLength[@type=\"long\"]";
 
     enum LimitedStatus {
@@ -1032,28 +1007,12 @@ public class TestCheckCLDR extends TestFmwk {
             return;
         }
 
-        for (String path : sampleNewPaths) {
-            assertTrue(path,  SubmissionLocales.allowEvenIfLimited("fr", path, false, true));
-        }
-
-        for (String path : SAMPLE_EXCEPTIONAL_PATHS) {
-            assertTrue(path,  SubmissionLocales.allowEvenIfLimited("fr", path, false, false));
-        }
-
-        assertFalse(sampleDisallowedInLimitedSubmission,
-            SubmissionLocales.allowEvenIfLimited("fr", sampleDisallowedInLimitedSubmission, false, false));
-
-        // test non-cldr locale
-
-        for (String path : sampleNewPaths) {
-            assertFalse(path,  SubmissionLocales.allowEvenIfLimited("xx", path, false, true));
-        }
-        for (String path : SAMPLE_EXCEPTIONAL_PATHS) {
-            assertFalse(path,  SubmissionLocales.allowEvenIfLimited("xx", path, false, false));
-        }
-
-        // TODO enhance to check more conditions
-        // like old:         assertFalse("vo, !engSame, !isError, !isMissing", SubmissionLocales.allowEvenIfLimited("vo", pathNotSameValue, false, false));
+        /**
+         * Note:  Constants moved from here to data driven test.
+         * 
+         * see org.unicode.cldr.test.TestSubmissionLocales
+         *                       and TestSubmissionLocales.csv
+         */
 
         if (SHOW_LIMITED) {
             System.out.println();

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/test/TestSubmissionLocales.csv
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/test/TestSubmissionLocales.csv
@@ -1,0 +1,23 @@
+allowed,locale,error,missing,xpath
+#,#,#,#,#
+#,#,#,#,See TestSubmissionLocales.java
+#,#,#,#,#
+allowed,fr,-,-,//ldml/personNames/nameOrderLocales[@order="givenFirst"]
+allowed,fr,-,-,//ldml/personNames/nameOrderLocales[@order="surnameFirst"]
+-,mt,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"]
+-,mt,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"][@alt="variant"]
+allowed,fr,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"]
+allowed,fr,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"][@alt="variant"]
+-,fr,-,-,//ldml/units/unitLength[@type="long"]
+allowed,fr,error,-,//ldml/units/unitLength[@type="long"]
+allowed,fr,-,missing,//ldml/units/unitLength[@type="long"]
+allowed,fr,error,missing,//ldml/units/unitLength[@type="long"]
+-,xx,-,-,//ldml/localeDisplayNames/territories/territory[@type="SY"]
+-,xx,-,-,//ldml/personNames/nameOrderLocales[@order="givenFirst"]
+-,xx,-,-,//ldml/personNames/nameOrderLocales[@order="surnameFirst"]
+-,xx,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"]
+-,xx,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"][@alt="variant"]
+-,xx,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"]
+-,xx,-,-,//ldml/localeDisplayNames/territories/territory[@type="TR"][@alt="variant"]
+allowed,fr,-,-,//ldml/personNames/sampleName[@item="nativeFull"]/nameField[@type="credentials"]
+allowed,zh,-,-,//ldml/personNames/sampleName[@item="nativeFull"]/nameField[@type="credentials"]


### PR DESCRIPTION
CLDR-16140

- re-enable non-grammar locales (`zh`, `ja`)
- add .csv-driven test for submission locales

- [x] This PR completes the ticket.