### PR TITLE
CLDR-16319 deps: fix gh-pages breakage w/ ruby 2.7

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: git status ; git diff
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
       - name: Build Jekyll part of the site
         run: |


### PR DESCRIPTION
CLDR-13619

See https://github.com/unicode-org/cldr/actions/runs/3954024609/jobs/6770915378 for a successful run

I tried several things and wasn't able to do a local build… but, updating ruby to 2.7 seemed to succeed.

- [X] This PR completes the ticket.
