### PR TITLE
CLDR-16316 test: make it a warning if a currency code recently expired

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.DateConstants;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.InternalCldrException;
@@ -625,7 +626,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         }
 
         // For each territory, get all of its legal tender currencies.
-        Date now = new Date(System.currentTimeMillis());
+        Date now = DateConstants.NOW;
         scriptToCurrencies = new Relation(new HashMap<String, Set<String>>(), HashSet.class);
         for (Object curScript : scriptToTerritories.keySet()) {
             Set<String> territories = scriptToTerritories.get(curScript);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -25,6 +25,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.DateConstants;
 import org.unicode.cldr.util.DayPeriodInfo;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.EmojiConstants;
@@ -1844,12 +1845,10 @@ public class ExampleGenerator {
                     if (parts.contains("daylight")) {
                         tzOffset += currentZone.getDSTSavings();
                     }
-                    int MILLIS_PER_MINUTE = 1000 * 60;
-                    int MILLIS_PER_HOUR = MILLIS_PER_MINUTE * 60;
-                    int tm_hrs = tzOffset / MILLIS_PER_HOUR;
-                    int tm_mins = (tzOffset % MILLIS_PER_HOUR) / 60000; // millis per minute
+                    long tm_hrs = tzOffset / DateConstants.MILLIS_PER_HOUR;
+                    long tm_mins = (tzOffset % DateConstants.MILLIS_PER_HOUR) / DateConstants.MILLIS_PER_MINUTE;
                     result = setBackground(getMZTimeFormat() + " "
-                        + getGMTFormat(hourFormat, gmtFormat, tm_hrs, tm_mins));
+                        + getGMTFormat(hourFormat, gmtFormat, (int)tm_hrs, (int)tm_mins));
                 }
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriods.java
@@ -11,6 +11,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.DateConstants;
 import org.unicode.cldr.util.DayPeriodInfo;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.DayPeriodInfo.Span;
@@ -20,10 +21,10 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.With;
 import org.unicode.cldr.util.XPathParts;
