### PR TITLE
CLDR-16355 ja zh hant remove new from try

### DIFF
--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -8693,8 +8693,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<symbol draft="contributed">TRL</symbol>
 			</currency>
 			<currency type="TRY">
-				<displayName>新トルコリラ</displayName>
-				<displayName count="other">新トルコリラ</displayName>
+				<displayName>トルコリラ</displayName>
+				<displayName count="other">トルコリラ</displayName>
 				<symbol>TRY</symbol>
 				<symbol alt="narrow">₺</symbol>
 				<symbol alt="variant">TL</symbol>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -13658,13 +13658,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<symbol draft="contributed">TPE</symbol>
 			</currency>
 			<currency type="TRL">
-				<displayName>土耳其里拉</displayName>
-				<displayName count="other">土耳其里拉</displayName>
+				<displayName>土耳其里拉 (1922–2005)</displayName>
+				<displayName count="other">土耳其里拉 (1922–2005)</displayName>
 				<symbol draft="contributed">TRL</symbol>
 			</currency>
 			<currency type="TRY">
-				<displayName>新土耳其里拉</displayName>
-				<displayName count="other">新土耳其里拉</displayName>
+				<displayName>土耳其里拉</displayName>
+				<displayName count="other">土耳其里拉</displayName>
 				<symbol>TRY</symbol>
 				<symbol alt="narrow">₺</symbol>
 				<symbol alt="variant">TL</symbol>


### PR DESCRIPTION
CLDR-16355

- [X] This PR completes the ticket.

Translation of TRY (Turkish Lira) in Japanese and Traditional Chinese includes the word “new”, likely from it being called “New Turkish Lira” in the past. This PR removes "new" from the translation in both. It also updates zh_Hant translation of TRL to include year interval to avoid name collision.

ALLOW_MANY_COMMITS=true
