### PR TITLE
CLDR-16308 DAIP Latin-script intervalFormat adjustments should handle preceding literals

### DIFF
--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -4682,7 +4682,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">G y – G y</greatestDifference>
@@ -4755,61 +4755,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
-							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">y. – y. G</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
 							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
-							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
-							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
-							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
-							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
-							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
 							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
-							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
-							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5347,8 +5347,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. M – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLL</greatestDifference>
@@ -5358,7 +5358,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -5369,32 +5369,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">M/y – M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">d.M.y. – d.M.y.</greatestDifference>
-							<greatestDifference id="M">d.M.y. – d.M.y.</greatestDifference>
-							<greatestDifference id="y">d.M.y. – d.M.y.</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y.</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y.</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d.M.y. – E, d.M.y.</greatestDifference>
-							<greatestDifference id="M">E, d.M.y. – E, d.M.y.</greatestDifference>
-							<greatestDifference id="y">E, d.M.y. – E, d.M.y.</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y.</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y.</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">LLL – LLL y.</greatestDifference>
-							<greatestDifference id="y">LLL y. – LLL y.</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. MMM y.</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y.</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y.</greatestDifference>
-							<greatestDifference id="y">d. MMM y. – d. MMM y.</greatestDifference>
+							<greatestDifference id="y">d. MMM y. – d. MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y.</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y.</greatestDifference>
-							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y.</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">LLLL – LLLL y.</greatestDifference>
-							<greatestDifference id="y">LLLL y. – LLLL y.</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y.</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -1548,23 +1548,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -1589,12 +1589,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -2577,23 +2577,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -2618,12 +2618,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -3665,23 +3665,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -3706,12 +3706,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -3873,13 +3873,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<intervalFormatItem id="GyMMMd">
 							<greatestDifference id="d">d.–d. M. y G</greatestDifference>
 							<greatestDifference id="G">d. M. y G – d. M. y G</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="G">E d. M. y G – E d. M. y G</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
@@ -3934,23 +3934,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">d.–d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y–y G</greatestDifference>
@@ -3975,12 +3975,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -4486,13 +4486,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<intervalFormatItem id="GyMMMd">
 							<greatestDifference id="d">d.–d. M. y G</greatestDifference>
 							<greatestDifference id="G">d. M. y G – d. M. y G</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="G">E d. M. y G – E d. M. y G</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
@@ -4547,23 +4547,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">d.–d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y–y</greatestDifference>
@@ -4588,12 +4588,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">d.–d. M. y</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E d. M. – E d. M. y</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M. y</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -4853,23 +4853,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -4894,12 +4894,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -5147,23 +5147,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -5188,12 +5188,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -5441,23 +5441,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -5482,12 +5482,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -6350,23 +6350,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -6391,12 +6391,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -6644,23 +6644,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
@@ -6685,12 +6685,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d.–d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -1917,12 +1917,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">M.–M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1932,7 +1932,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -1965,7 +1965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -2449,13 +2449,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">dd.–dd.MM.y G</greatestDifference>
 							<greatestDifference id="G">dd.MM.y G – dd.MM.y G</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.y G</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.y G</greatestDifference>
 							<greatestDifference id="y">dd.MM.y – dd.MM.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
 							<greatestDifference id="d">E, dd.MM.y – E, dd.MM.y G</greatestDifference>
 							<greatestDifference id="G">E, dd.MM.y G – E, dd.MM.y G</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y G</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y G</greatestDifference>
 							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
@@ -2470,7 +2470,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="G">E, d. MMM y G – E E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
@@ -2512,11 +2512,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
 							<greatestDifference id="d">dd.–dd.MM.</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -2526,7 +2526,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -2541,12 +2541,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">dd.–dd.MM.y</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.y</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.y</greatestDifference>
 							<greatestDifference id="y">dd.MM.y – dd.MM.y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, dd. – E, dd.MM.y</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd.MM.y</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y</greatestDifference>
 							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -2559,7 +2559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1108,7 +1108,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">G y – G y</greatestDifference>
@@ -1149,25 +1149,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
-							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1192,12 +1192,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">LLL y – LLL y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. MMM y G</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y G</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y G</greatestDifference>
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1618,7 +1618,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">G y – G y</greatestDifference>
@@ -1632,13 +1632,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">dd.–dd.MM.y G</greatestDifference>
 							<greatestDifference id="G">dd.MM.y G – dd.MM.y G</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.y G</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.y G</greatestDifference>
 							<greatestDifference id="y">dd.MM.y – dd.MM.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
 							<greatestDifference id="d">E, dd.MM.y – E, dd.MM.y G</greatestDifference>
 							<greatestDifference id="G">E, dd.MM.y G – E, dd.MM.y G</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y G</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y G</greatestDifference>
 							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
@@ -1653,7 +1653,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="G">E, d. MMM y G – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
@@ -1691,25 +1691,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="H">H–H v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
-							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1734,12 +1734,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">LLL y – LLL y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. MMM y</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y</greatestDifference>
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -1996,9 +1996,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y – d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E d.M. – E d.M.y G</greatestDifference>
+							<greatestDifference id="d">E d.M. – E d.M.y G</greatestDifference>
 							<greatestDifference id="G">E d.M.y – E d.M.y G</greatestDifference>
-							<greatestDifference id="M">E d.M. – E d.M.y G</greatestDifference>
+							<greatestDifference id="M">E d.M. – E d.M.y G</greatestDifference>
 							<greatestDifference id="y">E d.M.y – E d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMM">
