### PR TITLE
CLDR-16292 Update supplemental/ordinals.xml for Spanish ordinal numbers of ~1 and ~3

### DIFF
--- a/common/rbnf/es.xml
+++ b/common/rbnf/es.xml
@@ -292,6 +292,8 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2">º;</rbnfrule>
                 <rbnfrule value="3">ᵉʳ;</rbnfrule>
                 <rbnfrule value="4">º;</rbnfrule>
+                <rbnfrule value="13">ᵉʳ;</rbnfrule>
+                <rbnfrule value="14">º;</rbnfrule>
                 <rbnfrule value="20">→→;</rbnfrule>
                 <rbnfrule value="100">→→;</rbnfrule>
             </ruleset>

--- a/common/rbnf/es_419.xml
+++ b/common/rbnf/es_419.xml
@@ -19,6 +19,8 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="2">º;</rbnfrule>
                 <rbnfrule value="3">ᵉʳ;</rbnfrule>
                 <rbnfrule value="4">º;</rbnfrule>
+                <rbnfrule value="13">ᵉʳ;</rbnfrule>
+                <rbnfrule value="14">º;</rbnfrule>
                 <rbnfrule value="20">→→;</rbnfrule>
                 <rbnfrule value="100">→→;</rbnfrule>
             </ruleset>

--- a/common/supplemental/ordinals.xml
+++ b/common/supplemental/ordinals.xml
@@ -36,8 +36,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
             <pluralRule count="other"> @integer 0, 5~19, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
         <pluralRules locales="es">
-            <pluralRule count="one">n % 10 = 1,3 @integer 1, 3, 11, 13, 21, 23, 31, 33, 41, 43, 51, 53, 101, 103, 1001, 1003, …</pluralRule>
-            <pluralRule count="other"> @integer 0, 2, 4~10, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
+            <!-- The rules only apply towards the masculine adjective form of ordinals -->
+            <pluralRule count="one">n % 10 = 1,3 and n % 100 != 11 @integer 1, 3, 13, 21, 23, 31, 33, 41, 43, 51, 53, 101, 103, 1001, 1003, …</pluralRule>
+            <pluralRule count="other"> @integer 0, 2, 4~12, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 
         <!-- 2: few,other -->


### PR DESCRIPTION
Spanish ordinal numbers First and Third will drop `o` in masculine adjective forms. 
e.g.,  1st day, 2nd day, 3rd day, 4th day, 5th day (English)= 1ᵉʳ día, 2º día, 3ᵉʳ día, 4º día, 5º día (Spanish)

The [supplemental/ordinals.xml](https://github.com/unicode-org/cldr/pull/2769/files#diff-41bbf64dc219b18617d1a124e4b6c0f8cfa47b2458afb7e2a092f077fc083b2b) should be updated accordingly. 

Reference 1: CLDR rbnf of `es`:  https://github.com/unicode-org/cldr/blob/835e0c982ed37f994c6363909d958e1731693c03/common/rbnf/es.xml#L289-L297

Reference 2: https://www.spanish.academy/blog/ordinal-numbers/



CLDR-16292

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
