### PR TITLE
CLDR-16450 bcp47: Add missing since= attributes, update currency descriptions

### DIFF
--- a/common/bcp47/currency.xml
+++ b/common/bcp47/currency.xml
@@ -67,9 +67,9 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="btn" description="Bhutanese Ngultrum"/>
             <type name="buk" description="Burmese Kyat" since="1.9"/>
             <type name="bwp" description="Botswanan Pula"/>
-            <type name="byb" description="Belarusian New Ruble (1994-1999)" since="1.9"/>
+            <type name="byb" description="Belarusian Ruble (1994-1999)" since="1.9"/>
             <type name="byn" description="Belarusian Ruble" since="31"/>
-            <type name="byr" description="Belarusian Ruble (2000–2016)" since="1.9"/>
+            <type name="byr" description="Belarusian Ruble (2000-2016)" since="1.9"/>
             <type name="bzd" description="Belize Dollar"/>
             <type name="cad" description="Canadian Dollar"/>
             <type name="cdf" description="Congolese Franc"/>
@@ -112,7 +112,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="fjd" description="Fijian Dollar"/>
             <type name="fkp" description="Falkland Islands Pound"/>
             <type name="frf" description="French Franc"/>
-            <type name="gbp" description="British Pound Sterling"/>
+            <type name="gbp" description="British Pound"/>
             <type name="gek" description="Georgian Kupon Larit" since="1.9"/>
             <type name="gel" description="Georgian Lari" since="1.9"/>
             <type name="ghc" description="Ghanaian Cedi (1979-2007)"/>
@@ -136,8 +136,8 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="idr" description="Indonesian Rupiah"/>
             <type name="iep" description="Irish Pound"/>
             <type name="ilp" description="Israeli Pound"/>
-            <type name="ilr" description="Israeli Sheqel (1980-1985)" since="1.9"/>
-            <type name="ils" description="Israeli New Sheqel"/>
+            <type name="ilr" description="Israeli Shekel (1980-1985)" since="1.9"/>
+            <type name="ils" description="Israeli New Shekel"/>
             <type name="inr" description="Indian Rupee"/>
             <type name="iqd" description="Iraqi Dinar" since="1.9"/>
             <type name="irr" description="Iranian Rial" since="1.9"/>
@@ -181,7 +181,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="mkd" description="Macedonian Denar" since="1.9"/>
             <type name="mkn" description="Macedonian Denar (1992-1993)" since="1.9"/>
             <type name="mlf" description="Malian Franc" since="1.9"/>
-            <type name="mmk" description="Myanma Kyat"/>
+            <type name="mmk" description="Myanmar Kyat"/>
             <type name="mnt" description="Mongolian Tugrik"/>
             <type name="mop" description="Macanese Pataca"/>
             <type name="mro" description="Mauritanian Ouguiya (1973-2017)"/>
@@ -189,7 +189,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="mtl" description="Maltese Lira"/>
             <type name="mtp" description="Maltese Pound"/>
             <type name="mur" description="Mauritian Rupee"/>
-            <type name="mvp" description="Maldivian Rupee" since="1.9"/>
+            <type name="mvp" description="Maldivian Rupee (1947-1981)" since="1.9"/>
             <type name="mvr" description="Maldivian Rufiyaa" since="1.9"/>
             <type name="mwk" description="Malawian Kwacha" since="1.9"/>
             <type name="mxn" description="Mexican Peso" since="1.9"/>
@@ -210,7 +210,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="omr" description="Omani Rial" since="1.9"/>
             <type name="pab" description="Panamanian Balboa"/>
             <type name="pei" description="Peruvian Inti"/>
-            <type name="pen" description="Peruvian Nuevo Sol"/>
+            <type name="pen" description="Peruvian Sol"/>
             <type name="pes" description="Peruvian Sol (1863-1965)" since="1.9"/>
             <type name="pgk" description="Papua New Guinean Kina"/>
             <type name="php" description="Philippine Peso"/>
@@ -219,7 +219,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="plz" description="Polish Zloty (1950-1995)" since="1.9"/>
             <type name="pte" description="Portuguese Escudo"/>
             <type name="pyg" description="Paraguayan Guarani"/>
-            <type name="qar" description="Qatari Rial"/>
+            <type name="qar" description="Qatari Riyal"/>
             <type name="rhd" description="Rhodesian Dollar"/>
             <type name="rol" description="Romanian Leu (1952-2006)" since="1.9"/>
             <type name="ron" description="Romanian Leu"/>
@@ -235,11 +235,11 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="sdp" description="Sudanese Pound (1957-1998)" since="1.9"/>
             <type name="sek" description="Swedish Krona"/>
             <type name="sgd" description="Singapore Dollar"/>
-            <type name="shp" description="Saint Helena Pound"/>
+            <type name="shp" description="St. Helena Pound"/>
             <type name="sit" description="Slovenian Tolar" since="1.9"/>
             <type name="skk" description="Slovak Koruna"/>
