### PR TITLE
CLDR-15034 kbd: add @ALLOWS_UESC DTD annotation

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -243,18 +243,28 @@ If it becomes necessary in the future, the format could extend the ISO layout to
 
 When explicitly specified, attributes can contain escaped characters. This specification uses two methods of escaping, the _UnicodeSet_ notation and the `\u{...}` notation.
 
+### UnicodeSet Escaping
+
 The _UnicodeSet_ notation is described in [UTS #35 section 5.3.3](tr35.md#Unicode_Sets) and allows for comprehensive character matching, including by character range, properties, names, or codepoints. Currently, the following attributes allow _UnicodeSet_ notation:
 
 * `from` or `before` on the `<transform>` element
 * `from` or `before` on the `<reorder>` element
 * `chars` on the [`<repertoire>`](#test-element-repertoire) test element.
 
+### UTS18 Escaping
+
 The `\u{...}` notation, a subset of hex notation, is described in [UTS #18 section 1.1](https://www.unicode.org/reports/tr18/#Hex_notation). It can refer to one or multiple individual codepoints. Currently, the following attributes allow the `\u{...}` notation:
 
-* `to`, `longPress`, `multiTap`, `hint` on the `<map>` element
+* `to`, `longPress`, `multiTap`, and `longPressDefault` on the `<key>` element
+* `to` on the `<flick>` element
 * `to` on the `<transform>` element
+* `to` and `display` on the `<display>` element
+* `baseCharacter` on the `<displayOptions>` element
+* Some attributes on [Keyboard Test Data](#Keyboard Test Data) subelements
 
 Characters of general category of Combining Mark (M), Control characters (Cc), Format characters (Cf), and whitespace other than space should be encoded using one of the notation above as appropriate.
+
+Attributes escaped in this manner are annotated with the `<!--@ALLOWS_UESC-->` DTD annotation, see [DTD Annotations](tr35.md#57-dtd-annotations)
 
 * * *
 
@@ -1050,6 +1060,8 @@ _Attribute:_ `to` (optional- `to` or `id` is required, or both)
 
 > Specifies the character or character sequence from the `keys/key` element that is to have a special display.
 
+This attribute may be escaped with `\u` notation, see [Escaping](#Escaping).
+
 _Attribute:_ `id` (optional- `to` or `id` is required, or both)
 
 > Specifies the `key` id. This is useful for keys which do not produce any output (no `to=` value), such as a shift key.
@@ -1057,6 +1069,8 @@ _Attribute:_ `id` (optional- `to` or `id` is required, or both)
 _Attribute:_ `display` (required)
 
 > Required and specifies the character sequence that should be displayed on the keytop for any key that generates the `@to` sequence or has the `@id`. (It is an error if the value of the `display` attribute is the same as the value of the `to` attribute, this would be an extraneous entry.)
+
+This attribute may be escaped with `\u` notation, see [Escaping](#Escaping).
 
 **Example**
 
@@ -1112,6 +1126,8 @@ _Attribute:_ `baseCharacter` (optional)
 > As a hint, the implementation may ignore this option.
 >
 > **Note** that not all base characters will be suitable as bases for combining marks.
+
+This attribute may be escaped with `\u` notation, see [Escaping](#Escaping).
 
 * * *
 
@@ -2259,7 +2275,7 @@ This attribute specifies that a multi-tap gesture should be performed on the spe
 
 > <small>
 >
-> Parents: [test](#test-element-emit)
+> Parents: [test](#test-element-test)
 >
 > Children: _none_
 >
@@ -2274,6 +2290,8 @@ _Attribute:_ `to` (required)
 
 This attribute specifies a string of output text representing a single keystroke or gesture. This string is intended to match the output of a `key`, `flick`, `longPress` or `multiTap` element or attribute.
 Tooling should give a hint if this attribute does not match at least one keystroke or gesture. Note that the specified text is not injected directly into the output buffer.
+
+This attribute may be escaped with `\u` notation, see [Escaping](#Escaping).
 
 **Example**
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -241,11 +241,11 @@ If it becomes necessary in the future, the format could extend the ISO layout to
 
 ### <a name="Escaping" href="#Escaping">Escaping</a>
 
-When explicitly specified, attributes can contain escaped characters. This specification uses two methods of escaping, the _UnicodeSet_ notation and the `\u{...}` notation.
+When explicitly specified, attribute values can contain escaped characters. This specification uses two methods of escaping, the _UnicodeSet_ notation and the `\u{...}` notation.
 
 ### UnicodeSet Escaping
 
-The _UnicodeSet_ notation is described in [UTS #35 section 5.3.3](tr35.md#Unicode_Sets) and allows for comprehensive character matching, including by character range, properties, names, or codepoints. Currently, the following attributes allow _UnicodeSet_ notation:
+The _UnicodeSet_ notation is described in [UTS #35 section 5.3.3](tr35.md#Unicode_Sets) and allows for comprehensive character matching, including by character range, properties, names, or codepoints. Currently, the following attribute values allow _UnicodeSet_ notation:
 
 * `from` or `before` on the `<transform>` element
 * `from` or `before` on the `<reorder>` element
@@ -253,7 +253,7 @@ The _UnicodeSet_ notation is described in [UTS #35 section 5.3.3](tr35.md#Unicod
 
 ### UTS18 Escaping
 
-The `\u{...}` notation, a subset of hex notation, is described in [UTS #18 section 1.1](https://www.unicode.org/reports/tr18/#Hex_notation). It can refer to one or multiple individual codepoints. Currently, the following attributes allow the `\u{...}` notation:
+The `\u{...}` notation, a subset of hex notation, is described in [UTS #18 section 1.1](https://www.unicode.org/reports/tr18/#Hex_notation). It can refer to one or multiple individual codepoints. Currently, the following attribute values allow the `\u{...}` notation:
 
 * `to`, `longPress`, `multiTap`, and `longPressDefault` on the `<key>` element
 * `to` on the `<flick>` element
@@ -264,7 +264,7 @@ The `\u{...}` notation, a subset of hex notation, is described in [UTS #18 secti
 
 Characters of general category of Combining Mark (M), Control characters (Cc), Format characters (Cf), and whitespace other than space should be encoded using one of the notation above as appropriate.
 
-Attributes escaped in this manner are annotated with the `<!--@ALLOWS_UESC-->` DTD annotation, see [DTD Annotations](tr35.md#57-dtd-annotations)
+Attribute values escaped in this manner are annotated with the `<!--@ALLOWS_UESC-->` DTD annotation, see [DTD Annotations](tr35.md#57-dtd-annotations)
 
 * * *
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3055,7 +3055,7 @@ and are included below the !ELEMENT or !ATTLIST line that they apply to. The cur
 | ---------------------| ----------- |
 | `<!--@VALUE-->`      | The attribute is not distinguishing, and is treated like an element value |
 | `<!--@METADATA-->`   | The attribute is a “comment” on the data, like the draft status. It is not typically used in implementations. |
-| `<!--@ALLOWS_UESC-->`   | The attribute's value can be escaped using the `\u` notation, see [Escaping](tr35-keyboards.md#Escaping). Does not require this notation to be used. |
+| `<!--@ALLOWS_UESC-->`   | The attribute value can be escaped using the `\u` notation, see [Escaping](tr35-keyboards.md#Escaping). Does not require this notation to be used. |
 | `<!--@ORDERED-->`    | The element's children are ordered, and do not inherit. |
 | `<!--@DEPRECATED-->` | The element or attribute is deprecated, and should not be used. |
 | `<!--@DEPRECATED: attribute-value1, attribute-value2-->` | The attribute values are deprecated, and should not be used. Spaces between tokens are not significant. |

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3055,6 +3055,7 @@ and are included below the !ELEMENT or !ATTLIST line that they apply to. The cur
 | ---------------------| ----------- |
 | `<!--@VALUE-->`      | The attribute is not distinguishing, and is treated like an element value |
 | `<!--@METADATA-->`   | The attribute is a “comment” on the data, like the draft status. It is not typically used in implementations. |
+| `<!--@ALLOWS_UESC-->`   | The attribute's value can be escaped using the `\u` notation, see [Escaping](tr35-keyboards.md#Escaping). Does not require this notation to be used. |
 | `<!--@ORDERED-->`    | The element's children are ordered, and do not inherit. |
 | `<!--@DEPRECATED-->` | The element or attribute is deprecated, and should not be used. |
 | `<!--@DEPRECATED: attribute-value1, attribute-value2-->` | The attribute values are deprecated, and should not be used. Spaces between tokens are not significant. |

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -1,5 +1,5 @@
 <!--
-Copyright © 1991-2022 Unicode, Inc.
+Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -90,14 +90,17 @@ Please see CLDR-15034 for the latest information. -->
 <!ELEMENT display EMPTY >
 <!ATTLIST display to CDATA #REQUIRED >
     <!--@MATCH:any-->
+    <!--@ALLOWS_UESC-->
 <!ATTLIST display display CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 
 <!ELEMENT displayOptions EMPTY >
 <!ATTLIST displayOptions baseCharacter CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 
 <!ELEMENT keys ( import*, ( key | flicks )*, special* ) >
 
@@ -111,14 +114,18 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST key to CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 <!ATTLIST key longPress CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 <!ATTLIST key longPressDefault CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 <!ATTLIST key multiTap CDATA #IMPLIED >
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 <!ATTLIST key switch NMTOKEN #IMPLIED >
     <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
     <!--@VALUE-->
@@ -138,6 +145,7 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST flick to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 
 <!ELEMENT layers ( import*, layer*, special* ) >
 <!ATTLIST layers form (hardware | touch) #REQUIRED >
@@ -169,6 +177,7 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST transform to CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 <!ATTLIST transform error (fail) #IMPLIED >
     <!--@VALUE-->
 

--- a/keyboards/dtd/ldmlKeyboard.xsd
+++ b/keyboards/dtd/ldmlKeyboard.xsd
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 1991-2022 Unicode, Inc.
+  Copyright © 1991-2023 Unicode, Inc.
   For terms of use, see http://www.unicode.org/copyright.html
   SPDX-License-Identifier: Unicode-DFS-2016
   CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <!--
   Important Note:
-  
+
   The CLDR Keyboard Workgroup is currently developing major changes to the
   CLDR keyboard specification.
-  
+
   This DTD is a work in progress.
-  
+
   Please see CLDR-15034 for the latest information.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
@@ -190,8 +190,10 @@
     </xs:complexType>
   </xs:element>
   <!-- @MATCH:any -->
+  <!-- @ALLOWS_UESC -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <xs:element name="displayOptions">
     <xs:complexType>
       <xs:attribute name="baseCharacter"/>
@@ -199,6 +201,7 @@
   </xs:element>
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <xs:element name="keys">
     <xs:complexType>
       <xs:sequence>
@@ -242,11 +245,15 @@
   <!-- @VALUE -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <!-- @VALUE -->
   <!-- @VALUE -->
@@ -271,6 +278,7 @@
   <!-- @MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))* -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <xs:element name="layers">
     <xs:complexType>
       <xs:sequence>
@@ -348,6 +356,7 @@
   <!-- @MATCH:any -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <!-- @VALUE -->
   <xs:element name="reorders">
     <xs:complexType>

--- a/keyboards/dtd/ldmlKeyboardTest.dtd
+++ b/keyboards/dtd/ldmlKeyboardTest.dtd
@@ -1,5 +1,5 @@
 <!--
-Copyright © 1991-2022 Unicode, Inc.
+Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -43,6 +43,7 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST startContext to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 
 <!ELEMENT keystroke EMPTY >
     <!--@ORDERED-->
@@ -64,6 +65,7 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST emit to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 
 <!ELEMENT backspace EMPTY >
     <!--@ORDERED-->
@@ -73,5 +75,6 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST check result CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
 
 <!ELEMENT special ANY >

--- a/keyboards/dtd/ldmlKeyboardTest.xsd
+++ b/keyboards/dtd/ldmlKeyboardTest.xsd
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 1991-2022 Unicode, Inc.
+  Copyright © 1991-2023 Unicode, Inc.
   For terms of use, see http://www.unicode.org/copyright.html
   SPDX-License-Identifier: Unicode-DFS-2016
   CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <!--
   Important Note:
-  
+
   The CLDR Keyboard Workgroup is currently developing major changes to the
   CLDR keyboard specification.
-  
+
   This DTD is a work in progress.
-  
+
   Please see CLDR-15034 for the latest information.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
@@ -97,6 +97,7 @@
   </xs:element>
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <xs:element name="keystroke">
     <xs:complexType>
       <xs:attribute name="key" use="required" type="xs:NMTOKEN"/>
@@ -122,6 +123,7 @@
   <!-- @ORDERED -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <xs:element name="backspace">
     <xs:complexType/>
   </xs:element>
@@ -134,6 +136,7 @@
   <!-- @ORDERED -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @ALLOWS_UESC -->
   <xs:element name="special" type="any"/>
   <xs:complexType name="any" mixed="true">
     <xs:sequence>


### PR DESCRIPTION
_(Note: Keyboard PR- not for v43!)_

CLDR-15034

Add a `<!--@ALLOWS_UESC-->` DTD annotation noting where `\u{…}` escaping is allowed on an attribute.
This does not address changes to UnicodeSet escaping, because there are still open issues around UnicodeSets in keyboard

CLDRFile is not affected, and the escaping is optional.

Currently this annotation is only on Keyboard attributes, so escaping is not permitted on any non-keyboard data items

ALLOW_MANY_COMMITS=true