### PR TITLE
CLDR-16199 Parallel GenerateProductionData has NPE again, re-un-parallelize it

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -139,8 +139,8 @@ public class GenerateProductionData {
         // get directories
 
         Arrays.asList(DtdType.values())
-            .parallelStream()
-            .unordered()
+            //.parallelStream()
+            //.unordered()
             .forEach(type -> {
             boolean isLdmlDtdType = type == DtdType.ldml;
 
@@ -206,7 +206,7 @@ public class GenerateProductionData {
             System.out.println(sourceFile + " => " + destinationFile);
             if (!destinationFile.mkdirs()) {
                 // if created, remove old contents
-                Arrays.stream(destinationFile.listFiles()).forEach(File::delete);
+                 Arrays.stream(destinationFile.listFiles()).forEach(File::delete);
             }
 
             Set<String> sorted = new TreeSet<>();
@@ -230,7 +230,7 @@ public class GenerateProductionData {
             final Factory theFactory = factory;
             final boolean isLdmlDtdType2 = isLdmlDtdType;
             sorted
-                .parallelStream()
+                //.parallelStream()
                 .forEach(file -> {
                     File sourceFile2 = new File(sourceFile, file);
                     File destinationFile2 = new File(destinationFile, file);


### PR DESCRIPTION
CLDR-16199

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16199)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Re-un-parallelize GenerateProductionData (As I previously did in #2257) to temporarily address NPE that occurs when running GenerateProductionData with current CLDR data & tools (as of commit d2420807cb 2022-Dec-06). For a longer-term fix I filed https://unicode-org.atlassian.net/browse/CLDR-16207