### PR TITLE
CLDR-16239 Change some inheritance markers to specific values in en_001.xml and en_GB.xml

### DIFF
--- a/common/main/en_001.xml
+++ b/common/main/en_001.xml
@@ -1298,7 +1298,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hr</unitPattern>
 				<unitPattern count="other">{0} hrs</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -8530,10 +8530,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>hours</displayName>
+				<unitPattern count="one">{0} hr</unitPattern>
+				<unitPattern count="other">{0} hrs</unitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>↑↑↑</displayName>


### PR DESCRIPTION
-Changes are limited to a few paths with short, duration-hour

-The values are derived by reverting to before drop-hard-inheritance, then running cldrmodify one locale at a time, parent before child

CLDR-16239

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
