### PR TITLE
CLDR-15034 kbd: update DTD, import should have distinguishing attrs

### DIFF
--- a/common/dtd/ldml.xsd
+++ b/common/dtd/ldml.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 1991-2022 Unicode, Inc.
+  Copyright © 1991-2023 Unicode, Inc.
   For terms of use, see http://www.unicode.org/copyright.html
   SPDX-License-Identifier: Unicode-DFS-2016
   CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -124,10 +124,10 @@
   <xs:element name="version">
     <xs:complexType>
       <xs:attribute name="number" use="required"/>
-      <xs:attribute name="cldrVersion" default="42">
+      <xs:attribute name="cldrVersion" default="43">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:enumeration value="42"/>
+            <xs:enumeration value="43"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
@@ -197,6 +197,7 @@
   <!-- @MATCH:literal/long, secondary, short, variant, menu -->
   <!-- @METADATA -->
   <!-- @DEPRECATED:true, false -->
+  <!-- @MATCH:any -->
   <!-- @METADATA -->
   <xs:element name="script">
     <xs:complexType mixed="true">
@@ -1223,6 +1224,7 @@
   <!-- @METADATA -->
   <!-- @METADATA -->
   <!-- @DEPRECATED -->
+  <!-- @MATCH:any -->
   <!-- @METADATA -->
   <!-- @VALUE -->
   <!-- @DEPRECATED -->
@@ -3707,7 +3709,7 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:literal/1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000, 100000000000000, approximately, atLeast, atMost, range, standard -->
+  <!-- @MATCH:literal/1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000, 100000000000000, 1000000000000000, 10000000000000000, 100000000000000000, 1000000000000000000, 10000000000000000000, approximately, atLeast, atMost, range, standard -->
   <!-- TODO: generalize this to be any (M=|d=)?<numberSystem> -->
   <!-- @MATCH:literal/M=romanlow, d=hanidays, hanidec, hebr, y=jpanyear -->
   <!-- @VALUE -->
@@ -4210,7 +4212,7 @@
     </xs:complexType>
   </xs:element>
   <!-- TODO: check to see if this should be minimized -->
-  <!-- @MATCH:literal/Bh, Bhm, Gy, GyM, GyMEd, GyMMM, GyMMMEd, GyMMMd, GyMd, H, Hm, Hmv, Hv, M, MEd, MMM, MMMEEEEd, MMMEd, MMMM, MMMMEd, MMMMd, MMMd, Md, d, h, hm, hmv, hv, y, yM, yMEd, yMMM, yMMMEEEEd, yMMMEd, yMMMM, yMMMMEEEEd, yMMMMEd, yMMMMd, yMMMd, yMd, GGGGGyM, GGGGGyMEd, GGGGGyMd, GyMMMM, GyMMMMEd, GyMMMMd -->
+  <!-- @MATCH:literal/Bh, Bhm, Gy, GyM, GyMEd, GyMMM, GyMMMEd, GyMMMd, GyMd, H, Hm, Hmv, Hmvvvv, Hv, Hvvvv, M, MEd, MMM, MMMEEEEd, MMMEd, MMMM, MMMMEd, MMMMd, MMMd, Md, d, h, hm, hmv, hmvvvv, hv, hvvvv, y, yM, yMEd, yMMM, yMMMEEEEd, yMMMEd, yMMMM, yMMMMEEEEd, yMMMMEd, yMMMMd, yMMMd, yMd, GGGGGyM, GGGGGyMEd, GGGGGyMd, GyMMMM, GyMMMMEd, GyMMMMd -->
   <!-- @MATCH:literal/variant -->
   <!-- @METADATA -->
   <!-- @DEPRECATED -->
@@ -7346,8 +7348,9 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:literal/variant -->
+  <!-- @MATCH:literal/variant, proposed, short -->
   <!-- @METADATA -->
+  <!-- @MATCH:any -->
   <!-- @METADATA -->
   <!-- # Use the cr element instead, with ICU syntax. -->
   <xs:element name="rules">
