### PR TITLE
CLDR-16122 v43 remove noise from test run

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCalculatedCoverageLevels.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCalculatedCoverageLevels.java
@@ -40,7 +40,6 @@ public class TestCalculatedCoverageLevels {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("allLocales")
-    @Test
     @Disabled
     /**
      * Test compares coverage level to the Locales.txt goals.


### PR DESCRIPTION
CLDR-16122

very very minor. But running tests was complaining because there were two test annotations on this test.  

- [ ] This PR completes the ticket.