### PR TITLE
CLDR-16437 fix misticketted

### DIFF
--- a/.github/COMMIT_METADATA.md
+++ b/.github/COMMIT_METADATA.md
@@ -12,6 +12,7 @@
 - 9e15f63e30cadf57b8eee0f6d6c3398263dfcdac CLDR-15470 v41 cherry pick
 - 7b370d06c506200e31f9053416ce98cf23d1d1b6 CLDR-16058 v42 cherry pick into v43
 - 5056ea26b4bcbee90652b487a88d79b7f506f432 CLDR-16098 v43 cherry pick
+- 7c8c8bb83ca253f499d4d5c08f968327611a6a70 CLDR-16437 v44 dep fix
 
 ### The following are items to skip for a certain CLDR version.
 ### Format: `# SKIP v00` followed by a list of commits to skip for that version (same structure as above)


### PR DESCRIPTION
- 7c8c8bb83ca253f499d4d5c08f968327611a6a70  (#2639) was opened in v43 and accidentally merged even though the ticket was already closed
- this fixes the commit metadata

CLDR-16437

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
