### PR TITLE
CLDR-16159 Report for person names

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.tool;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -8,6 +9,7 @@ import org.unicode.cldr.tool.FormattedFileWriter.Anchors;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRURLS;
+import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 import com.ibm.icu.text.ListFormatter;
@@ -45,6 +47,10 @@ public abstract class Chart {
         + (testFile == null ? "" : ", and for test data, access "  + dataFileLink(testFile))
         + ".</p>\n";
     }
+
+    static final String surveyUrl = CLDRConfig.getInstance().getProperty("CLDR_SURVEY_URL",
+        "http://st.unicode.org/cldr-apps/survey");
+
 
     private static String dataFileLink(String dataFile) {
         return "<a href='" + GITHUB_ROOT + dataFile + "' target='" + dataFile  + "'>" + dataFile + "</a>";
@@ -95,7 +101,18 @@ public abstract class Chart {
      * @param pw
      * @throws IOException
      */
-    public abstract void writeContents(FormattedFileWriter pw) throws IOException;
+    public void writeContents(FormattedFileWriter pw) throws IOException {
+        writeContents(pw.getStringWriter());
+    }
+
+    /**
+     * Work
+     * @param pw
+     * @throws IOException
+     */
+    public void writeContents(Writer pw) throws IOException {
+       throw new IllegalArgumentException();
+    }
 
     public void writeFooter(FormattedFileWriter pw) throws IOException {
         standardFooter(pw, AnalyticsID.CLDR);
@@ -145,5 +162,10 @@ public abstract class Chart {
             throw new IllegalArgumentException("Can't make TSV directory from " + targetDir);
         }
         return target;
+    }
+
+    public String getFixLinkFromPath(CLDRFile cldrFile, String path) {
+        String result = PathHeader.getLinkedView(surveyUrl, cldrFile, path);
+        return result == null ? "" : result;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
@@ -1,0 +1,129 @@
+package org.unicode.cldr.tool;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Map;
+
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.personname.PersonNameFormatter;
+import org.unicode.cldr.util.personname.PersonNameFormatter.FormatParameters;
+import org.unicode.cldr.util.personname.PersonNameFormatter.Order;
+import org.unicode.cldr.util.personname.PersonNameFormatter.SampleType;
+import org.unicode.cldr.util.personname.PersonNameFormatter.Usage;
+import org.unicode.cldr.util.personname.SimpleNameObject;
+
+public class ChartPersonName extends Chart {
+    private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
+    static final Factory FACTORY = CLDR_CONFIG.getCldrFactory();
+    static final CLDRFile ENGLISH = CLDR_CONFIG.getEnglish();
+    static final String DIR = CLDRPaths.CHART_DIRECTORY + "personNames/";
+    static final Map<SampleType, SimpleNameObject> ENGLISH_NAMES = PersonNameFormatter.loadSampleNames(ENGLISH);
+
+
+    private final String locale;
+
+    public ChartPersonName(String locale) {
+        super();
+        this.locale = locale;
+    }
+
+    public static void main(String[] args) throws IOException {
+        // Just for simple checking; will remove
+        try (Writer writer = new OutputStreamWriter(System.out)) {
+            writer.write("<html><body>");
+            new ChartPersonName("en").writeContents(writer);
+            writer.write("</body></html>");
+            writer.flush();
+        }
+    }
+
+    @Override
+    public String getDirectory() {
+        return DIR;
+    }
+
+    @Override
+    public String getTitle() {
+        return ENGLISH.getName(locale) + ": Person Names";
+    }
+
+    @Override
+    public String getExplanation() {
+        return
+            "<p>This chart shows the different ways that the sample native names and sample foreign names would be formatted.</p>"
+            ;
+    }
+
+
+    @Override
+    public String getFileName() {
+        return locale;
+    }
+
+    enum Filter {Main, Sorting, Monogram}
+    enum Source {NativeSamples, ForeignSamples}
+
+    @Override
+    public void writeContents(Writer pw) throws IOException {
+        CLDRFile cldrFile = FACTORY.make(locale, true);
+        Map<SampleType, SimpleNameObject> names = PersonNameFormatter.loadSampleNames(cldrFile);
+        if (names.isEmpty()) {
+            return;
+        }
+        PersonNameFormatter formatter = new PersonNameFormatter(cldrFile);
+
+        for (Source source : Source.values()) {
+            for (Filter filter : Filter.values()) {
+                TablePrinter tablePrinter = new TablePrinter()
+                    .addColumn("Order", "class='source'", null, "class='source'", true)
+                    .addColumn("Length", "class='source'", null, "class='source'", true)
+                    .addColumn("Usage", "class='source'", null, "class='source'", true)
+                    .addColumn("Formality", "class='source'", null, "class='source'", true);
+
+                for (SampleType sampleType : SampleType.ALL) {
+                    if (sampleType.isNative() == (source == Source.NativeSamples)) {
+                        tablePrinter.addColumn(sampleType.toString(), "class='target'", null, "class='target'", true);
+                    }
+                }
+                tablePrinter.addColumn("view", "class='source'", null, "class='source'", true);
+
+                for (FormatParameters parameters : FormatParameters.allCldr()) {
+                    if ((filter == Filter.Monogram) != (parameters.getUsage() == Usage.monogram)) {
+                        continue;
+                    } else if ((filter == Filter.Sorting) != (parameters.getOrder() == Order.sorting)) {
+                        continue;
+                    }
+                    tablePrinter
+                    .addRow()
+                    .addCell(parameters.getOrder())
+                    .addCell(parameters.getLength())
+                    .addCell(parameters.getUsage())
+                    .addCell(parameters.getFormality());
+
+                    for (SampleType sampleType : SampleType.ALL) {
+                        if (sampleType.isNative() == (source == Source.NativeSamples)) {
+                            final SimpleNameObject nameObject = names.get(sampleType);
+                            tablePrinter.addCell(nameObject == null
+                                ? "<i>missing</i>"
+                                    : formatter.format(nameObject, parameters));
+                        }
+                    }
+                    String path = "//ldml/personNames/personName[@order=\"" + parameters.getOrder()
+                        + "\"][@length=\"" + parameters.getLength()
+                        + "\"][@usage=\"" + parameters.getUsage()
+                        + "\"][@formality=\"" + parameters.getFormality()
+                        + "\"]/namePattern";
+                    tablePrinter.addCell(getFixLinkFromPath(cldrFile, path));
+                    tablePrinter.finishRow();
+                }
+                pw.write("\n<h2>" + source + ": " + filter + "</h2>\n");
+                pw.write(tablePrinter.toTable());
+                tablePrinter.clearRows();
+            }
+        }
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonNames.java
@@ -1,0 +1,70 @@
+package org.unicode.cldr.tool;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.unicode.cldr.tool.FormattedFileWriter.Anchors;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.FileCopier;
+
+public class ChartPersonNames extends Chart {
+
+    private static final Factory CLDR_FACTORY = CLDRConfig.getInstance().getCldrFactory();
+    static final String MAIN_HEADER = "<p>These charts shows the sample person names for different locales, formatted according to the locale's pattern.</p>";
+    private static final boolean DEBUG = false;
+    static final String DIR = CLDRPaths.CHART_DIRECTORY + "personNames/";
+
+    public static void main(String[] args) {
+        new ChartPersonNames().writeChart(null);
+    }
+
+    @Override
+    public String getDirectory() {
+        return DIR;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Person Name Charts";
+    }
+
+    @Override
+    public String getFileName() {
+        return "index";
+    }
+
+    @Override
+    public String getExplanation() {
+        return MAIN_HEADER;
+    }
+
+    @Override
+    public void writeContents(FormattedFileWriter pw) throws IOException {
+        FileCopier.ensureDirectoryExists(DIR);
+        FileCopier.copy(Chart.class, "index.css", DIR);
+        FormattedFileWriter.copyIncludeHtmls(DIR);
+
+        FormattedFileWriter.Anchors anchors = new FormattedFileWriter.Anchors();
+        writeSubcharts(anchors);
+        pw.setIndex("Main Chart Index", "../index.html");
+        pw.write(anchors.toString());
+    }
+
+    public void writeSubcharts(Anchors anchors) throws IOException {
+        Set<String> locales = CLDR_FACTORY.getAvailable();
+        for (String locale : locales) {
+            if (locale.equals("root")) {
+                continue;
+            }
+            CLDRFile cldrFile = CLDR_FACTORY.make(locale, false);
+            String nameOrderGivenFirst = cldrFile.getStringValue("//ldml/personNames/nameOrderLocales[@order=\"givenFirst\"]");
+            if (nameOrderGivenFirst == null) {
+                continue;
+            }
+            new ChartPersonName(locale).writeChart(anchors);
+        }
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
@@ -104,6 +104,10 @@ public class FormattedFileWriter extends java.io.Writer {
 
     private StringWriter out = new StringWriter();
 
+    protected StringWriter getStringWriter() {
+        return out;
+    }
+
     public FormattedFileWriter(String baseFileName, String title, String explanation, Anchors anchors)
         throws IOException {
         // we set up a bunch of variables, but we won't actually use them unless there is generate content. See close()

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/index.css
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/index.css
@@ -9,7 +9,8 @@ caption {
 
 td, th {
 	vertical-align: top;
-	text-align: left
+	text-align: left;
+	padding: 0.25em
 }
 
 td.source, th.source, span.source {


### PR DESCRIPTION
CLDR-16159

Note: This won't be complete until it is wired up to the Survey Tool. It uses the current Chart infrastructure, so it also adds charts for all the languages with person names. See https://github.com/unicode-org/cldr-staging/tree/main/docs/charts/43/personNames for those results.

It is separated into two main files to make the logic easier to see, and to allow calling ChartPersonName.java independently, eg from the ST back end. There is a little stub to show how this can be done in the main(), but there will probably be some other changes necessary.

There are some small changes to Chart.java and FormattedFileWriter.java, and to the index.css (to fix padding). 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
