### PR TITLE
CLDR-16346 Fix initials 2

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -14433,8 +14433,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<nameOrderLocales order="givenFirst">und ar</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">ko vi yue zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve"> </foreignSpaceReplacement>
-		<initialPattern type="initial">{0}</initialPattern>
-		<initialPattern type="initialSequence">{0}. {1}.</initialPattern>
+		<initialPattern type="initial">{0}.</initialPattern>
+		<initialPattern type="initialSequence">{0} {1}</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{title} {given} {given2} {surname} {generation}، {credentials}</namePattern>
 		</personName>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -9318,7 +9318,7 @@ annotations.
 		<nameOrderLocales order="surnameFirst">ja ko vi yue zh</nameOrderLocales>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">{0}.</initialPattern>
-		<initialPattern type="initialSequence">{0} {1}</initialPattern>
+		<initialPattern type="initialSequence">{0}{1}</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{title} {given} {given2} {surname} {generation}, {credentials}</namePattern>
 		</personName>
@@ -9356,7 +9356,7 @@ annotations.
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
+			<namePattern>{given-initial}{given2-initial} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname-initial}</namePattern>
@@ -9410,7 +9410,7 @@ annotations.
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
+			<namePattern>{surname} {given-initial}{given2-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{surname} {given-initial}</namePattern>
@@ -9440,7 +9440,7 @@ annotations.
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>{surname-core}, {given-initial} {given2-initial} {surname-prefix}</namePattern>
+			<namePattern>{surname-core}, {given-initial}{given2-initial} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -19410,7 +19410,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
+			<namePattern>{surname} {given-initial}{given2-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{surname} {given-initial}</namePattern>
@@ -19440,7 +19440,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
+			<namePattern>{surname}, {given-initial}{given2-initial}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -11589,22 +11589,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
-			<namePattern>{surname-core}{given}{given2}</namePattern>
+			<namePattern>{surname-core} {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>{surname}{given-informal}</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>{surname}{given-informal}</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>{surname-core}{given-initial}{given2-initial}</namePattern>
+			<namePattern>{surname-core} {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>{surname}{given-informal}</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">文傑</nameField>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -80,9 +80,7 @@ public class CheckPersonNames extends CheckCLDR {
         XPathParts parts = XPathParts.getFrozenInstance(path);
         switch(parts.getElement(2)) {
         case "personName":
-            value = fixedValueIfInherited(path, value).toString();
             NamePattern namePattern = NamePattern.from(0, value);
-
             ArrayList<List<String>> failures = namePattern.findInitialFailures(initialSeparator);
             for (List<String> row :    failures) {
                 String previousField = row.get(0);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -158,5 +158,4 @@ public class CheckPersonNames extends CheckCLDR {
         }
         return this;
     }
-
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -182,7 +182,7 @@ public class TestPersonNameFormatter extends TestFmwk{
             warnln("To see the contents of the English patterns, use -DTestPersonNameFormatter.SHOW");
         }
 
-        check(ENGLISH_NAME_FORMATTER, sampleNameObject1, "order=sorting; length=short", "Smith, J. B.");
+        check(ENGLISH_NAME_FORMATTER, sampleNameObject1, "order=sorting; length=short", "Smith, J.B.");
         check(ENGLISH_NAME_FORMATTER, sampleNameObject1, "length=long; usage=referring; formality=formal", "Dr. John Bob Smith Jr, MD");
 
 //        checkFormatterData(ENGLISH_NAME_FORMATTER);
@@ -576,7 +576,7 @@ public class TestPersonNameFormatter extends TestFmwk{
             case allCaps:
                 expected = "VAN BERK"; break;
             case initial:
-                expected = "v. B."; break;
+                expected = "v.B."; break;
             case initialCap:
                 expected = "Van Berk"; break;
             case monogram:
@@ -1104,7 +1104,7 @@ public class TestPersonNameFormatter extends TestFmwk{
     public void testInitials() {
         String[][] tests = {{
             "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"short\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern",
-            "〖<i>🟨 Native name and script:</i>〗〖❬Zendaya❭〗〖❬I.❭ ❬Adler❭〗〖❬M. S.❭ ❬H.❭ ❬Watson❭〗〖❬B. W.❭ ❬H. R.❭ ❬Wooster❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬Sinbad❭〗〖❬K.❭ ❬Müller❭〗〖❬Z.❭ ❬H.❭ ❬Stöber❭〗〖❬A. C.❭ ❬C. M.❭ ❬von Brühl❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Є.❭ ❬М.❭ ❬Шевченко❭〗〖❬太郎山田❭〗"
+            "〖<i>🟨 Native name and script:</i>〗〖❬Zendaya❭〗〖❬I.❭ ❬Adler❭〗〖❬M.S.H.❭ ❬Watson❭〗〖❬B.W.H.R.❭ ❬Wooster❭〗〖<i>🟧 Foreign name and native script:</i>〗〖❬Sinbad❭〗〖❬K.❭ ❬Müller❭〗〖❬Z.H.❭ ❬Stöber❭〗〖❬A.C.C.M.❭ ❬von Brühl❭〗〖<i>🟥 Foreign name and script:</i>〗〖❬Є.М.❭ ❬Шевченко❭〗〖❬太郎山田❭〗"
         }};
         ExampleGenerator exampleGenerator = checkExamples(ENGLISH, tests);
     }


### PR DESCRIPTION
CLDR-16346

Detect and fix inconsistencies between initial pattern and literals between initial fields. Handles the "J. R.R. Tolkien" case.

From Person Names WG agenda

Overall Recommendations AGREED

1. For en, en_GB: Switch to J.R.R. Tolkien.
  a. In en, drop space between initial fields, drop space in initial sequence pattern, 
  b. In en_GB, en_001, change to ^^^.
2. For ar, move period to ‘initial’. Was:
  a. <initialPattern type="initial">{0}</initialPattern>  R Gillam→R. Gillam
  b. <initialPattern type="initialSequence">{0}. {1}.</initialPattern> R. B. Gillam (same)
3. For nl, drop the space in the adjacent fields. 
  a. Will look like en, en_GB in (i) above
4. For yue, the sorting forms need spaces, eg
  a. <namePattern>{surname-core}{given-initial}{given2-initial}</namePattern>
  b. The FSR will cause them to be removed or replaced by ·
  c. <namePattern>{surname-core} {given-initial} {given2-initial}</namePattern>

Also adds Check and Test

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