@@ -8134,7 +8137,7 @@
   <!-- @ORDERED -->
   <!-- @MATCH:or/range/-1.0E20~1.0E20||literal/-x, 0, 0.x, NaN, -Inf, Inf, x,x, x.x -->
   <!-- @VALUE -->
-  <!-- @MATCH:literal/1,000, 100, 1000, 100000, 20 -->
+  <!-- @MATCH:literal/1,000, 100, 1000, 100000, 5, 20, 400, 8000, 160,000, 3,200,000, 64,000,000 -->
   <!-- @VALUE -->
   <!-- @VALUE -->
   <!-- @MATCH:literal/variant -->
@@ -8260,6 +8263,7 @@
       </xs:choice>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="nameOrderLocales">
     <xs:complexType mixed="true">
       <xs:attribute name="order" use="required">
@@ -8284,6 +8288,7 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:literal/variant -->
   <!-- @METADATA -->
   <!-- @METADATA -->
@@ -8304,7 +8309,8 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
-  <!-- @VALUE -->
+  <!-- @TECHPREVIEW -->
+  <!-- @METADATA -->
   <!-- @MATCH:literal/variant -->
   <!-- @METADATA -->
   <!-- @METADATA -->
@@ -8332,6 +8338,7 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:literal/variant -->
   <!-- @METADATA -->
   <!-- @METADATA -->
@@ -8350,10 +8357,11 @@
       <xs:attribute name="formality" type="xs:NMTOKENS"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:set/literal/givenFirst, surnameFirst, sorting -->
-  <!-- @MATCH:set/literal/long, medium, short -->
-  <!-- @MATCH:set/literal/referring, addressing, monogram -->
-  <!-- @MATCH:set/literal/formal, informal -->
+  <!-- @TECHPREVIEW -->
+  <!-- @MATCH:literal/givenFirst, surnameFirst, sorting -->
+  <!-- @MATCH:literal/long, medium, short -->
+  <!-- @MATCH:literal/referring, addressing, monogram -->
+  <!-- @MATCH:literal/formal, informal -->
   <xs:element name="namePattern">
     <xs:complexType mixed="true">
       <xs:attribute name="alt">
@@ -8377,6 +8385,7 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @METADATA -->
   <!-- @METADATA -->
   <xs:element name="sampleName">
@@ -8391,7 +8400,8 @@
       <xs:attribute name="item" use="required" type="xs:NMTOKENS"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:literal/givenOnly, givenSurnameOnly, given12Surname, full -->
+  <!-- @TECHPREVIEW -->
+  <!-- @MATCH:literal/nativeG, nativeGS, nativeGGS, nativeFull, foreignG, foreignGS, foreignGGS, foreignFull -->
   <xs:element name="nameField">
     <xs:complexType mixed="true">
       <xs:attribute name="type" use="required"/>
@@ -8409,7 +8419,8 @@
       <xs:attribute name="references"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:literal/prefix, given, given-informal, given2, surname, surname-prefix, surname-core, surname2, suffix -->
+  <!-- @TECHPREVIEW -->
+  <!-- @MATCH:literal/title, given, given-informal, given2, surname, surname-prefix, surname-core, surname2, generation, credentials -->
   <!-- @MATCH:literal/variant -->
   <!-- @METADATA -->
   <!-- @METADATA -->

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -78,7 +78,6 @@
 		<key id="super-2" to="²" longPress="₂" />
 		<key id="hyphen" to="-" /> <!-- 6 -->
 		<key id="underscore" to="_" /> <!-- 8 -->
-		<key id="umlaut" to="¨" />
 		<key id="a" flicks="a" to="a" longPress="à â á ä ã å ā" />
 		<flicks id="a">
 			<flick directions="nw" to="\u1234" />

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -5,6 +5,8 @@
     This is a sample data file.
     This file is subject to change.
     Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information.
+
+	Also NOTE: this is really a test keyboard.  CLDR-12026 will be for the real new azerty keyboard
 -->
 <keyboard locale="fr-t-k0-azerty" conformsTo="techpreview">
 	<locales>
@@ -16,9 +18,10 @@
 	<version number="1.0.0" />
 	<info author="Team Keyboard" normalization="NFC" layout="AZERTY" indicator="FR" />
 	<names>
