### PR TITLE
CLDR-16549 BRS v43: Update ICU4J libs to 2023-04-06 with coll fix; update readme & spec dates

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|43 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2023-03-27|
+|Date|2023-04-05|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-68/tr35.html">https://www.unicode.org/reports/tr35/tr35-68/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-67/tr35.html">https://www.unicode.org/reports/tr35/tr35-67/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|

--- a/readme.html
+++ b/readme.html
@@ -12,7 +12,7 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 43</h3>
-    <p>Last updated: 2023-Mar-27</p>
+    <p>Last updated: 2023-Apr-06</p>
 
     <!--<p><b>Note:</b> CLDR 43 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 43, intended for those wishing to do pre-release testing.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>73.1-release-73-rc</icu4j.version>
+		<icu4j.version>73.1-cldr-2023-04-06</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-16549

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Update ICU4J libs to version of maint/maint-73 after merge of collation update for quotes. Update dates for readme, spec.

ALLOW_MANY_COMMITS=true
