### PR TITLE
CLDR-16284 Remove Thai from no-space name scripts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -557,8 +557,8 @@ public class PersonNameFormatter {
                 }
             }
             return isBackground && bestValue != null
-                    ? ExampleGenerator.backgroundStartSymbol + bestValue + ExampleGenerator.backgroundEndSymbol
-                        : bestValue ;
+                ? ExampleGenerator.backgroundStartSymbol + bestValue + ExampleGenerator.backgroundEndSymbol
+                    : bestValue ;
         }
 
         public String formatInitial(String bestValue, FormatParameters nameFormatParameters) {
@@ -1543,11 +1543,16 @@ public class PersonNameFormatter {
         final Set<String> LOCALES_NOT_NEEDING_SPACES;
         LocaleSpacingData() {
             Set<String> _LOCALE_NOT_NEEDING_SPACES = new TreeSet<>();
+            Set<String> EXCLUSIONS = ImmutableSet.of("Thai");
             _LOCALE_NOT_NEEDING_SPACES.addAll(Arrays.asList("Jpan", "Hant", "Hans"));
             for (int i = 0; i < UScript.CODE_LIMIT; ++i) {
                 Info info = ScriptMetadata.getInfo(i);
-                if (info != null && info.lbLetters == Trinary.YES) {
-                    _LOCALE_NOT_NEEDING_SPACES.add(UScript.getShortName(i));
+                if (info != null
+                    && info.lbLetters == Trinary.YES) {
+                    final String script = UScript.getShortName(i);
+                    if (!EXCLUSIONS.contains(script)) {
+                        _LOCALE_NOT_NEEDING_SPACES.add(script);
+                    }
                 }
             }
             LOCALES_NOT_NEEDING_SPACES = ImmutableSet.copyOf(_LOCALE_NOT_NEEDING_SPACES);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -366,7 +366,7 @@ public class TestPersonNameFormatter extends TestFmwk{
         String[][] thTests = {
             {
                 "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"long\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
-                "〖<i>🟨 Native name and script:</i>〗〖❬ธนา❭〗〖❬ไอริณกล้าหาญ❭〗〖❬มานีชัยยศพิชิตชัย❭〗〖❬คุณปรีชากล้าหาญแสงระวี❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬ซินแบด❭〗〖❬เคเทอ❭ ❬มึลเลอร์❭〗〖❬ซาซิเลีย❭ ❬ฮามิช❭ ❬สโตเบอร์❭〗〖❬ศ.ดร.❭ ❬เอดา คอร์เนเลีย❭ ❬เซซาร์ มาร์ติน❭ ❬วอน บรืล❭ ❬พ.บ. ท.บ.❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Mr.❭ ❬Bertram Wilberforce❭ ❬Henry Robert❭ ❬Wooster❭ ❬Jr❭, ❬MP❭〗〖❬Єва❭ ❬Марія❭ ❬Шевченко❭〗〖❬太郎トーマス山田❭〗"
+                "〖<i>🟨 Native name and script:</i>〗〖❬ธนา❭〗〖❬ไอริณ❭ ❬กล้าหาญ❭〗〖❬มานี❭ ❬ชัยยศ❭ ❬พิชิตชัย❭〗〖❬คุณ❭ ❬ปรีชา❭ ❬กล้าหาญ❭ ❬แสงระวี❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬ซินแบด❭〗〖❬เคเทอ❭ ❬มึลเลอร์❭〗〖❬ซาซิเลีย❭ ❬ฮามิช❭ ❬สโตเบอร์❭〗〖❬ศ.ดร.❭ ❬เอดา คอร์เนเลีย❭ ❬เซซาร์ มาร์ติน❭ ❬วอน บรืล❭ ❬พ.บ. ท.บ.❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Mr.❭ ❬Bertram Wilberforce❭ ❬Henry Robert❭ ❬Wooster❭ ❬Jr❭, ❬MP❭〗〖❬Єва❭ ❬Марія❭ ❬Шевченко❭〗〖❬太郎トーマス山田❭〗"
             }
         };
         ExampleGenerator thExampleGenerator = checkExamples(thCldrFile, thTests);


### PR DESCRIPTION
CLDR-16284

Removing Thai from the list of scripts that don't need spaces in names.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
