### PR TITLE
CLDR-16215 Restore fr_CA grouping separator to U+00A0

### DIFF
--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -5701,7 +5701,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimumGroupingDigits>↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
+			<group> </group>
 			<percentSign>↑↑↑</percentSign>
 			<plusSign>↑↑↑</plusSign>
 			<minusSign>↑↑↑</minusSign>


### PR DESCRIPTION
CLDR-16215

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16215)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Undo inadvertent change to fr_CA grouping separator from the sequence of PR #2433 followed by #2609.