-		<name value="French" />
-		<name value="French AZERTY" />
+		<name value="French Test" />
+		<name value="French Test AZERTY" />
 	</names>
+
 	<settings fallback="omit" transformPartial="hide" /> <!-- "hide" makes this act like a dead keyTBD -->
 
 	<vkeys>
@@ -61,11 +64,12 @@
 		<key id="symbol" switch="symbol" />
 		<key id="base" switch="base" />
 
-
-		<key id="bksp" gap="true" /> <!-- TODO -->
-		<key id="extra" gap="true" /> <!-- TODO -->
-		<key id="enter" to="\u{000A}" /> <!-- TODO - implied key? -->
-		<key id="bullet" to="•" />
+		<!--
+			TODO: need discussion
+		<key id="bksp" gap="true" />
+		<key id="extra" gap="true" />
+		<key id="enter" to="\u{000A}" />
+		-->
 
 		<!-- extra keys -->
 		<key id="u-grave" to="ü" />
@@ -74,26 +78,29 @@
 		<key id="c-cedilla" to="ç" /> <!-- 9 -->
 		<key id="a-acute" to="à" /> <!-- 0 -->
 
+		<!-- extra symbols -->
+		<key id="bullet" to="•" />
 		<key id="umlaut" to="¨" />
 		<key id="super-2" to="²" longPress="₂" />
-		<key id="hyphen" to="-" /> <!-- 6 -->
-		<key id="underscore" to="_" /> <!-- 8 -->
-		<key id="a" flicks="a" to="a" longPress="à â á ä ã å ā" />
+
+		<!-- test key -->
+ 		<key id="a" flicks="a" to="a" longPress="à â á ä ã å ā" />
 		<flicks id="a">
 			<flick directions="nw" to="\u1234" />
 			<flick directions="nw se" to="\uFFFF" />
 			<flick directions="e" to="\uFFF0" />
 		</flicks>
 
+		<!-- test key -->
 		<key id="A" flicks="b" to="A" longPress="À Á Ä Ã Å Ā" />
 
+		<!-- test flick -->
 		<flicks id="b">
 			<flick directions="nw" to="\u4567" />
 			<flick directions="nw se" to="\uFFFF" />
 			<flick directions="e" to="\uFFF0" />
 		</flicks>
 
-		<key id="gap" gap="true" width="1.0" />
 		<!-- TODO: all additional maps, hardware and touch -->
 	</keys>
 

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -52,19 +52,32 @@
 	</displays>
 
 	<keys>
-		<key id="super-2" to="²" longPress="₂" />
-		<key id="amp" to="&amp;" /> <!-- 1 -->
+		<import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+
+		<!-- switch keys -->
+		<key id="shift" switch="shift" />
+		<key id="numeric" switch="numeric" />
+		<key id="symbol" switch="symbol" />
+		<key id="base" switch="base" />
+
+
+		<key id="bksp" gap="true" /> <!-- TODO -->
+		<key id="extra" gap="true" /> <!-- TODO -->
+		<key id="enter" to="\u{000A}" /> <!-- TODO - implied key? -->
+		<key id="bullet" to="•" />
+
+		<!-- extra keys -->
+		<key id="u-grave" to="ü" />
 		<key id="e-grave" to="é" /> <!-- 2 -->
-		<key id="quote" to="\u{22}" /> <!-- 3 to= " -->
-		<key id="apos" to="&apos;" /> <!-- 4 -->
-		<key id="open-paren" to="(" /> <!-- 5 -->
-		<key id="hyphen" to="-" /> <!-- 6 -->
 		<key id="e-acute" to="è" /> <!-- 7 -->
-		<key id="underscore" to="_" /> <!-- 8 -->
 		<key id="c-cedilla" to="ç" /> <!-- 9 -->
 		<key id="a-acute" to="à" /> <!-- 0 -->