+import static org.unicode.cldr.util.DateConstants.MILLIS_PER_DAY;
 
 public class GenerateDayPeriods {
     static final SupplementalDataInfo SDI = SupplementalDataInfo.getInstance();
-    private static final int MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
 
     public static void main(String[] args) throws IOException {
         try (PrintWriter out = FileUtilities.openUTF8Writer(CLDRPaths.GEN_DIRECTORY + "/supplemental", "dayPeriods.xml")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -137,6 +137,8 @@ public abstract class CLDRURLS {
 
     public static final String PRIORITY_SUMMARY_HELP_URL = "https://cldr.unicode.org/translation/getting-started/vetting-view#TOC-Priority-Items";
 
+    public static final String UPDATING_CURRENCY_CODES = "https://cldr.unicode.org/development/updating-codes/update-currency-codes";
+
     /**
      * Get the relative base URL for the SurveyTool.
      * This may be "/cldr-apps", for example.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateConstants.java
@@ -1,0 +1,23 @@
+package org.unicode.cldr.util;
+
+import java.util.Date;
+
+/**
+ * Some date related constants
+ */
+public class DateConstants {
+    /**
+     * Right now. A single constant so that it is consistent across callers.
+     */
+    public static final Date NOW = new Date();
+    public static final long MILLIS_PER_SECOND  = 60 * 1000;
+    public static final long MILLIS_PER_MINUTE  = MILLIS_PER_SECOND * 60;
+    public static final long MILLIS_PER_HOUR    = MILLIS_PER_MINUTE * 60;
+    public static final long MILLIS_PER_DAY     = MILLIS_PER_HOUR * 24;
+    public static final long MILLIS_PER_MONTH   = MILLIS_PER_DAY * 30;
+
+    /**
+     * A date a little less than 8 months ago.
+     */
+    public static final Date RECENT_HISTORY = new Date(NOW.getTime() - (MILLIS_PER_MONTH * 8));
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
@@ -351,9 +351,9 @@ public class DayPeriodInfo {
         return result.toString();
     }
 
-    public static String formatTime(int time) {
-        int minutes = time / (60 * 1000);
-        int hours = minutes / 60;
+    public static String formatTime(long time) {
+        long minutes = time / (60 * 1000);
+        long hours = minutes / 60;
         minutes -= hours * 60;
         return String.format("%02d:%02d", hours, minutes);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1434,13 +1434,13 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         recentMissing.retainAll(recentModernCurrencyCodes.keySet());
         if (recentMissing.size() != 0) {
             warnln("WARNING: Codes in ISO 4217 and until-recently legal tender in CLDR. " +
-                "(may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): " +
+                "(may need to update " + CLDRURLS.UPDATING_CURRENCY_CODES + " ): " +
                 currencyDateRelationToString(recentModernCurrencyCodes, recentMissing));
             missing.removeAll(recentMissing); // not errors
         }
         if (missing.size() != 0) {
             errln("Codes in ISO 4217 but not current tender in CLDR " +
-                "(may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): " +
+                "(may need to update " + CLDRURLS.UPDATING_CURRENCY_CODES + " ): " +
                 currencyDateRelationToString(nonModernCurrencyCodes, missing));
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1334,13 +1334,6 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     private static final Date LIMIT_FOR_NEW_CURRENCY = new Date(
         new Date().getYear() - 5, 1, 1);
-    private static final Date NOW = new Date();
-    private static final int MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
-    /**
-     * A year ago
-     */
-    private static final Date RECENT_HISTORY = new Date(NOW.getTime() - (MILLIS_PER_DAY*366));
-
     private Matcher oldMatcher = Pattern.compile(
         "\\bold\\b|\\([0-9]{4}-[0-9]{4}\\)", Pattern.CASE_INSENSITIVE)
         .matcher("");
@@ -1353,7 +1346,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
      *
      * @param args
      */
-    public void TestCurrency() {
+    public void TestSupplementalCurrency() {
         IsoCurrencyParser isoCodes = IsoCurrencyParser.getInstance();
         Set<String> currencyCodes = STANDARD_CODES
             .getGoodAvailableCodes("currency");
@@ -1402,9 +1395,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                 if (lastValue == null || lastValue.compareTo(end) > 0) {
                     currencyLastValid.put(currency, end);
                 }
-                if (start.compareTo(NOW) < 0 && end.compareTo(NOW) >= 0) { // Non-tender
-                    // is
-                    // OK...
+                if (start.compareTo(DateConstants.NOW) < 0 && end.compareTo(DateConstants.NOW) >= 0) { // Non-tender is OK...
                     modernCurrencyCodes.put(currency,
                         new Pair<>(territory,
                             dateInfo));
@@ -1413,7 +1404,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                     nonModernCurrencyCodes.put(currency,
                         new Pair<>(territory,
                             dateInfo));
-                    if (start.compareTo(NOW) < 0 && end.compareTo(RECENT_HISTORY) >= 0) {
+                    if (start.compareTo(DateConstants.NOW) < 0 && end.compareTo(DateConstants.RECENT_HISTORY) >= 0) {
                         // It was CLDR tender recently.
                         recentModernCurrencyCodes.put(currency,
                         new Pair<>(territory,
@@ -1444,17 +1435,13 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         if (recentMissing.size() != 0) {
             warnln("WARNING: Codes in ISO 4217 and until-recently legal tender in CLDR. " +
                 "(may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): " +
-                recentModernCurrencyCodes.entrySet().stream().filter(p -> recentMissing.contains(p.getKey()))
-                .map(p -> (p.getKey() + " ended=" + p.getValue().getSecond().getEnd()))
-                .collect(Collectors.joining(", ")));
+                currencyDateRelationToString(recentModernCurrencyCodes, recentMissing));
             missing.removeAll(recentMissing); // not errors
         }
         if (missing.size() != 0) {
             errln("Codes in ISO 4217 but not current tender in CLDR " +
                 "(may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): " +
-                nonModernCurrencyCodes.entrySet().stream().filter(p -> missing.contains(p.getKey()))
-                .map(p -> (p.getKey() + " ended=" + p.getValue().getSecond().getEnd()))
-                .collect(Collectors.joining(", ")));
+                currencyDateRelationToString(nonModernCurrencyCodes, missing));
         }
 
         for (String currency : modernCurrencyCodes.keySet()) {
@@ -1539,7 +1526,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                     Set<CurrencyDateInfo> currencyInfo = SUPPLEMENTAL
                         .getCurrencyDateInfo(territory);
                     for (CurrencyDateInfo dateInfo : currencyInfo) {
-                        if (dateInfo.getEnd().compareTo(NOW) < 0) {
+                        if (dateInfo.getEnd().compareTo(DateConstants.NOW) < 0) {
                             continue;
                         }
                         logln("\tCurrencies used instead: "
@@ -1565,6 +1552,12 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             errln("Modern territory missing currency: "
                 + territoriesWithoutModernCurrencies);
         }
+    }
+
+    private String currencyDateRelationToString(Relation<String, Pair<String, CurrencyDateInfo>> allCodes, Set<String> filter) {
+        return allCodes.entrySet().stream().filter(p -> filter.contains(p.getKey()))
+        .map(p -> p.getValue().getSecond().toString())
+        .collect(Collectors.joining(", "));
     }
 
     private void showCountries(final String title, Set<String> isoCountries,


### PR DESCRIPTION
- give 1 year for the ISO 4217 to be still in CLDR if it recently expired
- for example, the notice of extension for SLL only came the day after expiration
- also improve the output to include the actual expiration date

CLDR-16316

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true

-----

example output:

> `Warning: (TestSupplementalInfo.java:1445) WARNING: Codes in ISO 4217 and until-recently legal tender in CLDR. (may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): SLL end=Thu Mar 30 17:00:00 PDT 2023`

Previous error:

> `(TestSupplementalInfo.java:1428)  Error: Codes in ISO 4217 but not current tender in CLDR (may need to update https://cldr.unicode.org/development/updating-codes/update-currency-codes ): [SLL]`
