### PR TITLE
CLDR-16200 initial support for Beaufort units, currently non-convertible

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -7055,6 +7055,11 @@ annotations.
 				<unitPattern count="one">{0} knot</unitPattern>
 				<unitPattern count="other">{0} knots</unitPattern>
 			</unit>
+			<unit type="speed-beaufort">
+				<displayName>Beaufort</displayName>
+				<unitPattern count="one">Beaufort {0}</unitPattern>
+				<unitPattern count="other">Beaufort {0}</unitPattern>
+			</unit>
 			<unit type="temperature-generic">
 				<displayName>degrees temperature</displayName>
 				<unitPattern count="one">{0} degree temperature</unitPattern>
@@ -7983,6 +7988,11 @@ annotations.
 				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
+			<unit type="speed-beaufort">
+				<displayName>Bft</displayName>
+				<unitPattern count="one">B {0}</unitPattern>
+				<unitPattern count="other">B {0}</unitPattern>
+			</unit>
 			<unit type="temperature-celsius">
 				<displayName>deg. C</displayName>
 				<unitPattern count="one">{0}°C</unitPattern>
@@ -8870,6 +8880,11 @@ annotations.
 				<displayName>kn</displayName>
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
+			</unit>
+			<unit type="speed-beaufort">
+				<displayName>Bft</displayName>
+				<unitPattern count="one">B{0}</unitPattern>
+				<unitPattern count="other">B{0}</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -17684,6 +17684,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kt</unitPattern>
 				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
+			<unit type="speed-beaufort">
+				<displayName draft="provisional">windkracht</displayName>
+				<unitPattern count="one" draft="provisional">{0}</unitPattern>
+				<unitPattern count="other" draft="provisional">{0}</unitPattern>
+			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5026,6 +5026,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kn</displayName>
 				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
+			<unit type="speed-beaufort">
+				<displayName>Bft</displayName>
+				<unitPattern count="other">B {0}</unitPattern>
+			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
 				<unitPattern count="other">{0}°</unitPattern>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -12242,6 +12242,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
+			<unit type="speed-beaufort">
+				<displayName draft="provisional">蒲福風級</displayName>
+				<unitPattern count="other" draft="provisional">{0}级</unitPattern>
+			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
 				<unitPattern count="other">{0}°</unitPattern>

--- a/common/validity/unit.xml
+++ b/common/validity/unit.xml
@@ -74,7 +74,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				pressure-kilopascal
 				pressure-megapascal
 				pressure-ofhg
-				speed-kilometer-per-hour speed-knot speed-meter-per-second speed-mile-per-hour
+				speed-beaufort speed-kilometer-per-hour speed-knot speed-meter-per-second speed-mile-per-hour
 				temperature-celsius temperature-fahrenheit temperature-generic temperature-kelvin
 				torque-pound-force-foot 
 				torque-newton-meter

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1476,7 +1476,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         "pressure-hectopascal",
         "pressure-kilopascal",
         "pressure-megapascal",
-        "speed-kilometer-per-hour", "speed-meter-per-second", "speed-mile-per-hour", "speed-knot",
+        "speed-kilometer-per-hour", "speed-meter-per-second", "speed-mile-per-hour", "speed-knot", "speed-beaufort",
         "temperature-generic", "temperature-celsius", "temperature-fahrenheit", "temperature-kelvin",
         "torque-pound-force-foot",
         "torque-pound-foot", // deprecated

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -565,7 +565,7 @@ public class TestUnits extends TestFmwk {
         assertEquals("Units without Quantity", Collections.emptySet(), noQuantity);
     }
 
-    static final Set<String> NOT_CONVERTABLE = ImmutableSet.of("generic");
+    static final Set<String> NOT_CONVERTABLE = ImmutableSet.of("generic", "beaufort");
 
     private void checkUnitConvertability(UnitConverter converter, Output<String> compoundBaseUnit,
         Set<String> badUnits, Set<String> noQuantity, String type, String unit,
@@ -687,7 +687,7 @@ public class TestUnits extends TestFmwk {
         for (Entry<String, String> entry : TYPE_TO_CORE.entries()) {
             final String coreUnit = entry.getValue();
             final String unitType = entry.getKey();
-            if (coreUnit.equals("generic")) {
+            if (NOT_CONVERTABLE.contains(coreUnit)) {
                 continue;
             }
             String quantity = converter.getQuantityFromUnit(coreUnit, false);
@@ -961,7 +961,7 @@ public class TestUnits extends TestFmwk {
         Multimap<Set<UnitSystem>, R3<String, ConversionInfo, String>> systemsToUnits = TreeMultimap.create(Comparators.lexicographical(Ordering.natural()), Ordering.natural());
         for (String longUnit : VALID_REGULAR_UNITS) {
             String unit = Units.getShort(longUnit);
-            if (unit.equals("generic")) {
+            if (NOT_CONVERTABLE.contains(unit)) {
                 continue;
             }
             if (unit.contentEquals("centiliter")) {
@@ -1859,10 +1859,10 @@ public class TestUnits extends TestFmwk {
         //assertSuperset("long convertible units", "valid regular", unitsConvertibleLongIds, validLongUnitIds);
         Output<String> baseUnit = new Output<>();
         for (String longUnit : validLongUnitIds) {
-            if (longUnit.equals("temperature-generic")) {
+            String shortUnit = Units.getShort(longUnit);
+            if (NOT_CONVERTABLE.contains(shortUnit)) {
                 continue;
             }
-            String shortUnit = Units.getShort(longUnit);
             ConversionInfo conversionInfo = converter.parseUnitId(shortUnit, baseUnit, false);
             if (!assertNotNull("Can convert " + longUnit, conversionInfo)) {
                 converter.getUnitInfo(shortUnit, baseUnit);


### PR DESCRIPTION
CLDR-16200

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16200)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Initial support for Beaufort scale units (for wind speed). Data for `root` and `en`; provisional data for`zh` and `nl` (the latter formats without a unit symbol, checked that this does not generate errors in CLDR at least).

The conversion to other speed units is non-linear (see the ticket) which is not yet supported, so this  unit is currently marked as non-convertible in tests.

Usage data will be added in the future after we have confirmed localized formats for Beaufort units in the relevant locales.