-		<key id="close-paren" to=")" /> <!-- - -->
-		<key id="equal" to="=" />
+
+		<key id="umlaut" to="¨" />
+		<key id="super-2" to="²" longPress="₂" />
+		<key id="hyphen" to="-" /> <!-- 6 -->
+		<key id="underscore" to="_" /> <!-- 8 -->
 		<key id="umlaut" to="¨" />
 		<key id="a" flicks="a" to="a" longPress="à â á ä ã å ā" />
 		<flicks id="a">
@@ -88,10 +101,10 @@
 	<layers form="iso">
 		<!-- in DTD: required if conformsTo ≥ 41 -->
 		<layer modifier="none">
-			<row keys="super-2 amp e-grave quote apos open-paren hyphen e-acute underscore c-cedilla a-acute close-paren equal" />
+			<row keys="super-2 amp e-grave double-quote apos open-paren hyphen e-acute underscore c-cedilla a-acute close-paren equal" />
 			<row keys="a z e r t y u i o p caret dollar" />
 			<row keys="q s d f g h j k l m u-grave asterisk" />
-			<row keys="less-than w x c v b n comma semi-colon colon exclamation" />
+			<row keys="open-angle w x c v b n comma semi-colon colon bang" />
 			<row keys="space" />
 		</layer>
 
@@ -99,7 +112,7 @@
 			<row keys="1 2 3 4 5 6 7 8 9 0 degree plus" />
 			<row keys="A Z E R T Y U I O P umlaut pound" />
 			<row keys="Q S D F G H J K L M percent micro" />
-			<row keys="greater-than W X C V B N question-mark period slash section" />
+			<row keys="close-angle W X C V B N question period slash section" />
 			<row keys="space" />
 		</layer>
 	</layers>
@@ -109,28 +122,28 @@
 		<layer id="base">
 			<row keys="a z e r t y u i o p" />
 			<row keys="q s d f g h j k l m" />
-			<row keys="shift gap w x c v b n gap bksp" />
-			<row keys="numeric extra space enter" /> <!-- The default "space" definition includes `stretch="true"` -->
+			<row keys="shift gap w x c v b n gap" /> <!--TODO:  + bksp -->
+			<row keys="numeric extra space enter" />
 		</layer>
 
 		<layer id="shift">
 			<row keys="A Z E R T Y U I O P" />
 			<row keys="Q S D F G H J K L M" />
-			<row keys="base W X C V B N bksp" />
+			<row keys="base W X C V B N" />  <!--TODO:  + bksp -->
 			<row keys="numeric extra space enter" />
 		</layer>
 
 		<layer id="numeric">
 			<row keys="1 2 3 4 5 6 7 8 9 0" />
-			<row keys="hyphen slash colon semi-colon open-paren close-paren dollar amp at quote" />
-			<row keys="symbol period comma question exclamation quote bksp" />
+			<row keys="hyphen slash colon semi-colon open-paren close-paren dollar amp at double-quote" />
+			<row keys="symbol period comma question bang double-quote" /> <!--TODO:  + bksp -->
 			<row keys="base extra space enter" />
 		</layer>
 
 		<layer id="symbol">
-			<row keys="open-bracket close-bracket open-brace close-brace hash percent caret star plus equal" />
-			<row keys="underscore backslash pipe tilde less-than greater-than euro pound yen bullet" />
-			<row keys="numeric period comma question exclamation quote bksp" />
+			<row keys="open-square close-square open-curly close-curly hash percent caret asterisk plus equal" />
+			<row keys="underscore backslash pipe tilde open-angle close-angle euro pound yen bullet" />
+			<row keys="numeric period comma question bang double-quote" /> <!--TODO:  + bksp -->
 			<row keys="base extra space enter" />
 		</layer>
 	</layers>

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -23,9 +23,7 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
 <!ELEMENT import EMPTY >
 <!ATTLIST import path CDATA #REQUIRED >
     <!--@MATCH:any-->
-    <!--@VALUE-->
 <!ATTLIST import base (cldr) #IMPLIED >
