### PR TITLE
CLDR-16201 Drop -rate from unitPreferenceData usages rainfall-rate, snowfall-rate

### DIFF
--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -443,12 +443,12 @@ For terms of use, see http://www.unicode.org/copyright.html
             <unitPreference regions="001">kilometer-per-hour</unitPreference>
             <unitPreference regions="GB US">mile-per-hour</unitPreference>
         </unitPreferences>
-        <unitPreferences category="speed" usage="rainfall-rate">
+        <unitPreferences category="speed" usage="rainfall">
             <unitPreference regions="001">millimeter-per-hour</unitPreference>
             <unitPreference regions="BR">centimeter-per-hour</unitPreference>
             <unitPreference regions="US">inch-per-hour</unitPreference>
         </unitPreferences>
-        <unitPreferences category="speed" usage="snowfall-rate">
+        <unitPreferences category="speed" usage="snowfall">
             <unitPreference regions="001">centimeter-per-hour</unitPreference>
             <unitPreference regions="US">inch-per-hour</unitPreference>
         </unitPreferences>


### PR DESCRIPTION
CLDR-16201

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16201)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Per Mark and Shane comments in #2605, drop the "-rate" from the new unitPreferenceData speed category usage values "rainfall-rate", "snowfall-rate"