### PR TITLE
CLDR-16239 fix main lateral inheritance

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -26,16 +26,46 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.draft.FileUtilities;
-import org.unicode.cldr.test.*;
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.test.CLDRTest;
+import org.unicode.cldr.test.CoverageLevel2;
+import org.unicode.cldr.test.DisplayAndInputProcessor;
+import org.unicode.cldr.test.QuickCheck;
+import org.unicode.cldr.test.SubmissionLocales;
+import org.unicode.cldr.util.Annotations;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRFile.ExemplarType;
 import org.unicode.cldr.util.CLDRFile.NumberingSystem;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
+import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CLDRTool;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.DateTimeCanonicalizer;
 import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
+import org.unicode.cldr.util.DtdData;
+import org.unicode.cldr.util.DtdType;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.FileProcessor;
+import org.unicode.cldr.util.GlossonymConstructor;
+import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.LogicalGrouping;
+import org.unicode.cldr.util.PathChecker;
+import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.RegexLookup;
+import org.unicode.cldr.util.SimpleFactory;
+import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.StringId;
+import org.unicode.cldr.util.SupplementalDataInfo;
 // import org.unicode.cldr.util.Log;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
+import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.XPathParts.Comments;
 import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 
@@ -252,25 +282,25 @@ public class CLDRModify {
         + "\tr\t replace contents (otherwise new data will be draft=\"unconfirmed\")"
         + XPathParts.NEWLINE
         + "\tc\t ignore comments in <merge_dir> files"
-+ XPathParts.NEWLINE
-+ "-v\t incorporate vetting information, and generate diff files."
-+ XPathParts.NEWLINE
-+ "-z\t generate resolved files"
-+ XPathParts.NEWLINE
-+ "-p\t set path for -fx"
-+ XPathParts.NEWLINE
-+ "-u\t set user for -fb"
-+ XPathParts.NEWLINE
-+ "-a\t pattern: recurse over all subdirectories that match pattern"
-+ XPathParts.NEWLINE
-+ "-c\t check that resulting xml files are valid. Requires that a dtd directory be copied to the output directory, in the appropriate location."
-+ XPathParts.NEWLINE
-+ "-k\t config_file\twith -fk perform modifications according to what is in the config file. For format details, see:"
-+ XPathParts.NEWLINE
-+ "\t\thttp://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-passes/cldrmodify-config."
-+ XPathParts.NEWLINE
-+ "-f\t to perform various fixes on the files (add following arguments to specify which ones, eg -fxi)"
-+ XPathParts.NEWLINE;
+        + XPathParts.NEWLINE
+        + "-v\t incorporate vetting information, and generate diff files."
+        + XPathParts.NEWLINE
+        + "-z\t generate resolved files"
+        + XPathParts.NEWLINE
+        + "-p\t set path for -fx"
+        + XPathParts.NEWLINE
+        + "-u\t set user for -fb"
+        + XPathParts.NEWLINE
+        + "-a\t pattern: recurse over all subdirectories that match pattern"
+        + XPathParts.NEWLINE
+        + "-c\t check that resulting xml files are valid. Requires that a dtd directory be copied to the output directory, in the appropriate location."
+        + XPathParts.NEWLINE
+        + "-k\t config_file\twith -fk perform modifications according to what is in the config file. For format details, see:"
+        + XPathParts.NEWLINE
+        + "\t\thttp://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-passes/cldrmodify-config."
+        + XPathParts.NEWLINE
+        + "-f\t to perform various fixes on the files (add following arguments to specify which ones, eg -fxi)"
+        + XPathParts.NEWLINE;
 
     static final String HELP_TEXT2 = "Note: A set of bat files are also generated in <dest_dir>/diff. They will invoke a comparison program on the results."
         + XPathParts.NEWLINE;
@@ -1345,7 +1375,7 @@ public class CLDRModify {
             public void handleStart() {
                 if (preFactory == null) {
                     preFactory = SimpleFactory.make(list, ".*");
-                 }
+                }
                 String localeID = cldrFileToFilter.getLocaleID();
                 try {
                     preFile = preFactory.make(localeID, false /* not resolved */);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
@@ -34,10 +34,6 @@ public class CompareResolved {
             .setMatch(".*")),
         verbose(new Params()
             .setMatch(null)),
-        Vertical(new Params().setHelp("Only check values with vertical inheritance")
-            .setMatch(null)),
-        Horizontal(new Params().setHelp("Only check values with horizontal inheritance")
-            .setMatch(null)),
         ;
 
         // BOILERPLATE TO COPY
@@ -79,10 +75,6 @@ public class CompareResolved {
         }
 
         boolean verbose = MyOptions.verbose.option.doesOccur();
-
-        // TODO
-        Boolean onlyVertical = null; // !MyOptions.Vertical.option.doesOccur() ? null : Boolean.valueOf(MyOptions.Horizontal.option.getValue());
-        Boolean onlyHorizontal = null; // !MyOptions.Horizontal.option.doesOccur() ? null : Boolean.valueOf(MyOptions.Horizontal.option.getValue());
 
         // set up factories
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
@@ -32,11 +32,12 @@ public class CompareResolved {
             .setMatch(".*")),
         pathFilter(new Params().setHelp("Filter paths in each source file.")
             .setMatch(".*")),
-        verbose(new Params().setMatch(null)),
-        Vertical(new Params().setHelp("True to only check values with vertical inheritance")
-            .setMatch("true|false")),
-        Horizontal(new Params().setHelp("True to only check values with horizontal inheritance")
-            .setMatch("true|false")),
+        verbose(new Params()
+            .setMatch(null)),
+        Vertical(new Params().setHelp("Only check values with vertical inheritance")
+            .setMatch(null)),
+        Horizontal(new Params().setHelp("Only check values with horizontal inheritance")
+            .setMatch(null)),
         ;
 
         // BOILERPLATE TO COPY
@@ -106,7 +107,7 @@ public class CompareResolved {
         int diffCountAllLocales = 0;
 
         // cycle over locales
-        System.out.println("Locale\tPath\tChanged\tOriginal\tVert?\tHoriz?");
+        System.out.println("Locale\tRequested Path\tResolved Value (GEN)\ttResolved Value (Main)\tFound Locale (GEN)\tFound Locale (Main)\tFound Path (GEN)\tFound Path (Main)");
         for (String localeID : sourceFactory.getAvailable()) {
             if (fileMatcher != null && !fileMatcher.reset(localeID).find()) {
                 continue;
@@ -170,21 +171,22 @@ public class CompareResolved {
                     + "\t" + path //
                     + "\t" + sourceValue
                     + "\t" + compareValue //
-                    + "\t" + (verticalDiff ? "VΔ" : "")  //
-                    + "\t" + (horizontalDiff ? "HΔ" : "")
+                    + "\t" + sourceLocaleFound.value
                     + "\t" + compareLocaleFound.value
+                    + "\t" + abbreviate(sourcePathFound.value, path)
                     + "\t" + abbreviate(comparePathFound.value, path)
                     );
             }
-            if (verbose) {
+            if (verbose || diffCount != 0) {
                 System.out.println(localeID + "\t#filteredCount:\t" + filterCount + ", diffCount:\t" + diffCount);
             }
             filterCountAllLocales += filterCount;
             diffCountAllLocales += diffCount;
         }
-        if (verbose) {
-            System.out.println("ALL LOCALES: filteredCountAllLocales: " + filterCountAllLocales + ", diffCountAllLocales: " + diffCountAllLocales);
+        if (verbose || diffCountAllLocales != 0) {
+            System.out.println("ALL LOCALES" + "\t#filteredCount:\t" + filterCountAllLocales + ", diffCountAllLocales: " + diffCountAllLocales);
         }
+        System.out.println("DONE");
     }
 
     /*

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
@@ -703,11 +703,11 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
         if (limit < 0) {
             limit += size();
         }
-        String result = "";
+        StringBuilder result = new StringBuilder();
         for (int i = start; i < limit; ++i) {
-            result += elements.get(i).toString(XPATH_STYLE);
+            result.append(elements.get(i).toString(XPATH_STYLE));
         }
-        return result;
+        return result.toString();
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
@@ -681,6 +681,8 @@ public final class XPathParts implements Freezable<XPathParts>, Comparable<XPath
         return toString(elements.size());
     }
 
+    // TODO combine and optimize these
+
     public String toString(int limit) {
         if (limit < 0) {
             limit += size();


### PR DESCRIPTION
CLDR-16239

tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
- added option to retain unchanged files (this allows simple generation of a complete set) with -R
- for -f, added printing of number of changes to each file.
- changed fixList.add('V', "Fix values that would inherit laterally", which changes the following paths, but *just* those that inherit laterally:
  - if we have an L1 locale, change each ↑↑↑ value
  - if we don't have an L1 locale
    - change each ↑↑↑ value where its parent bailey value is different.
    - ALSO change each null value where its parent bailey value is different. (pulled my hair out for this one). This is done in a new handleEnd()
- Also added a new utility to get the parent chain. After the dust settles, this should probably be moved to a central location.

tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
- Added a new parameter 
- Made more verbose printout, but with abbreviated paths.
- Printed counts if either in verbose mode or there are diffs.

tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
- Minor optimization (we could do more to clean this up, later)

The resulting data was:

36,990 | fix ↑↑↑ lateral; L1
-- | --
87 | fix ↑↑↑ lateral; L2+
171 | fix null lateral; L2+

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
