### PR TITLE
CLDR-16411 BRS v43: Update ICU4J libs to 2023-02-21, update readme & copyrights

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ If a test or status check does not pass, see [Running Tests][] on the CLDR devel
 
 ## Copyright
 
-Copyright &copy; 1991-2022 Unicode, Inc.
+Copyright &copy; 1991-2023 Unicode, Inc.
 All rights reserved. [Terms of use][]
 
 [Survey Tool]: https://cldr.unicode.org/index/survey-tool

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ SPDX-License-Identifier: Unicode-DFS-2016
 
 ### Copyright
 
-Copyright &copy; 1991-2022 Unicode, Inc.
+Copyright &copy; 1991-2023 Unicode, Inc.
 All rights reserved.
 [Terms of use](https://www.unicode.org/copyright.html)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,6 @@ CLDR main page: [https://www.unicode.org/cldr](unicode.org/cldr)
 
 ##### Copyright
 
-Copyright &copy; 1991-2019 Unicode, Inc.
+Copyright &copy; 1991-2023 Unicode, Inc.
 All rights reserved.
 [Terms of use](https://www.unicode.org/copyright.html)

--- a/readme.html
+++ b/readme.html
@@ -4,7 +4,7 @@
   <head>
 	<meta http-equiv="Content-Type" content= "text/html; charset=utf-8">
 	<meta http-equiv="Content-Language" content="en-us">
-    <meta name="COPYRIGHT" content= "Copyright (c) 1991-2022 Unicode, Inc. All rights reserved.">
+    <meta name="COPYRIGHT" content= "Copyright (c) 1991-2023 Unicode, Inc. All rights reserved.">
     <meta name="DESCRIPTION" content= "Readme for Unicode CLDR with version number and other information.">
     <title>ReadMe for Unicode CLDR</title>
   </head>
@@ -12,13 +12,13 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 43</h3>
-    <p>Last updated: 2022-Oct-20</p>
+    <p>Last updated: 2023-Feb-21</p>
 
-    <p><b>Note:</b> CLDR 43 is in development and not recommended for use at this stage.</p>
+    <!--<p><b>Note:</b> CLDR 43 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 43, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a preliminary version of CLDR 43, intended for those wishing to do pre-release testing.
-    It is not recommended for production use.</p>-->
+    <p><b>Note:</b> This is a preliminary version of CLDR 43, intended for those wishing to do pre-release testing.
+    It is not recommended for production use.</p>
     <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 43, intended for testing.
     It is not recommended for production use.</p>-->
     <!--<p>This is the final release version of CLDR 43.</p>-->
@@ -54,17 +54,15 @@
  	  <li>Some CLDR tools depend on libraries in tools/cldr-code/libs/; use of these libraries is governed by separate license agreements.
  	  <ul>
  	    <li>Use of the ICU libraries is subject to the
- 	    <a href="https://github.com/unicode-org/icu/blob/main/icu4j/main/shared/licenses/LICENSE">ICU License</a>,
- 	    included as ICU-LICENSE.</li>
+ 	    <a href="https://github.com/unicode-org/icu/blob/main/icu4j/main/shared/licenses/LICENSE">ICU License</a>.</li>
  	    <li>Use of the Guava, Xerces, and Myanmar Tools libraries is subject to the
- 	    <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License</a>,
- 	    included as apache-license.txt.</li>
+ 	    <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License</a>.</li>
  	  </ul>
  	  </li>
  	</ul>
 
     <hr>
-    <p>Copyright &copy; 1991-2022 Unicode, Inc.<br>
+    <p>Copyright &copy; 1991-2023 Unicode, Inc.<br>
     All rights reserved.<br>
     <a href="http://www.unicode.org/copyright.html">Terms of use</a></p>
   </body>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>73.0.1-SNAPSHOT-cldr-2023-02-02</icu4j.version>
+		<icu4j.version>73.0.1-SNAPSHOT-cldr-2023-02-21</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>

--- a/unicode-license.txt
+++ b/unicode-license.txt
@@ -1,7 +1,7 @@
 ﻿UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
 
-See Terms of Use for definitions of Unicode Inc.'s
-Data Files and Software.
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
 
 NOTICE TO USER: Carefully read the following legal agreement.
 BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
@@ -13,7 +13,7 @@ THE DATA FILES OR SOFTWARE.
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 1991-2022 Unicode, Inc. All rights reserved.
+Copyright © 1991-2023 Unicode, Inc. All rights reserved.
 Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
CLDR-16411

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Update ICU4J libs to 2023-02-21 (after integration of CLDR 43-alpha1).

Update readme; update copyrights in various docs.

ALLOW_MANY_COMMITS=true