@@ -2013,7 +2013,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMMM y – d. MMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="G">E d. MMMM y G – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="y">E d. MMMM y – E d. MMMM y G</greatestDifference>
@@ -2058,8 +2058,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
-							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
+							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
+							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLLL</greatestDifference>
@@ -2069,7 +2069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMMM – d. MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -2102,7 +2102,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMMM y – d. MMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="y">E d. MMMM y – E d. MMMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -2611,7 +2611,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<intervalFormatItem id="GyMMMEd">
 							<greatestDifference id="d">E d.M – E d.M.y G</greatestDifference>
 							<greatestDifference id="G">E d.M.y – E d.M.y G</greatestDifference>
-							<greatestDifference id="M">E d.M. – E d.M.y G</greatestDifference>
+							<greatestDifference id="M">E d.M. – E d.M.y G</greatestDifference>
 							<greatestDifference id="y">E d.M.y – E d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMM">
@@ -2626,7 +2626,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMMM y – d. MMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="G">E d. MMMM y G – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM y G</greatestDifference>
 							<greatestDifference id="y">E d. MMMM y – E d. MMMM y G</greatestDifference>
@@ -2671,8 +2671,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
-							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
+							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
+							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLLL</greatestDifference>
@@ -2682,7 +2682,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMMM – d. MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -2693,7 +2693,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMMM – d. MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -2723,7 +2723,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMMM y – d. MMMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM y</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM y</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM y</greatestDifference>
 							<greatestDifference id="y">E d. MMMM y – E d. MMMM y</greatestDifference>
 						</intervalFormatItem>
@@ -2737,7 +2737,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMMM y – d. MMMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMMEd">
-							<greatestDifference id="d">E d. – E d. MMMM y</greatestDifference>
+							<greatestDifference id="d">E d. – E d. MMMM y</greatestDifference>
 							<greatestDifference id="M">E d. MMMM – E d. MMMM y</greatestDifference>
 							<greatestDifference id="y">E d. MMMM y – E d. MMMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1048,7 +1048,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">G MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="unconfirmed">G d. – d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">G d. – d. MMM y</greatestDifference>
 							<greatestDifference id="G" draft="unconfirmed">G d. MMM y – G d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">G d. MMM – d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">G d. MMM y – d. MMM y</greatestDifference>
@@ -1106,7 +1106,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="unconfirmed">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="unconfirmed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d. – d. MMM</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
@@ -1135,7 +1135,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="unconfirmed">d. – d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d. – d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">d. MMM – d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1074,12 +1074,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">M.–M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1089,7 +1089,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -1122,7 +1122,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>
@@ -1410,12 +1410,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">M.–M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1425,7 +1425,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -1458,7 +1458,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -1603,45 +1603,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">dd. – dd.</greatestDifference>
+							<greatestDifference id="d">dd. – dd.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y. G – y. G</greatestDifference>
-							<greatestDifference id="y">y. – y. G</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
 							<greatestDifference id="G">M. y. GGGGG – M. y. GGGGG</greatestDifference>
-							<greatestDifference id="M">M. y. – M. y. GGGGG</greatestDifference>
-							<greatestDifference id="y">M. y. – M. y. GGGGG</greatestDifference>
+							<greatestDifference id="M">M. y. – M. y. GGGGG</greatestDifference>
+							<greatestDifference id="y">M. y. – M. y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">d. M. y. – d. M. y. GGGGG</greatestDifference>
-							<greatestDifference id="G">d. M. y. – d. M. y. GGGGG</greatestDifference>
-							<greatestDifference id="M">d. M. y. – d. M. y. GGGGG</greatestDifference>
-							<greatestDifference id="y">d. M. y. – d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="d">d. M. y. – d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="G">d. M. y. – d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="M">d. M. y. – d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="y">d. M. y. – d. M. y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">E, d. M. y. – E, d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="d">E, d. M. y. – E, d. M. y. GGGGG</greatestDifference>
 							<greatestDifference id="G">E, d. M. y. GGGGG – E, d. M. y. GGGGG</greatestDifference>
-							<greatestDifference id="M">E, d. M. y. – E, d. M. y. GGGGG</greatestDifference>
-							<greatestDifference id="y">E, d. M. y. – E, d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="M">E, d. M. y. – E, d. M. y. GGGGG</greatestDifference>
+							<greatestDifference id="y">E, d. M. y. – E, d. M. y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
 							<greatestDifference id="G">MMM y. G – MMM y. G</greatestDifference>
 							<greatestDifference id="M">MMM y. G – MMM y. G</greatestDifference>
-							<greatestDifference id="y">MMM y. – MMM y. G</greatestDifference>
+							<greatestDifference id="y">MMM y. – MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
 							<greatestDifference id="G">d. MMM y. G – d. MMM y. G</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
-							<greatestDifference id="y">d. MMM y. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">d. MMM y. – d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
 							<greatestDifference id="d">E, d. MMM – E, d. MMM y. G</greatestDifference>
 							<greatestDifference id="G">E, d. MMM y. G – E, d. MMM y. G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
