### PR TITLE
CLDR-16318 v42 update ISO-4217 data since HRK is obsolete (#2646)

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/IsoCurrencyParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/IsoCurrencyParser.java
@@ -92,6 +92,7 @@ public class IsoCurrencyParser {
         .put("MEMBER COUNTRIES OF THE AFRICAN DEVELOPMENT BANK GROUP", "ZZ")
         .put("SISTEMA UNITARIO DE COMPENSACION REGIONAL DE PAGOS \"SUCRE\"", "ZZ")
         .put("EUROPEAN MONETARY CO-OPERATION FUND (EMCF)", "ZZ")
+        .put("TÜRKİYE", "TR")
         .build();
 
     static Map<String, String> iso4217CountryToCountryCode = new TreeMap<>();

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/ISO4217.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/ISO4217.txt
@@ -74,7 +74,7 @@ currency	|	CDF	|	Franc Congolais	|	CD	|	CONGO, THE DEMOCRATIC REPUBLIC OF	|	C
 currency	|	NZD	|	New Zealand Dollar	|	CK	|	COOK ISLANDS	|	C
 currency	|	CRC	|	Costa Rican Colon	|	CR	|	COSTA RICA	|	C
 currency	|	XOF	|	CFA Franc BCEAO †	|	CI	|	CÔTE D'IVOIRE	|	C
-currency	|	HRK	|	Croatian Kuna	|	HR	|	CROATIA	|	C
+currency	|	HRK	|	Croatian Kuna	|	HR	|	CROATIA	|	O
 currency	|	CUP	|	Cuban Peso	|	CU	|	CUBA	|	C
 currency	|	CYP	|	Cyprus Pound	|	CY	|	CYPRUS	|	O
 currency	|	CZK	|	Czech Koruna	|	CZ	|	CZECHIA	|	C

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2022-04-01">
+<ISO_4217 Pblshd="2023-01-01">
 	<CcyTbl>
 		<CcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -413,9 +413,9 @@
 		</CcyNtry>
 		<CcyNtry>
 			<CtryNm>CROATIA</CtryNm>
-			<CcyNm>Kuna</CcyNm>
-			<Ccy>HRK</Ccy>
-			<CcyNbr>191</CcyNbr>
+			<CcyNm>Euro</CcyNm>
+			<Ccy>EUR</Ccy>
+			<CcyNbr>978</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
@@ -1708,7 +1708,7 @@
 			<CcyMnrUnts>3</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
-			<CtryNm>TURKEY</CtryNm>
+			<CtryNm>TÜRKİYE</CtryNm>
 			<CcyNm>Turkish Lira</CcyNm>
 			<Ccy>TRY</Ccy>
 			<CcyNbr>949</CcyNbr>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2018-08-20">
+<ISO_4217 Pblshd="2023-01-01">
 	<HstrcCcyTbl>
 		<HstrcCcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -252,6 +252,13 @@
 			<Ccy>HRK</Ccy>
 			<CcyNbr>191</CcyNbr>
 			<WthdrwlDt>2015-06</WthdrwlDt>
+		</HstrcCcyNtry>
+		<HstrcCcyNtry>
+			<CtryNm>CROATIA</CtryNm>
+			<CcyNm>Kuna</CcyNm>
+			<Ccy>HRK</Ccy>
+			<CcyNbr>191</CcyNbr>
+			<WthdrwlDt>2023-01</WthdrwlDt>
 		</HstrcCcyNtry>
 		<HstrcCcyNtry>
 			<CtryNm>CYPRUS</CtryNm>


### PR DESCRIPTION
- originally CLDR-16263
- includes proper import from ISO-4217
- updated ISO4217.txt per process
- add a workaround for updated territory name TÜRKİYE in ISO-4217

(cherry picked from commit 25246c02e1c7fe80aed7da87c02717ea6c3575a3)

CLDR-13613

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
