### PR TITLE
CLDR-15034 kbd: spec: move hardware type into 'form'

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1151,7 +1151,7 @@ hardware or touch layout.
 - At least one `layers` element is required.
 - Multiple `<layers form="touch">` elements are allowed with distinct `minDeviceWidth` values.
 - At most one `<layers>` element is allowed per hardware `form`. In other words,
-at most one `<layers form="jis">` element is allowed.
+  at most one `<layers form="jis">` element is allowed.
 
 _Attribute:_ `form` (required)
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1149,19 +1149,24 @@ hardware or touch layout.
 > </small>
 
 - At least one `layers` element is required.
-- Multiple `<layers form="touch">` elements are allowed with distinct `minDeviceWidth` values.
-- At most one `<layers>` element is allowed per hardware `form`. In other words,
-  at most one `<layers form="jis">` element is allowed.
 
 _Attribute:_ `form` (required)
 
 > This attribute specifies the physical layout of a hardware keyboard,
-> or that the form is a touch layout.
+> or that the form is a `touch` layout.
 >
 > It is recommended to always have at least one hardware (non-touch) form.
 > If there is no `hardware` form, the implementation may need
 > to choose a different keyboard file, or use some other fallback behavior when using a
 > hardware keyboard.
+>
+> Multiple `<layers form="touch">` elements are allowed with distinct `minDeviceWidth` values.
+> At most one `<layers>` element is allowed per hardware `form`. In other words, at most one `<layers form="jis">` element is allowed.
+>
+> In most situations, only one hardware `layers` element will be included. Note that the typical keyboard author will be designing a keyboard based on their circumstances and the hardware that they are using. So, for example, if they are in South East Asia, they will almost certainly be using an 101 key hardware keyboard with US key caps. So we want them to be able to reference that (`<layers form="us">`) in their design, rather than having to work with an unfamiliar form. An implementation should be able to translate the keyboard designer's chosen form to the other hardware forms.
+
+
+
 >
 > When using an on-screen keyboard, if there is not a `<layers form="touch">`
 > element, the hardware elements can be used for on-screen use.
@@ -1175,7 +1180,7 @@ _Attribute:_ `form` (required)
 
 _Attribute:_ `minDeviceWidth`
 