-            <type name="sle" description="Sierra Leonean New Leone"/>
-            <type name="sll" description="Sierra Leonean Leone"/>
+            <type name="sle" description="Sierra Leonean Leone" since="41"/>
+            <type name="sll" description="Sierra Leonean Leone (1964—2022)"/>
             <type name="sos" description="Somali Shilling"/>
             <type name="srd" description="Surinamese Dollar"/>
             <type name="srg" description="Surinamese Guilder"/>
@@ -274,28 +274,28 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="uyp" description="Uruguayan Peso (1975-1993)" since="1.9"/>
             <type name="uyu" description="Uruguayan Peso"/>
             <type name="uyw" description="Uruguayan Nominal Wage Index Unit" since="34"/>
-            <type name="uzs" description="Uzbekistan Som" since="1.9"/>
+            <type name="uzs" description="Uzbekistani Som" since="1.9"/>
             <type name="veb" description="Venezuelan Bolívar (1871-2008)" since="1.9"/>
+            <type name="ved" description="Bolívar Soberano" since="41"/>
             <type name="vef" description="Venezuelan Bolívar (2008-2018)"/>
             <type name="ves" description="Venezuelan Bolívar" since="34"/>
-            <type name="ved" description="Bolívar Soberano" since="41"/>
             <type name="vnd" description="Vietnamese Dong"/>
             <type name="vnn" description="Vietnamese Dong (1978-1985)" since="1.9"/>
             <type name="vuv" description="Vanuatu Vatu"/>
             <type name="wst" description="Samoan Tala"/>
-            <type name="xaf" description="CFA Franc BEAC"/>
+            <type name="xaf" description="Central African CFA Franc"/>
             <type name="xag" description="Silver" since="1.9"/>
             <type name="xau" description="Gold" since="1.9"/>
             <type name="xba" description="European Composite Unit" since="1.9"/>
             <type name="xbb" description="European Monetary Unit" since="1.9"/>
-            <type name="xbc" description="European Unit of Account 9" since="1.9"/>
-            <type name="xbd" description="European Unit of Account 17" since="1.9"/>
+            <type name="xbc" description="European Unit of Account (XBC)" since="1.9"/>
+            <type name="xbd" description="European Unit of Account (XBD)" since="1.9"/>
             <type name="xcd" description="East Caribbean Dollar"/>
             <type name="xdr" description="Special Drawing Rights" since="1.9"/>
             <type name="xeu" description="European Currency Unit" since="1.9"/>
             <type name="xfo" description="French Gold Franc" since="1.9"/>
             <type name="xfu" description="French UIC-Franc" since="1.9"/>
-            <type name="xof" description="CFA Franc BCEAO"/>
+            <type name="xof" description="West African CFA Franc"/>
             <type name="xpd" description="Palladium" since="1.9"/>
             <type name="xpf" description="CFP Franc"/>
             <type name="xpt" description="Platinum" since="1.9"/>

--- a/common/bcp47/segmentation.xml
+++ b/common/bcp47/segmentation.xml
@@ -10,25 +10,25 @@ For terms of use, see http://www.unicode.org/copyright.html
     <version number="$Revision$"/>
     <keyword>
         <key name="dx" description="Scripts to exclude from dictionary break" valueType="multiple" since="38">
-            <type name="SCRIPT_CODE" description="ISO 15924 script code"/>
+            <type name="SCRIPT_CODE" description="ISO 15924 script code" since="38"/>
         </key>
 
         <key name="lb" description="Line break type key" since="27">
-            <type name="strict" description="CSS level 3 line-break=strict, e.g. treat CJ as NS"/>
-            <type name="normal" description="CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh"/>
-            <type name="loose" description="CSS lev 3 line-break=loose"/>
+            <type name="strict" description="CSS level 3 line-break=strict, e.g. treat CJ as NS" since="27"/>
+            <type name="normal" description="CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh" since="27"/>
+            <type name="loose" description="CSS lev 3 line-break=loose" since="27"/>
         </key>
 
         <key name="lw" description="Line break key for CSS lev 3 word-break options" since="28">
-            <type name="normal" description="CSS lev 3 word-break=normal, normal script/language behavior for midword breaks"/>
-            <type name="breakall" description="CSS lev 3 word-break=break-all, allow midword breaks unless forbidden by lb setting"/>
-            <type name="keepall" description="CSS lev 3 word-break=keep-all, prohibit midword breaks except for dictionary breaks"/>
-            <type name="phrase" description="Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline"/>
+            <type name="normal" description="CSS lev 3 word-break=normal, normal script/language behavior for midword breaks" since="28"/>
+            <type name="breakall" description="CSS lev 3 word-break=break-all, allow midword breaks unless forbidden by lb setting" since="28"/>
+            <type name="keepall" description="CSS lev 3 word-break=keep-all, prohibit midword breaks except for dictionary breaks" since="28"/>
+            <type name="phrase" description="Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline" since="41"/>
         </key>
 
         <key name="ss" description="Sentence break parameter key to control use of suppressions data" since="28">
-            <type name="none" description="Don't use segmentation suppressions data"/>
-            <type name="standard" description="Use segmentation suppressions data of type standard"/>
+            <type name="none" description="Don't use segmentation suppressions data" since="28"/>
+            <type name="standard" description="Use segmentation suppressions data of type standard" since="28"/>
         </key>
 
     </keyword>

