### PR TITLE
CLDR-16197 Allow Provisional paths during limited submission

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -8,13 +8,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.unicode.cldr.util.GrammarInfo;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.RegexUtilities;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.VoterReportStatus;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.VoterReportStatus.ReportId;
 
 import com.google.common.cache.CacheBuilder;
@@ -178,19 +172,23 @@ public final class SubmissionLocales {
 
     /**
      * Only call this if LIMITED_SUBMISSION
+     *
      * @param localeString
      * @param path
      * @param isError
      * @param isMissing
+     * @param voteStatus
      * @return true if submission is allowed, else false
      */
-    public static boolean allowEvenIfLimited(String localeString, String path, boolean isError, boolean isMissing) {
+    public static boolean allowEvenIfLimited(String localeString, String path, boolean isError, boolean isMissing, VettingViewer.VoteStatus voteStatus) {
 
         // Allow errors to be fixed
         if (isError) {
             return true;
         }
-
+        if (voteStatus == VettingViewer.VoteStatus.provisionalOrWorse) {
+            return true;
+        }
         // for new locales, allow basic paths
         if (SubmissionLocales.ALLOW_ALL_PATHS_BASIC.contains(localeString) &&
             // Only check coverage level for these locales

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -2347,7 +2347,7 @@ public class CLDRModify {
                 boolean isMissing = (oldValue == null || CLDRFile.DraftStatus.forXpath(fullXPath).ordinal() <= CLDRFile.DraftStatus.provisional.ordinal());
                 String locOrAncestor = localeID;
                 while (!"root".equals(locOrAncestor)) {
-                    if (SubmissionLocales.allowEvenIfLimited(locOrAncestor, xpath, isError, isMissing)) {
+                    if (SubmissionLocales.allowEvenIfLimited(locOrAncestor, xpath, isError, isMissing, VettingViewer.VoteStatus.ok_novotes)) {
                         return true;
                     }
                     locOrAncestor = LocaleIDParser.getParent(locOrAncestor);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -485,7 +485,8 @@ public class VettingViewer<T> {
             htmlMessage.setLength(0);
 
             final String oldValue = (baselineFileUnresolved == null) ? null : baselineFileUnresolved.getWinningValue(path);
-            if (skipForLimitedSubmission(path, errorStatus, oldValue)) {
+            final VoteStatus voteStatus = userVoteStatus.getStatusForUsersOrganization(sourceFile, path, organization);
+            if (skipForLimitedSubmission(path, errorStatus, voteStatus, oldValue)) {
                 return;
             }
             if (!onlyRecordErrors && choices.contains(NotificationCategory.changedOldValue) &&
@@ -498,7 +499,6 @@ public class VettingViewer<T> {
                 problems.add(NotificationCategory.inheritedChanged);
                 vc.problemCounter.increment(NotificationCategory.inheritedChanged);
             }
-            VoteStatus voteStatus = userVoteStatus.getStatusForUsersOrganization(sourceFile, path, organization);
             boolean itemsOkIfVoted = (voteStatus == VoteStatus.ok);
             MissingStatus missingStatus = onlyRecordErrors ? null : recordMissingChangedEtc(path, itemsOkIfVoted, value, oldValue);
             recordChoice(errorStatus, itemsOkIfVoted, onlyRecordErrors);
@@ -576,11 +576,11 @@ public class VettingViewer<T> {
             }
         }
 
-        private boolean skipForLimitedSubmission(String path, ErrorChecker.Status errorStatus, String oldValue) {
+        private boolean skipForLimitedSubmission(String path, ErrorChecker.Status errorStatus, VoteStatus voteStatus, String oldValue) {
             if (CheckCLDR.LIMITED_SUBMISSION) {
                 boolean isError = (errorStatus == ErrorChecker.Status.error);
                 boolean isMissing = (oldValue == null);
-                if (!SubmissionLocales.allowEvenIfLimited(localeId, path, isError, isMissing)) {
+                if (!SubmissionLocales.allowEvenIfLimited(localeId, path, isError, isMissing, voteStatus)) {
                     return true;
                 }
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
+import org.unicode.cldr.util.VettingViewer;
 
 public class TestSubmissionLocales {
     @ParameterizedTest
@@ -23,7 +24,7 @@ public class TestSubmissionLocales {
         final boolean isAllowed = allowed.equals("allowed");
         final boolean isError = error.equals("error");
         final boolean isMissing = missing.equals("missing");
-        assertEquals(isAllowed, SubmissionLocales.allowEvenIfLimited(locale, xpath, isError, isMissing),
+        assertEquals(isAllowed, SubmissionLocales.allowEvenIfLimited(locale, xpath, isError, isMissing, VettingViewer.VoteStatus.ok_novotes),
             () -> String.format("%s %s:%s", allowed, locale, xpath));
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -32,40 +32,20 @@ import org.unicode.cldr.test.SubmissionLocales;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.test.TestCache.TestResultBundle;
 import org.unicode.cldr.tool.LikelySubtags;
-import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.PathValueInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.CLDRLocale;
-import org.unicode.cldr.util.Counter;
-import org.unicode.cldr.util.DayPeriodInfo;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.DayPeriodInfo.Type;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.GrammarInfo;
-import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.Pair;
-import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.SurveyToolStatus;
-import org.unicode.cldr.util.PatternCache;
-import org.unicode.cldr.util.PatternPlaceholders;
 import org.unicode.cldr.util.PatternPlaceholders.PlaceholderInfo;
 import org.unicode.cldr.util.PatternPlaceholders.PlaceholderStatus;
-import org.unicode.cldr.util.SimpleXMLSource;
-import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
-import org.unicode.cldr.util.StringId;
-import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
-import org.unicode.cldr.util.XMLSource;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Row.R5;
@@ -812,7 +792,7 @@ public class TestCheckCLDR extends TestFmwk {
                             dummyPathValueInfo,
                             InputMethod.DIRECT,
                             ph,
-                            dummyUserInfo);
+                            dummyUserInfo, VettingViewer.VoteStatus.ok_novotes);
 
                         if (ph.shouldHide()) {
                             assertEquals("HIDE ==> FORBID_READONLY", StatusAction.FORBID_READONLY, action);
@@ -839,7 +819,7 @@ public class TestCheckCLDR extends TestFmwk {
                                         dummyPathValueInfo,
                                         InputMethod.DIRECT,
                                         ph,
-                                        dummyUserInfo);
+                                        dummyUserInfo, VettingViewer.VoteStatus.ok_novotes);
                                 }
                                 actionToExamplePath.put(key, Pair.of(dummyPathValueInfo.baselineValue != null, path));
                             }
@@ -963,7 +943,7 @@ public class TestCheckCLDR extends TestFmwk {
 
     /**
      * Check that the locale is valid, that it is either in or out of allowed locales, and that the locale is not deprecated
-     * @param language
+     * @param locale
      * @param expectedInCLDRLocales
      */
     private void checkLocaleOk(final String locale, final boolean expectedInCLDRLocales) {
@@ -1037,7 +1017,7 @@ public class TestCheckCLDR extends TestFmwk {
                     }
                     String value = cldrFile.getStringValue(path);
                     boolean isMissing = value == null;
-                    boolean allowed = SubmissionLocales.allowEvenIfLimited(locale, path, false, isMissing);
+                    boolean allowed = SubmissionLocales.allowEvenIfLimited(locale, path, false, isMissing, VettingViewer.VoteStatus.ok_novotes);
                     if (allowed) {
                         boolean isUnit = path.startsWith(UNIT_PATH);
                         counter.add(LimitedStatus.of(isUnit, isMissing), 1);


### PR DESCRIPTION
-Add VoteStatus as a parameter for SubmissionLocales.allowEvenIfLimited and elsewhere as needed

-Return true in allowEvenIfLimited if provisionalOrWorse

-Unit tests fall back with VettingViewer.VoteStatus.ok_novotes

-In DataPage.java, replace ourSrc parameter (in many methods) with cldrFile member, needed by DataPage.DataRow.getStatusAction

CLDR-16197

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