-> This attribute specifies the minimum required width, in millimeters (mm), of the touch surface.  The `layers` entry with the greatest matching width will be selected. This attribute is intended for `form="touch"`, but is supported for hardware forms`.
+> This attribute specifies the minimum required width, in millimeters (mm), of the touch surface.  The `layers` entry with the greatest matching width will be selected. This attribute is intended for `form="touch"`, but is supported for hardware forms.
 
 ### <a name="Element_layer" href="#Element_layer">Element: layer</a>
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1152,9 +1152,9 @@ _Attribute:_ `form` (required)
 
 > `form` may be either `hardware` or `touch`.
 >
-> There may only be a single `layers` with `form="hardware"`.
+> There may only be a single (at most one) `layers` element with `form="hardware"` for each `hardware=…` type.
 >
-> It is recommended to always have one
+> It is recommended to always have at least one
 > `<layers form="hardware">` element.
 > If there is no `hardware` form, the implementation may need
 > to choose a different keyboard file, or use some other fallback behavior when using a
@@ -1166,7 +1166,13 @@ _Attribute:_ `form` (required)
 _Attribute:_ `hardware`
 
 This attribute specifies the physical layout for the hardware keyboard.
+It is required for `form="hardware"` keyboards.
 Currently supported values are `us`, `iso`, `jis` and `abnt2`.
+
+- `abnt2` - Brazilian 103 key ABNT2 layout (iso + extra key left of right shift)
+- `iso` - European 102 key layout (extra key right of left shift)
+- `jis` - Japanese 109 key layout
+- `us` - ANSI 101 key layout
 
 _Attribute:_ `minDeviceWidth`
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1148,35 +1148,34 @@ hardware or touch layout.
 >
 > </small>
 
+- At least one `layers` element is required.
+- Multiple `<layers form="touch">` elements are allowed with distinct `minDeviceWidth` values.
+- At most one `<layers>` element is allowed per hardware `form`. In other words,
+at most one `<layers form="jis">` element is allowed.
+
 _Attribute:_ `form` (required)
 
-> `form` may be either `hardware` or `touch`.
+> This attribute specifies the physical layout of a hardware keyboard,
+> or that the form is a touch layout.
 >
-> There may only be a single (at most one) `layers` element with `form="hardware"` for each `hardware=…` type.
->
-> It is recommended to always have at least one
-> `<layers form="hardware">` element.
+> It is recommended to always have at least one hardware (non-touch) form.
 > If there is no `hardware` form, the implementation may need
 > to choose a different keyboard file, or use some other fallback behavior when using a
 > hardware keyboard.
 >
 > When using an on-screen keyboard, if there is not a `<layers form="touch">`
-> element, the `<layers form="hardware">` element can be used for on-screen use.
-
-_Attribute:_ `hardware` (required for `form="hardware"`)
-
-This attribute specifies the physical layout for the hardware keyboard.
-It is required for `form="hardware"` keyboards.
-Currently supported values are `us`, `iso`, `jis` and `abnt2`.
-
-- `abnt2` - Brazilian 103 key ABNT2 layout (iso + extra key left of right shift)
-- `iso` - European 102 key layout (extra key right of left shift)
-- `jis` - Japanese 109 key layout
-- `us` - ANSI 101 key layout
+> element, the hardware elements can be used for on-screen use.
+>
+> The following values are allowed:
+> - `touch` - Touch (non-hardware) layout.
+> - `abnt2` - Brazilian 103 key ABNT2 layout (iso + extra key left of right shift)
+> - `iso` - European 102 key layout (extra key right of left shift)
+> - `jis` - Japanese 109 key layout
+> - `us` - ANSI 101 key layout
 
 _Attribute:_ `minDeviceWidth`
 
-This attribute specifies the minimum required width, in millimeters (mm), of the touch surface.  The `layers` entry with the greatest matching width will be selected. This attribute is intended for `form="touch"`, but is supported for `form="hardware"`.
+> This attribute specifies the minimum required width, in millimeters (mm), of the touch surface.  The `layers` entry with the greatest matching width will be selected. This attribute is intended for `form="touch"`, but is supported for hardware forms`.
 
 ### <a name="Element_layer" href="#Element_layer">Element: layer</a>
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1161,17 +1161,18 @@ _Attribute:_ `form` (required)
 > hardware keyboard.
 >
 > Multiple `<layers form="touch">` elements are allowed with distinct `minDeviceWidth` values.
-> At most one `<layers>` element is allowed per hardware `form`. In other words, at most one `<layers form="jis">` element is allowed.
+> At most one hardware (non-`touch`) `<layers>` element is allowed. If a different key arrangement is desired between, for example, `us` and `iso` formats, these should be separated into two different keyboards.
 >
-> In most situations, only one hardware `layers` element will be included. Note that the typical keyboard author will be designing a keyboard based on their circumstances and the hardware that they are using. So, for example, if they are in South East Asia, they will almost certainly be using an 101 key hardware keyboard with US key caps. So we want them to be able to reference that (`<layers form="us">`) in their design, rather than having to work with an unfamiliar form. An implementation should be able to translate the keyboard designer's chosen form to the other hardware forms.
-
-
-
+> The typical keyboard author will be designing a keyboard based on their circumstances and the hardware that they are using. So, for example, if they are in South East Asia, they will almost certainly be using an 101 key hardware keyboard with US key caps. So we want them to be able to reference that (`<layers form="us">`) in their design, rather than having to work with an unfamiliar form.
+>
+> A mismatch between the hardware layout in the keyboard file, and the actual hardware used by the user could result in some keys being inaccessible to the user if their hardware cannot generate the scancodes corresponding to the layout specified by the `form=` attribute. Such keys could be accessed only via an on-screen keyboard utility. Conversely, a user with hardware keys that are not present in the specified `form=` will result in some hardware keys which have no function when pressed.
+>
 >
 > When using an on-screen keyboard, if there is not a `<layers form="touch">`
 > element, the hardware elements can be used for on-screen use.
 >
