### PR TITLE
CLDR-16416 xh, delete bogus minimalPairs

### DIFF
--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -4672,11 +4672,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="atMost">↑↑↑</pattern>
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
-		<minimalPairs>
-			<pluralMinimalPairs count="one" draft="contributed">{0}?</pluralMinimalPairs>
-			<pluralMinimalPairs count="other" draft="contributed">↑↑↑</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
-		</minimalPairs>
 	</numbers>
 	<units>
 		<unitLength type="long">


### PR DESCRIPTION
CLDR-16416

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16416)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Fix _data_ errors from running tests on production data in cldr-staging. The only such item was removal of bogus `minimalPairs` in `xh`.

ALLOW_MANY_COMMITS=true
