### PR TITLE
CLDR-16122 v43 BRS codes

### DIFF
--- a/common/validity/subdivision.xml
+++ b/common/validity/subdivision.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE supplementalData SYSTEM '../../common/dtd/ldmlSupplemental.dtd'>
 <!--
-	Copyright © 1991-2022 Unicode, Inc.
+	Copyright © 1991-2023 Unicode, Inc.
 	For terms of use, see http://www.unicode.org/copyright.html
 	SPDX-License-Identifier: Unicode-DFS-2016
 	CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -236,10 +236,10 @@
 			zagt zanl
 		</id>
 		<!-- Unknown/Undetermined subdivision codes (ZZZZ) are defined for all regular region codes. -->
-		<id type='subdivision' idStatus='unknown'>		<!-- 256 items -->
+		<id type='subdivision' idStatus='unknown'>		<!-- 257 items -->
 			aczzzz adzzzz aezzzz afzzzz agzzzz aizzzz alzzzz amzzzz aozzzz aqzzzz arzzzz aszzzz atzzzz auzzzz awzzzz axzzzz azzzzz
 			bazzzz bbzzzz bdzzzz bezzzz bfzzzz bgzzzz bhzzzz bizzzz bjzzzz blzzzz bmzzzz bnzzzz bozzzz bqzzzz brzzzz bszzzz btzzzz bvzzzz bwzzzz byzzzz bzzzzz
-			cazzzz cczzzz cdzzzz cfzzzz cgzzzz chzzzz cizzzz ckzzzz clzzzz cmzzzz cnzzzz cozzzz cpzzzz crzzzz cuzzzz cvzzzz cwzzzz cxzzzz cyzzzz czzzzz
+			cazzzz cczzzz cdzzzz cfzzzz cgzzzz chzzzz cizzzz ckzzzz clzzzz cmzzzz cnzzzz cozzzz cpzzzz cqzzzz crzzzz cuzzzz cvzzzz cwzzzz cxzzzz cyzzzz czzzzz
 			dezzzz dgzzzz djzzzz dkzzzz dmzzzz dozzzz dzzzzz
 			eazzzz eczzzz eezzzz egzzzz ehzzzz erzzzz eszzzz etzzzz
 			fizzzz fjzzzz fkzzzz fmzzzz fozzzz frzzzz

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateValidityXml.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateValidityXml.java
@@ -145,7 +145,7 @@ public class GenerateValidityXml {
             String type = entry.getKey();
             final Info info = entry.getValue();
             Multimap<Status, String> subtypeMap = info.getStatusMap();
-            try (TempPrintWriter output = TempPrintWriter.openUTF8Writer(CLDRPaths.COMMON_DIRECTORY, "validity/" + type + ".xml")) {
+            try (TempPrintWriter output = TempPrintWriter.openUTF8Writer(CLDRPaths.COMMON_DIRECTORY, "validity/" + type + ".xml").skipCopyright(true)) {
                 adder.target = output;
                 output.append(DtdType.supplementalData.header(MethodHandles.lookup().lookupClass())
                     + "\t<version number=\"$Revision" + "$\"/>\n"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TempPrintWriter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TempPrintWriter.java
@@ -185,7 +185,7 @@ public class TempPrintWriter extends Writer {
             if (line1.startsWith("# Date")) {
                 continue;
             }
-            if (skipCopyright && (line1.startsWith("# Copyright") || (line1.trim().startsWith("<!--") && line1.contains("Copyright")))) {
+            if (skipCopyright && (line1.startsWith("# Copyright") || line1.contains("Copyright ©"))) {
                 continue;
             }
             if (line1.startsWith("<p><b>Date:</b>")) {


### PR DESCRIPTION
- regen subdivision for CLDR-16397
- was needed due to CLDR-16293 CLDR-10923 - CQ
- also, improve skip of copyright lines

CLDR-16122

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