-    <!--@VALUE-->
 
 <!ELEMENT locales ( locale* ) >
 

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -14,6 +14,7 @@ This DTD is a work in progress.
 Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information. -->
 
 <!ELEMENT keyboard ( import*, locales?, version?, info?, names, settings?, vkeys?, displays?, keys?, layers*, transforms*, reorders?, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST keyboard locale CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-->
 <!ATTLIST keyboard conformsTo (techpreview) #REQUIRED >
@@ -21,18 +22,22 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@METADATA-->
 
 <!ELEMENT import EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST import path CDATA #REQUIRED >
     <!--@MATCH:any-->
 <!ATTLIST import base (cldr) #IMPLIED >
 
 <!ELEMENT locales ( locale* ) >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT locale EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST locale id CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-->
     <!--@VALUE-->
 
 <!ELEMENT version EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST version number CDATA #IMPLIED >
     <!-- Note: post techpreview, change cldrVersion to MATCH:version -->
     <!--@MATCH:semver-->
@@ -42,6 +47,7 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@METADATA-->
 
 <!ELEMENT info EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST info author CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
@@ -56,17 +62,21 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@VALUE-->
 
 <!ELEMENT names ( import*, name+, special* ) >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT name EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 <!ATTLIST name value CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
 
 <!ELEMENT special ANY >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT settings EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 <!ATTLIST settings fallback (omit) #IMPLIED >
     <!--@VALUE-->
 <!ATTLIST settings transformFailure (omit) #IMPLIED >
@@ -75,8 +85,10 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@VALUE-->
 
 <!ELEMENT vkeys ( import*, vkey*, special* ) >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT vkey EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST vkey from CDATA #REQUIRED >
     <!--@MATCH:any-->
 <!ATTLIST vkey to CDATA #REQUIRED >
@@ -84,8 +96,10 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@VALUE-->
 
 <!ELEMENT displays ( import*, display*, displayOptions*, special* ) >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT display EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST display to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@ALLOWS_UESC-->
@@ -95,14 +109,17 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT displayOptions EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST displayOptions baseCharacter CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT keys ( import*, ( key | flicks )*, special* ) >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT key EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST key id CDATA #REQUIRED >
     <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
 <!ATTLIST key flicks NMTOKEN #IMPLIED >
@@ -136,10 +153,12 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@VALUE-->
 
 <!ELEMENT flicks ( flick+, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST flicks id NMTOKEN #REQUIRED >
     <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
 
 <!ELEMENT flick EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST flick directions NMTOKENS #REQUIRED >
     <!--@MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))*-->
 <!ATTLIST flick to CDATA #REQUIRED >
