### PR TITLE
CLDR-16538 B Revise the likely subtags chart

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -85,7 +85,7 @@ import com.ibm.icu.util.ULocale;
 @CLDRTool(alias = "showlanguages", description = "Generate Language info charts")
 public class ShowLanguages {
     private static final boolean SHOW_NATIVE = true;
-    private static final boolean DO_FIRST_ONLY = true;
+    private static final boolean DO_FIRST_ONLY = false;
 
     static Comparator col = new org.unicode.cldr.util.MultiComparator(
         Collator.getInstance(new ULocale("en")),

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -85,7 +85,7 @@ import com.ibm.icu.util.ULocale;
 @CLDRTool(alias = "showlanguages", description = "Generate Language info charts")
 public class ShowLanguages {
     private static final boolean SHOW_NATIVE = true;
-    private static final boolean DO_FIRST_ONLY = false;
+    private static final boolean DO_FIRST_ONLY = true;
 
     static Comparator col = new org.unicode.cldr.util.MultiComparator(
         Collator.getInstance(new ULocale("en")),
@@ -987,6 +987,8 @@ public class ShowLanguages {
             String result = english.getName(type, value);
             if (result == null) {
                 result = value;
+            } else {
+                result = result.replace("'", "’"); // we use the name for an anchor, so fix
             }
             return result;
         }


### PR DESCRIPTION
CLDR-16538

Notes for reviewers

- I did a bit of refactoring so that I could do more rapid turnaround. That involved inlining private static StringWriter printLanguageData(...), so that disappeared (lines 104...), plus a flag to exit early.
- The only substantive changes are at line 936 and following. I reordered the columns, reset the sorting priority, and dropped the setSpanRows(false).
- At line 958, I disabled the normal handling of 'und' for the target language, so that it would be in an appropriate place.
- At line 962, I reordered the data in the cells to match the column headers.

I uploaded to the the chart to cldr-staging so that the results can be checked. It should show up soon (check that the date says 2023-04-11) at https://cldr-smoke.unicode.org/staging-dev/charts/43/supplemental/likely_subtags.html .

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