-							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>
@@ -1676,61 +1676,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">MM. – MM.</greatestDifference>
+							<greatestDifference id="M">MM. – MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd. MM. – dd. MM.</greatestDifference>
-							<greatestDifference id="M">dd. MM. – dd. MM.</greatestDifference>
+							<greatestDifference id="d">dd. MM. – dd. MM.</greatestDifference>
+							<greatestDifference id="M">dd. MM. – dd. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd. MM. – E, dd. MM.</greatestDifference>
-							<greatestDifference id="M">E, dd. MM. – E, dd. MM.</greatestDifference>
+							<greatestDifference id="d">E, dd. MM. – E, dd. MM.</greatestDifference>
+							<greatestDifference id="M">E, dd. MM. – E, dd. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">y. – y. G</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">MM. y. – MM. y. G</greatestDifference>
-							<greatestDifference id="y">MM. y. – MM. y. G</greatestDifference>
+							<greatestDifference id="M">MM. y. – MM. y. G</greatestDifference>
+							<greatestDifference id="y">MM. y. – MM. y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">dd. MM. y. – dd. MM. y. G</greatestDifference>
-							<greatestDifference id="M">dd. MM. y. – dd. MM. y. G</greatestDifference>
-							<greatestDifference id="y">dd. MM. y. – dd. MM. y. G</greatestDifference>
+							<greatestDifference id="d">dd. MM. y. – dd. MM. y. G</greatestDifference>
+							<greatestDifference id="M">dd. MM. y. – dd. MM. y. G</greatestDifference>
+							<greatestDifference id="y">dd. MM. y. – dd. MM. y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, dd. MM. y. – E, dd. MM. y. G</greatestDifference>
-							<greatestDifference id="M">E, dd. MM. y. – E, dd. MM. y. G</greatestDifference>
-							<greatestDifference id="y">E, dd. MM. y. – E, dd. MM. y. G</greatestDifference>
+							<greatestDifference id="d">E, dd. MM. y. – E, dd. MM. y. G</greatestDifference>
+							<greatestDifference id="M">E, dd. MM. y. – E, dd. MM. y. G</greatestDifference>
+							<greatestDifference id="y">E, dd. MM. y. – E, dd. MM. y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">LLL – LLL y. G</greatestDifference>
-							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">dd. – dd. MMM y. G</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM y. G</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM y. G</greatestDifference>
-							<greatestDifference id="y">dd. MMM y. – dd. MMM y. G</greatestDifference>
+							<greatestDifference id="y">dd. MMM y. – dd. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM y. G</greatestDifference>
-							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
-							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2186,28 +2186,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">dd. – dd.</greatestDifference>
+							<greatestDifference id="d">dd. – dd.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y. G – y. G</greatestDifference>
-							<greatestDifference id="y">y. – y. G</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
 							<greatestDifference id="G">MM. y. GGGGG – MM. y. GGGGG</greatestDifference>
-							<greatestDifference id="M">MM. y. – MM. y. GGGGG</greatestDifference>
-							<greatestDifference id="y">MM. y. – MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="M">MM. y. – MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="y">MM. y. – MM. y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">dd. MM. y. – dd. MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="d">dd. MM. y. – dd. MM. y. GGGGG</greatestDifference>
 							<greatestDifference id="G">dd. MM. y. GGGGG – dd. MM. y. GGGGG</greatestDifference>
-							<greatestDifference id="M">dd. MM. y. – dd. MM. y. GGGGG</greatestDifference>
-							<greatestDifference id="y">dd. MM. y. – dd. MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="M">dd. MM. y. – dd. MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="y">dd. MM. y. – dd. MM. y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">E, dd. MM. y. – E, dd. MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="d">E, dd. MM. y. – E, dd. MM. y. GGGGG</greatestDifference>
 							<greatestDifference id="G">E, dd. MM. y. GGGGG – E, dd. MM. y. GGGGG</greatestDifference>
-							<greatestDifference id="M">E, dd. MM. y. – E, dd. MM. y. GGGGG</greatestDifference>
-							<greatestDifference id="y">E, dd. MM. y. – E, dd. MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="M">E, dd. MM. y. – E, dd. MM. y. GGGGG</greatestDifference>
+							<greatestDifference id="y">E, dd. MM. y. – E, dd. MM. y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
 							<greatestDifference id="G">MMM y. G – MMM y. G</greatestDifference>
@@ -2215,16 +2215,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">MMM y – MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">dd. – dd. MMM y. G</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM y. G</greatestDifference>
 							<greatestDifference id="G">dd. MMM y. G – dd. MMM y. G</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM y. G</greatestDifference>
-							<greatestDifference id="y">dd. MMM y. – dd. MMM y. G</greatestDifference>
+							<greatestDifference id="y">dd. MMM y. – dd. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
 							<greatestDifference id="d">E, dd. MMM – E, dd. MMM y. G</greatestDifference>
 							<greatestDifference id="G">E, dd. MMM y. G – E, dd. MMM y. G</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM y. G</greatestDifference>