--- a/common/bcp47/timezone.xml
+++ b/common/bcp47/timezone.xml
@@ -96,7 +96,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="cacfq" description="Creston, Canada" alias="America/Creston" since="21.0.1"/>
             <type name="caedm" description="Edmonton, Canada" alias="America/Edmonton Canada/Mountain"/>
             <type name="caffs" description="Rainy River, Canada" alias="America/Rainy_River"/>
-            <type name="cafne" description="Fort Nelson, Canada" alias="America/Fort_Nelson"/>
+            <type name="cafne" description="Fort Nelson, Canada" alias="America/Fort_Nelson" since="29"/>
             <type name="caglb" description="Glace Bay, Canada" alias="America/Glace_Bay"/>
             <type name="cagoo" description="Goose Bay, Canada" alias="America/Goose_Bay"/>
             <type name="cahal" description="Halifax, Canada" alias="America/Halifax Canada/Atlantic"/>
@@ -177,7 +177,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="frpar" description="Paris, France" alias="Europe/Paris"/>
             <type name="galbv" description="Libreville, Gabon" alias="Africa/Libreville"/>
             <type name="gaza" description="Gaza Strip, Palestinian Territories" deprecated="true" preferred="gazastrp"/>
-            <type name="gazastrp" description="Gaza Strip, Palestinian Territories" alias="Asia/Gaza"/>
+            <type name="gazastrp" description="Gaza Strip, Palestinian Territories" alias="Asia/Gaza" since="40"/>
             <type name="gblon" description="London, United Kingdom" alias="Europe/London Europe/Belfast GB GB-Eire"/>
             <type name="gdgnd" description="Grenada" alias="America/Grenada"/>
             <type name="getbs" description="Tbilisi, Georgia" alias="Asia/Tbilisi"/>
@@ -190,7 +190,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="globy" description="Ittoqqortoormiit (Scoresbysund), Greenland" alias="America/Scoresbysund"/>
             <type name="glthu" description="Qaanaaq (Thule), Greenland" alias="America/Thule"/>
             <type name="gmbjl" description="Banjul, Gambia" alias="Africa/Banjul"/>
-            <type name="gmt" description="Greenwich Mean Time" alias="Etc/GMT Etc/GMT+0 Etc/GMT-0 Etc/GMT0 Etc/Greenwich GMT GMT+0 GMT-0 GMT0 Greenwich"/>
+            <type name="gmt" description="Greenwich Mean Time" alias="Etc/GMT Etc/GMT+0 Etc/GMT-0 Etc/GMT0 Etc/Greenwich GMT GMT+0 GMT-0 GMT0 Greenwich" since="31"/>
             <type name="gncky" description="Conakry, Guinea" alias="Africa/Conakry"/>
             <type name="gpbbr" description="Guadeloupe" alias="America/Guadeloupe"/>
             <type name="gpmsb" description="Marigot, Saint Martin" alias="America/Marigot"/>

--- a/common/bcp47/variant.xml
+++ b/common/bcp47/variant.xml
@@ -7,18 +7,18 @@
 	<version number="$Revision$" />
 	<keyword>
 		<key name="em" description="Emoji presentation style request" since="29">
-			<type name="emoji" description="use an emoji presentation for emoji characters if possible"/>
-			<type name="text" description="use a text presentation for emoji characters if possible"/>
-			<type name="default" description="use the default presentation as specified in UTR #51"/>
+			<type name="emoji" description="use an emoji presentation for emoji characters if possible" since="29"/>
+			<type name="text" description="use a text presentation for emoji characters if possible" since="29"/>
+			<type name="default" description="use the default presentation as specified in UTR #51" since="29"/>
 		</key>
 
 		<key name="rg" description="Alternate region for determining certain data values (e.g. default currency and units) specified by rgScope" since="29">
-			<type name="RG_KEY_VALUE" description="A region code from idValidity/id[type='region'][idStatus='regular'], suffixed with 'ZZZZ'" />
+			<type name="RG_KEY_VALUE" description="A region code from idValidity/id[type='region'][idStatus='regular'], suffixed with 'ZZZZ'" since="29"/>
 		</key>
 
 		<key name="sd" description="Region subdivision" since="28">
 			<type name="SUBDIVISION_CODE"
-				description="Valid unicode_subdivision_subtag for the region subtag as specified in LDML, based on subdivisionContainment data in supplementalData, prefixed by the associated unicode_region_subtag" />
+				description="Valid unicode_subdivision_subtag for the region subtag as specified in LDML, based on subdivisionContainment data in supplementalData, prefixed by the associated unicode_region_subtag" since="28"/>
 		</key>
 
 		<key name="va" description="Common locale variant type key">


### PR DESCRIPTION
CLDR-16450

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In bcp47 data:
- Add missing since= attribute for tags added since CLDR 21 that did not already have them.
- Update currency descriptions to match currency names in en.xml (but AsCII only, so e.g. change en-dash to hyphen-minus).

ALLOW_MANY_COMMITS=true
