### PR TITLE
CLDR-16122 v43 BRS: ISO-4217 amd 175, SLL -> 2023-12-31

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -958,7 +958,7 @@ The printed version of ISO-4217:2001
         </region>
         <region iso3166="SL">
             <currency iso4217="SLE" from="2022-07-01"/>
-            <currency iso4217="SLL" from="1964-08-04" to="2023-03-31"/>
+            <currency iso4217="SLL" from="1964-08-04" to="2023-12-31"/>
             <currency iso4217="GBP" from="1808-11-30" to="1966-02-04"/>
         </region>
         <region iso3166="SM">


### PR DESCRIPTION
CLDR-16122

- Per https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/news/public-notice-redenomination-leone.pdf
- SLL is legal tender through 2023-12-31
- per Bank of Sierra Leone note 2023-03-10

(See CLDR-15900 for prior amendments)

ALLOW_MANY_COMMITS=true
