### PR TITLE
CLDR-16234 st: allow manager/tc to update email and name

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -237,7 +237,7 @@ public class UserList {
         } else if ((UserRegistry.userCanModifyUser(me, u.user.id, u.user.userlevel))
             && (action.equals(LIST_ACTION_SETLOCALES))) {
             changeLocales(action, u);
-        } else if (UserRegistry.userCanDeleteUser(me, u.user.id, u.user.userlevel)) {
+        } else if (UserRegistry.userCanModifyUser(me, u.user.id, u.user.userlevel)) {
             changeOther(action, u);
         } else if (u.user.id == me.id) {
             u.ua.put(action, "<i>You can't change that setting on your own account.</i>");

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -1610,7 +1610,7 @@ public class UserRegistry {
         if (!managerUser.org.equals(otherUser.org)) {
             return false;
         }
-        if (!userCanModifyUsers(managerUser)) {
+        if (!userCanModifyUsers(managerUser)) {  // manager or tc
             return false;
         }
         if (targetId == managerUser.id) {
@@ -1623,9 +1623,9 @@ public class UserRegistry {
     }
 
     static boolean userCanDeleteUser(User managerUser, int targetId, int targetLevel) {
-        return (managerUser != null) && 
-            managerUser.getLevel().canDeleteUsers() && 
-            userCanModifyUser(managerUser, targetId, targetLevel) && 
+        return (managerUser != null) &&
+            managerUser.getLevel().canDeleteUsers() &&
+            userCanModifyUser(managerUser, targetId, targetLevel) &&
             targetLevel > managerUser.userlevel;
     }
 


### PR DESCRIPTION
- allow anyone with UserRegistry.userCanModifyUser() (basically manager/tc in your own org, or else admin for everyone) to update user email or user name
- Admin can still change orgs, etc.

This was inadvertently broken in CLDR-8603 (#2527), not realizing that 'userCanDeleteUser' was actually used for whether email and name could be modified.

CLDR-16234

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->
