### PR TITLE
CLDR-16470 BRS v43: update readme for beta1

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -12,15 +12,15 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 43</h3>
-    <p>Last updated: 2023-Feb-21</p>
+    <p>Last updated: 2023-Mar-13</p>
 
     <!--<p><b>Note:</b> CLDR 43 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 43, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <p><b>Note:</b> This is a preliminary version of CLDR 43, intended for those wishing to do pre-release testing.
-    It is not recommended for production use.</p>
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 43, intended for testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 43, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
+    <p><b>Note:</b> This is a pre-release candidate version of CLDR 43, intended for testing.
+    It is not recommended for production use.</p>
     <!--<p>This is the final release version of CLDR 43.</p>-->
 
     <p><strong>Important notes for CLDR 36 and later:</strong></p>


### PR DESCRIPTION
CLDR-16470

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

This was supposed to update both the IU4J libs in CLDR to the latest ICU version, and update the readme in CLDR for beta1. Unfortunately it only does the latter; a recent change in ICU4J per https://github.com/unicode-org/icu/pull/2326 eliminates from core the classes UnicodeMap and ElapsedTimer that a lot of CLDR code depends upon, so we cannot use the current ICU4J libs. 

ALLOW_MANY_COMMITS=true
