### PR TITLE
CLDR-16346 Automatically handle adjacent duplicate literals in person names

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -14448,7 +14448,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
+			<!--  <namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern> -->
 			<namePattern>{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -11192,7 +11192,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
 			<namePattern draft="contributed">↑↑↑</namePattern>
@@ -11246,7 +11246,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{surname-monogram-allCaps}.{given-monogram-allCaps}.{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
 			<namePattern draft="contributed">↑↑↑</namePattern>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -8961,7 +8961,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
 			<namePattern>↑↑↑</namePattern>
@@ -9015,7 +9015,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}.{given-monogram-allCaps}.{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
 			<namePattern>↑↑↑</namePattern>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -10201,10 +10201,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps} {given2-monogram-allCaps} {surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
+			<namePattern>{given-informal-monogram-allCaps} {surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{given} {given2-initial} {surname} {credentials}</namePattern>
@@ -10255,10 +10255,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps} {given-monogram-allCaps} {given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
+			<namePattern>{surname-monogram-allCaps} {given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2-initial} {credentials}</namePattern>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1165,4 +1165,21 @@ public class TestPersonNameFormatter extends TestFmwk{
         }
     }
 
+    public void testDuplicateAdjacentLiterals() {
+        FormatParameters parameters = FormatParameters.from("length=long; formality=formal");
+        NamePattern namePattern;
+        String actual;
+
+        namePattern = NamePattern.from(0, "•{given}.{given2}.{surname}•");
+        actual = namePattern.format(sampleNameObject4, parameters, FALLBACK_FORMATTER);
+        assertEquals("duplicates", "•Shinzō.Abe•", actual);
+
+       namePattern = NamePattern.from(0, "•{given}. {given2}. {surname}•");
+        actual = namePattern.format(sampleNameObject4, parameters, FALLBACK_FORMATTER);
+        assertEquals("duplicates", "•Shinzō. Abe•", actual);
+
+        namePattern = NamePattern.from(0, "•{given} {given2} {surname}•");
+        actual = namePattern.format(sampleNameObject4, parameters, FALLBACK_FORMATTER);
+        assertEquals("duplicates", "•Shinzō Abe•", actual);
+    }
 }


### PR DESCRIPTION
CLDR-16346

common/main/ar.xml

- retracted the special pattern

tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java

- I had to understand what the code was doing, so went ahead and added comments for the future.
- The main change was to coalesceLiterals. It is not just duplicates, but rather anytime we would get a repeat at the end of a combined literal

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java

- Added test cases

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
