### PR TITLE
CLDR-16192 Admin email encoding failure for non-ASCII text

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
@@ -291,34 +291,18 @@ public class WebContext implements Cloneable, Appendable {
     }
 
     /*
-     * Decode a single string from URL format into Unicode
+     * Return the input string, unchanged
      *
-     * @param res UTF-8 'encoded' bytes (expanded to a string)
+     * This method no longer serves any purpose since CLDR now requires UTF-8 encoding
+     * for all http requests and related services/configuration.
      *
-     * @return Unicode string (will return 'res' if no high bits were detected)
+     * This method is temporarily retained for compatibility with legacy code including .jsp.
+     *
+     * @param res the string
+     *
+     * @return the string
      */
     public static String decodeFieldString(String res) {
-        if (res == null)
-            return null;
-        byte[] asBytes = new byte[res.length()];
-        boolean wasHigh = false;
-        int n;
-        for (n = 0; n < res.length(); n++) {
-            asBytes[n] = (byte) (res.charAt(n) & 0x00FF);
-            // println(" n : " + (int)asBytes[n] + " .. ");
-            if (asBytes[n] < 0) {
-                wasHigh = true;
-            }
-        }
-        if (!wasHigh) {
-            return res; // no utf-8
-        }
-        try {
-            res = new String(asBytes, StandardCharsets.UTF_8);
-        } catch (Throwable t) {
-            return res;
-        }
-
         return res;
     }
 


### PR DESCRIPTION
-Simply return parameter unchanged for WebContext.decodeFieldString

-Comments

CLDR-16192

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
