### PR TITLE
CLDR-7674 Fix a few locales, adjust charts, test, and utility

### DIFF
--- a/common/main/cch.xml
+++ b/common/main/cch.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="cch"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="cch" draft="contributed">Atsam</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters draft="unconfirmed">[a {a\u0331} b c {ch} d {dy} e f g {g\u0331} {gb} {gw} {gy} h {hy} i j k ḵ {kp} {kw} l {ly} m n ṉ {ny} o p {ph} {py} r {ry} s {sh} t u v w {wh} y {y\u0331} z ʼ]</exemplarCharacters>
 		<exemplarCharacters type="index" draft="unconfirmed">[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z ʼ]</exemplarCharacters>

--- a/common/main/ken.xml
+++ b/common/main/ken.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="ken"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="ken" draft="contributed">Kɛnyaŋ</language>
+		</languages>
+	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a á à ǎ b c d e é è ě ɛ {ɛ\u0301} {ɛ\u0300} {ɛ\u030C} f g {gb} {gh} h i ɨ {ɨ\u0301} {ɨ\u0300} {ɨ\u030C} j k {kp} m n {ny} ŋ o ó ò ǒ ɔ {ɔ\u0301} {ɔ\u0300} {ɔ\u030C} p r s t u ú ù ǔ ʉ {ʉ\u0301} {ʉ\u0300} {ʉ\u030C} w y]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[l q v x z]</exemplarCharacters>

--- a/common/main/nv.xml
+++ b/common/main/nv.xml
@@ -10,6 +10,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<version number="$Revision$"/>
 		<language type="nv"/>
 	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="nv" draft="contributed">Diné Bizaad</language>
+		</languages>
+	</localeDisplayNames>
 	<layout>
 		<orientation>
 			<characterOrder>left-to-right</characterOrder>

--- a/common/main/sms.xml
+++ b/common/main/sms.xml
@@ -40,7 +40,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="pl" draft="unconfirmed">puolaǩiõll</language>
 			<language type="pt" draft="unconfirmed">portugalkiõll</language>
 			<language type="ru" draft="unconfirmed">ruõšš</language>
-			<language type="sms" draft="unconfirmed">sääʹmǩiõll</language>
+			<language type="sms" draft="contributed">sääʹmǩiõll</language>
 			<language type="sv" draft="unconfirmed">ruõccǩiõll</language>
 			<language type="th" draft="unconfirmed">thaiǩiõll</language>
 			<language type="zh" draft="unconfirmed">ǩiinaǩiõll</language>

--- a/common/main/ssy.xml
+++ b/common/main/ssy.xml
@@ -13,6 +13,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<localeDisplayNames>
 		<languages>
 			<language type="aa" draft="unconfirmed">Qafar</language>
+			<language type="ssy" draft="contributed">Saho</language>
 		</languages>
 		<scripts>
 			<script type="Latn" draft="unconfirmed">Latin</script>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -1014,7 +1014,7 @@ public class ShowLocaleCoverage {
                     }
 
                     Set<CoreItems> shownMissingPaths = EnumSet.noneOf(CoreItems.class);