-							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>
@@ -2259,61 +2259,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">MM. – MM.</greatestDifference>
+							<greatestDifference id="M">MM. – MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd. MM. – dd. MM.</greatestDifference>
-							<greatestDifference id="M">dd. MM. – dd. MM.</greatestDifference>
+							<greatestDifference id="d">dd. MM. – dd. MM.</greatestDifference>
+							<greatestDifference id="M">dd. MM. – dd. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd. MM. – E, dd. MM.</greatestDifference>
-							<greatestDifference id="M">E, dd. MM. – E, dd. MM.</greatestDifference>
+							<greatestDifference id="d">E, dd. MM. – E, dd. MM.</greatestDifference>
+							<greatestDifference id="M">E, dd. MM. – E, dd. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">y. – y.</greatestDifference>
+							<greatestDifference id="y">y. – y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">MM. y. – MM. y.</greatestDifference>
-							<greatestDifference id="y">MM. y. – MM. y.</greatestDifference>
+							<greatestDifference id="M">MM. y. – MM. y.</greatestDifference>
+							<greatestDifference id="y">MM. y. – MM. y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">dd. MM. y. – dd. MM. y.</greatestDifference>
-							<greatestDifference id="M">dd. MM. y. – dd. MM. y.</greatestDifference>
-							<greatestDifference id="y">dd. MM. y. – dd. MM. y.</greatestDifference>
+							<greatestDifference id="d">dd. MM. y. – dd. MM. y.</greatestDifference>
+							<greatestDifference id="M">dd. MM. y. – dd. MM. y.</greatestDifference>
+							<greatestDifference id="y">dd. MM. y. – dd. MM. y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, dd. MM. y. – E, dd. MM. y.</greatestDifference>
-							<greatestDifference id="M">E, dd. MM. y. – E, dd. MM. y.</greatestDifference>
-							<greatestDifference id="y">E, dd. MM. y. – E, dd. MM. y.</greatestDifference>
+							<greatestDifference id="d">E, dd. MM. y. – E, dd. MM. y.</greatestDifference>
+							<greatestDifference id="M">E, dd. MM. y. – E, dd. MM. y.</greatestDifference>
+							<greatestDifference id="y">E, dd. MM. y. – E, dd. MM. y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">LLL – LLL y.</greatestDifference>
-							<greatestDifference id="y">LLL y. – LLL y.</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">dd. – dd. MMM y.</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM y.</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM y.</greatestDifference>
-							<greatestDifference id="y">dd. MMM y. – dd. MMM y.</greatestDifference>
+							<greatestDifference id="y">dd. MMM y. – dd. MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM y.</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y.</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM y.</greatestDifference>
-							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y.</greatestDifference>
+							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">LLLL – LLLL y.</greatestDifference>
-							<greatestDifference id="y">LLLL y. – LLLL y.</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y.</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1102,7 +1102,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">G y – G y</greatestDifference>
@@ -1143,25 +1143,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
-							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1186,12 +1186,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">LLL y – LLL y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. MMM y G</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y G</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y G</greatestDifference>
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1612,7 +1612,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">G y – G y</greatestDifference>
@@ -1626,13 +1626,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">dd.–dd.MM.y G</greatestDifference>
 							<greatestDifference id="G">dd.MM.y G – dd.MM.y G</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.y G</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.y G</greatestDifference>
 							<greatestDifference id="y">dd.MM.y – dd.MM.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
 							<greatestDifference id="d">E, dd.MM.y – E, dd.MM.y G</greatestDifference>
 							<greatestDifference id="G">E, dd.MM.y G – E, dd.MM.y G</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y G</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.y G</greatestDifference>
 							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
@@ -1647,7 +1647,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="G">E, d. MMM y G – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
@@ -1685,25 +1685,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="H">H–H v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
-							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1728,12 +1728,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">LLL y – LLL y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. MMM y</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y</greatestDifference>
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -1774,7 +1774,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
 							<greatestDifference id="d">MM. dd–dd.</greatestDifference>
-							<greatestDifference id="M">MM. dd. – MM. dd.</greatestDifference>
+							<greatestDifference id="M">MM. dd. – MM. dd.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
 							<greatestDifference id="d">MM. dd., E – MM. dd., E</greatestDifference>
@@ -1785,7 +1785,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">MMM d–d.</greatestDifference>
-							<greatestDifference id="M">MMM d. – MMM d.</greatestDifference>
+							<greatestDifference id="M">MMM d. – MMM d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d">MMM d., E – d., E</greatestDifference>
@@ -1796,12 +1796,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">G y. MM–MM.</greatestDifference>
-							<greatestDifference id="y">G y. MM. – y. MM.</greatestDifference>
+							<greatestDifference id="y">G y. MM. – y. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">G y. MM. dd–dd.</greatestDifference>
-							<greatestDifference id="M">G y. MM. dd. – MM. dd.</greatestDifference>
-							<greatestDifference id="y">G y. MM. dd. – y. MM. dd.</greatestDifference>
+							<greatestDifference id="M">G y. MM. dd. – MM. dd.</greatestDifference>
+							<greatestDifference id="y">G y. MM. dd. – y. MM. dd.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
 							<greatestDifference id="d">G y. MM. dd., E – dd., E</greatestDifference>
@@ -1814,8 +1814,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">G y. MMM d–d.</greatestDifference>
-							<greatestDifference id="M">G y. MMM d. – MMM d.</greatestDifference>
-							<greatestDifference id="y">G y. MMM d. – y. MMM d.</greatestDifference>
+							<greatestDifference id="M">G y. MMM d. – MMM d.</greatestDifference>
+							<greatestDifference id="y">G y. MMM d. – y. MMM d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
 							<greatestDifference id="d">G y. MMM d., E – MMM d., E</greatestDifference>
@@ -2365,7 +2365,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
 							<greatestDifference id="d">M. d–d.</greatestDifference>
-							<greatestDifference id="M">M. d. – M. d.</greatestDifference>
+							<greatestDifference id="M">M. d. – M. d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
 							<greatestDifference id="d">M. dd., E – M. d., E</greatestDifference>
