### PR TITLE
CLDR-15995 fixes to charts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -51,6 +51,8 @@ import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ULocale;
 
 public class ShowData {
+    private static final boolean TOO_BIG_FOR_GITHUB = true;
+
     private static final int HELP1 = 0, HELP2 = 1, SOURCEDIR = 2, DESTDIR = 3,
         MATCH = 4, GET_SCRIPTS = 5,
         LAST_DIR = 6,
@@ -366,30 +368,31 @@ public class ShowData {
                 pw.println(headerAndFooter[1]);
                 pw.close();
             }
-            PrintWriter pw = FileUtilities.openUTF8Writer(targetDir, "all-changed.html");
-            String[] headerAndFooter = new String[2];
+            if (!TOO_BIG_FOR_GITHUB) {
+                PrintWriter pw = FileUtilities.openUTF8Writer(targetDir, "all-changed.html");
+                String[] headerAndFooter = new String[2];
 
-            getChartTemplate(
-                "Locale Data Summary for ALL-CHANGED",
-                ToolConstants.CHART_DISPLAY_VERSION,
-                "",
-                headerAndFooter, null, false);
-            pw.println(headerAndFooter[0]);
-            pw.println("<table border=\"1\" cellpadding=\"2\" cellspacing=\"0\">");
-            pw.println("<tr>" +
-                "<th>Section</th>" +
-                "<th>Page</th>" +
-                "<th>Header</th>" +
-                "<th>Code</th>" +
-                "<th>Old</th>" +
-                "<th>Changed</th>" +
-                "<th>Locales</th>" +
-                "</tr>");
-            for (Entry<PathHeader, Relation<String, String>> entry : pathHeaderToValuesToLocale.entrySet()) {
-                PathHeader ph = entry.getKey();
-                Set<Entry<String, Set<String>>> keyValuesSet = entry.getValue().keyValuesSet();
-                String rowspan = keyValuesSet.size() == 1 ? ">" : " rowSpan='" + keyValuesSet.size() + "'>";
-                pw
+                getChartTemplate(
+                    "Locale Data Summary for ALL-CHANGED",
+                    ToolConstants.CHART_DISPLAY_VERSION,
+                    "",
+                    headerAndFooter, null, false);
+                pw.println(headerAndFooter[0]);
+                pw.println("<table border=\"1\" cellpadding=\"2\" cellspacing=\"0\">");
+                pw.println("<tr>" +
+                    "<th>Section</th>" +
+                    "<th>Page</th>" +
+                    "<th>Header</th>" +
+                    "<th>Code</th>" +
+                    "<th>Old</th>" +
+                    "<th>Changed</th>" +
+                    "<th>Locales</th>" +
+                    "</tr>");
+                for (Entry<PathHeader, Relation<String, String>> entry : pathHeaderToValuesToLocale.entrySet()) {
+                    PathHeader ph = entry.getKey();
+                    Set<Entry<String, Set<String>>> keyValuesSet = entry.getValue().keyValuesSet();
+                    String rowspan = keyValuesSet.size() == 1 ? ">" : " rowSpan='" + keyValuesSet.size() + "'>";
+                    pw
                     .append("<tr><td class='g'").append(rowspan)
                     .append(ph.getSectionId().toString())
                     .append("</td><td class='g'").append(rowspan)
@@ -399,14 +402,14 @@ public class ShowData {
                     .append("</td><td class='g'").append(rowspan)
                     .append(ph.getCode())
                     .append("</td>");
-                boolean addRow = false;
-                for (Entry<String, Set<String>> s : keyValuesSet) {
-                    String value = s.getKey();
-                    int breakPoint = value.indexOf("→→");
-                    if (addRow) {
-                        pw.append("<tr>");
-                    }
-                    pw.append("<td>")
+                    boolean addRow = false;
+                    for (Entry<String, Set<String>> s : keyValuesSet) {
+                        String value = s.getKey();
+                        int breakPoint = value.indexOf("→→");
+                        if (addRow) {
+                            pw.append("<tr>");
+                        }
+                        pw.append("<td>")
                         .append(DataShower.getPrettyValue(value.substring(0, breakPoint)))
                         .append("</td><td class='v'>")
                         .append(DataShower.getPrettyValue(value.substring(breakPoint + 2)))
@@ -414,11 +417,12 @@ public class ShowData {
                         .append(Joiner.on(", ").join(s.getValue()))
                         .append("</td></tr>")
                         .append(System.lineSeparator());
-                    addRow = true;
+                        addRow = true;
+                    }
                 }
+                pw.println(headerAndFooter[1]);
+                pw.close();
             }
-            pw.println(headerAndFooter[1]);
-            pw.close();
         } finally {
             deltaTime = System.currentTimeMillis() - deltaTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -678,7 +678,7 @@ public class ShowLocaleCoverage {
                 + "The Core values are described on <a target='_blank' href='https://cldr.unicode.org/index/cldr-spec/core-data-for-new-locales'>Core Data</a>. "
                 + "</td></tr>\n"
                 + "<tr><th>Missing Features</th><td>These are not single items, but rather specific features, such as plural rules or unit grammar info. "
-                + "They are listed if missing at the computed level.<br>"
+                + "They are listed if missing at the computed level. For more information, see <a href='https://cldr.unicode.org/index/locale-coverage'>Missing Features</a><br>"
                 + "Example: <i>ⓜ collation</i> means this feature should be supported at a Moderate level.<br>"
                 + "<ul><li>"
                 + "<i>Except for Core, these are not accounted for in the percent values.</i>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -76,6 +76,9 @@ import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
 
 public class ShowLocaleCoverage {
+
+    private static final String TSV_BASE = "https://github.com/unicode-org/cldr-staging/blob/main/docs/charts/43/tsv/";
+
     // thresholds for measuring Level attainment
     private static final double BASIC_THRESHOLD = 1;
     private static final double MODERATE_THRESHOLD = 0.995;
@@ -651,13 +654,12 @@ public class ShowLocaleCoverage {
                 + "</ul></blockquote>\n"
                 + "<h3>Column Key</h3>\n"
                 + "<table class='subtle' style='margin-left:3em; margin-right:3em'>\n"
-                + "<tr><th>Direct.</th><td>The CLDR source directory</td></tr>\n"
                 + "<tr><th>Default Region</th><td>The default region for locale code, based on likely subtags</td></tr>\n"
                 + "<tr><th>№ Locales</th><td>Note that the coverage of regional locales inherits from their parents.</td></tr>\n"
                 + "<tr><th>Target Level</th><td>The default target Coverage Level in CLDR. "
                 + "Particular organizations may have different target levels. "
                 + "Languages with high levels of coverage are marked with ‡, even though they are not tracked by the technical committee.</td></tr>\n"
-                + "<tr><th>≟</th><td>Indicates whether the Computed Level equals the CLDR Target or not.</td></tr>\n"
+                + "<tr><th>≟</th><td>Indicates whether the CLDR Target is less than, equal to, or greater than the Computed Level.</td></tr>\n"
                 + "<tr><th>Computed Level</th><td>Computed from the percentage values, "
                 + "taking the first level that meets a threshold (currently 🄼 "
                 + percentFormat.format(MODERN_THRESHOLD)
@@ -678,14 +680,20 @@ public class ShowLocaleCoverage {
                 + "<tr><th>Missing Features</th><td>These are not single items, but rather specific features, such as plural rules or unit grammar info. "
                 + "They are listed if missing at the computed level.<br>"
                 + "Example: <i>ⓜ collation</i> means this feature should be supported at a Moderate level.<br>"
-                + "<i>Except for Core, these are not accounted for in the percent values.</i></td></tr>\n"
-                + "<tr><th><a href='https://github.com/unicode-org/cldr-staging/tree/main/docs/charts/42/tsv'>TSV Files</a>:</th><td>\n"
-                + "<ul><li>locale-coverage.tsv — A version of this file, suitable for loading into a spreadsheet.</li>\n"
-                + "<li>locale-missing.tsv — Missing items for the CLDR target locales.</li>\n"
-                + "<li>locale-missing-summary.tsv — Summary of missing items for the CLDR target locales, by Section/Page/Header.</li>\n"
-                + "<li>locale-missing-basic.tsv — Missing items that keep locales from reaching the Basic level.</li>\n"
-                + "<li>locale-missing-count.tsv — Counts of items per locale that are found, unconfirmed, or missing, at the target level. "
-                + "(Or at *basic, if there is no target level.)</li></td></tr>\n"
+                + "<ul><li>"
+                + "<i>Except for Core, these are not accounted for in the percent values.</i>"
+                + "</li><li>"
+                + "The information needs to be provided in tickets, not through the Survey Tool."
+                + "</li></ul>"
+                + "</td></tr>\n"
+                + "<tr><th>" + linkTsv("", "TSVFiles") + ":</th><td>\n"
+                + "<ul><li>" + linkTsv("locale-coverage.tsv") + " — A version of this file, suitable for loading into a spreadsheet.</li>\n"
+                + "<li>" + linkTsv("locale-missing.tsv") + " — Missing items for the CLDR target locales.</li>\n"
+                + "<li>" + linkTsv("locale-missing-summary.tsv") + " — Summary of missing items for the CLDR target locales, by Section/Page/Header.</li>\n"
+                + "<li>" + linkTsv("locale-missing-basic.tsv") + " — Missing items that keep locales from reaching the Basic level.</li>\n"
+                + "<li>" + linkTsv("locale-missing-counts.tsv") + " — Counts of items per locale that are found, unconfirmed, or missing, at the target level. "
+                + "(Or at *basic, if there is no target level.)</li>\n"
+                + "</td></tr>\n"
                 + "</table>\n"
                 );
 
@@ -710,8 +718,6 @@ public class ShowLocaleCoverage {
             int localeCount = 0;
 
             final TablePrinter tablePrinter = new TablePrinter()
-                .addColumn("Direct.", "class='source'", null, "class='source'", true)
-                .setBreakSpans(true).setSpanRows(false)
                 .addColumn("Language", "class='source'", CldrUtility.getDoubleLinkMsg(), "class='source'", true)
                 .setBreakSpans(true)
                 .addColumn("English Name", "class='source'", null, "class='source'", true)
@@ -937,7 +943,7 @@ public class ShowLocaleCoverage {
                             + "\t" + starredCounter.provisionalTotal //
                             + "\t" + starredCounter.unconfirmedTotal //
                             + "\tTotals");
-                        tsv_missing_basic.println("\t\t\t"); // for a proper table in github
+                        tsv_missing_basic.println("\t\t\t\t"); // for a proper table in github
                     }
 
                     int sumFound = 0;
@@ -1028,7 +1034,6 @@ public class ShowLocaleCoverage {
                         : " >";
 
                     tablePrinter.addRow()
-                    .addCell(seedString)
                     .addCell(language)
                     .addCell(ENGLISH.getName(language))
                     .addCell(file.getName(language))
@@ -1164,6 +1169,14 @@ public class ShowLocaleCoverage {
                 + ((end - start) / localeCount) + " millis/locale");
             ShowPlurals.appendBlanksForScrolling(pw);
         }
+    }
+
+    public static String linkTsv(String tsvFileName) {
+        return "<a href='" + TSV_BASE + tsvFileName + "' target='cldr-tsv'>" + tsvFileName + "</a>";
+    }
+
+    public static String linkTsv(String tsvFileName, String anchorText) {
+        return "<a href='" + TSV_BASE + tsvFileName + "' target='cldr-tsv'>" + anchorText + "</a>";
     }
 
     public static String getSpecialFlag(String locale) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -683,7 +683,7 @@ public class ShowLocaleCoverage {
                 + "<ul><li>locale-coverage.tsv — A version of this file, suitable for loading into a spreadsheet.</li>\n"
                 + "<li>locale-missing.tsv — Missing items for the CLDR target locales.</li>\n"
                 + "<li>locale-missing-summary.tsv — Summary of missing items for the CLDR target locales, by Section/Page/Header.</li>\n"
-                + "<li>locale-missing-basic.tsv — Missing items that keep locales from reaching the Basic level.</li></td></tr>\n"
+                + "<li>locale-missing-basic.tsv — Missing items that keep locales from reaching the Basic level.</li>\n"
                 + "<li>locale-missing-count.tsv — Counts of items per locale that are found, unconfirmed, or missing, at the target level. "
                 + "(Or at *basic, if there is no target level.)</li></td></tr>\n"
                 + "</table>\n"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/verify-index.html
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/verify-index.html
@@ -45,6 +45,7 @@
 		<li><a href='dates/index.html'>Dates</a></li>
 		<li><a href='zones/index.html'>Time Zones</a></li>
 		<li><a href='numbers/index.html'>Numbers</a></li>
+		<li><a href='personNames/index.html'>Numbers</a></li>
 	</ul>
 </body>
 </html>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/verify-index.html
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/verify-index.html
@@ -45,7 +45,7 @@
 		<li><a href='dates/index.html'>Dates</a></li>
 		<li><a href='zones/index.html'>Time Zones</a></li>
 		<li><a href='numbers/index.html'>Numbers</a></li>
-		<li><a href='personNames/index.html'>Numbers</a></li>
+		<li><a href='personNames/index.html'>Person Names</a></li>
 	</ul>
 </body>
 </html>


### PR DESCRIPTION
CLDR-15995

1. Modifies GenerateSidewaysView and ShowData to avoid generating files too large for github.
2. Modifies ShowLocaleCoverage to clean up the Key, drop the column that showed common vs seed, added links to the tsv files.
3. Fixed a missing index line (that effectively hid all the person name charts.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
4. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