@@ -148,11 +167,13 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT layers ( import*, layer*, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST layers form (touch | us | iso | jis | abnt2) #REQUIRED >
 <!ATTLIST layers minDeviceWidth CDATA #IMPLIED >
     <!--@MATCH:range/1~999-->
 
 <!ELEMENT layer ( row+, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST layer id NMTOKEN #IMPLIED >
     <!--@MATCH:any-->
 <!ATTLIST layer modifier NMTOKENS #IMPLIED >
@@ -160,15 +181,18 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
 
 <!ELEMENT row EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 <!ATTLIST row keys NMTOKENS #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
 
 <!ELEMENT transforms ( import*, transform*, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST transforms type (simple | final | backspace) #REQUIRED >
     <!--@MATCH:literal/simple, final, backspace-->
 
 <!ELEMENT transform EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST transform before CDATA #IMPLIED >
 <!ATTLIST transform from CDATA #REQUIRED >
     <!--@MATCH:any-->
@@ -180,8 +204,10 @@ Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest info
     <!--@VALUE-->
 
 <!ELEMENT reorders ( import*, reorder*, special* ) >
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT reorder EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST reorder before CDATA #IMPLIED >
 <!ATTLIST reorder from CDATA #REQUIRED >
 <!ATTLIST reorder order CDATA #IMPLIED >

--- a/keyboards/dtd/ldmlKeyboard.xsd
+++ b/keyboards/dtd/ldmlKeyboard.xsd
@@ -59,8 +59,6 @@
     </xs:complexType>
   </xs:element>
   <!-- @MATCH:any -->
-  <!-- @VALUE -->
-  <!-- @VALUE -->
   <xs:element name="locales">
     <xs:complexType>
       <xs:sequence>

--- a/keyboards/dtd/ldmlKeyboard.xsd
+++ b/keyboards/dtd/ldmlKeyboard.xsd
@@ -43,6 +43,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:validity/bcp47 -->
   <!-- @MATCH:any -->
   <!-- @METADATA -->
@@ -58,6 +59,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <xs:element name="locales">
     <xs:complexType>
@@ -66,11 +68,13 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="locale">
     <xs:complexType>
       <xs:attribute name="id" use="required"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:validity/bcp47 -->
   <!-- @VALUE -->
   <xs:element name="version">
@@ -85,6 +89,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- Note: post techpreview, change cldrVersion to MATCH:version -->
   <!-- @MATCH:semver -->
   <!-- @VALUE -->
@@ -98,6 +103,7 @@
       <xs:attribute name="indicator"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @MATCH:literal/NFC, NFD, other -->
@@ -115,15 +121,18 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="name">
     <xs:complexType>
       <xs:attribute name="value" use="required"/>
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <xs:element name="special" type="any"/>
+  <!-- @TECHPREVIEW -->
   <xs:element name="settings">
     <xs:complexType>
       <xs:attribute name="fallback">
@@ -150,6 +159,7 @@
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <!-- @VALUE -->
   <!-- @VALUE -->
   <!-- @VALUE -->
@@ -162,12 +172,14 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="vkey">
     <xs:complexType>
       <xs:attribute name="from" use="required"/>
       <xs:attribute name="to" use="required"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
@@ -181,12 +193,14 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="display">
     <xs:complexType>
       <xs:attribute name="to" use="required"/>
       <xs:attribute name="display" use="required"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @ALLOWS_UESC -->
   <!-- @MATCH:any -->
@@ -197,6 +211,7 @@
       <xs:attribute name="baseCharacter"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @ALLOWS_UESC -->
@@ -212,6 +227,7 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="key">
     <xs:complexType>
       <xs:attribute name="id" use="required"/>
@@ -245,6 +261,7 @@
       <xs:attribute name="width"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <!-- @VALUE -->
@@ -274,6 +291,7 @@
       <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <xs:element name="flick">
     <xs:complexType>
@@ -281,6 +299,7 @@
       <xs:attribute name="to" use="required"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))* -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
@@ -306,6 +325,7 @@
       <xs:attribute name="minDeviceWidth"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:range/1~999 -->
   <xs:element name="layer">
     <xs:complexType>
@@ -317,6 +337,7 @@
       <xs:attribute name="modifier" type="xs:NMTOKENS"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @MATCH:any -->
   <xs:element name="row">
@@ -325,6 +346,7 @@
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <xs:element name="transforms">
@@ -345,6 +367,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:literal/simple, final, backspace -->
   <xs:element name="transform">
     <xs:complexType>
@@ -360,6 +383,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
@@ -374,6 +398,7 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="reorder">
     <xs:complexType>
       <xs:attribute name="before"/>
@@ -390,6 +415,7 @@
     </xs:sequence>
   </xs:complexType>
 </xs:schema>
+<!-- @TECHPREVIEW -->
 <!-- @VALUE -->
 <!-- @VALUE -->
 <!-- @VALUE -->

--- a/keyboards/dtd/ldmlKeyboardTest.dtd
+++ b/keyboards/dtd/ldmlKeyboardTest.dtd
@@ -14,11 +14,13 @@ This DTD is a work in progress.
 Please see CLDR-15034 for the latest information. -->
 
 <!ELEMENT keyboardTest ( info, repertoire*, tests*, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST keyboardTest conformsTo (techpreview) #REQUIRED >
     <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!ELEMENT info EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST info keyboard CDATA #REQUIRED >
     <!--@VALUE-->
 <!ATTLIST info author CDATA #IMPLIED >
@@ -26,6 +28,7 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST info name NMTOKEN #REQUIRED >
 
 <!ELEMENT repertoire EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST repertoire chars CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
@@ -34,12 +37,15 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST repertoire name NMTOKEN #REQUIRED >
 
 <!ELEMENT tests ( test+, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST tests name NMTOKEN #REQUIRED >
 
 <!ELEMENT test ( startContext?, ( keystroke | emit | backspace | check )*, special* ) >
+    <!--@TECHPREVIEW-->
 <!ATTLIST test name NMTOKEN #REQUIRED >
 
 <!ELEMENT startContext EMPTY >
+    <!--@TECHPREVIEW-->
 <!ATTLIST startContext to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
@@ -47,6 +53,7 @@ Please see CLDR-15034 for the latest information. -->
 
 <!ELEMENT keystroke EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 <!ATTLIST keystroke key NMTOKEN #REQUIRED >
     <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
     <!--@VALUE-->
@@ -62,6 +69,7 @@ Please see CLDR-15034 for the latest information. -->
 
 <!ELEMENT emit EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 <!ATTLIST emit to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
@@ -69,12 +77,15 @@ Please see CLDR-15034 for the latest information. -->
 
 <!ELEMENT backspace EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 
 <!ELEMENT check EMPTY >
     <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
 <!ATTLIST check result CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT special ANY >
+    <!--@TECHPREVIEW-->

--- a/keyboards/dtd/ldmlKeyboardTest.dtd
+++ b/keyboards/dtd/ldmlKeyboardTest.dtd
@@ -22,10 +22,13 @@ Please see CLDR-15034 for the latest information. -->
 <!ELEMENT info EMPTY >
     <!--@TECHPREVIEW-->
 <!ATTLIST info keyboard CDATA #REQUIRED >
+    <!--@MATCH:any-->
     <!--@VALUE-->
 <!ATTLIST info author CDATA #IMPLIED >
+    <!--@MATCH:any-->
     <!--@METADATA-->
 <!ATTLIST info name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
 
 <!ELEMENT repertoire EMPTY >
     <!--@TECHPREVIEW-->
@@ -35,14 +38,17 @@ Please see CLDR-15034 for the latest information. -->
 <!ATTLIST repertoire type (default | simple | gesture | flick | longPress | multiTap | hardware) #IMPLIED >
     <!--@VALUE-->
 <!ATTLIST repertoire name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
 
 <!ELEMENT tests ( test+, special* ) >
     <!--@TECHPREVIEW-->
 <!ATTLIST tests name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
 
 <!ELEMENT test ( startContext?, ( keystroke | emit | backspace | check )*, special* ) >
     <!--@TECHPREVIEW-->
 <!ATTLIST test name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
 
 <!ELEMENT startContext EMPTY >
     <!--@TECHPREVIEW-->

--- a/keyboards/dtd/ldmlKeyboardTest.xsd
+++ b/keyboards/dtd/ldmlKeyboardTest.xsd
@@ -7,12 +7,12 @@
 -->
 <!--
   Important Note:
-
+  
   The CLDR Keyboard Workgroup is currently developing major changes to the
   CLDR keyboard specification.
-
+  
   This DTD is a work in progress.
-
+  
   Please see CLDR-15034 for the latest information.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
@@ -33,6 +33,7 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @METADATA -->
   <xs:element name="info">
@@ -42,6 +43,7 @@
       <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @VALUE -->
   <!-- @METADATA -->
   <xs:element name="repertoire">
@@ -63,6 +65,7 @@
       <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @VALUE -->
@@ -75,6 +78,7 @@
       <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="test">
     <xs:complexType>
       <xs:sequence>
@@ -90,11 +94,13 @@
       <xs:attribute name="name" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <xs:element name="startContext">
     <xs:complexType>
       <xs:attribute name="to" use="required"/>
     </xs:complexType>
   </xs:element>
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @ALLOWS_UESC -->
@@ -107,6 +113,7 @@
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <!-- @VALUE -->
   <!-- @MATCH:any -->
@@ -121,6 +128,7 @@
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @ALLOWS_UESC -->
@@ -128,12 +136,14 @@
     <xs:complexType/>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <xs:element name="check">
     <xs:complexType>
       <xs:attribute name="result" use="required"/>
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
+  <!-- @TECHPREVIEW -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @ALLOWS_UESC -->
@@ -144,3 +154,4 @@
     </xs:sequence>
   </xs:complexType>
 </xs:schema>
+<!-- @TECHPREVIEW -->

--- a/keyboards/dtd/ldmlKeyboardTest.xsd
+++ b/keyboards/dtd/ldmlKeyboardTest.xsd
@@ -44,8 +44,11 @@
     </xs:complexType>
   </xs:element>
   <!-- @TECHPREVIEW -->
+  <!-- @MATCH:any -->
   <!-- @VALUE -->
+  <!-- @MATCH:any -->
   <!-- @METADATA -->
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <xs:element name="repertoire">
     <xs:complexType>
       <xs:attribute name="chars" use="required"/>
@@ -69,6 +72,7 @@
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <!-- @VALUE -->
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <xs:element name="tests">
     <xs:complexType>
       <xs:sequence>
@@ -79,6 +83,7 @@
     </xs:complexType>
   </xs:element>
   <!-- @TECHPREVIEW -->
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <xs:element name="test">
     <xs:complexType>
       <xs:sequence>
@@ -95,6 +100,7 @@
     </xs:complexType>
   </xs:element>
   <!-- @TECHPREVIEW -->
+  <!-- @MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]* -->
   <xs:element name="startContext">
     <xs:complexType>
       <xs:attribute name="to" use="required"/>

--- a/keyboards/import/keys-Zyyy-currency.xml
+++ b/keyboards/import/keys-Zyyy-currency.xml
@@ -13,7 +13,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 -->
 <!DOCTYPE keys SYSTEM "../dtd/ldmlKeyboard.dtd">
 <keys>
+    <key id="dollar" to="$" />
     <key id="euro" to="€" />
     <key id="pound" to="£" />
-    <key id="dollar" to="$" />
+    <key id="yen" to="¥" />
 </keys>

--- a/keyboards/import/keys-Zyyy-punctuation.xml
+++ b/keyboards/import/keys-Zyyy-punctuation.xml
@@ -10,6 +10,7 @@
     <!-- General Symbols -->
     <key id="amp" to="\u{0026}" />
     <key id="apos" to="'" />
+    <key id="asterisk" to="*" />
     <key id="at" to="@" />
     <key id="backslash" to="\u{005C}" />
     <key id="bang" to="!" />
@@ -20,11 +21,13 @@
     <key id="close-square" to="]" />
     <key id="colon" to=":" />
     <key id="comma" to="," />
+    <key id="degree" to="°" />
     <key id="double-quote" to="\u{0022}" />
     <key id="equal" to="=" />
     <key id="grave" to="`" />
     <key id="hash" to="#" />
     <key id="hyphen" to="-" />
+    <key id="micro" to="µ" />
     <key id="not" to="¬" />
     <key id="open-angle" to="\u{003C}" />
     <key id="open-curly" to="{" />
@@ -35,9 +38,9 @@
     <key id="pipe" to="|" />
     <key id="plus" to="+" />
     <key id="question" to="?" />
+    <key id="section" to="§" />
     <key id="semi-colon" to=";" />
     <key id="slash" to="/" />
     <key id="tilde" to="~" />
-    <key id="umlaut" to="¨" />
     <key id="underscore" to="_" />
 </keys>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -643,6 +643,8 @@ public class TestDtdData extends TestFmwk {
                 || elementName.equals("layer") && attribute.equals("modifier")
                 || elementName.equals("map") && attribute.equals("id")
                 || elementName.equals("key") && attribute.equals("id")
+                || elementName.equals("import") && attribute.equals("path")
+                || elementName.equals("import") && attribute.equals("base")
                 || elementName.equals("layer") && attribute.equals("id")) {
                 return true;
             }


### PR DESCRIPTION
CLDR-15034

a few fixes:

- [X] update the DTD:  the attributes on `<import>` should be distinguishing, not 'value'.  Symptom: 'duplicate' errors from CLDR tests
- [x] update DTD with `@TECHPREVIEW` marker
- [x] update fr azerty so it builds. 
- …
- 
<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