@@ -2376,7 +2376,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">MMM d–d.</greatestDifference>
-							<greatestDifference id="M">MMM d. – MMM d.</greatestDifference>
+							<greatestDifference id="M">MMM d. – MMM d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d">MMM d., E – d., E</greatestDifference>
@@ -2387,12 +2387,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">y. MM–MM.</greatestDifference>
-							<greatestDifference id="y">y. MM. – y. MM.</greatestDifference>
+							<greatestDifference id="y">y. MM. – y. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">y. MM. dd–dd.</greatestDifference>
-							<greatestDifference id="M">y. MM. dd. – MM. dd.</greatestDifference>
-							<greatestDifference id="y">y. MM. dd. – y. MM. dd.</greatestDifference>
+							<greatestDifference id="M">y. MM. dd. – MM. dd.</greatestDifference>
+							<greatestDifference id="y">y. MM. dd. – y. MM. dd.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
 							<greatestDifference id="d">y. MM. dd., E – dd., E</greatestDifference>
@@ -2405,8 +2405,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">y. MMM d–d.</greatestDifference>
-							<greatestDifference id="M">y. MMM d. – MMM d.</greatestDifference>
-							<greatestDifference id="y">y. MMM d. – y. MMM d.</greatestDifference>
+							<greatestDifference id="M">y. MMM d. – MMM d.</greatestDifference>
+							<greatestDifference id="y">y. MMM d. – y. MMM d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
 							<greatestDifference id="d">y. MMM d., E – d., E</greatestDifference>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -1393,8 +1393,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1404,7 +1404,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -1423,8 +1423,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -1437,7 +1437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1685,8 +1685,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1696,7 +1696,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -1715,8 +1715,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -1729,7 +1729,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1977,8 +1977,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1988,7 +1988,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -2007,8 +2007,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -2021,7 +2021,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -2242,8 +2242,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -2253,7 +2253,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -2272,8 +2272,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -2286,7 +2286,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -2826,8 +2826,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -2837,7 +2837,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -2870,7 +2870,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>
@@ -3121,8 +3121,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -3132,7 +3132,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -3151,8 +3151,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -3165,7 +3165,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -3404,8 +3404,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -3415,7 +3415,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -3434,8 +3434,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -3448,7 +3448,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -3687,8 +3687,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -3698,7 +3698,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -3717,8 +3717,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -3731,7 +3731,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -3869,8 +3869,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -3880,7 +3880,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -3899,8 +3899,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -3913,7 +3913,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -4152,8 +4152,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -4163,7 +4163,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -4182,8 +4182,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -4196,7 +4196,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -4348,8 +4348,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -4359,7 +4359,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
@@ -4378,8 +4378,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d.M.y–d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
-							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d.M.y G</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.y G</greatestDifference>
 							<greatestDifference id="y">E, d.M.y – E, d.M.y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -4392,7 +4392,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/ksh.xml
+++ b/common/main/ksh.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -917,7 +917,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">dd. – dd. MM.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd. – dd. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">LLL–LLL</greatestDifference>
@@ -1225,7 +1225,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">dd. – dd. MM.</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd. – dd. MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">LLL–LLL</greatestDifference>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1378,12 +1378,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">M.–M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1393,7 +1393,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1423,7 +1423,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1827,12 +1827,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">M.–M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
-							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="d">dd.MM. – dd.MM.</greatestDifference>
+							<greatestDifference id="M">dd.MM. – dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM–MMM</greatestDifference>
@@ -1842,7 +1842,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1872,7 +1872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -3275,8 +3275,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMMEd">
 							<greatestDifference id="d">y MMMM d, E – MMMM d, E</greatestDifference>
-							<greatestDifference id="M">y MMMM d, E. – MMMM d, E.</greatestDifference>
-							<greatestDifference id="y">y MMMM d, E. – y MMMM d, E.</greatestDifference>
+							<greatestDifference id="M">y MMMM d, E. – MMMM d, E.</greatestDifference>
+							<greatestDifference id="y">y MMMM d, E. – y MMMM d, E.</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -2063,19 +2063,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="d">d.–d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">G y. – G y.</greatestDifference>
+							<greatestDifference id="G">G y. – G y.</greatestDifference>
 							<greatestDifference id="y">G y.–y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">GGGGG MM-y. – GGGGG MM-y.</greatestDifference>
-							<greatestDifference id="M">GGGGG MM-y. – MM-y.</greatestDifference>
-							<greatestDifference id="y">GGGGG MM-y. – MM-y.</greatestDifference>
+							<greatestDifference id="G">GGGGG MM-y. – GGGGG MM-y.</greatestDifference>
+							<greatestDifference id="M">GGGGG MM-y. – MM-y.</greatestDifference>
+							<greatestDifference id="y">GGGGG MM-y. – MM-y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">GGGGG dd-MM-y. – dd-MM-y.</greatestDifference>
-							<greatestDifference id="G">GGGGG dd-MM-y. – GGGGG dd-MM-y.</greatestDifference>
-							<greatestDifference id="M">GGGGG dd-MM-y. – dd-MM-y.</greatestDifference>
-							<greatestDifference id="y">GGGGG dd-MM-y. – dd-MM-y.</greatestDifference>
+							<greatestDifference id="d">GGGGG dd-MM-y. – dd-MM-y.</greatestDifference>
+							<greatestDifference id="G">GGGGG dd-MM-y. – GGGGG dd-MM-y.</greatestDifference>
+							<greatestDifference id="M">GGGGG dd-MM-y. – dd-MM-y.</greatestDifference>
+							<greatestDifference id="y">GGGGG dd-MM-y. – dd-MM-y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
 							<greatestDifference id="d">GGGGG dd-MM-y., E – dd-MM-y., E</greatestDifference>
