### PR TITLE
CLDR-16239 Resolve inheritance marker instead of skipping it

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -233,11 +233,11 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         this.dtdData = DtdData.getInstance(this.dtdType);
     }
 
-    public CLDRFile(XMLSource dataSource, XMLSource... resolvingParents) {
+    public CLDRFile(XMLSource dataSource, Factory factory, XMLSource... resolvingParents) {
         List<XMLSource> sourceList = new ArrayList<>();
         sourceList.add(dataSource);
         sourceList.addAll(Arrays.asList(resolvingParents));
-        this.dataSource = new ResolvingSource(sourceList);
+        this.dataSource = new ResolvingSource(sourceList, factory);
 
         if (DEBUG_CLDR_FILE) {
             creationTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(Calendar.getInstance().getTime());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Factory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Factory.java
@@ -142,10 +142,6 @@ public abstract class Factory implements SublocaleProvider {
         return make(currentLocaleID, true, madeWithMinimalDraftStatus);
     }
 
-    public static XMLSource makeResolvingSource(List<XMLSource> sources) {
-        return new ResolvingSource(sources);
-    }
-
     /**
      * Temporary wrapper for creating an XMLSource. This is a hack and should
      * only be used in the Survey Tool for now.
@@ -180,7 +176,7 @@ public abstract class Factory implements SublocaleProvider {
             sourceList.add(source);
             curLocale = LocaleIDParser.getParent(curLocale, ignoreExplicitParentLocale);
         }
-        return new ResolvingSource(sourceList);
+        return new ResolvingSource(sourceList, this);
     }
 
     public abstract DraftStatus getMinimalDraftStatus();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/RecordingCLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/RecordingCLDRFile.java
@@ -18,8 +18,8 @@ public class RecordingCLDRFile extends CLDRFile {
         super(dataSource);
     }
 
-    public RecordingCLDRFile(XMLSource dataSource, XMLSource... resolvingParents) {
-        super(dataSource, resolvingParents);
+    public RecordingCLDRFile(XMLSource dataSource, Factory factory, XMLSource... resolvingParents) {
+        super(dataSource, factory, resolvingParents);
     }
 
     public void clearRecordedPaths() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleDependencies.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleDependencies.java
@@ -131,7 +131,7 @@ public class TestExampleDependencies extends TestFmwk {
         XMLSource topSource = factory.makeSource(localeId);
         List<XMLSource> parents = getParentSources(factory, localeId);
         XMLSource[] a = new XMLSource[parents.size()];
-        return new RecordingCLDRFile(topSource, parents.toArray(a));
+        return new RecordingCLDRFile(topSource, factory, parents.toArray(a));
     }
 
     private void useModifying() throws IOException {
@@ -337,7 +337,7 @@ public class TestExampleDependencies extends TestFmwk {
         XMLSource topSource = factory.makeSource(localeId).cloneAsThawed(); // make top one modifiable
         List<XMLSource> parents = getParentSources(factory, localeId);
         XMLSource[] a = new XMLSource[parents.size()];
-        return new CLDRFile(topSource, parents.toArray(a));
+        return new CLDRFile(topSource, factory, parents.toArray(a));
     }
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -411,7 +411,7 @@ public class TestLocale extends TestFmwkPlus {
         root.putValueAtDPath(
             "//ldml/localeDisplayNames/codePatterns/codePattern[@type=\"territory\"]",
             "Territorie: {0}");
-        CLDRFile f = new CLDRFile(dxs, root);
+        CLDRFile f = new CLDRFile(dxs, testInfo.getCldrFactory(), root);
         ExampleGenerator eg = new ExampleGenerator(f, testInfo.getEnglish()
         );
         for (String[] row : tests) {


### PR DESCRIPTION
-Add TestInheritanceReplacement, same as in draft PR 2628

-In getPathLocation, get resolved value when reach INHERITANCE_MARKER

-Revise ResolvingSource constructor to include Factory

CLDR-16239

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