-> The following values are allowed:
+> The following values are allowed for the `form` attribute:
+>
 > - `touch` - Touch (non-hardware) layout.
 > - `abnt2` - Brazilian 103 key ABNT2 layout (iso + extra key left of right shift)
 > - `iso` - European 102 key layout (extra key right of left shift)

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1163,7 +1163,7 @@ _Attribute:_ `form` (required)
 > When using an on-screen keyboard, if there is not a `<layers form="touch">`
 > element, the `<layers form="hardware">` element can be used for on-screen use.
 
-_Attribute:_ `hardware`
+_Attribute:_ `hardware` (required for `form="hardware"`)
 
 This attribute specifies the physical layout for the hardware keyboard.
 It is required for `form="hardware"` keyboards.

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -79,7 +79,7 @@
 		<!-- TODO: all additional maps, hardware and touch -->
 	</keys>
 
-	<layers form="hardware" hardware="iso">
+	<layers form="iso">
 		<!-- in DTD: required if conformsTo ≥ 41 -->
 		<layer modifier="none">
 			<row keys="super-2 amp e-grave quote apos open-paren hyphen e-acute underscore c-cedilla a-acute close-paren equal" />

--- a/keyboards/3.0/mt-t-k0-47key.xml
+++ b/keyboards/3.0/mt-t-k0-47key.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "../dtd/ldmlKeyboard.dtd">
-<keyboard locale="mt" conformsTo="techpreview">
+<keyboard locale="mt-t-k0-47key" conformsTo="techpreview">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />

--- a/keyboards/3.0/mt-t-k0-47key.xml
+++ b/keyboards/3.0/mt-t-k0-47key.xml
@@ -8,8 +8,8 @@
     <info author="Steven R. Loomis" normalization="NFC" layout="QWERTY" indicator="MT" />
 
     <names>
-        <name value="Maltese" />
-        <name value="MSA 100:2002" />
+        <name value="Maltese 47-key" />
+        <name value="MSA 100:2002 47-key" />
     </names>
 
     <keys>
@@ -45,37 +45,37 @@
         <key id="gap" gap="true" width="1" />
     </keys>
 
-     <!-- 48-key -->
-    <layers form="iso">
+    <!-- 47-key: MSA 100:2002, Appendix, figure A.1 -->
+    <layers form="us">
         <layer modifier="none">
-            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 minus equals" />
-            <row keys="q w e r t y u i o p g-tikka h-maqtugha" />
-            <row keys="a s d f g h j k l semi-colon hash" />
-            <row keys="z-tikka z x c v b n m comma period slash" />
+            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha z-tikka" />
+            <row keys="a s d f g h j k l semi-colon apos" />
+            <row keys="z x c v b n m comma period slash" />
             <row keys="space" />
         </layer>
 
         <layer modifier="shift">
-            <row keys="C-tikka bang double-quote euro dollar percent caret amp open-paren close-paren underscore plus" />
-            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha" />
-            <row keys="A S D F G H J K L colon at tilde" />
-            <row keys="Z-tikka Z X C V B N M open-angle close-angle question" />
+            <row keys="C-tikka bang at euro dollar percent caret amp asterisk open-paren close-paren underscore plus" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha Z-tikka" />
+            <row keys="A S D F G H J K L colon double-quote" />
+            <row keys="Z X C V B N M open-angle close-angle question" />
             <row keys="space" />
         </layer>
 
         <layer modifier="altR">
             <row keys="grave gap gap pound gap gap gap gap gap gap gap gap gap" />
-            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square" />
-            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap gap" />
-            <row keys="backslash gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square backslash" />
+            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
             <row keys="space" />
         </layer>
 
         <layer modifier="altR-shift">