@@ -2140,8 +2140,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">dd.MM.–dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM. – E, dd.MM.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM. – E, dd.MM.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLL</greatestDifference>
@@ -2167,9 +2167,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">dd.MM.y.–dd.MM.y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, dd.MM.y. – E, dd.MM.y.</greatestDifference>
-							<greatestDifference id="M">E, dd.MM.y. – E, dd.MM.y.</greatestDifference>
-							<greatestDifference id="y">E, dd.MM.y. – E, dd.MM.y.</greatestDifference>
+							<greatestDifference id="d">E, dd.MM.y. – E, dd.MM.y.</greatestDifference>
+							<greatestDifference id="M">E, dd.MM.y. – E, dd.MM.y.</greatestDifference>
+							<greatestDifference id="y">E, dd.MM.y. – E, dd.MM.y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">y. 'gada' MMM–MMM</greatestDifference>

--- a/common/main/nds.xml
+++ b/common/main/nds.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1043,8 +1043,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="unconfirmed">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d.M. – E, d.M.</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="unconfirmed">MMM – MMM</greatestDifference>
@@ -1054,7 +1054,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="unconfirmed">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1070,8 +1070,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">d.M.y – d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d.M.y GGGGG</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.y GGGGG</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -1084,7 +1084,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, d. MMM – E, d. MMM y G</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1476,8 +1476,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="unconfirmed">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d.M.</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d.M.</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="unconfirmed">LLL – LLL</greatestDifference>
@@ -1487,7 +1487,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="unconfirmed">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1503,8 +1503,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">d.M.y – d.M.y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d.M.y</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.y</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d.M.y</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E, d.M. – E, d.M.y</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">E, d.M.y – E, d.M.y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
@@ -1517,7 +1517,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/prg.xml
+++ b/common/main/prg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -637,7 +637,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="unconfirmed">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, d. – E, d. MMM</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, d. MMM – E, d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -667,7 +667,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="unconfirmed">dd.MM 'st'. y – dd.MM 'st'. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="unconfirmed">E, dd. – E, dd.MM 'st'. y</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E, dd. – E, dd.MM 'st'. y</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, dd.MM – E, dd.MM 'st'. y</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">E, dd.MM 'st'. y – E, dd.MM 'st'. y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1271,7 +1271,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="contributed">d MMMM – d MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMMEd">
-							<greatestDifference id="d" draft="contributed">E, d. – E, d MMMM</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d. – E, d MMMM</greatestDifference>
 							<greatestDifference id="M" draft="contributed">E, d MMMM – E, d MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1315,7 +1315,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="contributed">d MMMM y – d MMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMMEd">
-							<greatestDifference id="d" draft="contributed">E, d. – E, d MMMM y G</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d. – E, d MMMM y G</greatestDifference>
 							<greatestDifference id="M" draft="contributed">E, d MMMM – E, d MMMM y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E, d MMMM y – E, d MMMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -1773,7 +1773,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d MMMM – d MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMMEd">
-							<greatestDifference id="d">E, d. – E, d MMMM</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d MMMM</greatestDifference>
 							<greatestDifference id="M">E, d MMMM – E, d MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1817,7 +1817,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d MMMM y – d MMMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMMEd">
-							<greatestDifference id="d">E, d. – E, d MMMM y</greatestDifference>
+							<greatestDifference id="d">E, d. – E, d MMMM y</greatestDifference>
 							<greatestDifference id="M">E, d MMMM – E, d MMMM y</greatestDifference>
 							<greatestDifference id="y">E, d MMMM y – E, d MMMM y</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -1494,7 +1494,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y G – y G</greatestDifference>
@@ -1523,15 +1523,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">LLL y – LLL y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">d. – d. M. y G</greatestDifference>
+							<greatestDifference id="d">d. – d. M. y G</greatestDifference>
 							<greatestDifference id="G">d. M. y G – d. M. y G</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="G">E d. M. y G – E d. M. y G</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
@@ -1567,26 +1567,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d">d. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E d. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
 							<greatestDifference id="M">LLLL – LLLL</greatestDifference>
@@ -1613,13 +1613,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">LLL y – LLL y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. M. y G</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="d">d. – d. M. y G</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E d. – E d. M. y G</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d">E d. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -2085,7 +2085,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">d. – d.</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y G – y G</greatestDifference>
@@ -2114,15 +2114,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">LLLL y – LLLL y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">d. – d. M. y G</greatestDifference>
+							<greatestDifference id="d">d. – d. M. y G</greatestDifference>
 							<greatestDifference id="G">d. M. y G – d. M. y G</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y G</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="G">E d. M. y G – E d. M. y G</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y G</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
@@ -2158,26 +2158,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">M. – M.</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">d. – d. M.</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
+							<greatestDifference id="d">d. – d. M.</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E d. – E d. M.</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
+							<greatestDifference id="d">E d. – E d. M.</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
 							<greatestDifference id="M">LLLL – LLLL</greatestDifference>
@@ -2204,13 +2204,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">M/y – M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">d. – d. M. y</greatestDifference>
-							<greatestDifference id="M">d. M. – d. M. y</greatestDifference>
+							<greatestDifference id="d">d. – d. M. y</greatestDifference>
+							<greatestDifference id="M">d. M. – d. M. y</greatestDifference>
 							<greatestDifference id="y">d. M. y – d. M. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E d. – E d. M. y</greatestDifference>
