### PR TITLE
CLDR-15071 Fix dtd tests

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -68,6 +68,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
     <!--@DEPRECATED:true, false-->
 <!ATTLIST language references CDATA #IMPLIED >
+    <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!ELEMENT script ( #PCDATA ) >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -2826,7 +2826,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT cr ( #PCDATA ) >
 <!ATTLIST cr alt NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/variant, proposed-->
+    <!--@MATCH:literal/variant, proposed, short-->
 <!ATTLIST cr draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST cr references CDATA #IMPLIED >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -2826,7 +2826,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT cr ( #PCDATA ) >
 <!ATTLIST cr alt NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/variant-->
+    <!--@MATCH:literal/variant, proposed-->
 <!ATTLIST cr draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST cr references CDATA #IMPLIED >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -465,6 +465,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
     <!--@DEPRECATED-->
 <!ATTLIST exemplarCharacters references CDATA #IMPLIED >
+    <!--@MATCH:any-->
     <!--@METADATA-->
 <!ATTLIST exemplarCharacters validSubLocales CDATA #IMPLIED >
     <!--@VALUE-->
@@ -2829,6 +2830,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST cr draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 <!ATTLIST cr references CDATA #IMPLIED >
+    <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!-- # Use the cr element instead, with ICU syntax. -->
@@ -3123,7 +3125,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:or/range/-1.0E20~1.0E20||literal/-x, 0, 0.x, NaN, -Inf, Inf, x,x, x.x-->
     <!--@VALUE-->
 <!ATTLIST rbnfrule radix CDATA #IMPLIED >
-    <!--@MATCH:literal/1,000, 100, 1000, 100000, 20-->
+    <!--@MATCH:literal/1,000, 100, 1000, 100000, 5, 20, 400, 8000, 160,000, 3,200,000, 64,000,000-->
     <!--@VALUE-->
 <!ATTLIST rbnfrule decexp CDATA #IMPLIED >
     <!--@VALUE-->

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -243,7 +243,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT era EMPTY >
 <!ATTLIST era type NMTOKEN #REQUIRED >
-    <!--@MATCH:range/0~250-->
+    <!--@MATCH:range/-2~250-->
 <!ATTLIST era start CDATA #IMPLIED >
     <!--@MATCH:time/yyyy-MM-dd-->
     <!--@VALUE-->
@@ -254,6 +254,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:regex/[a-z0-9]{3,8}(\-[a-z0-9]{3,8})*-->
     <!--@VALUE-->
 <!ATTLIST era aliases NMTOKENS #IMPLIED >
+    <!--@MATCH:set/regex/[a-z0-9]{2,8}(\-[a-z0-9]{3,8})*-->
     <!--@VALUE-->
 <!ATTLIST era named (true | false) #IMPLIED >
     <!--@VALUE-->
@@ -444,7 +445,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@DEPRECATED-->
 <!ATTLIST unitPreferences draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
-    <!--@DEPRECATED-->
 
 <!ELEMENT unitPreference ( #PCDATA ) >
     <!--@ORDERED-->
@@ -929,7 +929,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:validity/locale-->
     <!--@VALUE-->
 <!ATTLIST likelySubtag origin NMTOKENS #IMPLIED >
-    <!--@MATCH:set/literal/sil22,wikidata,special-->
+    <!--@MATCH:set/literal/sil1, wikidata, special-->
     <!--@METADATA-->
 
 <!ELEMENT metazoneInfo ( timezone* ) >

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -138,6 +138,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             element = element2;
             name = aName.intern();
             if (name.equals("draft") // normally never permitted on elements with children, but special cases...
+                && dtdType == DtdType.ldml
                 && !DRAFT_ON_NON_LEAF_ALLOWED.contains(element.getName())) {
                 int elementChildrenCount = element.getChildren().size();
                 if (elementChildrenCount > 1

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/json/LdmlConvertRulesTest.java
@@ -70,6 +70,7 @@ class LdmlConvertRulesTest {
 
         // Handled manually
         jsonSplittableAttrs.add(Pair.of("defaultContent", "locales"));
+        jsonSplittableAttrs.add(Pair.of("era", "aliases"));
 
         // handled as calendarPreferenceData
         jsonSplittableAttrs.add(Pair.of("calendarPreference", "ordering"));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -313,17 +313,17 @@ public class TestPaths extends TestFmwkPlus {
                     if (dtdData.isDeprecated(elementName, attributeName, "*")) {
                         if (attributeName.equals("draft")) {
                             testPaths.errln("Deprecated attribute in data: "
-                                            + dtdData.dtdType
-                                            + ":" + elementName
-                                            + ":" + attributeName
-                                            + " \t;" + fullName +
-                                            " - consider adding to DtdData.DRAFT_ON_NON_LEAF_ALLOWED if you are sure this is ok.");
+                                + dtdData.dtdType
+                                + ":" + elementName
+                                + ":" + attributeName
+                                + " \t;" + fullName +
+                                " - consider adding to DtdData.DRAFT_ON_NON_LEAF_ALLOWED if you are sure this is ok.");
                         } else {
                             testPaths.errln("Deprecated attribute in data: "
-                                            + dtdData.dtdType
-                                            + ":" + elementName
-                                            + ":" + attributeName
-                                            + " \t;" + fullName);
+                                + dtdData.dtdType
+                                + ":" + elementName
+                                + ":" + attributeName
+                                + " \t;" + fullName);
                         }
                         return true;
                     }
@@ -435,31 +435,27 @@ public class TestPaths extends TestFmwkPlus {
                     if (++count > maxPerDirectory) {
                         break;
                     }
-                    DtdType type = null;
-                    DtdData dtdData = null;
                     String fullName = dir2 + "/" + file;
                     for (Pair<String, String> pathValue : XMLFileReader.loadPathValues(fullName, new ArrayList<Pair<String, String>>(), true)) {
                         String path = pathValue.getFirst();
                         final String value = pathValue.getSecond();
                         XPathParts parts = XPathParts.getFrozenInstance(path);
-                        if (dtdData == null) {
-                            type = DtdType.valueOf(parts.getElement(0));
-                            dtdData = DtdData.getInstance(type);
-                        }
+                        DtdData dtdData = parts.getDtdData();
+                        DtdType type = dtdData.dtdType;
 
-                        XPathParts pathParts = XPathParts.getFrozenInstance(path);
-                        String finalElementString = pathParts.getElement(-1);
+
+                        String finalElementString = parts.getElement(-1);
                         Element finalElement = dtdData.getElementFromName().get(finalElementString);
                         if (!haveErrorsAlready.contains(finalElement)) {
                             ElementType elementType = finalElement.getType();
                             // HACK!!
-                            if (pathParts.size() > 1 && "identity".equals(pathParts.getElement(1))) {
+                            if (parts.size() > 1 && "identity".equals(parts.getElement(1))) {
                                 elementType = ElementType.EMPTY;
                                 logKnownIssue("cldrbug:9784", "fix TODO's in Attribute validity tests");
-                            } else if (pathParts.size() > 2
-                                && "validity".equals(pathParts.getElement(2))
+                            } else if (parts.size() > 2
+                                && "validity".equals(parts.getElement(2))
                                 && value.isEmpty()) {
-                                String typeValue = pathParts.getAttributeValue(-1, "type");
+                                String typeValue = parts.getAttributeValue(-1, "type");
                                 if ("TODO".equals(typeValue)
                                     || "locale".equals(typeValue)) {
                                     elementType = ElementType.EMPTY;
@@ -489,14 +485,14 @@ public class TestPaths extends TestFmwkPlus {
                         }
                         String dpath = CLDRFile.getDistinguishingXPath(path, normalizedPath);
                         if (!dpath.equals(path)) {
-                            checkParts(dpath, dtdData);
+                            checkParts(fileName + "/" + file, dpath, dtdData);
                         }
                         if (!normalizedPath.equals(path) && !normalizedPath[0].equals(dpath)) {
-                            checkParts(normalizedPath[0], dtdData);
+                            checkParts(fileName + "/" + file, normalizedPath[0], dtdData);
                         }
-                        parts = parts.cloneAsThawed();
-                        counter = removeNonDistinguishing(parts, dtdData, counter, removed, nonFinalValues);
-                        String cleaned = parts.toString();
+                        XPathParts mutableParts = parts.cloneAsThawed();
+                        counter = removeNonDistinguishing(mutableParts, dtdData, counter, removed, nonFinalValues);
+                        String cleaned = mutableParts.toString();
                         Pair<String, String> pair = Pair.of(type == DtdType.ldml ? file : type.toString(), cleaned);
                         if (seen.contains(pair)) {
 //                        parts.set(path);
@@ -526,7 +522,7 @@ public class TestPaths extends TestFmwkPlus {
         checkDeprecated.show(getInclusion());
     }
 
-    private void checkParts(String path, DtdData dtdData) {
+    private void checkParts(String file, String path, DtdData dtdData) {
         XPathParts parts = XPathParts.getFrozenInstance(path);
         Element current = dtdData.ROOT;
         for (int i = 0; i < parts.size(); ++i) {
@@ -538,13 +534,26 @@ public class TestPaths extends TestFmwkPlus {
                 if (!assertNotNull("element", current)) {
                     return; // failed
                 }
+                assertFalse(file + "/" + elementName + " deprecated", current.isDeprecated());
             }
             for (String attributeName : parts.getAttributeKeys(i)) {
                 Attribute attribute = current.getAttributeNamed(attributeName);
                 if (!assertNotNull("attribute", attribute)) {
                     return; // failed
                 }
-                // later, check values
+                assertFalse(file + "/" + elementName + "@" + attributeName + " deprecated", attribute.isDeprecated());
+
+                String value = parts.getAttributeValue(i, attributeName);
+                switch(attribute.getValueStatus(value)) {
+                case valid:
+                    break;
+                default:
+                    errln(file + "/" + elementName + "@" + attributeName
+                        + ", expected match to: " + attribute.getMatchString()
+                        + " actual: «" + value + "»");
+                    attribute.getValueStatus(value);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
CLDR-15071

I noticed that the tests were not catching a mismatch between the sil1 value in the .xml file and the sil22 value in the dtd. I looked into it, and found some problems in the test, where paths not being tested correctly. Fixed those, and the cases in the DTD that they exposed.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
