### PR TITLE
CLDR-16136 Allow empty FSR

### DIFF
--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -8513,6 +8513,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<personNames>
 		<nameOrderLocales order="givenFirst">und</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">km ko vi yue zh</nameOrderLocales>
+		<foreignSpaceReplacement xml:space="preserve"></foreignSpaceReplacement>
 		<sampleName item="nativeG">
 			<nameField type="given">សុខា</nameField>
 		</sampleName>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -10292,7 +10292,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<personNames>
 		<nameOrderLocales order="givenFirst">und lo</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">ko vi yue zh</nameOrderLocales>
-		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve"></foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -11304,7 +11304,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<personNames>
 		<nameOrderLocales order="givenFirst">und th</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">ko vi yue zh</nameOrderLocales>
-		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve"></foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -55,6 +55,10 @@ import com.ibm.icu.util.ULocale;
  */
 public class DisplayAndInputProcessor {
 
+    private static final String FSR_START_PATH = "//ldml/personNames/foreignSpaceReplacement";
+
+    private static final String EMPTY_ELEMENT_VALUE = "❮EMPTY❯";
+
     private static final boolean FIX_YEARS = true;
 
     public static final boolean DEBUG_DAIP = CldrUtility.getProperty("DEBUG_DAIP", false);
@@ -347,6 +351,10 @@ public class DisplayAndInputProcessor {
         } else {
             value = normalizeHyphens(value);
         }
+        // Fix up possibly empty field
+        if (value.isEmpty() && path.startsWith(FSR_START_PATH)) {
+            value = EMPTY_ELEMENT_VALUE;
+        }
         return value;
     }
 
