### PR TITLE
CLDR-16330 v42: deps: fix gh-pages breakage w/ ruby 2.7

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: git status ; git diff
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
       - name: Build Jekyll part of the site
         run: |


### PR DESCRIPTION
From CLDR-16319 (#2650)

(cherry picked from commit 0cf65943c0eb8fe7e3e490887bf5afba4240bd25)

CLDR-16330

- [X] This PR completes the ticket.