### PR TITLE
CLDR-16122 v43 spec: regenerate ToC

### DIFF
--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -78,7 +78,7 @@ The LDML specification is divided into the following parts:
   * 6.7 [Process a namePattern](#process-the-namepattern)
     * 6.7.1 [Handling foreign names](#handling-foreign-names)
     * 6.7.2 [Setting the spaceReplacement](#spaceReplacement)
-    * 6.7.3 [Examples of space replacement](#examples-examples)
+    * 6.7.3 [Examples of space replacement](#spaceReplacement-examples)
   * 6.8 [Formatting examples](#formatting-examples)
 * 7 [Sample Name](#sample-name)
   * 7.1 [Syntax](#syntax)
@@ -710,7 +710,7 @@ For the purposes of this algorithm, two base languages are said to __match__ whe
 Remember that **a name in a different script** will use a different locale for formatting, as per <a href="#switch-formatting-locales">Switch the formatting locale if necessary</a>.
 For example, when formatting a name for Japanese, if the name is in the Latin script, a Latin based locale will be used to format it, such as when “Albert Einstein” appears in Latin characters on [Albert Einstein](https://ja.wikipedia.org/wiki/Albert_Einstein)
 
-#### 6.7.3 <a name="examples-examples" href="#spaceReplacement-examples">Examples of space replacement</a>
+#### 6.7.3 <a name="spaceReplacement-examples" href="#spaceReplacement-examples">Examples of space replacement</a>
 
 To illustrate how foreign space replacement works, consider the following name data. For illustration, the name locale is given in the maximized form: in practice, `ja` would be used instead of `ja_Jpan_JP`, and so on.: For more information, see [Likely Subtags](tr35.html#Likely_Subtags).
 

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -67,31 +67,33 @@ The LDML specification is divided into the following parts:
 * 6 [Formatting Process](#formatting-process)
   * 6.1 [Derive the name locale](#derive-the-name-locale)
   * 6.2 [Derive the formatting locale](#derive-the-formatting-locale)
-      * 6.2.1 [Switch the formatting locale if necessary]("switch-formatting-locales)
+    * 6.2.1 [Switch the formatting locale if necessary](#switch-formatting-locales)
   * 6.3 [Derive the name order](#derive-the-name-order)
   * 6.4 [Choose a personName](#choose-a-personname)
-  * 6.5 [Choose a namePattern](#choose-a-namepattern")
-  * 6.6 [Access PersonName object](#access-personname")
-      * 6.6.1 [Handle missing surname](#missing-surname")
-      * 6.6.2 [Handle core and prefix](#core-and-prefix)
-      * 6.6.3 [Derive initials](#derive-initials)
+  * 6.5 [Choose a namePattern](#choose-a-namepattern)
+  * 6.6 [Access PersonName object](#access-personname-object)
+    * 6.6.1 [Handle missing surname](#missing-surname)
+    * 6.6.2 [Handle core and prefix](#core-and-prefix)
+    * 6.6.3 [Derive initials](#derive-initials)
   * 6.7 [Process a namePattern](#process-the-namepattern)
-      * 6.7.1 [Handling foreign names](#handling-foreign-names)
-      * 6.7.2 [Setting the spaceReplacement](#spaceReplacement)
-      * 6.7.3 [Examples of space replacement](#spaceReplacement-examples)
+    * 6.7.1 [Handling foreign names](#handling-foreign-names)
+    * 6.7.2 [Setting the spaceReplacement](#spaceReplacement)
+    * 6.7.3 [Examples of space replacement](#examples-examples)
   * 6.8 [Formatting examples](#formatting-examples)
 * 7 [Sample Name](#sample-name)
   * 7.1 [Syntax](#syntax)
   * 7.2 [Expected values](#expected-values)
 * 8 [PersonName Data Interface Examples](#personname-data-interface-examples)
+  * 8.1 [Example 1](#example-1)
+  * 8.2 [Example 2](#example-2)
 
 ## 1 <a name="CLDRPersonNames" href="#CLDRPersonNames">CLDR Person Names</a>
 
 ### 1.1 <a name="Introduction" href="#Introduction">Introduction</a>
 
-CLDR provides formatting for person names, such as John Smith or 宮崎駿. These use patterns to show how a name object (for example, from a database) should be formatted for a particular locale. Name data has fields for the parts of people’s names, such as a **given** field with a value of “Maria”, and a **surname** field value of “Schmidt”. 
+CLDR provides formatting for person names, such as John Smith or 宮崎駿. These use patterns to show how a name object (for example, from a database) should be formatted for a particular locale. Name data has fields for the parts of people’s names, such as a **given** field with a value of “Maria”, and a **surname** field value of “Schmidt”.
 
-There is a wide variety in the way that people’s names appear in different languages. 
+There is a wide variety in the way that people’s names appear in different languages.
 
 * People may have a different number of names, depending on their culture—they might have only one name (“Zendaya”), two (“Albert Einstein”), or three or more.
 * People may have multiple words in a particular name field, eg “Mary Beth” as a given name, or “van Berg” as a surname.
@@ -99,7 +101,7 @@ There is a wide variety in the way that people’s names appear in different lan
 * The ordering of name fields can be different across languages, as well as the spacing (or lack thereof) and punctuation.
 * Name formatting needs to be adapted to different circumstances, such as a need to be presented shorter or longer; formal or informal context; or when talking about someone, or talking to someone, or as a monogram (JFK).
 
-This document provides the [LDML](http://www.unicode.org/reports/tr35/) specification for formatting of personal names, using data, structure, and examples. 
+This document provides the [LDML](http://www.unicode.org/reports/tr35/) specification for formatting of personal names, using data, structure, and examples.
 
 The CLDR functionality is targeted at formatting names for typical usage on computers (e.g. contact names, automated greetings, etc.), rather than being designed for special circumstances or protocol, such addressing royalty. However, the structure may be enhanced in the future when it becomes clear that additional features are needed for some languages.
 
@@ -112,7 +114,7 @@ Additions to those structures were made to accomodate known issues in large popu
 The following features are currently out of scope for Person Names formating:
 
 * Grammatical inflection of formatted names.
-* Context-specific cultural aspects, such as when to use “-san” vs “-sama” when addressing a Japanese person. 
+* Context-specific cultural aspects, such as when to use “-san” vs “-sama” when addressing a Japanese person.
 * Providing lists of titles, generation terms, and credential (Mr, Ms., Mx., Dr., Jr., M.D., etc.).
 * Validation of input, such as  which fields are required, and what characters are allowed.
 * Combining alternative names, such as multicultural names in Hong Kong "[Jackie Chan Kong-Sang](https://en.wikipedia.org/wiki/Jackie_Chan)”, or ‘Dwayne “The Rock” Johnson’.
@@ -127,7 +129,7 @@ The following features are currently out of scope for Person Names formating:
     | Mary      |           | Beth Estrella |          |
     | Mary      |           | Beth          | Estrella |
 
-  * Parsing out the other components of a name in a string, such as surname prefixes ([Tussenvoegsel](https://en.wikipedia.org/wiki/Tussenvoegsel) in Dutch). 
+  * Parsing out the other components of a name in a string, such as surname prefixes ([Tussenvoegsel](https://en.wikipedia.org/wiki/Tussenvoegsel) in Dutch).
 
 ### 1.2 <a name="APIImplementation" href="#APIImplementation">API Implementation</a>
 
@@ -141,7 +143,7 @@ Logically, the model used for applying the CLDR data is the following:
 
 Conceptually, CLDR person name formatting depends on data supplied by a PersonName Data Interface. That could be a very thin interface that simply accesses a database record, or it could be a more sophisticated interface that can modify the raw data before presenting it to be formatted. For example, based on the formatting locale a PersonName data interface could transliterate names that are in another script, or supply equivalent titles in different languages.
 
-The specification below will talk about a “PersonName object” as an entity that is logically accessed via such an interface. If multiple formatted names are needed, such as in different scripts or with alternate names, or pronunciations (eg kana), the presumption is that those are logically separate PersonName objects. See [[Person Name Object](#person-name-object)]. 
+The specification below will talk about a “PersonName object” as an entity that is logically accessed via such an interface. If multiple formatted names are needed, such as in different scripts or with alternate names, or pronunciations (eg kana), the presumption is that those are logically separate PersonName objects. See [[Person Name Object](#person-name-object)].
 
 The following summarizes the name data supplied via the PersonName Data Interface:
 
@@ -188,8 +190,8 @@ Then the output is:
 
 The _title_ field is empty, so both it and the space that follows it in the formatting pattern are omitted from the output, the _given2_ field is formatted as an initial, and a preceding comma is placed before the _credentials_.
 
-Sections below specify the precise manner in which a pattern is selected, and how the pattern is modified for missing fields. 
-    
+Sections below specify the precise manner in which a pattern is selected, and how the pattern is modified for missing fields.
+
 ## 2 <a name="xml-structure" href="#xml-structure">XML Structure</a>
 
 Person name formatting data is stored as LDML with schema defined as follows.
@@ -235,9 +237,9 @@ The `<namePattern>` syntax is described in [[Person Name Format Patterns](#forma
 
 The `<personName>` element has attributes of `order`, `length`, `usage`, and `formality`, and contains one or more `<namePattern>` elements.
 
-* For each attribute, there must be at least one attribute value, no value can occur twice, and order is not important (but the canonical order of elements is `order, length, usage, formality`). Thus 
-    * `formality="informal informal"` is invalid, 
-    * as is `formality=""`. 
+* For each attribute, there must be at least one attribute value, no value can occur twice, and order is not important (but the canonical order of elements is `order, length, usage, formality`). Thus
+    * `formality="informal informal"` is invalid,
+    * as is `formality=""`.
     * `formality="formal informal"` is valid and canonical
     * `formality="informal formal"` is valid, but not canonical
 * A missing attribute is equivalent to a list of all valid values for that attribute. For example, if `formality=...` is missing, it is equivalent to `formality="formal informal"`.
@@ -307,7 +309,7 @@ The `type="initial"` is used to specify the pattern for how single initials are 
 
 The information that is to be formatted logically consists of a data object containing a number of fields. This data object is a construct for the purpose of formatting, and doesn’t represent the source of the name data. That is, the original source may contain more information. The PersonName object is merely a logical ‘transport’ of information to formatting; it may in actuality consist of, for example, an API that fetches fields from a database.
 
-Note that an application might have more than one set of name data for a given person, such as data for both a legal name and a nickname or preferred name. Or the source data may contain two whole sets of name data for a person from an Eastern Slavic region, one in Cyrillic characters and one in Latin characters. Or it might contain phonetic data for a name (commonly used in Japan). The additional application-specific information in person’s names is out of scope for the CLDR Person Name formatting data. Thus a calling application may produce more than one PersonName object to format depending on the purpose. 
+Note that an application might have more than one set of name data for a given person, such as data for both a legal name and a nickname or preferred name. Or the source data may contain two whole sets of name data for a person from an Eastern Slavic region, one in Cyrillic characters and one in Latin characters. Or it might contain phonetic data for a name (commonly used in Japan). The additional application-specific information in person’s names is out of scope for the CLDR Person Name formatting data. Thus a calling application may produce more than one PersonName object to format depending on the purpose.
 
 For illustration, the following is a sample PersonName object.
 
@@ -327,11 +329,11 @@ A modifier is supplied, _-informal_, which can be used to indicate which data el
 
 ## 4 <a name="4-person-name-attributes" href="#4-person-name-attributes">Person Name Attributes</a>
 
-A person name pattern may have any of four attributes: order, length, usage, and formality. LDML specifies that all the values for these attributes are unique. For example, because length=long is valid, usage=long cannot also be valid. That allows the pattern labels to be simple, because the attribute names can be skipped. That is, 
+A person name pattern may have any of four attributes: order, length, usage, and formality. LDML specifies that all the values for these attributes are unique. For example, because length=long is valid, usage=long cannot also be valid. That allows the pattern labels to be simple, because the attribute names can be skipped. That is,
 
 > `{order=givenFirst, length=long, usage=referring, formality=formal}`
 
-can be abbreviated without loss of information as: 
+can be abbreviated without loss of information as:
 
 > _givenFirst-long-referring-formal._
 
@@ -390,7 +392,7 @@ And when _`referring`_ to a person, it might place the surname first.:
 
 * Васильев Иван Петрович `// "Vasiliev Ivan Petrovich"`
 
-The `monogram` usage is for very short abbreviated names, such as might be found in online messaging text avatars or other annotations. Ideally, a `monogram` format should result in something that could fit in an em square. Some emoji provide examples of this: 🅰️ 🆎 🆘 
+The `monogram` usage is for very short abbreviated names, such as might be found in online messaging text avatars or other annotations. Ideally, a `monogram` format should result in something that could fit in an em square. Some emoji provide examples of this: 🅰️ 🆎 🆘
 
 When used with `length`, for many alphabetic locales a `monogram` would resolve to one, two, or three characters for short, medium, and long respectively. But that may vary depending on the usage in a locale.
 
@@ -421,13 +423,13 @@ A _namePattern_  is composed of a sequence of field IDs, each enclosed in curly 
 
 The Person Name formatting data assumes that the name data to be formatted consists of the fields in the table below. All of the fields may contain multiple words. Field IDs are lowercase ASCII alphanumeric, and start with an alphabetic character.
 
-When determining how a full name is to be placed into name fields, the data to be formatted should be organized functionally. That is, if a name part is on the dividing line between `given2` and `given`, the key feature is whether it would always occur with the rest of the given name. For example, in _“Mary Jean Smith”_, if _“Mary”_ never occurs without the _“Jean”_, then the given name should be _“Mary Jean”_. If _“Smith”_ never occurs without the _“Jean”_, the `surname` should be _“Jean Smith”_. Otherwise, _“Jean”_ would be the `given2` field. 
+When determining how a full name is to be placed into name fields, the data to be formatted should be organized functionally. That is, if a name part is on the dividing line between `given2` and `given`, the key feature is whether it would always occur with the rest of the given name. For example, in _“Mary Jean Smith”_, if _“Mary”_ never occurs without the _“Jean”_, then the given name should be _“Mary Jean”_. If _“Smith”_ never occurs without the _“Jean”_, the `surname` should be _“Jean Smith”_. Otherwise, _“Jean”_ would be the `given2` field.
 
-For example, a patronymic would be treated as a `given2` name in most slavic languages. 
+For example, a patronymic would be treated as a `given2` name in most slavic languages.
 
 In some cultures, two surnames are used to indicate the paternal and maternal family names or generational names indicating father, grandfather. The `surname2` field is used to indicate this. The CLDR PersonName formatting data assumes that if a PersonName object to be formatted does not have two surnames, then the `surname2` field is not populated. (That is, no pattern should have a `surname2` field without a surname field.) Order of fields in a pattern can vary arbitrarily by locale.
 
-In most cultures, there is a concept of nickname or preferred name, which is used in informal settings or sometimes to represent a “public” or “stage name”. The nickname or preferred name may be submitted as a separate PersonName object to be formatted, or included with a modifier such as `given-informal`. 
+In most cultures, there is a concept of nickname or preferred name, which is used in informal settings or sometimes to represent a “public” or “stage name”. The nickname or preferred name may be submitted as a separate PersonName object to be formatted, or included with a modifier such as `given-informal`.
 
 | Field      | Description<br/>Note: The values for each are as supplied by the PersonName object, via the PersonName data interface. |
 | ---------- | ----------- |
@@ -443,10 +445,10 @@ Some other examples:
 
 * British name: _John Ronald Reuel Tolkien_: `given` name is "John", `given2` name would be  "Ronald Reuel", and the `surame` is "Tolkien".
 * Dutch name: _Anneliese Louise van der Pol_: `given` name: "Anneliese", `given2` name: "Louise", `surname`: "van der Pol"
-    * Also surname-prefix: “van der”, surname-core: “Pol” — see below.	
+    * Also surname-prefix: “van der”, surname-core: “Pol” — see below.
 * French name: “Jean-Louis Trintignant” would _not_ be Jean (`given`) Louis (`given2`) Trintignant (`surname`), since “Louis” wouldn’t be discarded when formatting. Instead it would be Jean-Louis (`given`) Trintignant (`surname`)
 
-Note: If the legal name, stage name, etc. are substantially different, then that information can be logically in a separate PersonName object. That is, it is up to the implementation to maintain any distinctions that are important to it: CLDR PersonName formats is focusing on formatting a PersonName object that is given to it. 
+Note: If the legal name, stage name, etc. are substantially different, then that information can be logically in a separate PersonName object. That is, it is up to the implementation to maintain any distinctions that are important to it: CLDR PersonName formats is focusing on formatting a PersonName object that is given to it.
 
 `surname2` would only be asked for in certain locales, and where it is considered a separate, divisible name, such as in Mexico or Spain. For instance, in Mexico, the first and second surname are used for the legal name and in formal settings, and sometimes only the first surname is used in familiar or informal contexts.
 
@@ -471,9 +473,9 @@ The modifiers transform the input data as described in the following table:
 | initial    | Requests the initial grapheme cluster of each word in a field. The `initialPattern` patterns for the locale are used to create the format and layout for lists of initials. For example, if the initialPattern types are<br/>`<initialPattern type="initial">{0}.</initialPattern>`<br/>`<initialPattern type="initialSequence">{0} {1}</initialPattern>`<br/>then a name such as<br/>{ given: “John”, given2: “Ronald Reuel”, surname: “Tolkien” }<br/>could be represented as<br/>“{given-initial-allCaps} {given2-initial-allCaps} {surname}”<br/>and will format to “**J. R. R. Tolkien**”<br/><br/>_The default implementation uses the first grapheme cluster of each word for the value for the field; if the PersonName object has a locale, and CLDR supports a locale-specific grapheme cluster algorithm for that locale, then that algorithm is used. The PersonName object can override this, as detailed below._<br/><br/>Only the _“-initial”_ or the _“-monogram”_ modifier may be used, but not both. They are mutually exclusive. |
 | monogram   | Requests initial grapheme. Example: A name such as<br/>{ given: “Landon”, given2: “Bainard Crawford”, surname: “Johnson” }<br/>could be represented as<br/>“{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}”<br/>or “**LBJ**”<br/><br/>_The default implementation uses the first grapheme cluster of the value for the field; if the PersonName object has a locale, and CLDR supports a locale-specific grapheme cluster algorithm for that locale, then that algorithm is used. The PersonName object can override this, as detailed below. The difference between monogram an initial is that monogram only returns one element, not one element per word._<br/><br/>Only the _“-initial”_ or the _“-monogram”_ modifier may be used, but not both. They are mutually exclusive. |
 
-There may be more modifiers in the future. 
+There may be more modifiers in the future.
 
-Examples: 
+Examples:
 
 1. For the initial of the surname **_“de Souza”_**, in a language that treats the “de” as a tussenvoegsel, the PersonName object can automatically recast `{surname-initial}` to:<br/>`{surname-prefix-initial}{surname-core-initial-allCaps} `to get “dS” instead of “d”.
 2. If the locale expects a surname prefix to to be sorted after a surname, then both `{surname-core} `then `{surname-prefix}` would be used as in<br/>`{surname-core}, {given} {given2} {surname-prefix}`
@@ -510,7 +512,7 @@ Let the **full formatting locale** be the maximal likely locale for the formatte
 
 A few script values represent a set of scripts, such as Jpan = {Hani, Kana, Hira}. Two script codes are said to _match_ when they are either identical, or one represents a set which contains the other, or they both represent sets which intersect. For example, Hani and Jpan match, because {Hani, Kana, Hira} contains Hani.
 
-If the name script doesn't match the formatting script, then the name is formatted with the name locale, not the originally requested formatting locale. For example, when a Hindi formatter (hi-Deva) is called upon to format a name with the Ukrainian (Cyrillic) locale (uk-Cyrl), under the covers a Ukrainian (Cyrillic) formatter should be instantiated and used to format that name. 
+If the name script doesn't match the formatting script, then the name is formatted with the name locale, not the originally requested formatting locale. For example, when a Hindi formatter (hi-Deva) is called upon to format a name with the Ukrainian (Cyrillic) locale (uk-Cyrl), under the covers a Ukrainian (Cyrillic) formatter should be instantiated and used to format that name.
 
 ### 6.3 <a name="derive-the-name-order" href="#derive-the-name-order">Derive the name order</a>
 
@@ -525,7 +527,7 @@ A PersonName object’s fields are used to derive an order, as follows:
              1. If there is a precise match among the givenFirst nameOrderLocales for L, then let the nameOrder be givenFirst, and stop.
              2. Otherwise if there is a precise match among the surnameFirst nameOrderLocales for L, then let the nameOrder be surnameFirst, and stop.
 
-For example, here is a parent locale lookup chain: 
+For example, here is a parent locale lookup chain:
 
     de_Latn_DE ⇒ de_Latn ⇒ de_DE ⇒ de ⇒ und
 
@@ -585,7 +587,7 @@ A set of input parameters { order=O length=L usage=U formality=F } matches a per
 * The usage attribute values contain U or there is no usage attribute, and
 * The formality attribute values contain F or there is no formality attribute
 
-Example for input parameters 
+Example for input parameters
 
 > `order = `**`givenFirst`**`, length = `**`long`**`, usage = `**`referring`**`, formality = `**`formal`**
 
@@ -601,7 +603,7 @@ To find the matching personName element, traverse all the personNames in order u
 
 ### 6.5 <a name="choose-a-namepattern" href="#choose-a-namepattern">Choose a namePattern</a>
 
-To format a name, the fields in a namePattern are replaced with fields fetched from the PersonName Data Interface. The personName element can contain multiple namePattern elements. Choose one based on the fields in the input PersonName object that are populated: 
+To format a name, the fields in a namePattern are replaced with fields fetched from the PersonName Data Interface. The personName element can contain multiple namePattern elements. Choose one based on the fields in the input PersonName object that are populated:
 1. Find the set of patterns with the most populated fields.
 2. If there is just one element in that set, use it.
 2. Otherwise, among that set, find the set of patterns with the fewest unpopulated fields.
@@ -616,7 +618,8 @@ For example:
 4. Out of the remaining patterns A and B, pattern B wins, because it has only 3 unpopulated fields compared to pattern A.
 
 ### 6.6 <a name="access-personname-object" href="#access-personname-object">Access PersonName object</a>
-### 6.6.1 <a name="missing-surname" href="#missing-surname">Handle missing surname</a>
+
+#### 6.6.1 <a name="missing-surname" href="#missing-surname">Handle missing surname</a>
 
 All PersonName objects will have a given name (for mononyms the given name is used). However, there may not be a surname. In that case, the following process is followed so that formatted patterns produce reasonable results.
 
@@ -627,7 +630,7 @@ All PersonName objects will have a given name (for mononyms the given name is us
 
 As always, this is a logical description and may be optimized in implementations. For example, an implemenation may use an interface for P2 that just delegates calls to P1, with some redirection for accesses to surname and given name.
 
-### 6.6.2 <a name="core-and-prefix" href="#core-and-prefix">Handle core and prefix</a>
+#### 6.6.2 <a name="core-and-prefix" href="#core-and-prefix">Handle core and prefix</a>
 
 A given field may have a core value, a prefix value, and/or a ‘plain’ value (neither core nor prefix). If one or more of them are missing, then the returned values should be adjusted according to the table below. In each cell, a ✓ indicates that a value is available, an ✖️ if there is none, and a → indicates when a value is substituted.
 
@@ -644,7 +647,7 @@ A given field may have a core value, a prefix value, and/or a ‘plain’ value 
 
 For example, if the surname-prefix is "von und zu" and the surname-core is "Stettbach" and there is no surname (plain), then the derived value for the surname is "von und zu Stettbach". (The cases where existing values are changed for prefix and core (ie, ✓ → …) should not be necessary with well-formed PersonName data.)
 
-### 6.6.3 <a name="derive-initials" href="#derive-initials">Derive initials</a>
+#### 6.6.3 <a name="derive-initials" href="#derive-initials">Derive initials</a>
 
 The following process is used to produce initials when they are not supplied by the PersonName object. Assuming the input example is “Mary Beth”:
 
@@ -657,7 +660,7 @@ The following process is used to produce initials when they are not supplied by 
 
 See the “initial” modifier in the [Modifiers](#modifiers) section for more details.
 
-#### 6.7 <a name="process-the-namepattern" href="#process-the-namepattern">Process a namePattern</a>
+### 6.7 <a name="process-the-namepattern" href="#process-the-namepattern">Process a namePattern</a>
 
 The “winning” namePattern may still have fields that are unpopulated (empty) in the PersonName object. That namePattern is populated with field values with the following steps:
 
@@ -670,9 +673,9 @@ The “winning” namePattern may still have fields that are unpopulated (empty)
     1. If either is empty the result is the other one.
     2. If B matches the end of A, then the result is A. So xyz + yz ⇒ xyz, and xyz + xyz ⇒ xyz.
     3. Otherwise the result is A + B, further modified by replacing any sequence of two or more white space characters by the first whitespace character.
-5. All of the fields are replaced by the corresponding values from the PersonName object. 
+5. All of the fields are replaced by the corresponding values from the PersonName object.
 
-### 6.7.1 <a name="handling-foreign-names" href="#handling-foreign-names">Handling foreign names</a>
+#### 6.7.1 <a name="handling-foreign-names" href="#handling-foreign-names">Handling foreign names</a>
 
 There are two main challenges in dealing with foreign name formatting that needs to be considered. One is the ordering, which is dealt with under the section [[2.3 nameOrderLocales Element](#nameorderlocales-element)]. The other is spacing.
 
@@ -680,14 +683,14 @@ Some writing systems require spaces (or some other non-letters) to separate word
 
 If a locale requires spaces between words, the normal patterns for the formatting locale are used. On Wikipedia, for example, note the space within the Japanese name on pages from English and Korean (an ideographic space is used here for emphasis).
 
-* “​​[Hayao Miyazaki (宮崎<span style="background-color:aqua">　</span>駿, Miyazaki Hayao](https://en.wikipedia.org/wiki/Hayao_Miyazaki)…” or 
-* “[미야자키<span style="background-color:aqua">　</span>하야오(일본어: 宮﨑<span style="background-color:aqua">　</span>駿 Miyazaki Hayao](https://ko.wikipedia.org/wiki/%EB%AF%B8%EC%95%BC%EC%9E%90%ED%82%A4_%ED%95%98%EC%95%BC%EC%98%A4)…”. 
+* “​​[Hayao Miyazaki (宮崎<span style="background-color:aqua">　</span>駿, Miyazaki Hayao](https://en.wikipedia.org/wiki/Hayao_Miyazaki)…” or
+* “[미야자키<span style="background-color:aqua">　</span>하야오(일본어: 宮﨑<span style="background-color:aqua">　</span>駿 Miyazaki Hayao](https://ko.wikipedia.org/wiki/%EB%AF%B8%EC%95%BC%EC%9E%90%ED%82%A4_%ED%95%98%EC%95%BC%EC%98%A4)…”.
 
 If a locale **doesn’t** require spaces between words, there are two cases, based on whether the name is foreign or not (based on the PersonName objects explicit or calculated locale's language subtag). For example, the formatting locale might be Japanese, and the locale of the PersonName object might be de_CH, German (Switzerland), such as Albert Einstein. When the locale is foreign, the **foreignSpaceReplacement** is substituted for each space in the formatted name. When the name locale is native, a **nativeSpaceReplacement** is substituted for each space in the formatted name. The precise algorithm is given below.
 
 Here are examples for Albert Einstein in Japanese and Chinese:
-        * [アルベルト<span style="background-color:aqua">・</span>アインシュタイン](https://ja.wikipedia.org/wiki/%E3%82%A2%E3%83%AB%E3%83%99%E3%83%AB%E3%83%88%E3%83%BB%E3%82%A2%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%A5%E3%82%BF%E3%82%A4%E3%83%B3) 
-        * [阿尔伯特<span style="background-color:aqua">·</span>爱因斯坦](https://zh.wikipedia.org/wiki/%E9%98%BF%E5%B0%94%E4%BC%AF%E7%89%B9%C2%B7%E7%88%B1%E5%9B%A0%E6%96%AF%E5%9D%A6) 
+        * [アルベルト<span style="background-color:aqua">・</span>アインシュタイン](https://ja.wikipedia.org/wiki/%E3%82%A2%E3%83%AB%E3%83%99%E3%83%AB%E3%83%88%E3%83%BB%E3%82%A2%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%A5%E3%82%BF%E3%82%A4%E3%83%B3)
+        * [阿尔伯特<span style="background-color:aqua">·</span>爱因斯坦](https://zh.wikipedia.org/wiki/%E9%98%BF%E5%B0%94%E4%BC%AF%E7%89%B9%C2%B7%E7%88%B1%E5%9B%A0%E6%96%AF%E5%9D%A6)
 
 #### 6.7.2 <a name="spaceReplacement" href="#spaceReplacement">Setting the spaceReplacement</a>
 
@@ -700,12 +703,12 @@ Here are examples for Albert Einstein in Japanese and Chinese:
         2. The script has the script metadata property lbLetters = YES (this can also be algorithmically derived from the LineBreak property data).
     4. Otherwise, let nativeSpaceReplacement = " " (space)
 3. If the formatter base language matches the name base language, then let spaceReplacement = nativeSpaceReplacement, otherwise let spaceReplacement = foreignSpaceReplacement.
-4. Replace all sequences of space in the resolved pattern string by the spaceReplacement. 
+4. Replace all sequences of space in the resolved pattern string by the spaceReplacement.
 
 For the purposes of this algorithm, two base languages are said to __match__ when they identical, or if both are in {ja, zh, yue}.
 
 Remember that **a name in a different script** will use a different locale for formatting, as per <a href="#switch-formatting-locales">Switch the formatting locale if necessary</a>.
-For example, when formatting a name for Japanese, if the name is in the Latin script, a Latin based locale will be used to format it, such as when “Albert Einstein” appears in Latin characters on [Albert Einstein](https://ja.wikipedia.org/wiki/Albert_Einstein) 
+For example, when formatting a name for Japanese, if the name is in the Latin script, a Latin based locale will be used to format it, such as when “Albert Einstein” appears in Latin characters on [Albert Einstein](https://ja.wikipedia.org/wiki/Albert_Einstein)
 
 #### 6.7.3 <a name="examples-examples" href="#spaceReplacement-examples">Examples of space replacement</a>
 
@@ -751,15 +754,15 @@ Note in the `de_CH` locale, _ja_ is not listed in nameOrderLocales, and would th
    &lt;nameOrderLocales order="<strong>givenFirst</strong>"&gt;und <strong>de</strong>&lt;/nameOrderLocales&gt;
    &lt;nameOrderLocales order="surnameFirst"&gt;ko vi yue zh&lt;/nameOrderLocales&gt;
    &lt;foreignSpaceReplacemen xml:space="preserve"&gt;<span style="background-color:aqua"> </span>&lt;/foreignSpaceReplacement&gt;
-   . . . 
+   . . .
    &lt;personName order="givenFirst" length="medium" usage="referring" formality="formal"&gt;
       &lt;namePattern&gt;{given}<span style="background-color:aqua"> </span>{given2-initial}<span style="background-color:aqua"> </span>{surname}, {generation}&lt;/namePattern&gt;
    &lt;/personName&gt;
-   . . . 
+   . . .
    &lt;personName order="surnameFirst" length="medium" usage="referring" formality="formal"&gt;
       &lt;namePattern&gt;{surname}<span style="background-color:aqua">, </span>{given}<span style="background-color:aqua"> </span>{given2-initial}<span style="background-color:aqua">,</span> {generation}&lt;/namePattern&gt;
    &lt;/personName&gt;
-   . . . 
+   . . .
 &lt;/personNames&gt;`
 </pre>
 
@@ -1022,7 +1025,7 @@ The `nameField` values and their modifiers are described in the [Person Name Obj
 
 ## 8 <a name="personname-data-interface-examples" href="#personname-data-interface-examples">PersonName Data Interface Examples</a>
 
-### 8.1 <a name="8-1-example-1" href="#8-1-example-1">Example 1</a>
+### 8.1 <a name="example-1" href="#example-1">Example 1</a>
 
 Greek initials can be produced via the following process in the PersonName object, and returned to the formatter.
 
@@ -1039,7 +1042,7 @@ Examples:
 To make an initial when there are multiple words, an implementation might produce the following:
 
 * A field containing multiple words might skip some of them, such as in “Mohammed bin Ali bin Osman” (“MAO”).
-* The short version of "Son Heung-min" is "H. Son" and not "H. M. Son" or the like. Korean given-names have hyphens and the part after the hyphen is lower-case. 
+* The short version of "Son Heung-min" is "H. Son" and not "H. M. Son" or the like. Korean given-names have hyphens and the part after the hyphen is lower-case.
 
 
 * * *

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -827,7 +827,7 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
 	<tr><td>"phrase"</td>
 	    <td>Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline</td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeMeasurementSystemIdentifier" id="UnicodeMeasurementSystemIdentifier" href="#UnicodeMeasurementSystemIdentifier">Unicode Measurement System Identifier</a> defines a preferred measurement system. Specifying "ms" in a locale identifier overrides the default value specified by supplemental measurement system data (see Part 2 General, section 5 <a href="tr35-general.md#Measurement_System_Data">Measurement System Data</a>). The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="ms" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/measure.xml" target="_blank">measure.xml</a></b>. 
+<tr><td colspan="4"><b>A <a name="UnicodeMeasurementSystemIdentifier" id="UnicodeMeasurementSystemIdentifier" href="#UnicodeMeasurementSystemIdentifier">Unicode Measurement System Identifier</a> defines a preferred measurement system. Specifying "ms" in a locale identifier overrides the default value specified by supplemental measurement system data (see Part 2 General, section 5 <a href="tr35-general.md#Measurement_System_Data">Measurement System Data</a>). The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="ms" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/measure.xml" target="_blank">measure.xml</a></b>.
 The determination of preferred units depends on the locale identifer: the keys ms, mu, rg, the base locale (language, script, region) and the user preferences.
 <i>For information about preferred units and unit conversion, see <a href="tr35-info.md#Unit_Conversion">Unit Conversion</a> and <a href="tr35-info.md#Unit_Preferences">Unit Preferences</a>.</i>
 </td></tr>
@@ -3174,48 +3174,48 @@ Processes sometimes encounter invalid number or date patterns, such as a number 
   * Produce an error (set an error code or throw an exception) when an attempt is made to create a formatter with such a pattern or to apply such a pattern to an existing formatter.
 
 ## 8 <a name="Data_Size" href="#Data_Size">Data Size Reduction</a>
-Software implementations may have constrained memory requirements. 
-The following outlines some techniques for filtering out CLDR data for a particular implementation. 
+Software implementations may have constrained memory requirements.
+The following outlines some techniques for filtering out CLDR data for a particular implementation.
 The exact filtering would depend on the particular requirements of the implementation in question, of course.
 
-Locale data can be _sliced_ to exclude data not needed by a particular implementation. 
-This can be _vertical slicing_: excluding a locale and all the locales inheriting from them, or _horizontal slicing_: excluding particular types of data from all locales. 
+Locale data can be _sliced_ to exclude data not needed by a particular implementation.
+This can be _vertical slicing_: excluding a locale and all the locales inheriting from them, or _horizontal slicing_: excluding particular types of data from all locales.
 For example:
   * A vertical slice could retain only those locales used in a particular set of markets, such as EU locales.
   * A horizontal slice could remove all data in the emoji/ directory, which are annotations for emoji and symbols.
-  
+
 Of course, both of these techniques can be applied.
 
 ### 8.1 <a name="Vertical_Slicing" href="#Vertical_Slicing">Vertical Slicing</a>
 
-Locales chosen to filter out depend very much on the particular implementation. 
-Some information that might be useful for determining that that is the [Supplemental Territory Information](https://unicode.org/reports/tr35/tr35-info.html#Supplemental_Territory_Information), 
-which provides information on the use of languages in different countries/regions. 
+Locales chosen to filter out depend very much on the particular implementation.
+Some information that might be useful for determining that that is the [Supplemental Territory Information](https://unicode.org/reports/tr35/tr35-info.html#Supplemental_Territory_Information),
+which provides information on the use of languages in different countries/regions.
 (For a human-readable chart, see [Territory-Language Information](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/territory_language_information.html).)
 
-It is important to note that if a particular locale is in a vertical slice, then all of its parents should be as well, because of inheritance. 
+It is important to note that if a particular locale is in a vertical slice, then all of its parents should be as well, because of inheritance.
 This is not a factor if the data is fully resolved, as in the JSON format data.
 
-Slicing can also remove related supplemental data. 
-For example, the likely subtags data includes a large number of languages that may not be of interest for all implementations. 
-Where an the implementation only includes (say) the CLDR locales at Basic coverage in [Unicode CLDR - Coverage Levels](https://cldr.unicode.org/index/cldr-spec/coverage-levels) 
+Slicing can also remove related supplemental data.
+For example, the likely subtags data includes a large number of languages that may not be of interest for all implementations.
+Where an the implementation only includes (say) the CLDR locales at Basic coverage in [Unicode CLDR - Coverage Levels](https://cldr.unicode.org/index/cldr-spec/coverage-levels)
 (and locales inheriting from them), the likely subtag data that doesn’t match can be filtered out.
 
-### 8.2 <a name="Horizontal_Slicing" href="#Horizontal_Slicing">Horizontal_Slicing</a>
+### 8.2 <a name="Horizontal_Slicing" href="#Horizontal_Slicing">Horizontal Slicing</a>
 
-The main reason to perform horizontal slicing is when a particular feature is not used, so the implementation wants to remove the data required for powering that feature. 
-For example, if an application isn't performing date formatting, it can remove all date formatting data (transitively). 
+The main reason to perform horizontal slicing is when a particular feature is not used, so the implementation wants to remove the data required for powering that feature.
+For example, if an application isn't performing date formatting, it can remove all date formatting data (transitively).
 It must take care to retain data used by other features: in the previous example, the number formatting data where currencies are being formatted.
 
-Locales may also have data on a field-by-field basis that is reasonable to filter out. 
-For example, locales that meet the Modern level of coverage typically also include some data at a Comprehensive level. 
-That data is not typically needed for most implementations, and can typically be filtered out. 
-For example, in CLDR version 43, 58% of the script names (`//ldml/localeDisplayNames/scripts/script[@type="*"]`) are at the Comprehensive level; 
+Locales may also have data on a field-by-field basis that is reasonable to filter out.
+For example, locales that meet the Modern level of coverage typically also include some data at a Comprehensive level.
+That data is not typically needed for most implementations, and can typically be filtered out.
+For example, in CLDR version 43, 58% of the script names (`//ldml/localeDisplayNames/scripts/script[@type="*"]`) are at the Comprehensive level;
 in fact, ~20% of all of values for the Modern level locales are at the Comprehensive level.
 
-The easiest way to do that is to use the CLDR Java tooling (the `cldr-code` package) to filter the data before generating the implementation's data format. 
-That way allows the implementation to have direct access to the CoverageLevel code that can determine the coverage level, for a given locale and path. 
-Once the data is transformed, such as to the JSON format, the CoverageLevel code is no longer accessible. 
+The easiest way to do that is to use the CLDR Java tooling (the `cldr-code` package) to filter the data before generating the implementation's data format.
+That way allows the implementation to have direct access to the CoverageLevel code that can determine the coverage level, for a given locale and path.
+Once the data is transformed, such as to the JSON format, the CoverageLevel code is no longer accessible.
 For example, here is a code snippet:
 
 ```

--- a/tools/scripts/tr-archive/fix-tocs.js
+++ b/tools/scripts/tr-archive/fix-tocs.js
@@ -12,11 +12,11 @@ const contentsEnd = /^## .*$/; // end of contents: the next ##
 
 // ToC entries we don't want, for deletion
 const tocDelete = [
-    /^\* \[.*Unicode Technical Standard.*$/,
-    /^  \* \[_Summary_\].*$/,
-    /^  \* \[_Status_\].*$/,
-    /^\* \[Parts\].*$/,
-    /^\* \[Contents of.*$/
+    /^[ ]*\* \[.*Unicode Technical Standard.*$/,
+    /^[ ]*\* \[_Summary_\].*$/,
+    /^[ ]*\* \[_Status_\].*$/,
+    /^[ ]*\* \[Parts\].*$/,
+    /^[ ]*\* \[Contents of.*$/
 ];
 
 const gfmOpts = {


### PR DESCRIPTION
CLDR-16122

- also drop some extra whitespace
- regen ToC using `cd tools/scripts/tr-archive ; npm ci ; npm run fix-tocs`
- fix the generator tool to not add extra junk on top of the tr35 ToC

Note that this tool runs automatically before the HTML is published.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
