### PR TITLE
CLDR-16246 update PR template to allow multi commits by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,5 @@ license before the PR is accepted.
 - sign: https://cla-assistant.io/unicode-org/cldr
 - license: https://www.unicode.org/copyright.html#License
 -->
+
+ALLOW_MANY_COMMITS=true


### PR DESCRIPTION
CLDR-16246

Many PRs are landed which fail the 'single commit check'.  It would be better to quell this error so that we can see when there are real errors.


Examples: 
#2616 #2575 #2578 #2562

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
