### PR TITLE
CLDR-16323 Fix patterns with given-initial

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1082,7 +1082,7 @@ public class TestPersonNameFormatter extends TestFmwk{
     public void testInitials() {
         String[][] tests = {{
             "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"short\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
-            "〖<i>🟨 Native name and script:</i>〗〖❬Z.❭〗〖❬I.❭ ❬Adler❭〗〖❬M. S.❭ ❬H.❭ ❬Watson❭〗〖❬B. W.❭ ❬H. R.❭ ❬Wooster❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬S.❭〗〖❬K.❭ ❬Müller❭〗〖❬Z.❭ ❬H.❭ ❬Stöber❭〗〖❬A. C.❭ ❬C. M.❭ ❬von Brühl❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Є.❭ ❬М.❭ ❬Шевченко❭〗〖❬太郎山田❭〗"
+            "〖<i>🟨 Native name and script:</i>〗〖❬Zendaya❭〗〖❬I.❭ ❬Adler❭〗〖❬M. S.❭ ❬H.❭ ❬Watson❭〗〖❬B. W.❭ ❬H. R.❭ ❬Wooster❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬Sinbad❭〗〖❬K.❭ ❬Müller❭〗〖❬Z.❭ ❬H.❭ ❬Stöber❭〗〖❬A. C.❭ ❬C. M.❭ ❬von Brühl❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Є.❭ ❬М.❭ ❬Шевченко❭〗〖❬太郎山田❭〗"
         }};
         ExampleGenerator exampleGenerator = checkExamples(ENGLISH, tests);
     }


### PR DESCRIPTION
CLDR-16323

The previous PR fixed most problems, but one remained.

That code handles the case where the name data is a monogram (no surname) and there's no {given} in the pattern. It does that by using a filtered NameObject that returns the given name instead of the surname. 

1. That mostly works. Where it doesn't is in cases of "Z" in the nativeG column on https://unicode-org.github.io/cldr-staging/charts/43/verify/personNames/en_GB.html, where we would not expect just an initial (if there were a surname, it would be a full name).
2. The problem comes when we have a monogram, and the pattern is {given-initial} {surname} (perhaps with additional items like {title}. We get just "Z" (or "Z." in https://unicode-org.github.io/cldr-staging/charts/43/verify/personNames/en.html).
3. We could of course address this by adding extra patterns in the data. However, we'd have to add it everywhere for a very common case. And the extra patterns are so very cumbersome for vetters (and us).

My proposal is: 

In the filtered name object, change it to return null for 'given'. That has no effect on 2.1 above.
We then add an additional condition:

- where the name data is a monogram (no surname) and there's no {given} or {given-initial} in the pattern

Spot-checking, this fixed the problems with Z (or Z.)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
