### PR TITLE
CLDR-16272 limit some reports during limited submission

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -23,6 +23,7 @@ import org.unicode.cldr.util.VettingParameters;
 import org.unicode.cldr.util.VoterReportStatus.ReportId;
 import org.unicode.cldr.util.VoterReportStatus.ReportStatus;
 import org.unicode.cldr.util.VoterProgress;
+import org.unicode.cldr.util.VoterReportStatus;
 
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
@@ -96,6 +97,7 @@ public class Dashboard {
             final CLDRLocale locale = CLDRLocale.getInstance(localeId);
             ReportStatus reportStatus = ReportsDB.getInstance().getReportStatus(userId, locale);
             EnumSet<ReportId> incomplete = EnumSet.complementOf(reportStatus.completed);
+            incomplete.retainAll(VoterReportStatus.ReportId.getReportsAvailable()); // remove reports not actually available
             if (!incomplete.isEmpty()) {
                 ReviewNotificationGroup rng = new ReviewNotificationGroup("Reports", "", "");
                 incomplete.forEach(r -> rng.add(r.name()));

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -515,7 +515,7 @@ public class SurveyAjax extends HttpServlet {
                                 report.put("url", m.urlStub());
                                 reports.put(report);
                             }
-                            for (final ReportId m : ReportId.values()) {
+                            for (final ReportId m : ReportId.getReportsAvailable()) {
                                 JSONObject report = new JSONObject();
                                 report.put("url", "r_" + m.name());
                                 reports.put(report);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
@@ -157,7 +157,7 @@ public class ReportAPI {
         for (final CLDRLocale loc : locales) {
             LocaleReportVettingResult rr = new LocaleReportVettingResult();
             rr.locale = loc.toString();
-            for (final ReportId report : ReportId.values()) {
+            for (final ReportId report : ReportId.getReportsAvailable()) {
                 Map<ReportAcceptability, Set<Integer>> statistics = db.updateResolver(loc, report, allUsers, res);
                 rr.reports.add(new ReportVettingResult(report, res, statistics));
                 statistics.values().forEach(s -> rr.addVoters(s));
@@ -274,6 +274,9 @@ public class ReportAPI {
         if (mySession.user == null || mySession.user.id != user) {
             return Response.status(Status.FORBIDDEN).build();
         }
+        if (!report.isAvailable()) {
+            return Response.status(Status.FORBIDDEN).build();
+        }
         ReportsDB.getInstance()
             .markReportComplete(user, CLDRLocale.getInstance(locale),
                 report, update.completed, update.acceptable);
@@ -328,6 +331,9 @@ public class ReportAPI {
         if (!SurveyMain.getLocalesSet().contains(loc)) {
             // No such locale
             return Response.status(Status.NOT_FOUND).build();
+        }
+        if (!report.isAvailable()) {
+            return Response.status(Status.FORBIDDEN).build();
         }
         final String result;
         try {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
@@ -291,7 +291,7 @@ public class ReportAPI {
         schema = @Schema(type = SchemaType.ARRAY, implementation = String.class))
     )
     public Response listReports() {
-        return Response.ok().entity(ReportId.values()).build();
+        return Response.ok().entity(ReportId.getReportsAvailable().toArray()).build();
     }
     @Schema(description = "update to user’s report status")
     public static final class ReportUpdate {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.test;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -12,6 +14,8 @@ import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.RegexUtilities;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.VoterReportStatus;
+import org.unicode.cldr.util.VoterReportStatus.ReportId;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -60,6 +64,13 @@ public final class SubmissionLocales {
         .addAll(CLDR_LOCALES)
         .addAll(HIGH_LEVEL_LOCALES)
         .build();
+
+    /**
+     * Subset of reports open for this release
+     */
+    private static final Set<ReportId> LIMITED_SUBMISSION_REPORTS = Collections.unmodifiableSet(EnumSet.of(
+        VoterReportStatus.ReportId.personnames
+    ));
 
 
     /**
@@ -225,5 +236,9 @@ public final class SubmissionLocales {
             System.out.println(RegexUtilities.showMismatch(matcher, path));
         }
         return result;
+    }
+
+    public static Set<ReportId> getReportsAvailableInLimited() {
+        return LIMITED_SUBMISSION_REPORTS;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterReportStatus.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoterReportStatus.java
@@ -7,6 +7,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.unicode.cldr.test.CheckCLDR;
+import org.unicode.cldr.test.SubmissionLocales;
+
 
 /**
  * This interface is for objects which can expose information on which reports have been completed.
@@ -23,7 +26,23 @@ public abstract class VoterReportStatus<T> {
         datetime, // non-Chart
         zones, // non-Chart
         compact, // non-Chart, aka 'numbers'
-        personnames // Chart
+        personnames; // Chart
+
+        /**
+         * True if this report is available in this vetting period
+         * @return
+         */
+        public boolean isAvailable() {
+            return (!CheckCLDR.LIMITED_SUBMISSION) || (SubmissionLocales.getReportsAvailableInLimited().contains(this));
+        }
+
+        public static Set<ReportId> getReportsAvailable() {
+            if (!CheckCLDR.LIMITED_SUBMISSION) {
+                return EnumSet.allOf(ReportId.class);
+            } else {
+                return SubmissionLocales.getReportsAvailableInLimited();
+            }
+        }
     };
 
     public enum ReportAcceptability {


### PR DESCRIPTION
CLDR-16272

- add a limited set of available reports in SubmissionLocales
- only show available reports in the sidebar
- don't count unavailable reports against completion in Dashboard
- throw 403 Forbidden if user tries to navigate to or vote on un-available reports

- [X] This PR completes the ticket.


ALLOW_MANY_COMMITS=true
