### PR TITLE
CLDR-16199 ckb_IR needs H time formats for calendars inherited from ckb

### DIFF
--- a/common/main/ckb_IR.xml
+++ b/common/main/ckb_IR.xml
@@ -63,26 +63,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<timeFormats>
 					<timeFormatLength type="full">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>HH:mm:ss zzzz</pattern>
+							<datetimeSkeleton>HHmmsszzzz</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="long">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>HH:mm:ss z</pattern>
+							<datetimeSkeleton>HHmmssz</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="medium">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>HH:mm:ss</pattern>
+							<datetimeSkeleton>HHmmss</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="short">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>HH:mm</pattern>
+							<datetimeSkeleton>HHmm</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 				</timeFormats>


### PR DESCRIPTION
CLDR-16199

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16199)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Per supplemental data, IR prefers time cycle H.
So ckb_IR needs to provide standard time formats explicitly using H for all calendars inherited from ckb (which defaults to IQ and time cycle h).