### PR TITLE
CLDR-16136 The examples are not updating properly.

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
@@ -266,6 +266,17 @@ public class ExampleDependencies {
         "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern")
     .putAll("//ldml/personNames/initialPattern[@type=\"*\"]",
         "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
-        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern")
+        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern",
+        "//ldml/personNames/initialPattern[@type=\"*\"]"
+        )
+    .putAll("//ldml/personNames/nameOrderLocales[@order=\"*\"]",
+        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
+        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern",
+        "//ldml/personNames/nameOrderLocales[@order=\"*\"]"
+        )
+    .putAll("//ldml/personNames/foreignSpaceReplacement",
+        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
+        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern"
+        )
     .build();
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -557,7 +557,10 @@ public class ExampleGenerator {
      */
     PersonNamesCache personNamesCache = exCache.registerCache(new PersonNamesCache(),
         "//ldml/personNames/sampleName[@item=\"*\"]/nameField[@type=\"*\"]",
-        "//ldml/personNames/initialPattern[@type=\"*\"]");
+        "//ldml/personNames/initialPattern[@type=\"*\"]",
+        "//ldml/personNames/foreignSpaceReplacement",
+        "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern"
+        );
 
     private static final Function<String, String> BACKGROUND_TRANSFORM = x
         -> backgroundStartSymbol + x + backgroundEndSymbol;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -523,6 +523,15 @@ public class PersonNameFormatter {
         public String applyModifierFallbacks(FormatParameters nameFormatParameters, Set<Modifier> remainingModifers, String bestValue) {
             // apply default algorithms
 
+            boolean isBackground = false;
+
+            // apply HACK special treatment for ExampleGenerator
+            if (bestValue.startsWith(ExampleGenerator.backgroundStartSymbol)
+                && bestValue.endsWith(ExampleGenerator.backgroundEndSymbol)) {
+                isBackground = true;
+                bestValue = bestValue.substring(1,bestValue.length()-1);
+            }
+
             for (Modifier modifier : remainingModifers) {
                 switch(modifier) {
                 case initial:
@@ -547,7 +556,9 @@ public class PersonNameFormatter {
                     break;
                 }
             }
-            return bestValue;
+            return isBackground
+                ? ExampleGenerator.backgroundStartSymbol + bestValue + ExampleGenerator.backgroundEndSymbol
+                    : bestValue ;
         }
 
         public String formatInitial(String bestValue, FormatParameters nameFormatParameters) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -556,9 +556,9 @@ public class PersonNameFormatter {
                     break;
                 }
             }
-            return isBackground
-                ? ExampleGenerator.backgroundStartSymbol + bestValue + ExampleGenerator.backgroundEndSymbol
-                    : bestValue ;
+            return isBackground && bestValue != null
+                    ? ExampleGenerator.backgroundStartSymbol + bestValue + ExampleGenerator.backgroundEndSymbol
+                        : bestValue ;
         }
 
         public String formatInitial(String bestValue, FormatParameters nameFormatParameters) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -123,7 +123,7 @@ public class TestPersonNameFormatter extends TestFmwk{
             "length=medium; usage=addressing; formality=formal", "{given} {given2-initial} {surname}",
             "length=medium; usage=addressing; formality=formal", "{given} {surname}",
             "length=medium; usage=addressing; formality=formal", "{given} {surname}",
-            "length=long; usage=monogram; formality=formal", "{given-initial}{surname-initial}",
+            "length=long; usage=monogram; formality=formal", "{given-monogram}{surname-monogram}",
             "order=givenFirst", "{title} {given} {given2} {surname} {surname2} {credentials}",
             "order=surnameFirst", "{surname} {surname2} {title} {given} {given2} {credentials}",
             "order=sorting", "{surname} {surname2}, {title} {given} {given2} {credentials}");
