### PR TITLE
CLDR-16408 in Ethiopic transform aliases, -Geminated? → _Geminate

### DIFF
--- a/common/transforms/und-Ethi-t-und-latn-m0-aethiopi-geminate.xml
+++ b/common/transforms/und-Ethi-t-und-latn-m0-aethiopi-geminate.xml
@@ -3,7 +3,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<transforms>
-		<transform source="Ethi" target="Latn" variant="Aethiopi_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/Aethiopica-Geminate und-Latn-t-und-ethi-m0-aethiopi-geminate">
+		<transform source="Ethi" target="Latn" variant="Aethiopi_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/Aethiopica_Geminate und-Latn-t-und-ethi-m0-aethiopi-geminate">
 			<tRule><![CDATA[
 ########################################################################
 #

--- a/common/transforms/und-Ethi-t-und-latn-m0-alaloc-geminate.xml
+++ b/common/transforms/und-Ethi-t-und-latn-m0-alaloc-geminate.xml
@@ -3,7 +3,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<transforms>
-		<transform source="Ethi" target="Latn" variant="ALALOC_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/ALALOC-Geminate und-Latn-t-und-ethi-m0-alaloc-geminate">
+		<transform source="Ethi" target="Latn" variant="ALALOC_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/ALALOC_Geminate und-Latn-t-und-ethi-m0-alaloc-geminate">
 			<tRule><![CDATA[
 ########################################################################
 #

--- a/common/transforms/und-Ethi-t-und-latn-m0-beta_metsehaf-geminate.xml
+++ b/common/transforms/und-Ethi-t-und-latn-m0-beta_metsehaf-geminate.xml
@@ -3,7 +3,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<transforms>
-		<transform source="Ethi" target="Latn" variant="Beta_Metsehaf_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/BetaMetsehaf-Geminate und-Latn-t-und-ethi-m0-betamets-geminate">
+		<transform source="Ethi" target="Latn" variant="Beta_Metsehaf_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/BetaMetsehaf_Geminate und-Latn-t-und-ethi-m0-betamets-geminate">
 			<tRule><![CDATA[
 ########################################################################
 #

--- a/common/transforms/und-Ethi-t-und-latn-m0-ies-jes-1964-geminate.xml
+++ b/common/transforms/und-Ethi-t-und-latn-m0-ies-jes-1964-geminate.xml
@@ -3,7 +3,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<transforms>
-		<transform source="Ethi" target="Latn" variant="IES_JES_1964_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/IES_JES_1964-Geminated und-Latn-t-und-ethi-m0-iesjes-1964-geminate">
+		<transform source="Ethi" target="Latn" variant="IES_JES_1964_Geminate" direction="forward" draft="contributed" alias="Ethiopic-Latin/IES_JES_1964_Geminate und-Latn-t-und-ethi-m0-iesjes-1964-geminate">
 			<tRule><![CDATA[
 ########################################################################
 #


### PR DESCRIPTION
CLDR-16408

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In the non-BCP-47 aliases for the newly-added Ethiopic Geminate transforms, the fragment -Geminate (or in one case -Geminated) needed to instead use an underscore, since it is part of a complete variant name such as ALALOC_Geminate or  IES_JES_1964_Geminate. Otherwise ICU could not parse the name.

ALLOW_MANY_COMMITS=true
