### PR TITLE
CLDR-16136 Tweak FSR conditions

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LikelySubtags.java
@@ -125,7 +125,17 @@ public class LikelySubtags {
         return maximize(ltp);
     }
 
-    private String maximize(LanguageTagParser ltp) {
+    /** Maximize to a string (modifying the LanguageTagParser in so doing) */
+    public String maximize(LanguageTagParser ltp) {
+        if (maximizeInPlace(ltp)) {
+            return ltp.toString();
+        } else {
+            return null;
+        }
+    }
+
+    /** Maximize in place, for use when the modified LanguageTagParser is the desired return value */
+    public boolean maximizeInPlace(LanguageTagParser ltp) {
         String language = ltp.getLanguage();
         String region = ltp.getRegion();
         String script = ltp.getScript();
@@ -155,11 +165,11 @@ public class LikelySubtags {
         // check whole
         String result = toMaximized.get(ltp.toString());
         if (result != null) {
-            return ltp.set(result)
+            ltp.set(result)
                 .setVariants(variants)
                 .setExtensions(extensions)
-                .setLocaleExtensions(localeExtensions)
-                .toString();
+                .setLocaleExtensions(localeExtensions);
+            return true;
         }
 
         boolean noLanguage = language.equals("und");
@@ -184,10 +194,10 @@ public class LikelySubtags {
                     if (!noRegion) {
                         ltp.setRegion(region);
                     }
-                    return ltp.setVariants(variants)
+                    ltp.setVariants(variants)
                         .setExtensions(extensions)
-                        .setLocaleExtensions(localeExtensions)
-                        .toString();
+                        .setLocaleExtensions(localeExtensions);
+                    return true;
                 }
             }
         }
@@ -208,14 +218,14 @@ public class LikelySubtags {
                 if (!noRegion) {
                     ltp.setRegion(region);
                 }
-                return ltp.setVariants(variants)
+                ltp.setVariants(variants)
                     .setExtensions(extensions)
-                    .setLocaleExtensions(localeExtensions)
-                    .toString();
+                    .setLocaleExtensions(localeExtensions);
+                return true;
             }
         }
 
-        return null; // couldn't maximize
+        return false; // couldn't maximize
     }
 
     // TODO, optimize if needed by adding private routine that maximizes a LanguageTagParser instead of multiple parsings

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -70,12 +70,13 @@ public class TestPersonNameFormatter extends TestFmwk{
     public static final boolean SHOW = System.getProperty("TestPersonNameFormatter.SHOW") != null;
 
     private static final CLDRConfig CONFIG = CLDRConfig.getInstance();
-    final FallbackFormatter FALLBACK_FORMATTER = new FallbackFormatter(ULocale.ENGLISH, "{0}*", "{0} {1}", null, false);
+    final FallbackFormatter FALLBACK_FORMATTER = new FallbackFormatter(ULocale.ENGLISH, "{0}*", "{0} {1}", null, null, false);
     final CLDRFile ENGLISH = CONFIG.getEnglish();
     final PersonNameFormatter ENGLISH_NAME_FORMATTER = new PersonNameFormatter(ENGLISH);
     final Map<SampleType, SimpleNameObject> ENGLISH_SAMPLES = PersonNameFormatter.loadSampleNames(ENGLISH);
     final Factory factory = CONFIG.getCldrFactory();
     final CLDRFile jaCldrFile = factory.make("ja", true);
+    final CLDRFile thCldrFile = factory.make("th", true);
 
     public static void main(String[] args) {
         new TestPersonNameFormatter().run(args);
@@ -356,6 +357,14 @@ public class TestPersonNameFormatter extends TestFmwk{
         };
         ExampleGenerator jaExampleGenerator = checkExamples(jaCldrFile, jaTests);
 
+        String[][] thTests = {
+            {
+                "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"long\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
+                "〖<i>🟨 Native name and script:</i>〗〖❬ธนา❭〗〖❬ไอริณกล้าหาญ❭〗〖❬วีระพลชัยยศพิชิตชัย❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬ศ.ดร.❭ ❬โสพล❭ ❬ชัยฤทธิ์❭ ❬ณ นคร❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Mr.❭ ❬Bertram Wilberforce❭ ❬Henry Robert❭ ❬Wooster❭ ❬Jr❭, ❬MP❭〗〖❬Єва❭ ❬Марія❭ ❬Шевченко❭〗〖❬太郎トーマス山田❭〗"
+            }
+        };
+        ExampleGenerator thExampleGenerator = checkExamples(thCldrFile, thTests);
+
 
         // next test that the example generator returns non-null for all expected cases
 
@@ -399,7 +408,7 @@ public class TestPersonNameFormatter extends TestFmwk{
     private void checkExampleGenerator(ExampleGenerator exampleGenerator, String path, String value, String expected) {
         final String example = exampleGenerator.getExampleHtml(path, value);
         String actual = ExampleGenerator.simplify(example);
-        if (!assertEquals("Example for " + value, expected, actual)) {
+        if (!assertEquals(exampleGenerator.getCldrFile().getLocaleID() + " example for " + value, expected, actual)) {
             int debug = 0;
         }
     }


### PR DESCRIPTION
CLDR-16136

Found that the logic didn't work for Thai. Changes:

tools/cldr-code/src/main/java/org/unicode/cldr/tool/LikelySubtags.java

- Slight reworking of the code to allow access to methods that directly manipulate a LanguageTagParser, which is more convenient to use for what we want.

tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java

- added the formatter language and script, so that "is a foreign language" is not dependent on anything but the likely language and script. This was to take care of an old TODO, where the old code just did a raw comparison, and would miss that en and en-UK are not "foreign languages" for the purpose of picking foreign space replacements.
- added a nativeSpaceReplacement. For the locales  that don't need spaces, this is set to "", otherwise it is " ".
  - NOTE we might want to make this settable in the future by vetters

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java

- Added an test of Thai formatting, to verify that it handles the problem



- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
