### PR TITLE
CLDR-16532 Ignore missing hidden notifications table if db is too old

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReviewHide.java
@@ -103,8 +103,11 @@ public class ReviewHide {
                 this.hiddenNotifications.put(subtype, xpstrid, val);
             }
         } catch (SQLException sqe) {
-            SurveyLog.logException(sqe, "Getting hidden notifications for uid#" + userId + " in " + localeId, null);
-            throw new InternalError("Error getting hidden notifications: " + sqe.getMessage());
+            // first version with cldr_dash_hide table is 42; silently ignore exceptions for earlier versions
+            if (Integer.parseInt(SurveyMain.getNewVersion()) >= 42) {
+                SurveyLog.logException(sqe, "Getting hidden notifications for uid#" + userId + " in " + localeId, null);
+                throw new InternalError("Error getting hidden notifications: " + sqe.getMessage());
+            }
         } finally {
             DBUtils.close(rs, s, conn);
         }


### PR DESCRIPTION
-Avoid throwing exception with db before version 42, for testing other features than hidden notifications

-Earlier versions had versioned tables like cldr_dash_hide_41 or cldr_review_hide_38

CLDR-16532

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
