### PR TITLE
CLDR-16389 v43 update analytics tags

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
@@ -133,34 +133,27 @@ public abstract class Chart {
        throw new IllegalArgumentException("Not implemented yet");
     }
 
-    public void writeFooter(FormattedFileWriter pw) throws IOException {
-        standardFooter(pw, AnalyticsID.CLDR);
+    private static final class AnalyticsHelper {
+        private static final AnalyticsHelper INSTANCE = new AnalyticsHelper();
+
+        public final String str;
+
+        AnalyticsHelper() {
+            str = ToolUtilities.getUTF8Data("analytics.html").lines().collect(Collectors.joining("\n"));
+        }
     }
 
-    private enum AnalyticsID {
-        CLDR("UA-7672775-1"), ICU("UA-7670213-1"), ICU_GUIDE("UA-7670256-1"), UNICODE("UA-7670213-1"), UNICODE_UTILITY("UA-8314904-1");
+    public enum AnalyticsID {
+        CLDR("G-BPN1D3SEJM"), ICU("G-06PL1DM20S"), ICU_GUIDE("UA-7670256-1"), UNICODE("G-GC4HXC4GVQ"), UNICODE_UTILITY("G-0M7Q5QLZPV");
         public final String id;
 
         private AnalyticsID(String id) {
             this.id = id;
         }
-    }
 
-    private static void standardFooter(FormattedFileWriter pw, AnalyticsID analytics) throws IOException {
-        pw.write("<div style='text-align: center; margin-top:2em; margin-bottom: 60em;'><br>\n"
-            + "<a href='https://www.unicode.org/copyright.html'>\n"
-            + "<img src='https://www.unicode.org/img/hb_notice.gif' style='border-style: none; width: 216px; height:50px;' alt='Access to Copyright and terms of use'>"
-            + "</a>\n"
-            + "</div><script>\n\n"
-            + "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){"
-            + "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),"
-            + "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)"
-            + "})(window,document,'script','//www.google-analytics.com/analytics.js','ga');"
-            + "  ga('create', '"
-            + analytics
-            + "', 'auto');"
-            + "  ga('send', 'pageview');"
-            + "</script>\n");
+        public String getScript() {
+            return AnalyticsHelper.INSTANCE.str.replaceAll("TAG_ID", id);
+        }
     }
 
     public final void writeChart(Anchors anchors) {
@@ -169,7 +162,6 @@ public abstract class Chart {
             x.setDirectory(getDirectory());
             x.setShowDate(getShowDate());
             writeContents(x);
-            writeFooter(x);
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
@@ -190,7 +182,7 @@ public abstract class Chart {
 
     /**
      * Attempt to allocate the Chart that goes along with this report
-     * Also see {@link org.unicode.cldr.util.VoterReportStatus.ReportId} 
+     * Also see {@link org.unicode.cldr.util.VoterReportStatus.ReportId}
      * and keep up to date
      */
     public static Chart forReport(final ReportId report, final String locale) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
@@ -161,7 +161,8 @@ public class FormattedFileWriter extends java.io.Writer {
             "%title%", title,
             "%index%", indexLink,
             "%index-title%", indexTitle,
-            "%body%", contents };
+            "%body%", contents,
+            "%analytics%", Chart.AnalyticsID.CLDR.getScript() };
         writeTargetWithReplacements(dir, targetFileName, templateFileName, replacements);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -341,7 +341,7 @@ public class GenerateChangeChart {
             out.write("</div>");
             PrintWriter pw2 = org.unicode.cldr.draft.FileUtilities.openUTF8Writer(dir, filename);
             String[] replacements = { "%header%", "", "%title%", title, "%version%", ToolConstants.CHART_DISPLAY_VERSION,
-                "%date%", CldrUtility.isoFormatDateOnly(new Date()), "%body%", out.toString() };
+                "%date%", CldrUtility.isoFormatDateOnly(new Date()), "%body%", out.toString(), "%analytics%", Chart.AnalyticsID.CLDR.getScript() };
             final String templateFileName = "chart-template.html";
             FileUtilities.appendBufferedReader(ToolUtilities.getUTF8Data(templateFileName), pw2, replacements);
             pw2.close();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -707,6 +707,7 @@ public class ShowData {
             .add("%index%", "index.html")
             .add("%header%", header)
             .add("%version%", version)
+            .add("%analytics%", Chart.AnalyticsID.CLDR.getScript())
             .add("%date%", showDate ? CldrUtility.isoFormatDateOnly(new Date()) : "");
         if (indexTitle != null) {
             langTag

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrUtility.java
@@ -48,6 +48,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.unicode.cldr.draft.FileUtilities;
+import org.unicode.cldr.tool.Chart;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
@@ -176,15 +177,7 @@ public class CldrUtility {
         return getPath(path, null);
     }
 
-    public static final String ANALYTICS = "<script>\n"
-        + "var gaJsHost = ((\"https:\" == document.location.protocol) ? \"https://ssl.\" : \"http://www.\");\n"
-        + "document.write(unescape(\"%3Cscript src='\" + gaJsHost + \"google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E\"));\n"
-        + "</script>\n"
-        + "<script>\n"
-        + "try {\n"
-        + "var pageTracker = _gat._getTracker(\"UA-7672775-1\");\n"
-        + "pageTracker._trackPageview();\n"
-        + "} catch(err) {}</script>";
+    public static final String ANALYTICS = Chart.AnalyticsID.CLDR.getScript();
 
     public static final List<String> MINIMUM_LANGUAGES = Arrays.asList(new String[] { "ar", "en", "de", "fr", "hi",
         "it", "es", "pt", "ru", "zh", "ja" }); // plus language itself

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/analytics.html
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/analytics.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=TAG_ID"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'TAG_ID');
+</script>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/chart-template.html
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/chart-template.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+%analytics%
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>%title%</title>
 <link rel="stylesheet" type="text/css"
@@ -44,7 +45,7 @@
 				<tr><td style="text-align: center" colSpan="3"><a class="upLink" href="%index%">%index-title%</a></td></tr>
 			</table>
 		</div>
-<!-- 
+<!--
 		<div align="center">
 			<table style="margin: 1em">
 				<tr>
@@ -56,22 +57,16 @@
 			</table>
 		</div>
 		 -->
-		%body%
-		<script>
-			(function(i, s, o, g, r, a, m) {
-				i['GoogleAnalyticsObject'] = r;
-				i[r] = i[r] || function() {
-					(i[r].q = i[r].q || []).push(arguments)
-				}, i[r].l = 1 * new Date();
-				a = s.createElement(o), m = s.getElementsByTagName(o)[0];
-				a.async = 1;
-				a.src = g;
-				m.parentNode.insertBefore(a, m)
-			})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-			ga('create', 'UA-7672775-1', 'auto');
-			ga('send', 'pageview');
-		</script>
+<!-- begin main body-->
+%body%
+<!-- end main body -->
 	</div>
-</body>
+	<div style='text-align: center; margin-top:2em; margin-bottom: 60em;'><br>
+		<a href='https://www.unicode.org/copyright.html'>
+			<img src='https://www.unicode.org/img/hb_notice.gif' style='border-style: none; width: 216px; height:50px;'
+				alt='Access to Copyright and terms of use'>
+		</a>
+	</div>
 
+</body>
 </html>


### PR DESCRIPTION
CLDR-16389

- we had at least 2 different versions of the tags, consolidated
- dropped standardFooter because the FormattedFileWriter already uses chart-template.html which now includes the footer and analytics (no longer at the foot per guidance)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
