### PR TITLE
CLDR-16428 spec: Fix formatting of likely subtags algorithm

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2041,20 +2041,20 @@ This operation is performed in the following way.
    2. Replace any deprecated subtags with their canonical values using the `<alias>` data in supplemental metadata. Use the first value in the replacement list, if it exists. Language tag replacements may have multiple parts, such as "sh" ➞ "sr_Latn" or "mo" ➞ "ro_MD". In such a case, the original script and/or region are retained if there is one. Thus "sh_Arab_AQ" ➞ "sr_Arab_AQ", not "sr_Latn_AQ".
    3. If the tag is a legacy language tag (marked as “Type: grandfathered” in BCP 47; see `<variable id="$grandfathered" type="choice">` in the supplemental data), then return it.
    4. Remove the script code 'Zzzz' and the region code 'ZZ' if they occur.
-   5. Get the components of the cleaned-up source tag _(languages, scripts,_ and _regions_), plus any variants and extensions.
+   5. Get the components of the cleaned-up source tag _(language<sub>s</sub>, script<sub>s</sub>,_ and _region<sub>s</sub>_), plus any variants and extensions.
 2. **Lookup.** Look up each of the following in order, and stop on the first match:
-   1. _languages_scripts_regions_
-   2. _languages_regions_
-   3. _languages_scripts_
-   4. __languages__
-   5. und\__scripts_
+   1. _language<sub>s</sub>\_script<sub>s</sub>\_region<sub>s</sub>_
+   2. _language<sub>s</sub>\_region<sub>s</sub>_
+   3. _language<sub>s</sub>\_script<sub>s</sub>_
+   4. _language<sub>s</sub>_
+   5. und\__script<sub>s</sub>_
 3. **Return**
    1. If there is no match, either return
       1.  an error value, or
       2.  the match for "und" (in APIs where a valid language tag is required).
-   2. Otherwise there is a match = _languagem_scriptm_regionm_
-   3. Let xr = xs if xs is not empty, and xm otherwise.
-   4. Return the language tag composed of _languager _ scriptr _ regionr_ + variants + extensions .
+   2. Otherwise there is a match = _language<sub>m</sub>\_script<sub>m</sub>\_region<sub>m</sub>_
+   3. Let x<sub>r</sub> = x<sub>s</sub> if x<sub>s</sub> is not empty, and x<sub>m</sub> otherwise.
+   4. Return the language tag composed of _language<sub>r</sub>\_script<sub>r</sub>\_region<sub>r</sub>_ + variants + extensions.
 
 The lookup can be optimized. For example, if any of the tags in Step 2 are the same as previous ones in that list, they do not need to be tested.
 


### PR DESCRIPTION
CLDR-16428

- [x] This PR completes the ticket.

The old HTML spec had subscripts: https://www.unicode.org/reports/tr35/tr35-61/tr35.html#Likely_Subtags

The subscripts seem to have gotten lost in Markdown. I added them back with HTML.