-							<greatestDifference id="M">E d. M. – E d. M. y</greatestDifference>
+							<greatestDifference id="d">E d. – E d. M. y</greatestDifference>
+							<greatestDifference id="M">E d. M. – E d. M. y</greatestDifference>
 							<greatestDifference id="y">E d. M. y – E d. M. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">

--- a/common/main/smn.xml
+++ b/common/main/smn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -794,19 +794,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
-							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
+							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
+							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">MMMM d.–d.</greatestDifference>
-							<greatestDifference id="M">MMMM d. – MMMM d.</greatestDifference>
+							<greatestDifference id="M">MMMM d. – MMMM d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">MMMM E d. – E d.</greatestDifference>
-							<greatestDifference id="M">MMMM E d. – MMMM E d.</greatestDifference>
+							<greatestDifference id="d">MMMM E d. – E d.</greatestDifference>
+							<greatestDifference id="M">MMMM E d. – MMMM E d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y–y G</greatestDifference>
@@ -831,12 +831,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">MMMM d.–d. y G</greatestDifference>
-							<greatestDifference id="M">MMMM d. – MMMM d. y G</greatestDifference>
+							<greatestDifference id="M">MMMM d. – MMMM d. y G</greatestDifference>
 							<greatestDifference id="y">MMMM d. y – MMMM d. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">MMMM E d. – E d. y G</greatestDifference>
-							<greatestDifference id="M">MMMM E d. – MMMM E d. y G</greatestDifference>
+							<greatestDifference id="d">MMMM E d. – E d. y G</greatestDifference>
+							<greatestDifference id="M">MMMM E d. – MMMM E d. y G</greatestDifference>
 							<greatestDifference id="y">MMMM E d. y – MMMM E d. y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
@@ -1278,19 +1278,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d.M.–d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
-							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
+							<greatestDifference id="d">E d. – E d.M.</greatestDifference>
+							<greatestDifference id="M">E d.M. – E d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">LLL–LLLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">MMM d.–d.</greatestDifference>
-							<greatestDifference id="M">MMM d. – MMM d.</greatestDifference>
+							<greatestDifference id="M">MMM d. – MMM d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">MMMM E d. – E d.</greatestDifference>
-							<greatestDifference id="M">MMMM E d. – MMMM E d.</greatestDifference>
+							<greatestDifference id="d">MMMM E d. – E d.</greatestDifference>
+							<greatestDifference id="M">MMMM E d. – MMMM E d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y–y</greatestDifference>
@@ -1300,7 +1300,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">LLLL y – LLLL y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">d. – d.M.y</greatestDifference>
+							<greatestDifference id="d">d. – d.M.y</greatestDifference>
 							<greatestDifference id="M">d.M.–d.M.y</greatestDifference>
 							<greatestDifference id="y">d.M.y–d.M.y</greatestDifference>
 						</intervalFormatItem>
@@ -1315,12 +1315,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">MMMM d.–d. y</greatestDifference>
-							<greatestDifference id="M">MMMM d. – MMMM d. y</greatestDifference>
+							<greatestDifference id="M">MMMM d. – MMMM d. y</greatestDifference>
 							<greatestDifference id="y">MMMM d. y – MMMM d. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">MMMM E d. – E d. y</greatestDifference>
-							<greatestDifference id="M">MMMM E d. – MMMM E d. y</greatestDifference>
+							<greatestDifference id="d">MMMM E d. – E d. y</greatestDifference>
+							<greatestDifference id="M">MMMM E d. – MMMM E d. y</greatestDifference>
 							<greatestDifference id="y">MMMM E d. y – MMMM E d. y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1525,7 +1525,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">d. MMM – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -1537,7 +1537,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
 							<greatestDifference id="d">d.M.y – d.M.y. GGGGG</greatestDifference>
-							<greatestDifference id="M">d.M.y. – d.M.y.</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y.</greatestDifference>
 							<greatestDifference id="y">d.M.y – d.M.y. GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
@@ -1552,7 +1552,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">d–d. MMM y. G</greatestDifference>
 							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
-							<greatestDifference id="y">d. MMM y. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">d. MMM y. – d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
 							<greatestDifference id="d">E, d. MMM – E, d. MMM y. G</greatestDifference>
@@ -1561,7 +1561,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">MMMM – MMMM y. G</greatestDifference>
-							<greatestDifference id="y">MMMM y. – MMMM y. G</greatestDifference>
+							<greatestDifference id="y">MMMM y. – MMMM y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2110,7 +2110,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
@@ -2118,35 +2118,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">M – M. y.</greatestDifference>
-							<greatestDifference id="y">M.y. – M.y.</greatestDifference>
+							<greatestDifference id="y">M.y. – M.y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">d. M. y. – d. M. y.</greatestDifference>
-							<greatestDifference id="M">d. M. y. – d. M. y.</greatestDifference>
-							<greatestDifference id="y">d. M. y. – d. M. y.</greatestDifference>
+							<greatestDifference id="d">d. M. y. – d. M. y.</greatestDifference>
+							<greatestDifference id="M">d. M. y. – d. M. y.</greatestDifference>
+							<greatestDifference id="y">d. M. y. – d. M. y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d. M. y. – E, d. M. y.</greatestDifference>
-							<greatestDifference id="M">E, d. M. y. – E, d. M. y.</greatestDifference>
-							<greatestDifference id="y">E, d. M. y. – E, d. M. y.</greatestDifference>
+							<greatestDifference id="d">E, d. M. y. – E, d. M. y.</greatestDifference>
+							<greatestDifference id="M">E, d. M. y. – E, d. M. y.</greatestDifference>
+							<greatestDifference id="y">E, d. M. y. – E, d. M. y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">MMM–MMM y.</greatestDifference>
-							<greatestDifference id="y">MMM y. – MMM y.</greatestDifference>
+							<greatestDifference id="y">MMM y. – MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">dd.–dd. MMM y.</greatestDifference>
 							<greatestDifference id="M">dd. MMM – dd. MMM y.</greatestDifference>
