### PR TITLE
CLDR-16468 v43 JSON drop code_fallback and constructed data

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -53,6 +53,14 @@ import com.ibm.icu.util.ULocale;
  */
 @CLDRTool(alias = "ldml2json", description = "Convert CLDR data to JSON")
 public class Ldml2JsonConverter {
+    // Icons
+    private static final String DONE_ICON = "✅";
+    private static final String GEAR_ICON = "⚙️";
+    private static final String PACKAGE_ICON = "📦";
+    private static final String SECTION_ICON = "📍";
+    private static final String TYPE_ICON = "📂";
+
+    // File prefix
     private static final String CLDR_PKG_PREFIX = "cldr-";
     private static final String FULL_TIER_SUFFIX = "-full";
     private static final String MODERN_TIER_SUFFIX = "-modern";
@@ -150,6 +158,7 @@ public class Ldml2JsonConverter {
                 .add("Modern", 'M', "(true|false)", "true", "Whether to include the -modern tier");
 
     public static void main(String[] args) throws Exception {
+        System.out.println(GEAR_ICON + " " + Ldml2JsonConverter.class.getName() + " options:");
         options.parse(args, true);
 
         Timer overallTimer = new Timer();
@@ -157,21 +166,22 @@ public class Ldml2JsonConverter {
         final String rawType = options.get("type").getValue();
 
         if (RunType.all.name().equals(rawType)) {
+            // Running all types
             for(final RunType t : RunType.values()) {
                 if (t == RunType.all) continue;
                 System.out.println();
-                System.out.println("#######################  " + t + " #######################");
+                System.out.println(TYPE_ICON + "#######################  " + t + " #######################");
                 Timer subTimer = new Timer();
                 subTimer.start();
                 processType(t.name());
-                System.out.println(t + "\tFinished in " + subTimer.toMeasureString());
+                System.out.println(TYPE_ICON + " " + t + "\tFinished in " + subTimer.toMeasureString());
                 System.out.println();
             }
         } else {
             processType(rawType);
         }
 
-        System.out.println("\n\n###\n\nFinished everything in " + overallTimer.toMeasureString());
+        System.out.println("\n\n###\n\n" + DONE_ICON + " Finished everything in " + overallTimer.toMeasureString());
     }
 
     static void processType(final String runType) throws Exception {
@@ -1042,7 +1052,7 @@ public class Ldml2JsonConverter {
 
     public void writePackageJson(String outputDir, String packageName) throws IOException {
         PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/" + packageName, "package.json");
-        logger.fine("Creating packaging file => " + outputDir + File.separator + packageName + File.separator + "package.json");
+        logger.fine(PACKAGE_ICON+" Creating packaging file => " + outputDir + File.separator + packageName + File.separator + "package.json");
         JsonObject obj = new JsonObject();
         writeBasicInfo(obj, packageName, true);
 
@@ -1088,7 +1098,7 @@ public class Ldml2JsonConverter {
 
     public void writeBowerJson(String outputDir, String packageName) throws IOException {
         PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/" + packageName, "bower.json");
-        logger.fine("Creating packaging file => " + outputDir + File.separator + packageName + File.separator + "bower.json");
+        logger.fine(PACKAGE_ICON+" Creating packaging file => " + outputDir + File.separator + packageName + File.separator + "bower.json");
         JsonObject obj = new JsonObject();
         writeBasicInfo(obj, packageName, false);
         if (type == RunType.supplemental) {
@@ -1116,7 +1126,7 @@ public class Ldml2JsonConverter {
 
     public void writeDefaultContent(String outputDir) throws IOException {
         PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/cldr-core", "defaultContent.json");
-        System.out.println("Creating packaging file => " + outputDir + "/cldr-core" + File.separator + "defaultContent.json");
+        System.out.println(PACKAGE_ICON+" Creating packaging file => " + outputDir + "/cldr-core" + File.separator + "defaultContent.json");
         JsonObject obj = new JsonObject();
         obj.add("defaultContent", gson.toJsonTree(skippedDefaultContentLocales));
         outf.println(gson.toJson(obj));
@@ -1124,10 +1134,9 @@ public class Ldml2JsonConverter {
     }
 
     public void writeCoverageLevels(String outputDir) throws IOException {
-        final Splitter SEMICOLON = Splitter.on(';').trimResults();
         try (PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/cldr-core", "coverageLevels.json");) {
             final Map<String, String> covlocs = new TreeMap<>();
-            System.out.println("Creating packaging file => " + outputDir + "/cldr-core" + File.separator + "coverageLevels.json from coverageLevels.txt");
+            System.out.println(PACKAGE_ICON+" Creating packaging file => " + outputDir + "/cldr-core" + File.separator + "coverageLevels.json from coverageLevels.txt");
             CalculatedCoverageLevels ccl = CalculatedCoverageLevels.getInstance();
             for (final Map.Entry<String, org.unicode.cldr.util.Level> e : ccl.getLevels().entrySet()) {
                 final String uloc = e.getKey();
@@ -1157,7 +1166,7 @@ public class Ldml2JsonConverter {
 
     public void writeAvailableLocales(String outputDir) throws IOException {
         PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/cldr-core", "availableLocales.json");
-        System.out.println("Creating packaging file => " + outputDir + "/cldr-core" + File.separator + "availableLocales.json");
+        System.out.println(PACKAGE_ICON+" Creating packaging file => " + outputDir + "/cldr-core" + File.separator + "availableLocales.json");
         JsonObject obj = new JsonObject();
         obj.add("availableLocales", gson.toJsonTree(avl));
         outf.println(gson.toJson(obj));
@@ -1185,7 +1194,7 @@ public class Ldml2JsonConverter {
 
     public void writePackageList(String outputDir) throws IOException {
         PrintWriter outf = FileUtilities.openUTF8Writer(outputDir + "/cldr-core", "cldr-packages.json");
-        System.out.println("Creating packaging metadata file => " + outputDir + File.separator + "cldr-core" + File.separator + "cldr-packages.json and PACKAGES.md");
+        System.out.println(PACKAGE_ICON+" Creating packaging metadata file => " + outputDir + File.separator + "cldr-core" + File.separator + "cldr-packages.json and PACKAGES.md");
         PrintWriter pkgs = FileUtilities.openUTF8Writer(outputDir + "/..", "PACKAGES.md");
 
         pkgs.println("# CLDR JSON Packages");
@@ -1669,7 +1678,7 @@ public class Ldml2JsonConverter {
 
     private final String progressPrefix(int readCount, int totalCount) {
         double asPercent = ((double)readCount/(double)totalCount) * 100.0;
-        return String.format("%s\t[%s]:\t", type, percentFormatter.format(asPercent));
+        return String.format(SECTION_ICON+" %s\t[%s]:\t", type, percentFormatter.format(asPercent));
     }
 
     /**
@@ -1734,14 +1743,14 @@ public class Ldml2JsonConverter {
             .filter(p -> p.getSecond() == 0) // filter out only files which produced no output
             .map(p -> p.getFirst())
             .toArray();
-        System.out.println(progressPrefix(total, total) + " Completed parallel process of " + total + " file(s)");
+        System.out.println(progressPrefix(total, total) + " " + DONE_ICON + " Completed parallel process of " + total + " file(s)");
         if (noOutputFiles.length > 0) {
             System.err.println("WARNING: These " + noOutputFiles.length + " file(s) did not produce any output (check JSON config):");
             for (final Object f : noOutputFiles) {
                 final String loc = f.toString();
                 final String uloc = unicodeLocaleToString(f.toString());
                 if (skipBcp47LocalesWithSubtags && type.locales() && HAS_SUBTAG.matcher(uloc).matches()) {
-                    System.err.println("\t- " + loc + " (Skipped due to '-T true': " + uloc + ")");
+                    System.err.println("\t- " + loc + " ❎ (Skipped due to '-T true': " + uloc + ")");
                 } else {
                     System.err.println("\t- " + loc);
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -561,7 +561,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     }
 
     /**
-     * Find out where the value was found (for resolving locales). Returns code-fallback as the location if nothing is
+     * Find out where the value was found (for resolving locales). Returns {@link XMLSource#CODE_FALLBACK_ID} as the location if nothing is
      * found
      *
      * @param distinguishedXPath
@@ -575,7 +575,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     }
 
     /**
-     * Find out where the value was found (for resolving locales). Returns code-fallback as the location if nothing is
+     * Find out where the value was found (for resolving locales). Returns {@link XMLSource#CODE_FALLBACK_ID} as the location if nothing is
      * found
      *
      * @param distinguishedXPath
@@ -2456,7 +2456,14 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         }
     }
 
+    /**
+     * Fillin value for {@link CLDRFile#getSourceLocaleID(String, Status)}
+     */
     public static class Status {
+        /**
+         * XPath where originally found. May be {@link GlossonymConstructor#PSEUDO_PATH} if the value was constructed.
+         * @see GlossonymnConstructor
+         */
         public String pathWhereFound;
 
         @Override
@@ -2580,7 +2587,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
 
     /**
      * Shortcut for getting the string value for the winning path.
-     * If the winning value is an INHERITANCE_MARKER (used in survey
+     * If the winning value is an {@link CldrUtility#INHERITANCE_MARKER} (used in survey
      * tool), then the Bailey value is returned.
      *
      * @param path
@@ -2593,7 +2600,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
 
     /**
      * Shortcut for getting the string value for a path.
-     * If the string value is an INHERITANCE_MARKER (used in survey
+     * If the string value is an {@link CldrUtility#INHERITANCE_MARKER} (used in survey
      * tool), then the Bailey value is returned.
      *
      * @param path
@@ -2605,12 +2612,12 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
 
     /**
      * Shortcut for getting the string value for a path.
-     * If the string value is an INHERITANCE_MARKER (used in survey
+     * If the string value is an {@link CldrUtility#INHERITANCE_MARKER} (used in survey
      * tool), then the Bailey value is returned.
      *
      * @param path the given xpath
-     * @param pathWhereFound if not null, to be filled in with the path where the value is actually found
-     * @param localeWhereFound if not null, to be filled in with the locale where the value is actually found
+     * @param pathWhereFound if not null, to be filled in with the path where the value is actually found. May be {@link GlossonymConstructor#PSEUDO_PATH} if constructed.
+     * @param localeWhereFound if not null, to be filled in with the locale where the value is actually found. May be {@link XMLSource#CODE_FALLBACK_ID} if not in root.
      * @return the string value
      */
     public String getStringValueWithBailey(String path, Output<String> pathWhereFound, Output<String> localeWhereFound) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
@@ -87,8 +87,10 @@ public class CldrUtility {
     public final static Pattern SEMI_SPLIT = PatternCache.get("\\s*;\\s*");
 
     private static final boolean HANDLEFILE_SHOW_SKIP = false;
-    // Constant for "∅∅∅". Indicates that a child locale has no value for a
-    // path even though a parent does.
+    /**
+     * Constant for "∅∅∅". Indicates that a child locale has no value for a
+     * path even though a parent does.
+     */
     public static final String NO_INHERITANCE_MARKER = new String(new char[] { 0x2205, 0x2205, 0x2205 });
 
     /**
@@ -1399,7 +1401,7 @@ public class CldrUtility {
 
     private static final class CopyrightHelper {
         public static final CopyrightHelper INSTANCE = new CopyrightHelper();
-        public final String COPYRIGHT_SHORT = 
+        public final String COPYRIGHT_SHORT =
             "Copyright \u00A9 1991-" + Calendar.getInstance().get(Calendar.YEAR) + " Unicode, Inc.";
     }
 
@@ -1415,7 +1417,7 @@ public class CldrUtility {
      * Returns the '## License' section in markdown.
      */
     public static String getCopyrightMarkdown() {
-        return "## License\n" + 
+        return "## License\n" +
         "\n" +
         getCopyrightShort() + "\n" +
         "[Terms of Use](http://www.unicode.org/copyright.html)\n\n" +


### PR DESCRIPTION
CLDR-16468

- add a `-R` option to include the old redundant data (off by default)
- will make JSON much smaller
- cosmetic improvements to the progress bars
- apidoc improvements to CLDRFile

Example of data no longer included: (composite diff)

```diff
-          "apc": "apc",
-          "hi-Latn": "الهندية (اللاتينية)",
-            "lepc": "lepc",
-            "limb": "limb",
-            "mathbold": "mathbold",
-            "mathdbl": "mathdbl",
-            "mathmono": "mathmono",
-            "mathsanb": "mathsanb",
-            "mathsans": "mathsans",
```

```diff
-            "symbol": "ADP"
```

```diff
-          "ABL1943": "ABL1943",
-          "AKUAPEM": "AKUAPEM",
-          "ALALC97": "ALALC97",
-          "ALUKU": "ALUKU",
-          "AO1990": "AO1990",
-          "ARANES": "ARANES",
```


- [X] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