@@ -1068,5 +1068,12 @@ public class TestPersonNameFormatter extends TestFmwk{
         thCldrFile.write(pw);
         final String wholeFile = sw.toString();
         assertTrue("Contains foreignSpaceReplacement", wholeFile.contains("foreignSpaceReplacement"));
+    }
+
+    public void testInitials() {
+        String[][] tests = {{
+            "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"short\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern", ""
+        }};
+        ExampleGenerator exampleGenerator = checkExamples(ENGLISH, tests);
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -119,11 +119,11 @@ public class TestPersonNameFormatter extends TestFmwk{
         NamePatternData namePatternData = new NamePatternData(
             localeToOrder,
             "order=surnameFirst; length=short; usage=addressing; formality=formal", "{surname-allCaps} {given}",
+            "length=short; usage=referring; formality=formal", "{given-initial}{given2-initial}{surname-initial}",
             "length=short; usage=addressing; formality=formal", "{given} {given2-initial} {surname}",
             "length=medium; usage=addressing; formality=formal", "{given} {given2-initial} {surname}",
             "length=medium; usage=addressing; formality=formal", "{given} {surname}",
             "length=medium; usage=addressing; formality=formal", "{given} {surname}",
-            "length=long; usage=monogram; formality=formal", "{given-monogram}{surname-monogram}",
             "order=givenFirst", "{title} {given} {given2} {surname} {surname2} {credentials}",
             "order=surnameFirst", "{surname} {surname2} {title} {given} {given2} {credentials}",
             "order=sorting", "{surname} {surname2}, {title} {given} {given2} {credentials}");
@@ -135,7 +135,7 @@ public class TestPersonNameFormatter extends TestFmwk{
         check(personNameFormatter, sampleNameObject1, "length=short; usage=addressing; formality=formal", "John B. Smith");
         check(personNameFormatter, sampleNameObject2, "length=short; usage=addressing; formality=formal", "John Smith");
         check(personNameFormatter, sampleNameObject1, "length=long; usage=addressing; formality=formal", "Dr. John Bob Smith Barnes Pascal MD");
-        check(personNameFormatter, sampleNameObject3, "length=long; usage=monogram; formality=formal", "J* B*S*"); // TODO This is wrong
+        check(personNameFormatter, sampleNameObject3, "length=short; usage=referring; formality=formal", "J* B*S*");
         check(personNameFormatter, sampleNameObject4, "order=surnameFirst; length=short; usage=addressing; formality=formal", "ABE Shinzō");
     }
 
@@ -1072,7 +1072,8 @@ public class TestPersonNameFormatter extends TestFmwk{
 
     public void testInitials() {
         String[][] tests = {{
-            "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"short\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern", ""
+            "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"short\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
+            "〖<i>🟨 Native name and script:</i>〗〖❬Z.❭〗〖❬I.❭ ❬Adler❭〗〖❬M. S.❭ ❬H.❭ ❬Watson❭〗〖❬B. W.❭ ❬H. R.❭ ❬Wooster❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬S.❭〗〖❬K.❭ ❬Müller❭〗〖❬Z.❭ ❬H.❭ ❬Stöber❭〗〖❬A. C.❭ ❬C. M.❭ ❬von Brühl❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Є.❭ ❬М.❭ ❬Шевченко❭〗〖❬太郎山田❭〗"
         }};
         ExampleGenerator exampleGenerator = checkExamples(ENGLISH, tests);
     }


### PR DESCRIPTION
CLDR-16136

The example cache needs to have the dependencies updated. In particular:

The namePattern examples depend on:

1. nameSamples
2. initial patterns
3. nameOrderLocales
4. foreignSpaceReplacement

tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
- Update the general Example generators with changes to the above.

tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
- There is also a special cache to keep from recreating the personname samples and formatter, so update that with changes to the above.

tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
- There was also a bug in the examples, where personnames needs to know about the background/forground flags. It has to remove then re-add them in the case of generated initials, etc.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
- Added test for the initials.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
