### PR TITLE
CLDR-14770 chr,ps: remove incorrect curly quotes intended to mark literals

### DIFF
--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -1587,8 +1587,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">’ᏒᎾᏙᏓᏆᏍᏗ’ W ’ᎾᎿ’ MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="other">’ᏒᎾᏙᏓᏆᏍᏗ’ W ’ᎾᎿ’ MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="one">ᏒᎾᏙᏓᏆᏍᏗ W ᎾᎿ MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="other">ᏒᎾᏙᏓᏆᏍᏗ W ᎾᎿ MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
 						<dateFormatItem id="yM">M/y</dateFormatItem>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -1586,7 +1586,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">اونۍ‘ W د MMMM‘</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="one">اونۍ W د MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">اونۍ W د MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>


### PR DESCRIPTION
CLDR-14770

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-14770)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Remove incorrect curly quotes (\u2018, \u2019) that appear to have been intended as the apostrophe (\u0027) used to mark literal text. The apostrophe would not be needed in these cases anyway (since the literal text is non-ASCII), and in the `ps` case the \u2018s were spanning the wrong range anyway (and removing them makes the MMMMW "one" format match the "other" format, as is the case for the yw formats).

ALLOW_MANY_COMMITS=true
