### PR TITLE
CLDR-16425 v43 BRS: JSON

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -313,6 +313,8 @@ class LdmlConvertRules {
         new SplittableAttributeSpec("measurementSystem-category-temperature", "territories", "type"),
         new SplittableAttributeSpec("paperSize", "territories", "type"),
         new SplittableAttributeSpec("parentLocale", "locales", "parent"),
+        new SplittableAttributeSpec("collations", "locales", "parent"), // parentLocale component=collations
+        new SplittableAttributeSpec("segmentations", "locales", "parent"), // parentLocale component=segmentations
         new SplittableAttributeSpec("hours", "regions", null),
         new SplittableAttributeSpec("dayPeriodRules", "locales", null),
         // new SplittableAttributeSpec("group", "contains", "group"),

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Level.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Level.java
@@ -160,4 +160,14 @@ public enum Level {
         }
         return result;
     }
+
+    /**
+     * Returns true if this is at least the other level.
+     * Example:  lev.isAtLeast(Level.MODERN)
+     * @param other
+     * @return
+     */
+    public boolean isAtLeast(Level other) {
+        return getLevel() >= other.getLevel();
+    }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -26,7 +26,7 @@ section=weekData ; path=//cldr/supplemental/weekData/.* ; package=core
 section=timeData ; path=//cldr/supplemental/timeData/.* ; package=core
 section=measurementData ; path=//cldr/supplemental/measurementData/.* ; package=core
 section=codeMappings ; path=//cldr/supplemental/codeMappings/.* ; package=core
-section=parentLocales ; path=//cldr/supplemental/parentLocales/.* ; package=core
+section=parentLocales ; path=//cldr/supplemental/parentLocales.* ; package=core
 section=references ; path=//cldr/supplemental/references/.* ; package=core
 section=telephoneCodeData ; path=//cldr/supplemental/telephoneCodeData/.* ; package=core
 section=windowsZones ; path=//cldr/supplemental/windowsZones/.* ; package=core

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -170,3 +170,6 @@
 < (.*/personNames)/(sampleName)\[@item="([^"]*)"\]/nameField\[@type="([^"]*)"\]$
 > $1/$2/$3/$4
 
+# ParentLocales
+< (.*/parentLocales)\[@component="([^"]*)"\]/(parentLocale)(.*)$
+> $1/$2$4

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCalculatedCoverageLevels.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCalculatedCoverageLevels.java
@@ -2,10 +2,22 @@ package org.unicode.cldr.util;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 
 public class TestCalculatedCoverageLevels {
     @Test
@@ -20,5 +32,46 @@ public class TestCalculatedCoverageLevels {
         () -> assertTrue(CalculatedCoverageLevels.getInstance().isLocaleAtLeastBasic("en"), "en=true"),
         () -> assertTrue(CalculatedCoverageLevels.getInstance().isLocaleAtLeastBasic("fr"), "fr=true"),
         () -> assertFalse(CalculatedCoverageLevels.getInstance().isLocaleAtLeastBasic("und"), "und=false"));
+    }
+
+    public static Stream<Arguments> allLocales() {
+        return CLDRConfig.getInstance().getFullCldrFactory().getAvailable().stream().map(str -> arguments(str));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allLocales")
+    @Test
+    @Disabled
+    /**
+     * Test compares coverage level to the Locales.txt goals.
+     * Skipped because it fails (for cv, as of v43), but there may be a useful form for it in the future
+     * @param locale
+     */
+    void TestCoverageLevelsVsCldrOrg(final String locale) {
+        final Level coverageLevel = CalculatedCoverageLevels.getInstance().getLevels().get(locale);
+        assumeTrue(coverageLevel != null, () -> "CalculatedCoverageLevel not available for " + locale);
+        final Level localeCoverageLevel = StandardCodes.make().getHighestLocaleCoverageLevel("Cldr", locale);
+        assumeTrue(localeCoverageLevel != null, () -> "Cldr membership not available for " + locale);
+        assertTrue(localeCoverageLevel.compareTo(coverageLevel) >= 0,
+            () -> String.format("Expected Locales.txt:Cldr=%s at least coverageLevels=%s", coverageLevel.name(), localeCoverageLevel.name()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "en_US, modern",
+        "en, modern",
+        "mul, null",
+        "root, modern",
+        "sr_Cyrl, modern",
+        "sr_Cyrl_XK, modern",
+        "sr, modern",
+    })
+    void TestEffective(final String loc, String l) {
+        Level level = null;
+        if (!l.equals("null")) {
+            level = Level.fromString(l.toUpperCase());
+        }
+        CalculatedCoverageLevels ccl = CalculatedCoverageLevels.getInstance(); // TODO: data sensitivity.  Ideally would use a private instance of CCL from a static file.
+        assertEquals(level, ccl.getEffectiveCoverageLevel(loc));
     }
 }


### PR DESCRIPTION
- fixes for CoverageLevel reader
- add `und` to coverageLocales.txt for convenience 
- maybe a new command line option ✨ 

CLDR-16425

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