-                    Level computedWithCore = computed == Level.UNDETERMINED ? Level.CORE : computed;
+                    Level computedWithCore = computed == Level.UNDETERMINED ? Level.BASIC : computed;
                     for (CoreItems item : specialMissingPaths) {
                         if (item.desiredLevel.compareTo(computedWithCore) <= 0) {
                             shownMissingPaths.add(item);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CoreCoverageInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CoreCoverageInfo.java
@@ -3,7 +3,6 @@ package org.unicode.cldr.util;
 import java.io.File;
 import java.util.Arrays;
 import java.util.EnumMap;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -15,10 +14,14 @@ import org.unicode.cldr.draft.ScriptMetadata.Info;
 import org.unicode.cldr.draft.ScriptMetadata.Trinary;
 import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.util.CLDRFile.ExemplarType;
+import org.unicode.cldr.util.Iso639Data.Type;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.UnicodeSet;
@@ -30,6 +33,17 @@ public class CoreCoverageInfo {
     private static final SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
     private static final LikelySubtags ls = new LikelySubtags();
 
+    public enum Sublevel {
+        /**
+         * Needs to be present at the start of that level's vetting
+         */
+        start,
+        /**
+         * (default) Only to be present by the end start of that level's vetting
+         */
+        end
+        }
+
     public enum CoreItems {
         default_content(Level.CORE),
         likely_subtags(Level.CORE),
@@ -37,28 +51,44 @@ public class CoreCoverageInfo {
         orientation(Level.CORE),
         time_cycle(Level.CORE),
 
-        // time cycle
+        own_language(Level.BASIC),
+        own_regions(Level.BASIC),
 
-        casing(Level.MODERATE),
-        plurals(Level.MODERATE),
-        ordinals(Level.MODERATE),
+        casing(Level.MODERATE, Sublevel.start),
+        plurals(Level.MODERATE, Sublevel.start),
         collation(Level.MODERATE),
 
-        grammar(Level.MODERN),
+        grammar(Level.MODERN, Sublevel.start),
+        ordinals(Level.MODERN),
         romanization(Level.MODERN),
         ;
 
-        public static Set<CoreItems> ONLY_RECOMMENDED = ImmutableSet.copyOf(
-            EnumSet.of(romanization, ordinals));
-
-        public static final int COUNT = CoreItems.values().length;
-        public final Level desiredLevel;
-
-        CoreItems(Level desiredLevel) {
-            this.desiredLevel = desiredLevel;
+        public static final Set<CoreItems> ALL = ImmutableSet.copyOf(CoreItems.values());
+        public static final Multimap<Level, CoreItems> LEVEL_TO_ITEMS;
+        static {
+            final Multimap<Level, CoreItems> _levelToItems = TreeMultimap.create();
+            ALL.forEach(x -> {
+                for (Level level : Level.values()) {
+                    if (level.compareTo(x.desiredLevel) <= 0) {
+                        _levelToItems.put(x.desiredLevel,x);
+                    }
+                }
+            });
+            LEVEL_TO_ITEMS = ImmutableMultimap.copyOf(_levelToItems);
         }
+
+        public final Level desiredLevel;
+        public final Sublevel sublevel;
+
         CoreItems() {
             this(Level.CORE);
+        }
+        CoreItems(Level desiredLevel) {
+            this(desiredLevel, Sublevel.end);
+        }
+        CoreItems(Level desiredLevel, Sublevel sublevel) {
+            this.desiredLevel = desiredLevel;
+            this.sublevel = sublevel;
         }
         @Override
         public String toString() {
@@ -67,19 +97,20 @@ public class CoreCoverageInfo {
     }
     static UnicodeSet RTL = new UnicodeSet("[[:bc=R:][:bc=AL:]]").freeze();
 
-    public static Set<CoreItems> getCoreCoverageInfo(CLDRFile file, Multimap<CoreItems,String> detailedErrors) {
+    public static Set<CoreItems> getCoreCoverageInfo(CLDRFile resolvedFile, Multimap<CoreItems,String> detailedErrors) {
         detailedErrors.clear();
-        if (file.isResolved()) {
-            file = file.getUnresolved();
+        if (!resolvedFile.isResolved()) {
+            throw new IllegalArgumentException();
         }
+        CLDRFile file = resolvedFile.getUnresolved();
         String locale = file.getLocaleID();
         LanguageTagParser ltp = new LanguageTagParser();
         locale = ltp.set(locale).getLanguageScript();
-        String baseLanguage = ltp.getLanguage();
-        String script = ltp.getScript();
-        String region = ltp.getRegion();
+        final String baseLanguage = ltp.getLanguage();
+        final String script = ltp.getScript();
+        final String region = ltp.getRegion();
 
-        Set<CoreItems> result = EnumSet.noneOf(CoreItems.class);
+        //Set<CoreItems> result = EnumSet.noneOf(CoreItems.class);
 
         //      (02) Orientation (bidi writing systems only) [main/xxx.xml]
         UnicodeSet main = file.getExemplarSet(ExemplarType.main, null);
@@ -87,23 +118,17 @@ public class CoreCoverageInfo {
 
         String path = "//ldml/layout/orientation/characterOrder";
         String value = file.getStringValue(path);
-        if ("right-to-left".equals(value) == isRtl) {
-            result.add(CoreItems.orientation);
-        } else {
+        if ("right-to-left".equals(value) != isRtl) {
             detailedErrors.put(CoreItems.orientation, path);
         }
 
         //      (01) Plural rules [supplemental/plurals.xml and ordinals.xml]
         //      For more information, see cldr-spec/plural-rules.
         if (sdi.getPluralLocales(PluralType.cardinal).contains(baseLanguage)) {
-            result.add(CoreItems.plurals);
-        } else {
             detailedErrors.put(CoreItems.plurals, "//supplementalData/plurals[@type=\"cardinal\"]/pluralRules[@locales=\"" + locale
                 + "\"]/pluralRule[@count=\"other\"]");
         }
         if (sdi.getPluralLocales(PluralType.ordinal).contains(baseLanguage)) {
-            result.add(CoreItems.ordinals);
-        } else {
             detailedErrors.put(CoreItems.ordinals, "//supplementalData/plurals[@type=\"ordinal\"]/pluralRules[@locales=\"" + locale
                 + "\"]/pluralRule[@count=\"other\"]");
         }
@@ -111,26 +136,60 @@ public class CoreCoverageInfo {
         //      (01) Default content script and region (normally: normally country with largest population using that language, and normal script for that).  [supplemental/supplementalMetadata.xml]
 
         String defaultContent = sdi.getDefaultContentLocale(locale);
-        if (defaultContent != null || locale.equals("no")) {
-            result.add(CoreItems.default_content);
-        } else {
+        if (defaultContent == null) { //  || locale.equals("no")
             detailedErrors.put(CoreItems.default_content, "//supplementalData/supplementalMetadata/defaultContent");
         }
         // likely subtags
-        String max = ls.maximize(locale);
-        String maxLangScript = null;
+        final String max = ls.maximize(locale);
+        String maxLangScript = "";
+        String maxScript = "";
+        String maxRegion = "";
         if (max != null) {
             ltp.set(max);
             maxLangScript = ltp.getLanguageScript();
-            script = ltp.getScript();
-            region = ltp.getRegion();
-            if (!script.isEmpty() && !region.isEmpty()) {
-                result.add(CoreItems.likely_subtags);
+            maxScript = ltp.getScript();
+            maxRegion = ltp.getRegion();
+            if (maxRegion.equals("ZZ")
+                || maxRegion.equals("001") && Iso639Data.getType(baseLanguage) != Type.Constructed) {
+                maxRegion = "";
             }
         }
-        if (!result.contains(CoreItems.likely_subtags)) {
+        if (maxScript.isEmpty() || maxRegion.isEmpty()) {
             detailedErrors.put(CoreItems.likely_subtags, "//supplementalData/likelySubtags");
         }
+
+        String bestScript = script.isEmpty() ? maxScript : script;
+        String bestRegion = region.isEmpty() ? maxRegion : region;
+
+        String languagePath = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, baseLanguage);
+        String languageName = resolvedFile.getStringValue(languagePath);
+        if (languageName == null) {
+            detailedErrors.put(CoreItems.own_language, languagePath);
+        } else {
+            String localeWhereFound = resolvedFile.getSourceLocaleID(languagePath, null);
+            if ("root".equals(localeWhereFound)
+                || "code-fallback".equals(localeWhereFound)) {
+                detailedErrors.put(CoreItems.own_language, languagePath);
+            }
+        }
+
+        if (bestRegion.isEmpty()){
+            detailedErrors.put(CoreItems.own_regions, "//supplementalData/likelySubtags");
+        } else {
+            String regionPath = CLDRFile.getKey(CLDRFile.TERRITORY_NAME, bestRegion);
+            String regionName = file.getStringValue(regionPath);
+            if (regionName == null) {
+                detailedErrors.put(CoreItems.own_regions, regionPath);
+            } else {
+                String localeWhereFound = resolvedFile.getSourceLocaleID(regionPath, null);
+                if (XMLSource.ROOT_ID.equals(localeWhereFound)
+                    || XMLSource.CODE_FALLBACK_ID.equals(localeWhereFound)) {
+                    detailedErrors.put(CoreItems.own_regions, regionPath);
+                }
+            }
+        }
+        // NOTE: other regions will be captured in the coverageLevels
+
         // (N) Verify the country data ( i.e. which territories in which the language is spoken enough to create a locale ) [supplemental/supplementalData.xml]
         // we verify that there is at least one region
         // we try 3 cases: language, locale, maxLangScript
@@ -141,9 +200,7 @@ public class CoreCoverageInfo {
         if (territories == null && maxLangScript != null) {
             territories = sdi.getTerritoriesForPopulationData(maxLangScript);
         }
-        if (territories != null && territories.size() != 0) {
-            result.add(CoreItems.country_data);
-        } else {
+        if (territories == null || territories.isEmpty()) {
             detailedErrors.put(CoreItems.country_data, "//supplementalData/territoryInfo");
             sdi.getTerritoriesForPopulationData(locale); // for debugging
         }
@@ -151,21 +208,20 @@ public class CoreCoverageInfo {
         //      If a spreadsheet, for each letter (or sequence) in the exemplars, what is the corresponding Latin letter (or sequence).
         //      More sophisticated users can do a better job, supplying a file of rules like transforms/Arabic-Latin-BGN.xml.
 
-        if (script.equals("Latn")) {
-            result.add(CoreItems.romanization);
-        } else {
+        if (!bestScript.equals("Latn")) {
             boolean found = false;
-            Set<String> scriptNames = getScriptNames(script);
-            Set<String> tempErrors = new LinkedHashSet<>();
-            for (String scriptName : scriptNames) {
-                for (String[] pair : ROMANIZATION_PATHS) {
-                    String filename = pair[0] + scriptName + pair[1];
-                    if (hasFile(SpecialDir.transforms, filename)) {
-                        result.add(CoreItems.romanization);
-                        found = true;
-                        break;
-                    } else {
-                        tempErrors.add(script); // debugging
+            Set<String> scriptLongCodes = getScriptNames(bestScript);
+            if (scriptLongCodes != null) {
+                Set<String> debugErrors = new LinkedHashSet<>();
+                for (String scriptLongCode : scriptLongCodes) {
+                    for (String[] pair : ROMANIZATION_PATHS) {
+                        String filename = pair[0] + scriptLongCode + pair[1];
+                        if (hasFile(SpecialDir.transforms, filename)) {
+                            found = true;
+                            break;
+                        } else {
+                            debugErrors.add(script);
+                        }
                     }
                 }
             }
@@ -180,15 +236,9 @@ public class CoreCoverageInfo {
 
         //      (N) Casing information (cased scripts only, according to ScriptMetadata.txt)
         //      This will be in common/casing
-        Info scriptData = ScriptMetadata.getInfo(script);
-        if (scriptData.hasCase == Trinary.YES) {
-            if (hasFile(SpecialDir.casing, baseLanguage)) {
-                result.add(CoreItems.casing);
-            } else {
-                detailedErrors.put(CoreItems.casing, "//ldml/metadata/casingData/casingItem[@type=\"*\"]");
-            }
-        } else {
-            result.add(CoreItems.casing);
+        Info scriptData = ScriptMetadata.getInfo(bestScript);
+        if (scriptData != null && scriptData.hasCase == Trinary.YES && !hasFile(SpecialDir.casing, baseLanguage)) {
+            detailedErrors.put(CoreItems.casing, "//ldml/metadata/casingData/casingItem[@type=\"*\"]");
         }
         //      (N) Collation rules [non-Survey Tool]
         //      For details, see cldr-spec/collation-guidelines.
@@ -197,27 +247,21 @@ public class CoreCoverageInfo {
 
         // check for file cldr/collation/<language>.xml
         if (hasFile(SpecialDir.collation, baseLanguage)) {
-            result.add(CoreItems.collation);
-        } else {
             detailedErrors.put(CoreItems.collation, "//ldml/collations/collation[@type=\"standard\"]");
         }
 
         Map<String, PreferredAndAllowedHour> timeData = sdi.getTimeData();
-        if (timeData.get(region) != null) {
-            result.add(CoreItems.time_cycle);
-        } else {
+        if (timeData.get(bestRegion) == null) {
             detailedErrors.put(CoreItems.time_cycle, "//supplementalData/timeData/hours");
         }
 
         GrammarInfo grammarInfo = sdi.getGrammarInfo(locale);
-        if (grammarInfo != null) {
-            result.add(CoreItems.grammar);
-        } else {
+        if (grammarInfo == null) {
             detailedErrors.put(CoreItems.grammar, "//supplementalData/grammaticalData/grammaticalFeatures");
         }
 
         // finalize
-        return ImmutableSet.copyOf(result);
+        return ImmutableSet.copyOf(Sets.difference(CoreItems.ALL, detailedErrors.keySet()));
     }
 
     private static final String[][] ROMANIZATION_PATHS = {
@@ -241,10 +285,13 @@ public class CoreCoverageInfo {
         if (result != null) {
             return result;
         }
-        result = new HashSet();
-        String name = UScript.getName(UScript.getCodeFromName(script));
-        result.add(name);
-        result.add(script);
+        result = new HashSet<>();
+        try {
+            String name = UScript.getName(UScript.getCodeFromName(script));
+            result.add(name);
+            result.add(script);
+        } catch (Exception e) {
+        }
         return result;
     }
 


### PR DESCRIPTION
CLDR-7674
*.xml files
Added names as per ticket

tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
- Minor change to set default to basic for the last column

tools/cldr-code/src/main/java/org/unicode/cldr/util/CoreCoverageInfo.java
- Significant revamp here. 
- Added 3 items at Basic level (we had moved up from Core). 
- Added static sets for quick access to the CoreItems at each level (and below)
- Added a sublevel, to distinguish the ones that should be present at the start. 
- Moved ordinals to Modern (discussed earlier, since we don't depend on them in CLDR itself)
- Restructured the main function getCoreCoverageInfo
    - Now compute result at the end, simplifying the code and making less error-prone
    - Better tests of edge cases like ZZ and 001
    - Handles the autonym (own language) and denonym (own region)
 
tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
- Cleaned up the logic
- Emits warnings for missing items

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
