### PR TITLE
CLDR-16224 st: updates to loading and retry

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAjax.js
+++ b/tools/cldr-apps/js/src/esm/cldrAjax.js
@@ -110,7 +110,7 @@ function onChange(request, xhrArgs) {
       xhrArgs.load(request.response);
     }
   } else if (xhrArgs.error) {
-    xhrArgs.error(makeErrorMessage(request, xhrArgs.url));
+    xhrArgs.error(makeErrorMessage(request, xhrArgs.url), request);
   }
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrRetry.js
+++ b/tools/cldr-apps/js/src/esm/cldrRetry.js
@@ -41,10 +41,6 @@ function handleDisconnect(why, json, word, what) {
   errInfo.what = what;
   errInfo.json = json;
   console.log("Disconnect: " + why);
-
-  // window.location.href = "#retry"; // load() will be called
-  // Instead of looping via #retry, simply remount 'retry' directly
-  cldrGenericVue.load("retry_inplace");
 }
 
 // called as special.load

--- a/tools/cldr-apps/js/src/esm/cldrText.js
+++ b/tools/cldr-apps/js/src/esm/cldrText.js
@@ -15,7 +15,8 @@ const strings = {
 
   loadingMsg_desc: "Current loading status",
   loading_reloading: "Force Reloading Page",
-  loading_reload: "Reload",
+  loading_reload: "Reload This Page",
+  loading_home: "Start Over",
   loading_retrying: "Retrying",
   loading_nocontent: "This locale cannot be displayed.",
   loadingOneRow: "loading....",

--- a/tools/cldr-apps/js/src/views/WaitingPanel.vue
+++ b/tools/cldr-apps/js/src/views/WaitingPanel.vue
@@ -1,9 +1,7 @@
 <template>
   <div id="home">
     <!-- if $specialPage == retry then we have reached this page 'directly' -->
-    <h1 v-if="$specialPage != 'retry'" class="hang">
-      Waiting for the SurveyTool to start up…
-    </h1>
+    <h1 v-if="$specialPage != 'retry'" class="hang">Loading the SurveyTool…</h1>
     <h1>
       <a-spin size="large" :delay="1000" />
     </h1>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -98,7 +98,9 @@ public class VoteAPI {
                 description = "Forbidden, no access to this data"),
             @APIResponse(
                 responseCode = "404",
-                description = "Row or Locale does not exist"),
+                description = "Row or Locale does not exist. More details in the 'code' field.",
+                content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = STError.class))),
             @APIResponse(
                 responseCode = "500",
                 description = "Internal Server Error",

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -996,6 +996,7 @@ i.loadingMsgSpin {
 }
 */
 
+
 .loaderAnimIcon {
 	background-image: url('loader.gif');
 	background-repeat: no-repeat;
@@ -1924,12 +1925,13 @@ p.errCodeMsg {
     font-family: Georgia, "Times New Roman", Times, serif;
     font-weight: normal;
     font-style: normal;
-    padding-left:  20px;
     margin-left:  3em;
     margin-right:  3em;
     border:  2px solid silver;
 	font-size: larger;
 	white-space: pre-line;
+	padding: 0.5em;
+	background-color: #ecd290;
 }
 
 p.errCodeMsg .fgred {
@@ -1937,9 +1939,10 @@ p.errCodeMsg .fgred {
 }
 
 #LoadingMessageSection p.errCodeMsg button {
-    display:  block;
+    display:  inline-block;
     margin-top: 1em;
-    font-size: x-large;
+    font-size: larger;
+	margin-left: 0.5em;
 }
 
 .cldr_substituted {


### PR DESCRIPTION
- handleDisconnect no longer tries to load the 'loading' page.  That page only should show up if the ST is not up yet.
- on loading rows, process the error code properly and display the error, such as E_BAD_SECTION
- update the errCodeMsg box to have a Reload and a Home button

CLDR-16224

- [X] This PR completes the ticket.


## Examples

### on an incorrect section (i.e. bad URL) 

![image](https://user-images.githubusercontent.com/855219/208588125-03628e71-fcf3-427e-a58e-9f70c43fda8a.png)

### On an incorrect locale (bad URL) 

![image](https://user-images.githubusercontent.com/855219/208588181-57a2fdec-1714-4e67-b849-e1188facbf97.png)
