### PR TITLE
CLDR-16122 v43 BRS: fix fi,nl

### DIFF
--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -7605,9 +7605,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SLL">
-				<displayName>Sierra Leonen leone</displayName>
-				<displayName count="one">Sierra Leonen leone</displayName>
-				<displayName count="other">Sierra Leonen leonea</displayName>
+				<displayName>Sierra Leonen leone (1964—2022)</displayName>
+				<displayName count="one">Sierra Leonen leone (1964—2022)</displayName>
+				<displayName count="other">Sierra Leonen leonea (1964—2022)</displayName>
 				<symbol>SLL</symbol>
 			</currency>
 			<currency type="SOS">

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -14957,9 +14957,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SLL">
-				<displayName>Sierraleoonse leone</displayName>
-				<displayName count="one">Sierraleoonse leone</displayName>
-				<displayName count="other">Sierraleoonse leone</displayName>
+				<displayName>Sierraleoonse leone (1964—2022)</displayName>
+				<displayName count="one">Sierraleoonse leone (1964—2022)</displayName>
+				<displayName count="other">Sierraleoonse leone (1964—2022)</displayName>
 				<symbol>SLL</symbol>
 			</currency>
 			<currency type="SOS">


### PR DESCRIPTION
- fi and nl had `SLE` and `SLL` with identical localizations

- SLL is obsolete and needs  (1964—2022)

CLDR-16122

ALLOW_MANY_COMMITS=true
