### PR TITLE
CLDR-16508 js: workaround ERR_OSSL_EVP_UNSUPPORTED

### DIFF
--- a/tools/cldr-apps/js/webpack-test.config.js
+++ b/tools/cldr-apps/js/webpack-test.config.js
@@ -10,6 +10,7 @@ module.exports = {
     library: "cldrTestBundle",
     libraryTarget: "var",
     libraryExport: "default",
+    hashFunction: "sha256"
   },
   mode: "development",
   devtool: "source-map",

--- a/tools/cldr-apps/js/webpack.config.js
+++ b/tools/cldr-apps/js/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     library: "cldrBundle",
     libraryTarget: "var",
     libraryExport: "default",
+    hashFunction: "sha256"
   },
   mode: "development",
   devtool: "source-map",


### PR DESCRIPTION
- ref: https://stackoverflow.com/a/69476335/185799
- when we bump webpack to 5.54+ maybe in #2781  or successors, will redo this workaround (see link above)

CLDR-16508

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