@@ -494,8 +502,8 @@ public class DisplayAndInputProcessor {
         if (path.startsWith("//ldml/personNames/")) {
             if (path.startsWith("//ldml/personNames/nameOrderLocales")) {
                 value = normalizeNameOrderLocales(value);
-            } else if (path.startsWith("//ldml/personNames/foreignSpaceReplacement")) {
-                if (value.trim().equalsIgnoreCase("❮EMPTY❯}")) {
+            } else if (path.startsWith(FSR_START_PATH)) {
+                if (value.trim().equalsIgnoreCase(EMPTY_ELEMENT_VALUE)) {
                     value = "";
                 }
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -3,14 +3,34 @@
 
 package org.unicode.cldr.test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.ibm.icu.util.Output;
 import org.unicode.cldr.test.CheckExemplars.ExemplarType;
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.util.AnnotationUtil;
+import org.unicode.cldr.util.Builder;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.DateTimeCanonicalizer;
 import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
+import org.unicode.cldr.util.Emoji;
+import org.unicode.cldr.util.ICUServiceBuilder;
+import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
+import org.unicode.cldr.util.With;
+import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -26,6 +46,7 @@ import com.ibm.icu.text.Transform;
 import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
+import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
 
 /**
@@ -470,10 +491,15 @@ public class DisplayAndInputProcessor {
             value = value.replace("...", "…");
         }
 
-        if (path.startsWith("//ldml/personNames/nameOrderLocales")) {
-            value = normalizeNameOrderLocales(value);
+        if (path.startsWith("//ldml/personNames/")) {
+            if (path.startsWith("//ldml/personNames/nameOrderLocales")) {
+                value = normalizeNameOrderLocales(value);
+            } else if (path.startsWith("//ldml/personNames/foreignSpaceReplacement")) {
+                if (value.trim().equalsIgnoreCase("❮EMPTY❯}")) {
+                    value = "";
+                }
+            }
         }
-
         // Replace Arabic presentation forms with their nominal counterparts
         value = replaceArabicPresentationForms(value);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -53,6 +53,9 @@ public class DtdData extends XMLFileReader.SimpleHandler {
     private MapComparator<String> elementComparator;
     private MapComparator<String> attributeComparator;
 
+    // TODO Make this data driven
+    public static final Set<String> EMPTY_VALUE_ALLOWED_IN_PCDATA = ImmutableSet.of("nameOrderLocales", "foreignSpaceReplacement");
+
     public final Element ROOT;
     public final Element PCDATA = elementFrom("#PCDATA");
     public final Element ANY = elementFrom("ANY");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -396,11 +396,11 @@ public class PathDescription {
 
         + "^//ldml/personNames/nameOrderLocales\\[@order=\"([^\"]*)\"]"
         + RegexLookup.SEPARATOR
-        + "Person name order for locales. For more information, please see "
+        + "Person name order for locales. If there are none with a particular direction, insert zxx. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/foreignSpaceReplacement"
         + RegexLookup.SEPARATOR
-        + "For foreign personal names displayed in your locale, any special character that replaces a space (defaults to regular space). For more information, please see "
+        + "For foreign personal names displayed in your locale, any special character that replaces a space (defaults to regular space). If spaces are to be removed, insert ❮EMPTY❯. For more information, please see "
         + CLDRURLS.PERSON_NAME_FORMATS + ".\n"
         + "^//ldml/personNames/initialPattern\\[@type=\"initial\"]"
         + RegexLookup.SEPARATOR

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -576,4 +576,17 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         val = daip.processInput(xpath, "a  ।  b", null);
         assertEquals("U+0964 DEVANAGARI DANDA with spaces becomes pipe", normVal, val);
     }
+
+    private static final String FSR_START_PATH = "//ldml/personNames/foreignSpaceReplacement";
+    private static final String EMPTY_ELEMENT_VALUE = "❮EMPTY❯";
+
+    public void TestFSR() {
+        DisplayAndInputProcessor daip = new DisplayAndInputProcessor(info.getEnglish(), false);
+        String xpath = FSR_START_PATH;
+        String val = daip.processInput(xpath, EMPTY_ELEMENT_VALUE, null);
+        assertEquals("Empty FSR input", "", val);
+        String roundTrip = daip.processForDisplay(xpath, "");
+        assertEquals("Empty FSR output", EMPTY_ELEMENT_VALUE, roundTrip);
+    }
+
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -13,17 +13,28 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.ChainedMap.M4;
 import org.unicode.cldr.util.ChainedMap.M5;
+import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdData.Attribute;
 import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdData.ElementType;
+import org.unicode.cldr.util.DtdType;
+import org.unicode.cldr.util.Pair;
+import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
+import org.unicode.cldr.util.PathStarrer;
+import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.XMLFileReader;
+import org.unicode.cldr.util.XPathParts;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -447,8 +458,8 @@ public class TestPaths extends TestFmwkPlus {
                                     logKnownIssue("cldrbug:9784", "fix TODO's in Attribute validity tests");
                                 }
                             }
-                            if ((elementType == ElementType.PCDATA) == (value.isEmpty())
-                                && !finalElement.name.equals("nameOrderLocales")) {
+                            if ((elementType == ElementType.PCDATA) == value.isEmpty()
+                                && !DtdData.EMPTY_VALUE_ALLOWED_IN_PCDATA.contains(finalElement.name)) {
                                 errln("PCDATA ≠ emptyValue inconsistency:"
                                     + "\tfile=" + fileName + "/" + file
                                     + "\telementType=" + elementType

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -22,8 +22,20 @@ import org.unicode.cldr.test.CheckCLDR.Phase;
 import org.unicode.cldr.test.CheckPlaceHolders;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.tool.LikelySubtags;
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRTransforms;
+import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdData.Attribute;
+import org.unicode.cldr.util.DtdType;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.Organization;
+import org.unicode.cldr.util.PathStarrer;
+import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.FallbackFormatter;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Field;
@@ -350,7 +362,7 @@ public class TestPersonNameFormatter extends TestFmwk{
         String[][] thTests = {
             {
                 "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"long\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
-                "〖<i>🟨 Native name and script:</i>〗〖❬ธนา❭〗〖❬ไอริณกล้าหาญ❭〗〖❬วีระพลชัยยศพิชิตชัย❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬ศ.ดร.❭ ❬โสพล❭ ❬ชัยฤทธิ์❭ ❬ณ นคร❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Mr.❭ ❬Bertram Wilberforce❭ ❬Henry Robert❭ ❬Wooster❭ ❬Jr❭, ❬MP❭〗〖❬Єва❭ ❬Марія❭ ❬Шевченко❭〗〖❬太郎トーマス山田❭〗"
+                "〖<i>🟨 Native name and script:</i>〗〖❬ธนา❭〗〖❬ไอริณกล้าหาญ❭〗〖❬วีระพลชัยยศพิชิตชัย❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬ศ.ดร.โสพลชัยฤทธิ์ณนคร❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Mr.❭ ❬Bertram Wilberforce❭ ❬Henry Robert❭ ❬Wooster❭ ❬Jr❭, ❬MP❭〗〖❬Єва❭ ❬Марія❭ ❬Шевченко❭〗〖❬太郎トーマス山田❭〗"
             }
         };
         ExampleGenerator thExampleGenerator = checkExamples(thCldrFile, thTests);


### PR DESCRIPTION
CLDR-16136

I realized that there is no way for vetters to enter an empty FSR. So we need to handle it like we did zxx for the nameOrderLocales.

That is done here. 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