-            <row keys="not gap gap gap gap gap gap gap gap gap gap gap gap" />
-            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly" />
-            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap gap" />
-            <row keys="pipe gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="tilde gap gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly pipe" />
+            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
             <row keys="space" />
         </layer>
     </layers>

--- a/keyboards/3.0/mt.xml
+++ b/keyboards/3.0/mt.xml
@@ -8,13 +8,13 @@
     <info author="Steven R. Loomis" normalization="NFC" layout="QWERTY" indicator="MT" />
 
     <names>
-        <name value="Maltese (48-key)" />
-        <!-- <name value="MSA 100:2002" /> -->
+        <name value="Maltese" />
+        <name value="MSA 100:2002" />
     </names>
 
     <keys>
         <!-- imports -->
-        <import base="cldr" path="techpreview/key-Zyyy-punctuation.xml"/>
+        <import base="cldr" path="techpreview/key-Zyyy-punctuation.xml" />
 
         <!-- accent grave -->
         <key id="a-grave" to="à" />
@@ -28,13 +28,13 @@
         <key id="u-grave" to="ù" />
         <key id="U-grave" to="Ù" />
 
-        <!-- tikka and maqtua -->
-        <key id="c-tikka" to="ċ" />
+        <!-- tikka and maqtugha -->
+        <key id="c-tikka" to="ċ" /> <!-- tikka is a dot -->
         <key id="C-tikka" to="Ċ" />
         <key id="g-tikka" to="ġ" />
         <key id="G-tikka" to="Ġ" />
-        <key id="h-maqtua" to="ħ" />
-        <key id="H-maqtua" to="Ħ" />
+        <key id="h-maqtugha" to="ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="H-maqtugha" to="Ħ" /> <!-- maqtugħa, i.e. cut -->
         <key id="z-tikka" to="ż" />
         <key id="Z-tikka" to="Ż" />
 
@@ -45,10 +45,11 @@
         <key id="gap" gap="true" width="1" />
     </keys>
 
+     <!-- 48-key -->
     <layers form="iso">
         <layer modifier="none">
             <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 minus equals" />
-            <row keys="q w e r t y u i o p g-tikka h-maqtua" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha" />
             <row keys="a s d f g h j k l semi-colon hash" />
             <row keys="z-tikka z x c v b n m comma period slash" />
             <row keys="space" />
@@ -56,7 +57,7 @@
 
         <layer modifier="shift">
             <row keys="C-tikka bang double-quote euro dollar percent caret amp open-paren close-paren underscore plus" />
-            <row keys="Q W E R T Y U I O P G-tikka H-maqtua" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha" />
             <row keys="A S D F G H J K L colon at tilde" />
             <row keys="Z-tikka Z X C V B N M open-angle close-angle question" />
             <row keys="space" />
@@ -78,4 +79,40 @@
             <row keys="space" />
         </layer>
     </layers>
+
+    <!-- 47-key: MSA 100:2002, Appendix, figure A.1 -->
+    <layers form="us">
+        <layer modifier="none">
+            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha z-tikka" />
+            <row keys="a s d f g h j k l semi-colon apos" />
+            <row keys="z x c v b n m comma period slash" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="shift">
+            <row keys="C-tikka bang at euro dollar percent caret amp asterisk open-paren close-paren underscore plus" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha Z-tikka" />
+            <row keys="A S D F G H J K L colon double-quote" />
+            <row keys="Z X C V B N M open-angle close-angle question" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="altR">
+            <row keys="grave gap gap pound gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square backslash" />
+            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="altR-shift">
+            <row keys="tilde gap gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly pipe" />
+            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+    </layers>
+
 </keyboard>

--- a/keyboards/3.0/mt.xml
+++ b/keyboards/3.0/mt.xml
@@ -45,7 +45,7 @@
         <key id="gap" gap="true" width="1" />
     </keys>
 
