### PR TITLE
CLDR-15826 Fix PersonName Check warnings and errors

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAccessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAccessor.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.test;
 
+import org.unicode.cldr.test.CheckCLDR.Phase;
+
 /**
  * Special interface for testing; allows test cases to avoid setting up a fake CLDR file.
  */
@@ -8,4 +10,5 @@ public interface CheckAccessor {
     public String getUnresolvedStringValue(String path);
     public String getLocaleID();
     public CheckCLDR getCause();
+    public Phase getPhase();
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
@@ -9,10 +9,19 @@ package org.unicode.cldr.test;
 import java.util.List;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.InternalCldrException;
+import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.SpecialLocales;
+import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
+import org.unicode.cldr.util.ValuePathStatus;
+import org.unicode.cldr.util.XMLSource;
 
 /**
  * Checks locale data for coverage.<br>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -77,7 +77,8 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         "/inText",
         "/orientation",
         "/symbol[@alt=\"narrow\"]",
-        "/characters/parseLenients"
+        "/characters/parseLenients",
+        "/nameOrderLocales"
     };
 
     static String[] DATE_PARTS = {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -6,39 +6,21 @@ import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Type;
 import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.XPathParts;
+import org.unicode.cldr.util.personname.PersonNameFormatter;
+import org.unicode.cldr.util.personname.PersonNameFormatter.Optionality;
 import org.unicode.cldr.util.personname.PersonNameFormatter.SampleType;
 
-import com.google.common.collect.ImmutableMultimap;
 import com.ibm.icu.text.UnicodeSet;
 
 public class CheckPersonNames extends CheckCLDR {
 
-    static final String MISSING = "∅∅∅";
-    /**
-     * @internal, public for testing
-     */
-    public static final ImmutableMultimap<SampleType, String> REQUIRED = ImmutableMultimap.<SampleType, String> builder()
-        .putAll(SampleType.nativeG, "given")
-        .putAll(SampleType.nativeGS, "given", "surname")
-        .putAll(SampleType.nativeGGS, "given", "surname")
-        .putAll(SampleType.nativeFull, "given", "surname")
-        .putAll(SampleType.foreignG, "given")
-        .putAll(SampleType.foreignGS, "given", "surname")
-        .putAll(SampleType.foreignGGS, "given", "given2", "surname")
-        .putAll(SampleType.foreignFull, "prefix", "given", "given-informal", "given2", "surname", "surname2", "suffix")
-        .build();
-    /**
-     * @internal, public for testing
-     */
-    public static final ImmutableMultimap<SampleType, String> REQUIRED_EMPTY = ImmutableMultimap.<SampleType, String> builder()
-        .putAll(SampleType.nativeG, "prefix", "given-informal", "given2", "surname", "surname-prefix", "surname-core", "surname2", "suffix")
-        .putAll(SampleType.nativeGS, "prefix", "given2", "surname-prefix", "surname-core", "surname2", "suffix")
-        .putAll(SampleType.foreignG, "prefix", "given-informal", "given2", "surname", "surname-prefix", "surname-core", "surname2", "suffix")
-        .putAll(SampleType.foreignGS, "prefix", "given2", "surname-prefix", "surname-core", "surname2", "suffix")
-        .build();
-
+    static final String MISSING = CldrUtility.NO_INHERITANCE_MARKER;
     boolean isRoot = false;
+    boolean hasRootParent = false;
+
     UnicodeSet allowedCharacters;
 
     static final UnicodeSet BASE_ALLOWED = new UnicodeSet("[\\p{sc=Common}\\p{sc=Inherited}]").freeze();
@@ -51,6 +33,7 @@ public class CheckPersonNames extends CheckCLDR {
     public CheckCLDR setCldrFileToCheck(CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         String localeId = cldrFileToCheck.getLocaleID();
         isRoot = localeId.equals("root");
+        hasRootParent = "root".equals(LocaleIDParser.getParent(localeId));
 
         // other characters are caught by CheckForExemplars
         String script = new LikelySubtags().getLikelyScript(localeId);
@@ -77,12 +60,15 @@ public class CheckPersonNames extends CheckCLDR {
     @Override
     public CheckCLDR handleCheck(String path, String fullPath, String value, Options options,
         List<CheckStatus> result) {
-        if (value == null || isRoot || !path.startsWith("//ldml/personNames/")) {
+        if (value == null
+            || isRoot
+            || !path.startsWith("//ldml/personNames/")) {
             return this;
         }
 
         XPathParts parts = XPathParts.getFrozenInstance(path);
         String category = parts.getElement(2);
+
         if (category.equals("sampleName")) {
             if (!allowedCharacters.containsAll(value)) {
                 UnicodeSet bad = new UnicodeSet().addAll(value).removeAll(allowedCharacters);
@@ -90,32 +76,40 @@ public class CheckPersonNames extends CheckCLDR {
                     .setMainType(CheckStatus.errorType)
                     .setSubtype(Subtype.badSamplePersonName)
                     .setMessage("Illegal characters in sample name: " + bad.toPattern(false)));
-            } else {
-                Type status = CheckStatus.warningType;
+            } else if (getCldrFileToCheck().getUnresolved().getStringValue(path) != null) {
+
+                // (Above) We only check for an error if there is a value in the UNresolved file.
+                // That is, we don't want MISSING that is inherited from root to cause an error, unless it is explicitly inherited
+
+                // We also check that
+                // - if there is a surname2, there must be either a surname or surname.core
+
                 String message = null;
-                SampleType item = SampleType.valueOf(parts.getAttributeValue(2, "item"));
+                SampleType sampleType = SampleType.valueOf(parts.getAttributeValue(2, "item"));
                 String modifiedField = parts.getAttributeValue(3, "type");
-                boolean isMissing = value.equals(MISSING);
-                if (isMissing) {
-                    if (REQUIRED.get(item).contains(modifiedField)) {
+                boolean isMissingInUnresolved = value.equals(MISSING) || hasRootParent && value.equals(CldrUtility.INHERITANCE_MARKER);
+
+                final Optionality optionality = sampleType.getOptionality(modifiedField);
+                if (isMissingInUnresolved) {
+                    if (optionality == Optionality.required) {
                         message = "This value must not be empty (" + MISSING + ")";
-                    } else if (modifiedField.equals("surname")) {
-                        String surname2 = getCldrFileToCheck().getStringValue(path.replace("surname", "surname2"));
-                        if (!surname2.equals(MISSING)) {
-                            message = "The value for 'surname' must not be empty (" + MISSING + ") unless 'surname2' is.";
-                        }
                     }
                 } else { // not missing, so...
-                    status = CheckStatus.errorType;
-                    if (REQUIRED_EMPTY.get(item).contains(modifiedField)) {
+                    if (optionality == Optionality.disallowed) {
                         message = "This value must be empty (" + MISSING + ")";
-                    } else if (modifiedField.equals("multiword") && !value.contains(" ")) {
-                        message = "All multiword fields must have 2 (or more) words separated by spaces";
+                    } else if (modifiedField.equals("surname2")) {
+                        String surname = getCldrFileToCheck().getStringValue(path).replace("surname2", "surname");
+                        String surnameCore = getCldrFileToCheck().getStringValue(path).replace("surname2", "surname-core");
+                        if (surname.equals(MISSING) && surnameCore.equals(MISSING)) {
+                            message = "The value for '" + modifiedField + "' must not be empty (" + MISSING + ") unless 'surname2' is.";
+                        }
                     }
                 }
                 if (message != null) {
+                    getPhase();
+                    final Type mainType = getPhase() != Phase.BUILD ? CheckStatus.errorType : CheckStatus.warningType; // we need to be able to check this in without error
                     result.add(new CheckStatus().setCause(this)
-                        .setMainType(status)
+                        .setMainType(mainType)
                         .setSubtype(Subtype.badSamplePersonName)
                         .setMessage(message));
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -14,7 +14,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Type;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.Pair;
+import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Field;
 import org.unicode.cldr.util.personname.PersonNameFormatter.FormatParameters;
@@ -176,9 +182,10 @@ public class CheckPlaceHolders extends CheckCLDR {
         Set<Modifier> modifiers = fieldType.getModifiers();
         Output<String> errorMessage = new Output<>();
         Modifier.getCleanSet(modifiers, errorMessage);
+        final Type mainType = checkAccessor.getPhase() != Phase.BUILD ? CheckStatus.errorType : CheckStatus.warningType;
         if (errorMessage.value != null) {
             result.add(new CheckStatus().setCause(checkAccessor)
-                .setMainType(CheckStatus.warningType)
+                .setMainType(mainType)
                 .setSubtype(Subtype.invalidPlaceHolder)
                 .setMessage(errorMessage.value));
             return;
@@ -192,9 +199,9 @@ public class CheckPlaceHolders extends CheckCLDR {
                 // we must have a given
                 if (fieldType.getModifiers().isEmpty()) {
                     result.add(new CheckStatus().setCause(checkAccessor)
-                        .setMainType(CheckStatus.warningType)
+                        .setMainType(mainType)
                         .setSubtype(Subtype.invalidPlaceHolder)
-                        .setMessage("Names must have a value for the ‘given‘ field. Mononyms (like ‘Lady Gaga’) use given, not surname"));
+                        .setMessage("Names must have a value for the ‘given‘ field. Mononyms (like ‘Zendaya’) use given, not surname"));
                 }
                 break;
             case surname:

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import org.unicode.cldr.test.CheckAccessor;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
-import org.unicode.cldr.test.CheckPersonNames;
+import org.unicode.cldr.test.CheckCLDR.Phase;
 import org.unicode.cldr.test.CheckPlaceHolders;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.tool.LikelySubtags;
@@ -35,6 +35,7 @@ import org.unicode.cldr.util.personname.PersonNameFormatter.Modifier;
 import org.unicode.cldr.util.personname.PersonNameFormatter.NameObject;
 import org.unicode.cldr.util.personname.PersonNameFormatter.NamePattern;
 import org.unicode.cldr.util.personname.PersonNameFormatter.NamePatternData;
+import org.unicode.cldr.util.personname.PersonNameFormatter.Optionality;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Order;
 import org.unicode.cldr.util.personname.PersonNameFormatter.SampleType;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Usage;
@@ -529,16 +530,16 @@ public class TestPersonNameFormatter extends TestFmwk{
     }
 
     public void TestCheckPersonNames() {
-        Map<SampleType, SimpleNameObject> names = PersonNameFormatter.loadSampleNames(ENGLISH);
-        assertEquals("REQUIRED contains all sampleTypes", SampleType.ALL, CheckPersonNames.REQUIRED.keySet());
         for (SampleType sampleType : SampleType.ALL) {
-            assertTrue(sampleType + " doesn't have conflicts", Collections.disjoint(
-                CheckPersonNames.REQUIRED.get(sampleType),
-                CheckPersonNames.REQUIRED_EMPTY.get(sampleType)));
+            for (String modifiedField : ModifiedField.ALL_SAMPLES) {
+                Optionality optionality = sampleType.getOptionality(modifiedField);
+                Optionality expected = sampleType.getRequiredFields().contains(modifiedField) ? Optionality.required
+                    : sampleType.getAllFields().contains(modifiedField) ? Optionality.optional
+                        : Optionality.disallowed;
+                assertEquals(sampleType + "/" + modifiedField, expected, optionality);
+            }
         }
     }
-
-
 
     public void TestFallbackFormatter() {
         FormatParameters testFormatParameters = new FormatParameters(Order.givenFirst, Length.short_name, Usage.referring, Formality.formal);
@@ -687,6 +688,12 @@ public class TestPersonNameFormatter extends TestFmwk{
         public CheckCLDR getCause() {
             throw new UnsupportedOperationException("not available in stub");
         }
+
+        @Override
+        public Phase getPhase() {
+            return null;
+        }
+
         @Override
         public String toString() {
             // TODO Auto-generated method stub


### PR DESCRIPTION
CLDR-15826

- [ ] This PR completes the ticket.

tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAccessor.java

- Needed access to the Phase() in the CheckAccessor.

tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java

- Name Order locales were being changed for exemplars, but those are just ASCII

tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java

- Dropped the old (ugly) REQUIRED and REQUIRED_EMPTY. The info is improved, and moved to SampleType. So we can just test with sampleType.getOptionality(modifiedField);
- The logic in handleCheck is improved. We are about whether the MISSING values are in the locale either explicitly or by explicit inheritance, but don't show errors if we don't yet have a value added to the locale.
- We emit warnings in BUILD phase (so we can check in), but errors in Submission, etc.

tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java

- We emit warnings in BUILD phase (so we can check in), but errors in Submission, etc.

tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
- Here is where we build the set of items that are required vs optional into the SampleType, along with a getter (getOptionality(…)) that we can use in unittests and Checks
- Rebuild the test for TestCheckPersonNames to use sampleType.getOptionality.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
