### PR TITLE
CLDR-16127 Throw exception for zone not in ICU

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1452,8 +1452,12 @@ public class PathHeader implements Comparable<PathHeader> {
                 @Override
                 public String transform(String source0) {
                     String theTerritory = Containment.getRegionFromZone(source0);
-                    if (theTerritory == null || theTerritory == "001") {
-                        theTerritory = "ZZ";
+                    if (theTerritory == null || "001".equals(theTerritory)  || "ZZ".equals(theTerritory)) {
+                        if ("Etc/Unknown".equals(source0)) {
+                            theTerritory = "ZZ";
+                        } else {
+                            throw new IllegalArgumentException("ICU needs zone update? Source: " + source0 + "; Territory: " + theTerritory);
+                        }
                     }
                     if (singlePageTerritories.contains(theTerritory)) {
                         return englishFile.getName(CLDRFile.TERRITORY_NAME, theTerritory);


### PR DESCRIPTION
-In PathHeader.java, only allow Etc/Unknown to give null/001/ZZ

-This would have informed us sooner of needed ICU update for America/Ciudad_Juarez

CLDR-16127

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
