### PR TITLE
CLDR-16433 Document changes in person names

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -3162,10 +3162,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT personNames ( alias | ( nameOrderLocales*, foreignSpaceReplacement*, initialPattern*, personName*, sampleName*, special* ) ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT nameOrderLocales ( #PCDATA ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST nameOrderLocales order (givenFirst | surnameFirst) #REQUIRED >
 <!ATTLIST nameOrderLocales alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
@@ -3175,7 +3173,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT foreignSpaceReplacement ( #PCDATA ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST foreignSpaceReplacement xml:space (default | preserve) "preserve" >
     <!--@METADATA-->
 <!ATTLIST foreignSpaceReplacement alt NMTOKENS #IMPLIED >
@@ -3186,7 +3183,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT initialPattern ( #PCDATA ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST initialPattern type (initial | initialSequence) #REQUIRED >
 <!ATTLIST initialPattern alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
@@ -3196,7 +3192,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT personName ( alias | ( namePattern+, special* ) ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST personName order NMTOKENS #IMPLIED >
     <!--@MATCH:literal/givenFirst, surnameFirst, sorting-->
 <!ATTLIST personName length NMTOKENS #IMPLIED >
@@ -3207,7 +3202,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:literal/formal, informal-->
 
 <!ELEMENT namePattern ( #PCDATA ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST namePattern alt (1 | 2) #IMPLIED >
 <!ATTLIST namePattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
@@ -3215,12 +3209,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 
 <!ELEMENT sampleName ( alias | ( nameField+, special* ) ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST sampleName item NMTOKENS #REQUIRED >
     <!--@MATCH:literal/nativeG, nativeGS, nativeGGS, nativeFull, foreignG, foreignGS, foreignGGS, foreignFull-->
 
 <!ELEMENT nameField ( #PCDATA ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST nameField type CDATA #REQUIRED >
     <!--@MATCH:literal/title, given, given-informal, given2, surname, surname-prefix, surname-core, surname2, generation, credentials-->
 <!ATTLIST nameField alt NMTOKENS #IMPLIED >

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 8: Person Names
 
-|Version|43 (draft)              |
+|Version|43 (draft)                      |
 |-------|------------------------|
 |Editors|Mark Davis, Peter Edberg,  Rich Gillam, Alex Kolisnychenko, Mike McKenna and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
 
@@ -96,8 +96,6 @@ There is a wide variety in the way that people’s names appear in different lan
 
 This document provides the [LDML](http://www.unicode.org/reports/tr35/) specification for formatting of personal names, using data, structure, and examples. 
 
-> **This is a technology preview; thus not intended for production software (except where itself marked as a technology preview). We have gathered a first round of data, and intend to refine the way in which we gather data. We are looking for additional feedback on the tech preview so that we can make improvements. For example, there are a few areas where we intend enhancements: handling native vs foreign names (in the native script); handling prefix and suffix fields; and so on.**
-
 The CLDR functionality is targeted at formatting names for typical usage on computers (e.g. contact names, automated greetings, etc.), rather than being designed for special circumstances or protocol, such addressing royalty. However, the structure may be enhanced in the future when it becomes clear that additional features are needed for some languages.
 
 This addition to CLDR is based on review of current standards and practices that exist in LDAP, hcard, HTML and various other international standards and commercial implementations.
@@ -110,8 +108,7 @@ The following features are currently out of scope for Person Names formating:
 
 * Grammatical inflection of formatted names.
 * Context-specific cultural aspects, such as when to use “-san” vs “-sama” when addressing a Japanese person. 
-* Providing lists of prefixes and suffixes (Mr, Ms., Mx., Dr., etc.).
-* Distinctions among prefixes and suffixes, such as title (Dr., Prof., Sir), gender-honorifics, generation (Jr., IV), accreditations (MBA, Esq.).
+* Providing lists of titles, generation terms, and credential (Mr, Ms., Mx., Dr., Jr., M.D., etc.).
 * Validation of input, such as  which fields are required, and what characters are allowed.
 * Combining alternative names, such as multicultural names in Hong Kong "[Jackie Chan Kong-Sang](https://en.wikipedia.org/wiki/Jackie_Chan)”, or ‘Dwayne “The Rock” Johnson’.
 * More than two levels of formality for names.
@@ -144,12 +141,13 @@ The specification below will talk about a “PersonName object” as an entity t
 The following summarizes the name data supplied via the PersonName Data Interface:
 
 * Name data is composed of one or more name parts, which are categorized in this standard as
-    * _prefix_ - a string that may precede a name and may indicate an honorific, title, etc.
+    * _title_ - a string that represents one or more honorifics or titles, such as “Mr.”, or “Herr Doctor”.
     * _given_ - usually a name given to someone that is not passed to a person by way of parentage
     * _given2_ - name or names that may appear between the first given name string and the surname. In the West, this may be a middle name, in Slavic regions it may be a patronymic name, and in parts of the Middle East, it may be the _nasab (نسب)_ or series of patronymics.
     * _surname_ - usually the family name passed to a person that indicates their family, tribe, or community. In most Western languages, this is known as the last name.
     * _surname2_ - in some cultures, both the parent’s surnames are used and need to be handled separately for formatting in different contexts.
-    * _suffix_ - a string that may succeed a person’s name to indicate status, generation, or title.
+    * _generation_ - a string that represents a generation marker, such as “Jr.” or “III”.
+    * _credentials_ - a string that represents one or more credentials or accreditations, such as “M.D.”, or “MBA”.
     * _See the section on [[Fields](#5-1-fields)] for more details._
 * Name data may have additional attributes that this specification accommodates.
     * _-informal_ - A name may have a formal and an informal presentation form, for example “Bob” vs “Robert” or “Са́ша” vs “Алекса́ндра”. This is accomplished by using the simple construct _given-informal_.
@@ -171,19 +169,19 @@ To format a name correctly, the correct context needs to be known. The context i
 
 As an example, consider a person’s name that may contain:
 
-| `prefix` | `given`  | `given2` | `surname` | `suffix` |
-| -------- | -------- | -------- | --------- | -------- |
-|          | Robin    | Finley   | Wang      | Ph.D.    |
+| `title`  | `given`  | `given2` | `surname` | `credentials` |
+| -------- | -------- | -------- | --------- | --------      |
+|          | Robin    | Finley   | Wang      | Ph.D.         |
 
 If the selected personName data has the following formatting pattern:
 
-> `{prefix} {given} {given2-initial} {surname}, {suffix}`
+> `{title} {given} {given2-initial} {surname}, {credentials}`
 
 Then the output is:
 
 > Robin F. Wang, Ph.D.
 
-The _prefix_ field is empty, so both it and the space that follows it in the formatting pattern are omitted from the output, the _given2_ field is formatted as an initial, and a preceding comma is placed before the _suffix_.
+The _title_ field is empty, so both it and the space that follows it in the formatting pattern are omitted from the output, the _given2_ field is formatted as an initial, and a preceding comma is placed before the _credentials_.
 
 Sections below specify the precise manner in which a pattern is selected, and how the pattern is modified for missing fields. 
     
@@ -310,7 +308,7 @@ For illustration, the following is a sample PersonName object.
 
 | Field            | Value        | Comment                         |
 | ---------------- | ------------ | ------------------------------- |
-| `prefix`         | “Dr.”        |                                 |
+| `title`          | “Dr.”        |                                 |
 | `given`          | “William”    |                                 |
 | `given-informal` | “Bill”       | example inclusion of "nickname" |
 | `given2`         | “Torval”     |                                 |
@@ -348,7 +346,7 @@ For example, when the display language is Japanese, it is customary to use _surn
 
 ### 4.2 <a name="4-2-length" href="#4-2-length">length</a>
 
-The `length` attribute specifies the relative length of a formatted name depending on context. For example, a `long` formal name in English would include prefix, given, given2, surname plus suffix; whereas a `short` informal name may only be the given name.
+The `length` attribute specifies the relative length of a formatted name depending on context. For example, a `long` formal name in English might include title, given, given2, surname plus generation and credentials; whereas a `short` informal name may only be the given name.
 
 Note that the formats may be the same for different lengths depending on the formality, usage, and cultural conventions for the locale. For example, medium and short may be the same for a particular context.
 
@@ -374,7 +372,7 @@ Slavic languages provide a good  example of `addressing` vs `referring`. An exam
 
 | Field            | Value        | Comment                         |
 | ---------------- | ------------ | ------------------------------- |
-| `prefix`         | “г-н”        | “Mr.”                           |
+| `title`          | “г-н”        | “Mr.”                           |
 | `given`          | “Иван”       | “Ivan”                          |
 | `given2`         | “Петрович”   | “Petrovich”                     |
 | `surname`        | “Васильев”   | “Vasiliev”                      |
@@ -399,8 +397,8 @@ Note that the formats may be the same for different formality scenarios dependin
 
 | Parameter  | Description |
 | ---------- | ----------- |
-| `formal`   | A more formal name for the individual. The composition depends upon the language. For example, a particular locale might include the prefix and suffix and a full middle name (given2) in the long form.<br/><br/>`length="medium", formality="formal"`<br/>“Robert J. Smith” |
-| `informal` | A less formal name for the individual. The composition depends upon the language. For example, a language might exclude the prefix, suffix and given2 (middle) name. Depending on the length, it may also exclude the surname. The formatting algorithm should choose any passed in name data that has an _informal_ attribute, if available.<br/><br/>`length="medium", formality="informal"`<br/>“Bob Smith” |
+| `formal`   | A more formal name for the individual. The composition depends upon the language. For example, a particular locale might include the title, generation, credentials and a full middle name (given2) in the long form.<br/><br/>`length="medium", formality="formal"`<br/>“Robert J. Smith” |
+| `informal` | A less formal name for the individual. The composition depends upon the language. For example, a language might exclude the title, credentials and given2 (middle) name. Depending on the length, it may also exclude the surname. The formatting algorithm should choose any passed in name data that has an _informal_ attribute, if available.<br/><br/>`length="medium", formality="informal"`<br/>“Bob Smith” |
 
 ## 5 <a name="5-namepattern-syntax" href="#5-namepattern-syntax">namePattern Syntax</a>
 
@@ -410,7 +408,7 @@ A _namePattern_  is composed of a sequence of field IDs, each enclosed in curly 
 | ------------ | ----------------------------- | -------- |
 | namePattern  | = literal?<br/><span style="white-space:nowrap">( modField  literal? )+;</span> | Two literals cannot be adjacent |
 | modField     | <span style="white-space:nowrap">= '{' field modifierList? '}';</span> | A name field, optionally modified |
-| field        | = 'prefix'<br/>\| 'given'<br/>\| 'given2'<br/>\| 'surname'<br/>\| 'surname2'<br/>\| 'suffix' ; | See [Fields](#5-1-fields) |
+| field        | = 'title'<br/>\| 'given'<br/>\| 'given2'<br/>\| 'surname'<br/>\| 'surname2'<br/>\|  'generation'<br/>\| 'credentials' ; | See [Fields](#5-1-fields) |
 | modifierList | = '-informal'?<br/><span style="white-space:nowrap">( '-allCaps' \| ‘-initialCap' )?;</span><br/><span style="white-space:nowrap">( '-initial'  \| '-monogram' )?</span><br/><span style="white-space:nowrap">( '-prefix' \| '-core' )?</span> | Optional modifiers that can be applied to name parts, see [Modifiers](#5-2-modifiers). Note that some modifiers are exclusive: only `prefix` or `core`, only `initial` or `monogram`, only `allCaps` or `initialCap`. |
 | literal      | = codepoint+ ; | One or more Unicode codepoints. |
 
@@ -428,12 +426,13 @@ In most cultures, there is a concept of nickname or preferred name, which is use
 
 | Field      | Description<br/>Note: The values for each are as supplied by the PersonName object, via the PersonName data interface. |
 | ---------- | ----------- |
-| `prefix`   | Typically a title, honorific, or generational qualifier.<br/>Example: ‘Ms.’, ‘Mr.’, ’Dr’, ‘President’<br/><br/>Note that CLDR PersonName formats data does not define regional or locale-specific lists of prefixes, honorifics, or titles such as “Mr”, “Ms”, “Mx”, “Prof”, “Jr”, etc. |
+| `title`   | A title or honorific qualifier.<br/>Example: ‘Ms.’, ‘Mr.’, ’Dr’, ‘President’<br/><br/>Note that CLDR PersonName formats data does not define regional or locale-specific lists of titles or honorifics such as “Mr”, “Ms”, “Mx”, “Prof”, etc. |
 | `given`    | The “given” name. Can be multiple words such as “Mary Ann”.<br/>Examples:  “Janus”, “Mary Jean”, or “Jean-Louis”|
 | `given2`   | Additional given name or names or middle name, usually names(s) written between the given and surname. Can be multiple words. In some references, also known as a “second” or “additional” given name or patronymic. This field is separate from the “given” field because it is often optional in various presentation forms.<br/>Examples:  “Horatio Wallace” as in<br/>`{ given: "Janus", `**`given2: "Horatio Wallace"`**`, surname: "Young" }`<br/><br/>“S.” as in “Harry S. Truman”. Yes, his full middle name was legally just “S.”.|
 | `surname`  | The “family name”. Can be more than one word.<br/><br/>Example: “van Gogh” as in<br/>`{ given: "Vincent", given2: "Willem", `**`surname: "van Gogh"`**` }`<br/><br/>Other examples: “Heathcote-Drummond-Willoughby” as in “William Emanuel Heathcote-Drummond-Willoughby III”|
 | `surname2` | Secondary surname (used in some cultures), such as second or maternal surname in Mexico and Spain. This field is separate from the “surname” field because it is often optional in various presentation forms, and is considered a separate distinct name in some cultures.<br/><br/>Example: “Barrientos” in “Diego Rivera Barrientos”;<br/>`{ given: "Diego", surname: "Rivera", `**`surname2: "Barrientos"`**` }`<br/><br/>Example: if "Mary Jane Smith" moves to Spain the new name may be<br/>`{ given: "Mary", given2: "Jane", surname: "Smith", `**`surname2: "Jones"`**` }`|
-| `suffix`   | Typically a title, honorific, or generational qualifier.<br/>Example: “PhD”, “Jr.”<br/><br/>Example: “Sonny Jarvis Jr.”<br/>`{ given: "Salvatore", given2: "Blinken", surname: "Jarvis", `**`suffix: "Jr."`**` }`<br/><br/>An alternate PersonName object may be presented for formatting using the “stage” name from the application’s data:<br/>`{ given: "Salvatore", given-informal: "Sonny", given2: "", surname: "Jarvis", `**`suffix: "Jr."`**` }` |
+| `credentials`   | A credential or accreditation qualifier.<br/>Example: “PhD”, “MBA”<br/><br/>Example: “Sonny Jarvis MD”<br/>`{ given: "Salvatore", given2: "Blinken", surname: "Jarvis", `**`credentials: "MBA"`**` }`<br/><br/>An alternate PersonName object may be presented for formatting using the “stage” name from the application’s data:<br/>`{ given: "Salvatore", given-informal: "Sonny", given2: "", surname: "Jarvis", `**`credentials: "MBA"`**` }` |
+| `generation`   | A generation qualifier.<br/>Example: “III”, “Jr.”<br/><br/>Example: “Sonny Jarvis Jr.”<br/>`{ given: "Salvatore", given2: "Blinken", surname: "Jarvis", `**`generation: "Jr."`**` }` |
 
 Some other examples:
 
@@ -463,7 +462,7 @@ The modifiers transform the input data as described in the following table:
 | prefix     | Return the “prefix” name, or the “tussenvoegsel'' if present. For example, “van der Poel” becomes “van der”, “bint Fadi” becomes “bint”, “di Santis” becomes “di”. Note that what constitutes the prefix is language- and locale-sensitive. It may be passed in as part of the PersonName object, similar to the _“-informal”_ modifier, e.g. as _“surname-prefix”_.<br/><br/>The implementation of this modifier depends on the PersonName object. CLDR does not currently provide support for automatic identification of tussenvoegsels, but may in the future.<br/><br/>If the resulting _“-prefix”_ value is empty, it defaults to an empty string.<br/><br/>An example sorting pattern for “Johannes van den Berg” may be<br/>{surname-core}, {given} {given2} {surname-prefix}<br/><br/>Only the _“-prefix”_ or the _“-core”_ modifier may be used, but not both. They are mutually exclusive. |
 | core       | Return the “core” name, removing any tussenvoegsel. For example, “van der Poel” becomes “Poel”, “bint Fadi” becomes “Fadi”, “di Santis” becomes “Santis”. Note that what constitutes the core is language- and locale-sensitive.<br/><br/>The implementation of this modifier depends on the PersonName object. CLDR does not currently provide support for identification of tussenvoegsel, but may in the future.<br/><br/>If the resulting _“-core”_ value is empty, it defaults to the field it modifies. E.g., if _“surname-core”_ is empty in the PersonName object to be formatted, it will default to the _“surname”_ field.<br/><br/>Vice-versa, if the _surname_ field is empty, the formatter will attempt to use _surname-prefix_ and _surname-core_, if present, to format the name.<br/><br/>Only the _“-prefix”_ or the _“-core”_ modifier may be used, but not both. They are mutually exclusive. |
 | allCaps    | Requests the element in all caps, which is desired In some contexts. For example, a new guideline in Japan is that for the Latin representation of Japanese names, the family name comes first and is presented in all capitals. This would be represented as<br/>“{surname-allCaps} {given}”<br/><br/>Hayao Miyazaki (宮崎 駿) would be represented in Latin characters in Japan (ja-Latn-JP) as _“MIYAZAKI Hayao”_<br/><br/>_The default implementation uses the default Unicode uppercase algorithm; if the PersonName object being formatted has a locale, and CLDR supports a locale-specific algorithm for that locale, then that algorithm is used. The PersonName object can override this, as detailed below._<br/><br/>Only the _“-allCaps”_ or the _“-initalCap”_ modifier may be used, but not both. They are mutually exclusive. |
-| initialCap | Request the element with the first grapheme capitalized, and remaining characters unchanged. This is used in cases where an element is usually in lower case but may need to be modified. For example in Dutch, the name<br/>{ prefix: “dhr.”, given: ”Johannes”, surname: “van den Berg” },<br/>when addressed formally, would need to be “dhr. Van den Berg”. This would be represented as<br/>“{prefix} {surname-initialCap}”<br/><br/>Only the _“-allCaps”_ or the _“-initalCap”_ modifier may be used, but not both. They are mutually exclusive. |
+| initialCap | Request the element with the first grapheme capitalized, and remaining characters unchanged. This is used in cases where an element is usually in lower case but may need to be modified. For example in Dutch, the name<br/>{ title: “dhr.”, given: ”Johannes”, surname: “van den Berg” },<br/>when addressed formally, would need to be “dhr. Van den Berg”. This would be represented as<br/>“{title} {surname-initialCap}”<br/><br/>Only the _“-allCaps”_ or the _“-initalCap”_ modifier may be used, but not both. They are mutually exclusive. |
 | initial    | Requests the initial grapheme cluster of each word in a field. The `initialPattern` patterns for the locale are used to create the format and layout for lists of initials. For example, if the initialPattern types are<br/>`<initialPattern type="initial">{0}.</initialPattern>`<br/>`<initialPattern type="initialSequence">{0} {1}</initialPattern>`<br/>then a name such as<br/>{ given: “John”, given2: “Ronald Reuel”, surname: “Tolkien” }<br/>could be represented as<br/>“{given-initial-allCaps} {given2-initial-allCaps} {surname}”<br/>and will format to “**J. R. R. Tolkien**”<br/><br/>_The default implementation uses the first grapheme cluster of each word for the value for the field; if the PersonName object has a locale, and CLDR supports a locale-specific grapheme cluster algorithm for that locale, then that algorithm is used. The PersonName object can override this, as detailed below._<br/><br/>Only the _“-initial”_ or the _“-monogram”_ modifier may be used, but not both. They are mutually exclusive. |
 | monogram   | Requests initial grapheme. Example: A name such as<br/>{ given: “Landon”, given2: “Bainard Crawford”, surname: “Johnson” }<br/>could be represented as<br/>“{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}”<br/>or “**LBJ**”<br/><br/>_The default implementation uses the first grapheme cluster of the value for the field; if the PersonName object has a locale, and CLDR supports a locale-specific grapheme cluster algorithm for that locale, then that algorithm is used. The PersonName object can override this, as detailed below. The difference between monogram an initial is that monogram only returns one element, not one element per word._<br/><br/>Only the _“-initial”_ or the _“-monogram”_ modifier may be used, but not both. They are mutually exclusive. |
 
@@ -518,11 +517,11 @@ A PersonName object’s fields are used to derive an order, as follows:
 
 For example, here is a parent locale lookup chain: 
 
-    de_Latn_DE ⇒ de_Latn ⇒ de_DE ⇒ de ⇒ und
+    de_Latn_de ⇒ de_Latn ⇒ de_de ⇒ de ⇒ und
 
 In other words, you'll check the givenFirst and surnameFirst resources for the following locales, in this order:
 
-    de_Latn_DE, und_Latn_DE, de_Latn, und_Latn, de_DE, und_DE, de, und
+    de_Latin_DE, und_Latn_DE, de_Latn, und_Latn, de_DE, und_DE, de, und
 
 This process will always terminate, because there is always a und value in one of the two nameOrderLocales elements.
 
@@ -552,7 +551,7 @@ As an example for English, this may look like:
 ```xml
 <personNames>
   <personName order="givenFirst" length="long" usage="referring" formality="formal">
-    <namePattern>{prefix} {given} {given2} {surname}, {suffix}</namePattern>
+    <namePattern>{title} {given} {given2} {surname}, {credentials}</namePattern>
   </personName>
   <personName order="givenFirst" length="long" usage="referring" formality="informal">
     <namePattern>{given} «{given2}» {surname}</namePattern>
@@ -619,24 +618,24 @@ If the “winning” namePattern still has fields that are unpopulated in the Pe
 The personName element contains:
 
 
-> `<namePattern>{prefix} {given} {given2} {surname}, {suffix}</namePattern>`
+> `<namePattern>{title} {given} {given2} {surname}, {credentials}</namePattern>`
 
 
 The input PersonName object contains:
 
-| `prefix` | `given` | `given2` | `surname` | `suffix` |
-| -------- | ------- | -------- | --------- | -------- |
-|          | Raymond | J.       | Johnson   | Jr.      |
+| `title` | `given` | `given2` | `surname` | `generation` |
+| -------- | ------- | -------- | --------- | --------      |
+|          | Raymond | J.       | Johnson   | Jr.           |
 
 The output is:
 
 > Raymond J. Johnson, Jr.
 
-The “prefix” field is empty, and so both it and the space that follows it are omitted from the output, according to rule 1 above.
+The “title” field is empty, and so both it and the space that follows it are omitted from the output, according to rule 1 above.
 
 If, instead, the input PersonName object contains:
 
-| `prefix` | `given` | `given2` | `surname` | `suffix` |
+| `title` | `given` | `given2` | `surname` | `generation` |
 | -------- | ------- | -------- | --------- | -------- |
 |          | Raymond | J.       | Johnson   |          |
 
@@ -644,9 +643,9 @@ The output is:
 
 > Raymond J. Johnson
 
-The “prefix” field is empty, and so both it and the space that follows it are omitted from the output, according to rule 1 above.
+The “title” field is empty, and so both it and the space that follows it are omitted from the output, according to rule 1 above.
 
-The “suffix” field is also empty, so it and both the comma and the space that precede it are omitted from the output, according to rule 2 above.
+The “generation” field is also empty, so it and both the comma and the space that precede it are omitted from the output, according to rule 2 above.
 
 #### 6.6.2 <a name="examples-for-rule-3-and-the-interaction-between-the-rules" href="#examples-for-rule-3-and-the-interaction-between-the-rules">Examples for rule 3 and the interaction between the rules</a>
 
@@ -794,11 +793,11 @@ Suppose the PersonNames formatting patterns for `ja_JP` and `de_CH` contained th
    &lt;<strong>foreignSpaceReplacement</strong> xml:space="preserve"&gt;<span style="background-color:aqua">・</span>&lt;/foreignSpaceReplacement&gt;
    . . .
    &lt;personName order="<strong>givenFirst</strong>" length="medium" usage="referring" formality="formal"&gt;
-      &lt;namePattern&gt;{given}<span style="background-color:aqua"> </span>{given2}<span style="background-color:aqua"> </span>{surname}{suffix}&lt;/namePattern&gt;
+      &lt;namePattern&gt;{given}<span style="background-color:aqua"> </span>{given2}<span style="background-color:aqua"> </span>{surname}{generation}&lt;/namePattern&gt;
    &lt;/personName&gt;
    . . .
    &lt;personName order="<strong>surnameFirst</strong>" length="medium" usage="referring" formality="formal"&gt;
-      &lt;namePattern&gt;{surname}{given2}{given}{suffix}&lt;/namePattern&gt;
+      &lt;namePattern&gt;{surname}{given2}{given}{generation}&lt;/namePattern&gt;
    &lt;/personName&gt;
    . . .
 &lt;/personNames&gt;
@@ -815,11 +814,11 @@ Note in the `de_CH` locale, _ja_ is not listed in nameOrderLocales, and would th
    &lt;foreignSpaceReplacemen xml:space="preserve"&gt;<span style="background-color:aqua"> </span>&lt;/foreignSpaceReplacement&gt;
    . . . 
    &lt;personName order="givenFirst" length="medium" usage="referring" formality="formal"&gt;
-      &lt;namePattern&gt;{given}<span style="background-color:aqua"> </span>{given2-initial}<span style="background-color:aqua"> </span>{surname}, {suffix}&lt;/namePattern&gt;
+      &lt;namePattern&gt;{given}<span style="background-color:aqua"> </span>{given2-initial}<span style="background-color:aqua"> </span>{surname}, {generation}&lt;/namePattern&gt;
    &lt;/personName&gt;
    . . . 
    &lt;personName order="surnameFirst" length="medium" usage="referring" formality="formal"&gt;
-      &lt;namePattern&gt;{surname}<span style="background-color:aqua">, </span>{given}<span style="background-color:aqua"> </span>{given2-initial}<span style="background-color:aqua">,</span> {suffix}&lt;/namePattern&gt;
+      &lt;namePattern&gt;{surname}<span style="background-color:aqua">, </span>{given}<span style="background-color:aqua"> </span>{given2-initial}<span style="background-color:aqua">,</span> {generation}&lt;/namePattern&gt;
    &lt;/personName&gt;
    . . . 
 &lt;/personNames&gt;`

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -484,7 +484,7 @@ The details of the XML structure behind the data referenced here are in [XML Str
 Create a **full name locale** as follows.
 
 1. First, let the **full formatting locale** be the fully-fleshed-out formatting locale using likely subtags.
-2. If there is a name locale available via the PersonName data interface, obtain the full name locale from the name locale using likely subtags. Thus de ⇒ de_Latn_de.
+2. If there is a name locale available via the PersonName data interface, obtain the full name locale from the name locale using likely subtags. Thus de ⇒ de_Latn_DE.
 3. Otherwise the full name locale is created based on the characters in the name and the full formatting locale, as follows:
     1. Find the predominant script for the name in the following way.
         1. For each character in the given and surname, find the script(s) of the character using the Script_Extensions property.
@@ -517,7 +517,7 @@ A PersonName object’s fields are used to derive an order, as follows:
 
 For example, here is a parent locale lookup chain: 
 
-    de_Latn_de ⇒ de_Latn ⇒ de_de ⇒ de ⇒ und
+    de_Latn_DE ⇒ de_Latn ⇒ de_DE ⇒ de ⇒ und
 
 In other words, you'll check the givenFirst and surnameFirst resources for the following locales, in this order:
 
@@ -763,20 +763,33 @@ There are two main challenges in dealing with foreign name formatting that needs
 
 Some writing systems require spaces (or some other non-letters) to separate words. For example, [Hayao Miyazaki](https://en.wikipedia.org/wiki/Hayao_Miyazaki) is written in English with given name first and with a space between the two name fields, while in Japanese there is no space with surname first: [宮崎駿](https://ja.wikipedia.org/wiki/%E5%AE%AE%E5%B4%8E%E9%A7%BF)
 
+Those locales are determined using the Script Metadata as follows.
+1. Get the likely script of the formatting locale, using LikelySubtags
+2. If the likely script is Thai, it needs spaces.
+3. Otherwise, if the likely script is Jpan, Hant, or Hans, it doesn't need spaces
+4. Otherwise, if the likely script has the script metadata property lbLetters = YES, it doesn't need spaces
+5. Otherwise, it needs spaces
+
+Then:
+
 1. If a locale requires spaces between words, the normal patterns for the formatting locale are used. On Wikipedia, for example, note the space within the Japanese name on pages from English and Korean (an ideographic space is used here for emphasis).
 
 * “​​[Hayao Miyazaki (宮崎<span style="background-color:aqua">　</span>駿, Miyazaki Hayao](https://en.wikipedia.org/wiki/Hayao_Miyazaki)…” or 
 * “[미야자키<span style="background-color:aqua">　</span>하야오(일본어: 宮﨑<span style="background-color:aqua">　</span>駿 Miyazaki Hayao](https://ko.wikipedia.org/wiki/%EB%AF%B8%EC%95%BC%EC%9E%90%ED%82%A4_%ED%95%98%EC%95%BC%EC%98%A4)…”. 
 
-2. If a locale **doesn’t** require spaces between words, there are two cases, based on whether the foreign name is written in the locale’s script, or the foreign name is left in its native script. In both cases, patterns from the **locale of the name** are used. For example, the formatting locale might be Japanese, and the locale of the PersonName object might be de_CH, German (Switzerland), such as Albert Einstein.
+2. If a locale **doesn’t** require spaces between words, there are two cases, based on whether the name is foreign or not (based on the PersonName objects explicit or calculated locale's language subtag). For example, the formatting locale might be Japanese, and the locale of the PersonName object might be de_CH, German (Switzerland), such as Albert Einstein.
 
-    1. **The foreign name is written in the formatting locale’s script.** In that case, the **foreignSpaceReplacement** is substituted for each space in the patterns from the _locale of the name_. Here are examples for Albert Einstein in Japanese and Chinese:
+    1. **The name is native** In that case, the patterns are used as is.
+    2. **The name is foreign** In that case, the **foreignSpaceReplacement** is substituted for each space formatted name. Here are examples for Albert Einstein in Japanese and Chinese:
         * [アルベルト<span style="background-color:aqua">・</span>アインシュタイン](https://ja.wikipedia.org/wiki/%E3%82%A2%E3%83%AB%E3%83%99%E3%83%AB%E3%83%88%E3%83%BB%E3%82%A2%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%A5%E3%82%BF%E3%82%A4%E3%83%B3) 
         * [阿尔伯特<span style="background-color:aqua">·</span>爱因斯坦](https://zh.wikipedia.org/wiki/%E9%98%BF%E5%B0%94%E4%BC%AF%E7%89%B9%C2%B7%E7%88%B1%E5%9B%A0%E6%96%AF%E5%9D%A6) 
-    2. **The foreign name is written in a different script.** In that case, the patterns from the **locale of the name** are used as is. More precisely, a different locale's data is used to format the name.
-        * [Albert Einstein](https://de.wikipedia.org/wiki/Albert_Einstein) 
+
 
 In both cases, the ordering may be changed according to the **Name Order for Locales** settings that each locale provides. If the PersonName object does not supply a locale for a name, then a default locale will be derived based on other information (such as the script of the characters in the name fields).
+
+Remember that **a name in a different script** will use a different locale for formatting. 
+For example, when formatting a name for Japanese, if the name is in the Latin script, a Latin based locale will be used to format it, such as when “Albert Einstein” appears in Latin characters on [Albert Einstein](https://ja.wikipedia.org/wiki/Albert_Einstein) 
+
 
 To illustrate how foreign space replacement works, consider the following name data. For illustration, the name locale is given in the maximized form: in practice, `ja` would be used instead of `ja_Jpan_JP`, and so on.: For more information, see [Likely Subtags](tr35.html#Likely_Subtags).
 

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -48,7 +48,7 @@ The LDML specification is divided into the following parts:
   * 1.2 [API Implementation](#APIImplementation)
   * 1.3 [Person Name Formatting Overview](#PersonNameFormattingOverview)
   * 1.4 [Example Usage](#ExampleUsage)
-* 2 [XML Structure](#2-xml-structure)
+* 2 [XML Structure](#xml-structure)
   * 2.1 [personNames Element](#personnames-element)
   * 2.2 [personName Element](#personname-element)
   * 2.3 [nameOrderLocales Element](#nameorderlocales-element)
@@ -57,27 +57,27 @@ The LDML specification is divided into the following parts:
     * 2.5.1 [Syntax](#syntax)
 * 3 [Person Name Object](#person-name-object)
 * 4 [Person Name Attributes](#4-person-name-attributes)
-  * 4.1 [order](#4-1-order)
-  * 4.2 [length](#4-2-length)
-  * 4.3 [usage](#4-3-usage)
+  * 4.1 [order](#order)
+  * 4.2 [length](#length)
+  * 4.3 [usage](#usage)
   * 4.4 [formality](#formality)
 * 5 [namePattern Syntax](#5-namepattern-syntax)
-  * 5.1 [Fields](#5-1-fields)
-  * 5.2 [Modifiers](#5-2-modifiers)
-* 6 [Formatting Process](#6-formatting-process)
-  * 6.1 [Derive the name locale](#6-1-derive-the-name-locale)
-  * 6.2 [Derive the formatting locale](#6-2-derive-the-formatting-locale)
-  * 6.3 [Derive the name order](#6-3-derive-the-name-order)
-  * 6.4 [Choose a personName](#6-4-choose-a-personname)
-  * 6.5 [Choose a namePattern](#6-5-choose-a-namepattern)
-  * 6.6 [Examples of choosing a namePattern](#6-6-examples-of-choosing-a-namepattern)
+  * 5.1 [Fields](#fields)
+  * 5.2 [Modifiers](#modifiers)
+* 6 [Formatting Process](#formatting-process)
+  * 6.1 [Derive the name locale](#derive-the-name-locale)
+  * 6.2 [Derive the formatting locale](#derive-the-formatting-locale)
+  * 6.3 [Derive the name order](#derive-the-name-order)
+  * 6.4 [Choose a personName](#choose-a-personname)
+  * 6.5 [Choose a namePattern](#choose-a-namepattern)
+  * 6.6 [Examples of choosing a namePattern](#examples-of-choosing-a-namepattern)
     * 6.6.1 [Examples for rules 1 and 2](#examples-for-rules-1-and-2)
     * 6.6.2 [Examples for rule 3 and the interaction between the rules](#examples-for-rule-3-and-the-interaction-between-the-rules)
-  * 6.7 [Deriving initials](#6-7-deriving-initials)
-  * 6.8 [Handling foreign names](#6-8-handling-foreign-names)
-* 7 [Sample Name](#7-sample-name)
-  * 7.1 [Syntax](#7-1-syntax)
-  * 7.2 [Expected values](#7-2-expected-values)
+  * 6.7 [Deriving initials](#deriving-initials)
+  * 6.8 [Handling foreign names](#handling-foreign-names)
+* 7 [Sample Name](#sample-name)
+  * 7.1 [Syntax](#syntax)
+  * 7.2 [Expected values](#expected-values)
 * 8 [PersonName Data Interface Examples](#personname-data-interface-examples)
 
 ## 1 <a name="CLDRPersonNames" href="#CLDRPersonNames">CLDR Person Names</a>
@@ -148,11 +148,11 @@ The following summarizes the name data supplied via the PersonName Data Interfac
     * _surname2_ - in some cultures, both the parent’s surnames are used and need to be handled separately for formatting in different contexts.
     * _generation_ - a string that represents a generation marker, such as “Jr.” or “III”.
     * _credentials_ - a string that represents one or more credentials or accreditations, such as “M.D.”, or “MBA”.
-    * _See the section on [[Fields](#5-1-fields)] for more details._
+    * _See the section on [[Fields](#fields)] for more details._
 * Name data may have additional attributes that this specification accommodates.
     * _-informal_ - A name may have a formal and an informal presentation form, for example “Bob” vs “Robert” or “Са́ша” vs “Алекса́ндра”. This is accomplished by using the simple construct _given-informal_.
     * _-prefix_ and _-core_ - In some languages the surname may have a prefix that needs to be treated differently, for example “van de Berg”. The data can refer to “van de” as _surname-prefix_ and “Berg” with _surname-core_ and the PersonNames formatters will format them correctly in Dutch and many other languages.
-    * _See the section on [[Modifiers](#5-2-modifiers)] for more details._
+    * _See the section on [[Modifiers](#modifiers)] for more details._
 
 To format a name correctly, the correct context needs to be known. The context is composed of:
 
@@ -185,7 +185,7 @@ The _title_ field is empty, so both it and the space that follows it in the form
 
 Sections below specify the precise manner in which a pattern is selected, and how the pattern is modified for missing fields. 
     
-## 2 <a name="2-xml-structure" href="#2-xml-structure">XML Structure</a>
+## 2 <a name="xml-structure" href="#xml-structure">XML Structure</a>
 
 Person name formatting data is stored as LDML with schema defined as follows.
 
@@ -201,7 +201,7 @@ The LDML top-level `<personNames>` element contains information regarding the fo
 
 The `<personName>` element contains the format patterns, or `<namePattern>` elements, for a specific context and is described in [[namePattern Syntax](#5-namepattern-syntax)]
 
-The `<namePattern>` syntax is described in [[Person Name Format Patterns](#6-formatting-process)].
+The `<namePattern>` syntax is described in [[Person Name Format Patterns](#formatting-process)].
 
 ```xml
 <!ELEMENT personName ( namePattern+ ) >
@@ -249,7 +249,7 @@ which produces output like _“Smith, Robert James”_. See [[namePattern Syntax
 
 ### 2.3 <a name="nameorderlocales-element" href="#nameorderlocales-element">nameOrderLocales Element</a>
 
-The `<nameOrderLocales>` element is optional, and contains information about selecting patterns based on the locale of a passed in PersonName object to determine the order of elements in a formatted name. For more information see [[NameOrder](#6-3-derive-the-name-order)]. It has a structure as follows:
+The `<nameOrderLocales>` element is optional, and contains information about selecting patterns based on the locale of a passed in PersonName object to determine the order of elements in a formatted name. For more information see [[NameOrder](#derive-the-name-order)]. It has a structure as follows:
 
 ```xml
 <!ELEMENT nameOrderLocales `( #PCDATA )`>
@@ -316,9 +316,9 @@ For illustration, the following is a sample PersonName object.
 | `nameLocale`     | “und-US”     | this is just for illustration   |
 | `preferredOrder` | “givenFirst” | this too                        |
 
-A PersonName object is logically composed of the fields above plus other possible variations. See [[Fields](#5-1-fields)]. There must be at least one field present: either a `given` or `surname` field. Other fields are optional, and some of them can be constructed from other fields if necessary.
+A PersonName object is logically composed of the fields above plus other possible variations. See [[Fields](#fields)]. There must be at least one field present: either a `given` or `surname` field. Other fields are optional, and some of them can be constructed from other fields if necessary.
 
-A modifier is supplied, _-informal_, which can be used to indicate which data element to choose when formatting informal cases which might include nicknames or preferred names. For more details, see section on [_[Modifiers](#5-2-modifiers)_] in [namePattern Syntax](#5-namepattern-syntax) below.
+A modifier is supplied, _-informal_, which can be used to indicate which data element to choose when formatting informal cases which might include nicknames or preferred names. For more details, see section on [_[Modifiers](#modifiers)_] in [namePattern Syntax](#5-namepattern-syntax) below.
 
 ## 4 <a name="4-person-name-attributes" href="#4-person-name-attributes">Person Name Attributes</a>
 
@@ -332,7 +332,7 @@ can be abbreviated without loss of information as:
 
 Each of these attributes are described below using sample PersonName objects as examples.
 
-### 4.1 <a name="4-1-order" href="#4-1-order">order</a>
+### 4.1 <a name="order" href="#order">order</a>
 
 The order attribute is used for patterns with different orders of fields. The order=sorting patterns are chosen based on input parameters, while the choice between givenFirst and surnameFirst is based on features of the PersonName object to be formatted and the nameOrder element values.
 
@@ -344,7 +344,7 @@ The order attribute is used for patterns with different orders of fields. The or
 
 For example, when the display language is Japanese, it is customary to use _surnameFirst_ for names of people from Japan and Hungary, but use _givenFirst_ for names of people from the United States and France. Although the English pattern for sorting is distinct from the other patterns (except for unusual names), that is not necessarily the case in other languages.
 
-### 4.2 <a name="4-2-length" href="#4-2-length">length</a>
+### 4.2 <a name="length" href="#length">length</a>
 
 The `length` attribute specifies the relative length of a formatted name depending on context. For example, a `long` formal name in English might include title, given, given2, surname plus generation and credentials; whereas a `short` informal name may only be the given name.
 
@@ -356,7 +356,7 @@ Note that the formats may be the same for different lengths depending on the for
 | `medium`  | A `medium` length is between long and short.<br/>Example: `usage="referring", formality="formal"`<br/>_“Robert Smith”_ |
 | `short`   | A `short` length uses a minimum set of names.<br/>Example: `usage="referring", formality="formal"`<br/>_“Mr. Smith”_ |
 
-### 4.3 <a name="4-3-usage" href="#4-3-usage">usage</a>
+### 4.3 <a name="usage" href="#usage">usage</a>
 
 The usage indicates if the formatted name is being used to address someone, refer to someone, or present their name in an abbreviated form.
 
@@ -408,11 +408,11 @@ A _namePattern_  is composed of a sequence of field IDs, each enclosed in curly 
 | ------------ | ----------------------------- | -------- |
 | namePattern  | = literal?<br/><span style="white-space:nowrap">( modField  literal? )+;</span> | Two literals cannot be adjacent |
 | modField     | <span style="white-space:nowrap">= '{' field modifierList? '}';</span> | A name field, optionally modified |
-| field        | = 'title'<br/>\| 'given'<br/>\| 'given2'<br/>\| 'surname'<br/>\| 'surname2'<br/>\|  'generation'<br/>\| 'credentials' ; | See [Fields](#5-1-fields) |
-| modifierList | = '-informal'?<br/><span style="white-space:nowrap">( '-allCaps' \| ‘-initialCap' )?;</span><br/><span style="white-space:nowrap">( '-initial'  \| '-monogram' )?</span><br/><span style="white-space:nowrap">( '-prefix' \| '-core' )?</span> | Optional modifiers that can be applied to name parts, see [Modifiers](#5-2-modifiers). Note that some modifiers are exclusive: only `prefix` or `core`, only `initial` or `monogram`, only `allCaps` or `initialCap`. |
+| field        | = 'title'<br/>\| 'given'<br/>\| 'given2'<br/>\| 'surname'<br/>\| 'surname2'<br/>\|  'generation'<br/>\| 'credentials' ; | See [Fields](#fields) |
+| modifierList | = '-informal'?<br/><span style="white-space:nowrap">( '-allCaps' \| ‘-initialCap' )?;</span><br/><span style="white-space:nowrap">( '-initial'  \| '-monogram' )?</span><br/><span style="white-space:nowrap">( '-prefix' \| '-core' )?</span> | Optional modifiers that can be applied to name parts, see [Modifiers](#modifiers). Note that some modifiers are exclusive: only `prefix` or `core`, only `initial` or `monogram`, only `allCaps` or `initialCap`. |
 | literal      | = codepoint+ ; | One or more Unicode codepoints. |
 
-### 5.1 <a name="5-1-fields" href="#5-1-fields">Fields</a>
+### 5.1 <a name="fields" href="#fields">Fields</a>
 
 The Person Name formatting data assumes that the name data to be formatted consists of the fields in the table below. All of the fields may contain multiple words. Field IDs are lowercase ASCII alphanumeric, and start with an alphabetic character.
 
@@ -450,7 +450,7 @@ Note: If the legal name, stage name, etc. are substantially different, then that
 
 How names get placed into fields to be formatted is beyond the scope of CLDR PersonName formats; this document just lays out the assumptions the formatting code makes when formatting the names.
 
-### 5.2 <a name="5-2-modifiers" href="#5-2-modifiers">Modifiers</a>
+### 5.2 <a name="modifiers" href="#modifiers">Modifiers</a>
 
 Each field in a pattern can have one or more modifiers. The modifiers can be appended to any field name, such as `{given-initial}` for the first grapheme of the given name. If more than one modifier is applied, they must be structured as in the EBNF.
 
@@ -473,13 +473,13 @@ Examples:
 1. For the initial of the surname **_“de Souza”_**, in a language that treats the “de” as a tussenvoegsel, the PersonName object can automatically recast `{surname-initial}` to:<br/>`{surname-prefix-initial}{surname-core-initial-allCaps} `to get “dS” instead of “d”.
 2. If the locale expects a surname prefix to to be sorted after a surname, then both `{surname-core} `then `{surname-prefix}` would be used as in<br/>`{surname-core}, {given} {given2} {surname-prefix}`
 
-## 6 <a name="6-formatting-process" href="#6-formatting-process">Formatting Process</a>
+## 6 <a name="formatting-process" href="#formatting-process">Formatting Process</a>
 
-The patterns are in personName elements, which are themselves in a personNames container element. The following describes how these patterns are chosen. If the name locale is different than the formatting locale, then additional processing needs to take place: see [Handling foreign names](#6-8-handling-foreign-names).
+The patterns are in personName elements, which are themselves in a personNames container element. The following describes how these patterns are chosen. If the name locale is different than the formatting locale, then additional processing needs to take place: see [Handling foreign names](#handling-foreign-names).
 
-The details of the XML structure behind the data referenced here are in [XML Structure](#2-xml-structure).
+The details of the XML structure behind the data referenced here are in [XML Structure](#xml-structure).
 
-### 6.1 <a name="6-1-derive-the-name-locale" href="#6-1-derive-the-name-locale">Derive the name locale</a>
+### 6.1 <a name="derive-the-name-locale" href="#derive-the-name-locale">Derive the name locale</a>
 
 Create a **full name locale** as follows.
 
@@ -497,13 +497,13 @@ Create a **full name locale** as follows.
 
 In all steps below, the "name locale" is the full name locale.
 
-### 6.2 <a name="6-2-derive-the-formatting-locale" href="#6-2-derive-the-formatting-locale">Derive the formatting locale</a>
+### 6.2 <a name="derive-the-formatting-locale" href="#derive-the-formatting-locale">Derive the formatting locale</a>
 
 If the full name locale is different from the full formatting locale, and the predominant script of the name is different from the script of the formatting locale, then let the full formatting locale be the full name locale.
 
 In all steps below, the "formatting locale" is the full formatting locale.
 
-### 6.3 <a name="6-3-derive-the-name-order" href="#6-3-derive-the-name-order">Derive the name order</a>
+### 6.3 <a name="derive-the-name-order" href="#derive-the-name-order">Derive the name order</a>
 
 A PersonName object’s fields are used to derive an order, as follows:
 
@@ -542,7 +542,7 @@ Here are some more examples. Note that if there is no order field or locale fiel
 |                                  | fr                       | givenFirst      |
 |                                  |                          | givenFirst      |
 
-### 6.4 <a name="6-4-choose-a-personname" href="#6-4-choose-a-personname">Choose a personName</a>
+### 6.4 <a name="choose-a-personname" href="#choose-a-personname">Choose a personName</a>
 
 The personName data in CLDR provides representations for how names are to be formatted across the different axes of _order_, _length_, _usage_, and _formality_. More than one `namePattern` can be associated with a single `personName` entry. An algorithm is then used to choose the best `namePattern` to use.
 
@@ -591,7 +591,7 @@ To find the matching personName element, traverse all the personNames in order u
 
 ### 6.5 <a name="choose-and-process-namepattern" href="#choose-and-process-namepattern">Choose and process a namePattern</a>
 
-#### 6.5.1 <a name="6-5-choose-a-namepattern" href="#6-5-choose-a-namepattern">Choose a namePattern</a>
+#### 6.5.1 <a name="choose-a-namepattern" href="#choose-a-namepattern">Choose a namePattern</a>
 
 To format a name, the fields in a namePattern are replaced with fields fetched from the PersonName Data Interface. The personName element can contain multiple namePattern elements. Choose one based on the fields in the input PersonName object that are populated: 
 1. Find the set of patterns with the most populated fields.
@@ -621,7 +621,7 @@ If the “winning” namePattern still has fields that are unpopulated in the Pe
   3. If B matches the end of A, then the result is A. So xyz + yz ⇒ xyz, and xyz + xyz ⇒ xyz.
   4. Otherwise the result is A + B, but with any sequence of two or more white space characters replaced by the first whitespace character. 
 
-### 6.6 <a name="6-6-examples-of-choosing-a-namepattern" href="#6-6-examples-of-choosing-a-namepattern">Examples of choosing a namePattern</a>
+### 6.6 <a name="examples-of-choosing-a-namepattern" href="#examples-of-choosing-a-namepattern">Examples of choosing a namePattern</a>
 
 #### 6.6.1 <a name="examples-for-rules-1-and-2" href="#examples-for-rules-1-and-2">Examples for rules 1 and 2</a>
 
@@ -744,7 +744,7 @@ The output is:
 
 > F. Baz
 
-### 6.7 <a name="6-7-deriving-initials" href="#6-7-deriving-initials">Deriving initials</a>
+### 6.7 <a name="deriving-initials" href="#deriving-initials">Deriving initials</a>
 
 The following process is used to produce initials when they are not supplied by the PersonName object. Assuming the input example is “Mary Beth”:
 
@@ -755,9 +755,9 @@ The following process is used to produce initials when they are not supplied by 
 | 3. The ***initial*** pattern is applied to each<br/>`  <initialPattern type="initial">{0}.</initialPattern>` | “M.” and “B.” |
 | 4. Finally recombined with ***initialSequence***<br/>`  <initialPattern type="initialSequence">{0} {1}</initialPattern>` | “M. B.” |
 
-See the “initial” modifier in the [Modifiers](#5-2-modifiers) section for more details.
+See the “initial” modifier in the [Modifiers](#modifiers) section for more details.
 
-### 6.8 <a name="6-8-handling-foreign-names" href="#6-8-handling-foreign-names">Handling foreign names</a>
+### 6.8 <a name="handling-foreign-names" href="#handling-foreign-names">Handling foreign names</a>
 
 There are two main challenges in dealing with foreign name formatting that needs to be considered. One is the ordering, which is dealt with under the section [[2.3 nameOrderLocales Element](#nameorderlocales-element)]. The other is spacing.
 
@@ -935,27 +935,32 @@ The name data would resolve as follows:
 </table>
 <br/>
 
-## 7 <a name="7-sample-name" href="#7-sample-name">Sample Name</a>
+## 7 <a name="sample-name" href="#sample-name">Sample Name</a>
 
 The sampleName element is used for test names in the personNames LDML data for each locale to aid in testing and display in the CLDR Survey Tool. They are not intended to be used in production software as prompts or placeholders in a user interface and should not be displayed in a user interface.
 
-### 7.1 <a name="7-1-syntax" href="#7-1-syntax">Syntax</a>
+### 7.1 <a name="syntax" href="#syntax">Syntax</a>
 
 ```xml
 <!ELEMENT sampleName ( nameField+ )  >
 <!ATTLIST sampleName item NMTOKENS #REQUIRED >
 ```
 
-* `NMTOKENS` must be one of `( givenOnly | givenSurnameOnly | given12Surname | full )`. However, these may change arbitrarily in the future.
+* `NMTOKENS` must be one of `( nativeG, nativeGS, nativeGGS, nativeFull, foreignG, foreignGS, foreignGGS, foreignFull )`. However, these may change arbitrarily in the future.
 
-### 7.2 <a name="7-2-expected-values" href="#7-2-expected-values">Expected values</a>
+### 7.2 <a name="expected-values" href="#expected-values">Expected values</a>
 
+The item values starting with "native" are expected to be native names, in native script.
+The item values starting with "foreign" are expected to be foreign names, in native script.
+There are no foreign names or native names in a foreign script, because those should be handled by a different locale's data.
+
+The rest of the item value indicates how many fields are present.
 For the expected sample name items, assume a name such as Mr. Richard “Rich” Edward Smith Iglesias Ph.D.
 
-* `givenOnly` is for an example name with only the given is presented: “Richard” or “Rich” (informal)
-* `givenSurnameOnly` is for an example name with only the given name and surname: “Richard Smith” or “Rich Smith” (informal)
-* `given12Surname` is for an example using all given names and a surname: “Richard Edward Smith” and “Rich E. Smith” (informal)
-* `full` is used to present a name using all fields: “Mr. Richard Edward Smith Iglesias, Ph.D.”
+* `G` is for an example name with only the given is presented: “Richard” or “Rich” (informal)
+* `GS` is for an example name with only the given name and surname: “Richard Smith” or “Rich Smith” (informal)
+* `GSS` is for an example using both given and given2 names and a surname: “Richard Edward Smith” and “Rich E. Smith” (informal)
+* `Full` is used to present a name using all possible fields: “Mr. Richard Edward Smith Iglesias, Ph.D.”
 
 The `nameField` values and their modifiers are described in the [Person Name Object](#person-name-object) and [namePattern Syntax](#5-namepattern-syntax) sections.
 
@@ -973,14 +978,11 @@ Examples:
 * Χριστίνα Λόπεζ (Christina Lopez) ⟶ Χ. Λόπεζ (C. Lopez)
 * Ντέιβιντ Λόπεζ (David Lopez) ⟶ Ντ. Λόπεζ (D. Lopez)<br/>Note that Ντ is a digraph representing the sound D.
 
-### 8.2 <a name="8-2-example-2" href="#8-2-example-2">Example 2</a>
+### 8.2 <a name="example-2" href="#example-2">Example 2</a>
 
 To make an initial when there are multiple words, an implementation might produce the following:
 
-* Janus H. W. Young ⇒ {given2-initial} producing “H.W.”.
-* Erik Martin van der Poel: {given2-initial} producing “V” by default, but might produce “vdP” or P in other languages.
-* A field containing multiple words might not actually initialize all of them, such as in “Mohammed bin Ali bin Osman” (“MAO”).
-* John Ronald Reuel Tolkien as “J.R.R. Tolkien” from { given: “John”, given2: “Ronald Reuel”, surname: “Tolkien” }
+* A field containing multiple words might skip some of them, such as in “Mohammed bin Ali bin Osman” (“MAO”).
 * The short version of "Son Heung-min" is "H. Son" and not "H. M. Son" or the like. Korean given-names have hyphens and the part after the hyphen is lower-case. 
 
 

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -49,18 +49,18 @@ The LDML specification is divided into the following parts:
   * 1.3 [Person Name Formatting Overview](#PersonNameFormattingOverview)
   * 1.4 [Example Usage](#ExampleUsage)
 * 2 [XML Structure](#2-xml-structure)
-  * 2.1 [personNames Element](#2-1-personnames-element)
-  * 2.2 [personName Element](#2-2-personname-element)
-  * 2.3 [nameOrderLocales Element](#2-3-nameorderlocales-element)
-  * 2.4 [foreignSpaceReplacement Element](#2-4-foreignspacereplacement-element)
-  * 2.5 [initialPattern Element](#2-5-initialpattern-element)
+  * 2.1 [personNames Element](#personnames-element)
+  * 2.2 [personName Element](#personname-element)
+  * 2.3 [nameOrderLocales Element](#nameorderlocales-element)
+  * 2.4 [foreignSpaceReplacement Element](#foreignspacereplacement-element)
+  * 2.5 [initialPattern Element](#initialpattern-element)
     * 2.5.1 [Syntax](#syntax)
-* 3 [Person Name Object](#3-person-name-object)
+* 3 [Person Name Object](#person-name-object)
 * 4 [Person Name Attributes](#4-person-name-attributes)
   * 4.1 [order](#4-1-order)
   * 4.2 [length](#4-2-length)
   * 4.3 [usage](#4-3-usage)
-  * 4.4 [formality](#4-4-formality)
+  * 4.4 [formality](#formality)
 * 5 [namePattern Syntax](#5-namepattern-syntax)
   * 5.1 [Fields](#5-1-fields)
   * 5.2 [Modifiers](#5-2-modifiers)
@@ -78,7 +78,7 @@ The LDML specification is divided into the following parts:
 * 7 [Sample Name](#7-sample-name)
   * 7.1 [Syntax](#7-1-syntax)
   * 7.2 [Expected values](#7-2-expected-values)
-* 8 [PersonName Data Interface Examples](#8-personname-data-interface-examples)
+* 8 [PersonName Data Interface Examples](#personname-data-interface-examples)
 
 ## 1 <a name="CLDRPersonNames" href="#CLDRPersonNames">CLDR Person Names</a>
 
@@ -136,7 +136,7 @@ Logically, the model used for applying the CLDR data is the following:
 
 Conceptually, CLDR person name formatting depends on data supplied by a PersonName Data Interface. That could be a very thin interface that simply accesses a database record, or it could be a more sophisticated interface that can modify the raw data before presenting it to be formatted. For example, based on the formatting locale a PersonName data interface could transliterate names that are in another script, or supply equivalent titles in different languages.
 
-The specification below will talk about a “PersonName object” as an entity that is logically accessed via such an interface. If multiple formatted names are needed, such as in different scripts or with alternate names, or pronunciations (eg kana), the presumption is that those are logically separate PersonName objects. See [[Person Name Object](#3-person-name-object)]. 
+The specification below will talk about a “PersonName object” as an entity that is logically accessed via such an interface. If multiple formatted names are needed, such as in different scripts or with alternate names, or pronunciations (eg kana), the presumption is that those are logically separate PersonName objects. See [[Person Name Object](#person-name-object)]. 
 
 The following summarizes the name data supplied via the PersonName Data Interface:
 
@@ -189,7 +189,7 @@ Sections below specify the precise manner in which a pattern is selected, and ho
 
 Person name formatting data is stored as LDML with schema defined as follows.
 
-### 2.1 <a name="2-1-personnames-element" href="#2-1-personnames-element">personNames Element</a>
+### 2.1 <a name="personnames-element" href="#personnames-element">personNames Element</a>
 
 ```xml
 <!ELEMENT personNames ( nameOrderLocales*, foreignSpaceReplacement?, initialPattern*, personName+, sampleName* ) >
@@ -197,7 +197,7 @@ Person name formatting data is stored as LDML with schema defined as follows.
 
 The LDML top-level `<personNames>` element contains information regarding the formatting of person names, and the formatting of person names in specific contexts for a specific locale.
 
-### 2.2 <a name="2-2-personname-element" href="#2-2-personname-element">personName Element</a>
+### 2.2 <a name="personname-element" href="#personname-element">personName Element</a>
 
 The `<personName>` element contains the format patterns, or `<namePattern>` elements, for a specific context and is described in [[namePattern Syntax](#5-namepattern-syntax)]
 
@@ -247,7 +247,7 @@ A `namePattern` contains a list of PersonName fields enclosed in curly braces, s
 
 which produces output like _“Smith, Robert James”_. See [[namePattern Syntax](#5-namepattern-syntax)] for more details.
 
-### 2.3 <a name="2-3-nameorderlocales-element" href="#2-3-nameorderlocales-element">nameOrderLocales Element</a>
+### 2.3 <a name="nameorderlocales-element" href="#nameorderlocales-element">nameOrderLocales Element</a>
 
 The `<nameOrderLocales>` element is optional, and contains information about selecting patterns based on the locale of a passed in PersonName object to determine the order of elements in a formatted name. For more information see [[NameOrder](#6-3-derive-the-name-order)]. It has a structure as follows:
 
@@ -265,7 +265,7 @@ An example from English may look like the following
 
 This would tell the formatting code, when handling person name data from an English locale, to use patterns with the `givenFirst` order attribute for all data except name data from Korean, Vietnamese, Cantonese, and Chinese locales, where the `surnameFirst` patterns should be used.
 
-### 2.4 <a name="2-4-foreignspacereplacement-element" href="#2-4-foreignspacereplacement-element">foreignSpaceReplacement Element</a>
+### 2.4 <a name="foreignspacereplacement-element" href="#foreignspacereplacement-element">foreignSpaceReplacement Element</a>
 
 The `<foreignSpaceReplacement>` element is used to specify how delimiters should appear between name parts when the name data (name locale) is different from the requested locale (formatting locale)., but they both use the same script.
 
@@ -277,7 +277,7 @@ The `<foreignSpaceReplacement>` element is used to specify how delimiters should
 * `xml:space` must be set to `'preserve'` so that actual spaces in the pattern are preserved. See [W3C XML White Space Handling](https://www.w3.org/TR/xml/#sec-white-space).
 * The `#PCDATA `is the character sequence used to replace spaces between fields for name data from a name locale that is different from the formatting locale, but are in the same script.
 
-### 2.5 <a name="2-5-initialpattern-element" href="#2-5-initialpattern-element">initialPattern Element</a>
+### 2.5 <a name="initialpattern-element" href="#initialpattern-element">initialPattern Element</a>
 
 The `<initialPattern>` element is used to specify how to format initials of name parts.
 
@@ -298,7 +298,7 @@ The `type="initial"` is used to specify the pattern for how single initials are 
 
 > `<initialPattern type="initialSequence">{0} {1}</initialPattern>`
 
-## 3 <a name="3-person-name-object" href="#3-person-name-object">Person Name Object</a>
+## 3 <a name="person-name-object" href="#person-name-object">Person Name Object</a>
 
 The information that is to be formatted logically consists of a data object containing a number of fields. This data object is a construct for the purpose of formatting, and doesn’t represent the source of the name data. That is, the original source may contain more information. The PersonName object is merely a logical ‘transport’ of information to formatting; it may in actuality consist of, for example, an API that fetches fields from a database.
 
@@ -389,7 +389,7 @@ The `monogram` usage is for very short abbreviated names, such as might be found
 
 When used with `length`, for many alphabetic locales a `monogram` would resolve to one, two, or three characters for short, medium, and long respectively. But that may vary depending on the usage in a locale.
 
-### 4.4 <a name="4-4-formality" href="#4-4-formality">formality</a>
+### 4.4 <a name="formality" href="#formality">formality</a>
 
 The `formality` indicates the formality of usage. A name on a badge for an informal gathering may be much different from an award announcement at the Nobel Prize Ceremonies.
 
@@ -589,7 +589,9 @@ To match a personName, all four attributes in the personName must match (a missi
 
 To find the matching personName element, traverse all the personNames in order until the first one is found. This will always terminate since the data is well-formed in CLDR.
 
-### 6.5 <a name="6-5-choose-a-namepattern" href="#6-5-choose-a-namepattern">Choose a namePattern</a>
+### 6.5 <a name="choose-and-process-namepattern" href="#choose-and-process-namepattern">Choose and process a namePattern</a>
+
+#### 6.5.1 <a name="6-5-choose-a-namepattern" href="#6-5-choose-a-namepattern">Choose a namePattern</a>
 
 To format a name, the fields in a namePattern are replaced with fields fetched from the PersonName Data Interface. The personName element can contain multiple namePattern elements. Choose one based on the fields in the input PersonName object that are populated: 
 1. Find the set of patterns with the most populated fields.
@@ -605,11 +607,19 @@ For example:
 3. Pattern C is discarded, because it has the least number of populated name fields.
 4. Out of the remaining patterns A and B, pattern B wins, because it has only 3 unpopulated fields compared to pattern A.
 
-If the “winning” namePattern still has fields that are unpopulated in the PersonName object, we alter the pattern algorithmically as follows:
+#### 6.5.1 <a name="process-the-namepattern" href="#process-the-namepattern">Choose a namePattern</a>
 
-1. If one or more fields at the start of the pattern are empty, all fields, whitespace, and literal text before the **first** populated field are deleted.
-2. If one or more fields at the end of the pattern are empty, all fields, whitespace, and literal text after the **last** populated field are deleted.
-3. For each empty field in the middle of the pattern (going from left to right), that field and all literal text between it and the nearest whitespace or field on both sides is deleted. If this results in two whitespace characters next to each other, they are coalesced into one.
+If the “winning” namePattern still has fields that are unpopulated in the PersonName object, we process the pattern algorithmically with the following steps:
+
+1. If one or more fields at the start of the pattern are empty, all fields and literal text before the **first** populated field are omitted.
+2. If one or more fields at the end of the pattern are empty, all fields and literal text after the **last** populated field are omitted.
+3. Processing from the start of the remaining pattern:
+  1. If there are two or more empty fields separated only by literals, the fields and the literals between them are removed.
+  2. If there is a single empty field, it is removed.
+4. If the processing from step 3 results in two adjacent literals (call them A and B), they are coalesced into one literal as follows:
+  1. If either is empty the result is the other one.
+  3. If B matches the end of A, then the result is A. So xyz + yz ⇒ xyz, and xyz + xyz ⇒ xyz.
+  4. Otherwise the result is A + B, but with any sequence of two or more white space characters replaced by the first whitespace character. 
 
 ### 6.6 <a name="6-6-examples-of-choosing-a-namepattern" href="#6-6-examples-of-choosing-a-namepattern">Examples of choosing a namePattern</a>
 
@@ -749,11 +759,9 @@ See the “initial” modifier in the [Modifiers](#5-2-modifiers) section for mo
 
 ### 6.8 <a name="6-8-handling-foreign-names" href="#6-8-handling-foreign-names">Handling foreign names</a>
 
-There are two main challenges in dealing with foreign name formatting that needs to be considered. One is the ordering, which is dealt with under the section [[2.3 nameOrderLocales Element](#2-3-nameorderlocales-element)]. The other is spacing.
+There are two main challenges in dealing with foreign name formatting that needs to be considered. One is the ordering, which is dealt with under the section [[2.3 nameOrderLocales Element](#nameorderlocales-element)]. The other is spacing.
 
-Some writing systems require spaces (or some other non-letters) to separate words. For example, [Hayao Miyazaki](https://en.wikipedia.org/wiki/Hayao_Miyazaki) is written in English with given name first and with a space between the two name fields, while in Japanese there is no space with surname first: 
-
-> [宮崎駿](https://ja.wikipedia.org/wiki/%E5%AE%AE%E5%B4%8E%E9%A7%BF)
+Some writing systems require spaces (or some other non-letters) to separate words. For example, [Hayao Miyazaki](https://en.wikipedia.org/wiki/Hayao_Miyazaki) is written in English with given name first and with a space between the two name fields, while in Japanese there is no space with surname first: [宮崎駿](https://ja.wikipedia.org/wiki/%E5%AE%AE%E5%B4%8E%E9%A7%BF)
 
 1. If a locale requires spaces between words, the normal patterns for the formatting locale are used. On Wikipedia, for example, note the space within the Japanese name on pages from English and Korean (an ideographic space is used here for emphasis).
 
@@ -765,15 +773,12 @@ Some writing systems require spaces (or some other non-letters) to separate word
     1. **The foreign name is written in the formatting locale’s script.** In that case, the **foreignSpaceReplacement** is substituted for each space in the patterns from the _locale of the name_. Here are examples for Albert Einstein in Japanese and Chinese:
         * [アルベルト<span style="background-color:aqua">・</span>アインシュタイン](https://ja.wikipedia.org/wiki/%E3%82%A2%E3%83%AB%E3%83%99%E3%83%AB%E3%83%88%E3%83%BB%E3%82%A2%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%A5%E3%82%BF%E3%82%A4%E3%83%B3) 
         * [阿尔伯特<span style="background-color:aqua">·</span>爱因斯坦](https://zh.wikipedia.org/wiki/%E9%98%BF%E5%B0%94%E4%BC%AF%E7%89%B9%C2%B7%E7%88%B1%E5%9B%A0%E6%96%AF%E5%9D%A6) 
-    2. **The foreign name is written in a different script.** In that case, the patterns from the **locale of the name** are used as is.
+    2. **The foreign name is written in a different script.** In that case, the patterns from the **locale of the name** are used as is. More precisely, a different locale's data is used to format the name.
         * [Albert Einstein](https://de.wikipedia.org/wiki/Albert_Einstein) 
 
 In both cases, the ordering may be changed according to the **Name Order for Locales** settings that each locale provides. If the PersonName object does not supply a locale for a name, then a default locale will be derived based on other information (such as the script of the characters in the name fields).
 
-> **Note** In the tech preview, the structure isn't yet powerful enough to handle cases with `foreignSpaceReplacement` where the formatting locale doesn’t need spaces between words, but the name locale has the same ordering as the formatting locale. 
-> For example, consider where the formatting locale is Thai, and the name is in English, but transliterated into Thai.
-
-To illustrate how foreign space replacement works, consider the following name data. For illustration, the name locale is given in the maximized form: in practice, `ja` would be used instead of `ja_Jpan_JP`, and so on.: For more information, see Likely Subtags [TBD add link].
+To illustrate how foreign space replacement works, consider the following name data. For illustration, the name locale is given in the maximized form: in practice, `ja` would be used instead of `ja_Jpan_JP`, and so on.: For more information, see [Likely Subtags](tr35.html#Likely_Subtags).
 
 | name locale   | given    | surname       |
 | ------------- | -------- | ------------- |
@@ -952,9 +957,9 @@ For the expected sample name items, assume a name such as Mr. Richard “Rich”
 * `given12Surname` is for an example using all given names and a surname: “Richard Edward Smith” and “Rich E. Smith” (informal)
 * `full` is used to present a name using all fields: “Mr. Richard Edward Smith Iglesias, Ph.D.”
 
-The `nameField` values and their modifiers are described in the [Person Name Object](#3-person-name-object) and [namePattern Syntax](#5-namepattern-syntax) sections.
+The `nameField` values and their modifiers are described in the [Person Name Object](#person-name-object) and [namePattern Syntax](#5-namepattern-syntax) sections.
 
-## 8 <a name="8-personname-data-interface-examples" href="#8-personname-data-interface-examples">PersonName Data Interface Examples</a>
+## 8 <a name="personname-data-interface-examples" href="#personname-data-interface-examples">PersonName Data Interface Examples</a>
 
 ### 8.1 <a name="8-1-example-1" href="#8-1-example-1">Example 1</a>
 


### PR DESCRIPTION
CLDR-16433

1. Removed prefixed section numbers from anchors (unfortunately, this caused many lines to change)
2. Dropped that this is tech preview
3. Changed prefix and suffix fields to title, generation, and credentials
4. Changed 6.5 to cover 2 topics, and made them 6.5.1 and 6.5.2
5. Described how to coalesce literals (and revamped the rest of the description)
6. Fixed the sample name categories
7.  Deleted some examples in 8.2 that aren't needed or are not explained clearly.
8. Fix the second on locales with scripts that don't need spaces between words.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
9. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
10. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