-							<greatestDifference id="y">dd. MMM y. – dd. MMM y.</greatestDifference>
+							<greatestDifference id="y">dd. MMM y. – dd. MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, dd. – E, dd. MMM y.</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y.</greatestDifference>
 							<greatestDifference id="M">E, dd. MMM – E, dd. MMM y.</greatestDifference>
-							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y.</greatestDifference>
+							<greatestDifference id="y">E, dd. MMM y. – E, dd. MMM y.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">MMMM – MMMM y.</greatestDifference>
-							<greatestDifference id="y">MMMM y. – MMMM y.</greatestDifference>
+							<greatestDifference id="y">MMMM y. – MMMM y.</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -1115,19 +1115,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">M/y (GGGGG) – M/y (GGGGG)</greatestDifference>
+							<greatestDifference id="G">M/y (GGGGG) – M/y (GGGGG)</greatestDifference>
 							<greatestDifference id="M">M/y – M/y (GGGGG)</greatestDifference>
 							<greatestDifference id="y">M/y – M/y (GGGGG)</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">d/M/y – d/M/y (GGGGG)</greatestDifference>
-							<greatestDifference id="G">d/M/y (GGGGG) – d/M/y (GGGGG)</greatestDifference>
+							<greatestDifference id="G">d/M/y (GGGGG) – d/M/y (GGGGG)</greatestDifference>
 							<greatestDifference id="M">d/M/y – d/M/y (GGGGG)</greatestDifference>
 							<greatestDifference id="y">d/M/y – d/M/y (GGGGG)</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
 							<greatestDifference id="d">E, d/M/y – E, d/M/y (GGGGG)</greatestDifference>
-							<greatestDifference id="G">E, d/M/y (GGGGG) – E, d/M/y (GGGGG)</greatestDifference>
+							<greatestDifference id="G">E, d/M/y (GGGGG) – E, d/M/y (GGGGG)</greatestDifference>
 							<greatestDifference id="M">E, d/M/y – E, d/M/y (GGGGG)</greatestDifference>
 							<greatestDifference id="y">E, d/M/y – E, d/M/y (GGGGG)</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/wae.xml
+++ b/common/main/wae.xml
@@ -582,8 +582,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="contributed">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">d. – d. MMM</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d" draft="contributed">E, d. MMM – E, d. MMM</greatestDifference>
@@ -764,8 +764,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="contributed">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">d. – d. MMM</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d" draft="contributed">E, d. MMM – E, d. MMM</greatestDifference>
@@ -793,12 +793,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="contributed">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">d. – d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. – d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="contributed">d. MMM – d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="contributed">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>
@@ -1140,8 +1140,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M" draft="contributed">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">d. – d. MMM</greatestDifference>
-							<greatestDifference id="M" draft="contributed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. – d. MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d. – d. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d" draft="contributed">E, d. MMM – E, d. MMM</greatestDifference>
@@ -1169,12 +1169,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y" draft="contributed">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">d. – d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d. – d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="contributed">d. MMM – d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="contributed">d. MMM y – d. MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">E, d. – E, d. MMM y</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d. – E, d. MMM y</greatestDifference>
 							<greatestDifference id="M" draft="contributed">E, d. MMM – E, d. MMM y</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E, d. MMM y – E, d. MMM y</greatestDifference>
 						</intervalFormatItem>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -749,10 +749,10 @@ public class DisplayAndInputProcessor {
         List<Object> items = fp.getItems();
         Object last = items.get(items.size() - 1);
         if (last instanceof String) {
-            String separator = last.toString(); // separator including spaces
+            String separator = last.toString(); // separator including spaces, and possibly preceding literal text (. or quoted)
             String replacement = separator;
-            if (scriptCode.equals("Latn") && (separator.equals(" - ") || separator.equals(" \u2013 "))) {
-                replacement = "\u2009\u2013\u2009"; // Per CLDR-14032
+            if (scriptCode.equals("Latn") && (separator.endsWith(" - ") || separator.endsWith(" \u2013 "))) {
+                replacement = separator.substring(0, separator.length()-3) + "\u2009\u2013\u2009"; // Per CLDR-14032,16308
             } else if (separator.contains("-")) {
                 replacement = separator.replace("-", "\u2013");
             }


### PR DESCRIPTION
CLDR-16308

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16308)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Adjusted DisplayAndInputProcessor (DAIP) so that the intervalFormat normalizations it performs for Latin-script locales (replacing hyphen or en-dash surrounded by space with en-dash \u2013 surrounded by thin space \u2009) work even if those characters are preceded by literal text such as a period or a quoted literal. It turn out that when DateTimePatternGenerator.FormatParser.getItems returns the tokens for the first part of the intervalFormat pattern, the last token - which ends with the spaces + hyphen/dash - also includes any preceding literal text which came after the last pattern character in the first part.

Then ran the updated DAIP to actually fix the problem intervalFormats. The differences are just changing regular space to thin space around an en-dash, to be consistent with the other intervalFormats in each of these locales.

ALLOW_MANY_COMMITS=true