-    <layers form="hardware" hardware="iso">
+    <layers form="iso">
         <layer modifier="none">
             <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 minus equals" />
             <row keys="q w e r t y u i o p g-tikka h-maqtua" />

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -148,11 +148,9 @@ Please see CLDR-15034 for the latest information. -->
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT layers ( import*, layer*, special* ) >
-<!ATTLIST layers form (hardware | touch) #REQUIRED >
+<!ATTLIST layers form (touch | us | iso | jis | abnt2) #REQUIRED >
 <!ATTLIST layers minDeviceWidth CDATA #IMPLIED >
     <!--@MATCH:range/1~999-->
-<!ATTLIST layers hardware NMTOKEN #IMPLIED >
-    <!--@MATCH:literal/us, iso, jis, abnt2-->
 
 <!ELEMENT layer ( row+, special* ) >
 <!ATTLIST layer id NMTOKEN #IMPLIED >

--- a/keyboards/dtd/ldmlKeyboard.xsd
+++ b/keyboards/dtd/ldmlKeyboard.xsd
@@ -289,17 +289,18 @@
       <xs:attribute name="form" use="required">
         <xs:simpleType>
           <xs:restriction base="xs:token">
-            <xs:enumeration value="hardware"/>
             <xs:enumeration value="touch"/>
+            <xs:enumeration value="us"/>
+            <xs:enumeration value="iso"/>
+            <xs:enumeration value="jis"/>
+            <xs:enumeration value="abnt2"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="minDeviceWidth"/>
-      <xs:attribute name="hardware" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
   <!-- @MATCH:range/1~999 -->
-  <!-- @MATCH:literal/us, iso, jis, abnt2 -->
   <xs:element name="layer">
     <xs:complexType>
       <xs:sequence>

--- a/keyboards/import/keys-Zyyy-punctuation.xml
+++ b/keyboards/import/keys-Zyyy-punctuation.xml
@@ -3,6 +3,7 @@
 <keys>
     <!-- General Symbols -->
     <key id="apos" to="'" />
+    <key id="asterisk" to="*" />
     <key id="bang" to="!" />
     <key id="close-paren" to=")" />
     <key id="double-quote" to="\u{0022}" />

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -634,7 +634,6 @@ public class TestDtdData extends TestFmwk {
                 || elementName.equals("layers") && attribute.equals("minDeviceWidth")
                 || elementName.equals("vkey") && attribute.equals("from")
                 || elementName.equals("layer") && attribute.equals("modifier")
-                || elementName.equals("layers") && attribute.equals("hardware")
                 || elementName.equals("map") && attribute.equals("id")
                 || elementName.equals("key") && attribute.equals("id")
                 || elementName.equals("key") && attribute.equals("stretch")


### PR DESCRIPTION
thanks to @mcdurdin suggestion below, this changes the format to the below. Dropping the `hardware=` attribute, and changing the meaning of `form` to be the hardware type or otherwise `touch`

- more than one hardware layout is allowed per file. This is pursuant to the 'single file' goal. Otherwise we will need one `fr.xml` for US and one `fr.xml` for ISO, etc.
- only one `layers` allowed per 'form'.  So, illegal to have two with `form="iso"`.

```xml
<keyboard>
    <layers form="touch" />
    <layers form="touch" minDeviceWidth="100" /> <!-- distinguished by device width -->
    <layers form="iso" /> <!-- hardware -->
    <layers form="us" /> <!-- hardware -->
</keyboard>
```

-----

<details><summary>previous format:</summary>

Previously, `form=touch` or `form=hardware`, and a separate attribute for `hardware=iso` etc.  Also previously, only one `hardware` layers was allowed.

```xml
<keyboard>
    <layers form="touch" /> <!-- etc… -->
    <layers form="touch" minDeviceWidth="100" /> <!-- etc… -->
    <layers form="hardware" hardware="iso" /> <!-- etc… -->
</keyboard>
```

</details>



CLDR-15034


ALLOW_MANY_COMMITS=true
