### PR TITLE
CLDR-16570 retire old cookies, use a jwt for keep-logged-in

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -148,6 +148,21 @@
 			<groupId>org.mybatis</groupId>
 			<artifactId>mybatis</artifactId>
 		</dependency>
+		<!-- jwt -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-gson</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AdminPanel.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AdminPanel.java
@@ -177,18 +177,10 @@ public class AdminPanel {
             return;
         }
         // zap any current login
-        Cookie c0 = WebContext.getCookie(request, SurveyMain.QUERY_EMAIL);
-        if (c0 != null) {
-            c0.setValue("");
-            c0.setMaxAge(0);
-            response.addCookie(c0);
-        }
-        Cookie c1 = WebContext.getCookie(request, SurveyMain.QUERY_PASSWORD);
-        if (c1 != null) {
-            c1.setValue("");
-            c1.setMaxAge(0);
-            response.addCookie(c1);
-        }
+        WebContext.clearCookie(request, response, SurveyMain.QUERY_EMAIL);
+        WebContext.clearCookie(request, response, SurveyMain.QUERY_PASSWORD);
+        WebContext.clearCookie(request, response, SurveyMain.COOKIE_SAVELOGIN);
+
         String orgs[] = UserRegistry.getOrgList();
         String myorg = orgs[(int) Math.rint(Math.random() * (orgs.length - 1))];
         JSONObject levels = new JSONObject();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/KeepLoggedInManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/KeepLoggedInManager.java
@@ -1,0 +1,181 @@
+package org.unicode.cldr.web;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.crypto.SecretKey;
+
+import org.apache.commons.io.FileUtils;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRConfigImpl;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+
+/**
+ * Manages the JWT used for staying logged in
+ */
+public class KeepLoggedInManager {
+    private static Logger logger = SurveyLog.forClass(KeepLoggedInManager.class);
+
+    /**
+     * Algorithm to use
+     */
+    private static final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithm.HS256;
+    /**
+     * Keyfile, just base64 encoded binary data
+     */
+    private static final String KEYFILE_NAME = KeepLoggedInManager.class.getName()+".key";
+    private final File keyFile;
+    private SecretKey key;
+
+    public static File getDefaultParent() {
+        final CLDRConfig config = CLDRConfig.getInstance();
+        if(config instanceof CLDRConfigImpl) {
+            File homeFile = CLDRConfigImpl.getInstance().getHomeFile();
+            if(homeFile == null) {
+                throw new IllegalArgumentException("CLDRConfigImpl present but getHomeFile() returned null.");
+            } else {
+                return homeFile;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Construct a KLM from the specified dir
+     * @param parentDir dir or null or the CLDRConfig default
+     */
+    public KeepLoggedInManager(File parentDir) throws IOException {
+        if (parentDir == null) {
+            parentDir = getDefaultParent();
+        }
+        if (parentDir == null) {
+            throw new NullPointerException("Can't find the parent dir for storing stuff.");
+        }
+
+        if (!parentDir.isDirectory()) {
+            throw new IllegalArgumentException("parent dir " + parentDir.getAbsolutePath() +" not a dir");
+        }
+
+        keyFile = new File(parentDir, KEYFILE_NAME);
+        logger.info("Setup with keyfile " + keyFile.getAbsolutePath());
+
+        if (keyFile.exists()) {
+            key = readKey(keyFile);
+        } else {
+            resetKey();
+        }
+
+        logger.info("Key read, fingerprint " + key.getAlgorithm() + "/"+key.getFormat());
+    }
+
+    synchronized void resetKey() throws IOException {
+        if (keyFile.exists()) {
+            keyFile.delete();
+        }
+        key = newSecretKey();
+        writeKey(keyFile, key);
+    }
+
+    private void writeKey(File f, SecretKey k) throws IOException {
+        FileUtils.write(f, Encoders.BASE64.encode(k.getEncoded()), StandardCharsets.US_ASCII);
+        f.setReadable(false, false); // nobody can read it...
+        f.setReadable(true, true);   // ...but the owner
+    }
+
+    private SecretKey readKey(File f) throws IOException {
+        final String s = FileUtils.readFileToString(f, StandardCharsets.US_ASCII);
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(s));
+    }
+
+    /**
+     * Request that a new key be installed.
+     */
+    private SecretKey newSecretKey() {
+        return Keys.secretKeyFor(SIGNATURE_ALGORITHM);
+    }
+
+    /**
+     * Testing only
+     * @return
+     */
+    SecretKey getKey() {
+        return key;
+    }
+
+    /**
+     * Create a JSON Web Token for the 'subject' (user ID #) specified.
+     * @param subject a user id, in this case "1234"
+     * @return JWT, see <https://jwt.io> for decoder
+     */
+    public String createJwtForSubject(String subject) {
+        final long now = System.currentTimeMillis();
+        return Jwts
+            .builder()
+            .setSubject(subject)
+            .signWith(key)
+            .setIssuedAt(new Date(now))
+            .setExpiration(new Date(now + (SurveyMain.TWELVE_WEEKS*1000L)))
+            .compact();
+    }
+
+    /**
+     * Testing only. Generates a JWT that already expired.
+     * @param subject
+     * @return
+     */
+    String createExpiredJwtForSubject(String subject) {
+        return Jwts
+            .builder()
+            .setSubject(subject)
+            .signWith(key)
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(0))
+            .compact();
+    }
+
+    /**
+     * Parse a JWT <https://jwt.io> string and return the subject.
+     * This is a simplified API, and returns null if ANY error occurred, such as malformed or expired jwt.
+     * @param jwt the jwt string
+     * @return the subject, such as "1234" or null if some error occurred.
+     */
+    public String getSubject(String jwt) {
+        if (jwt == null || jwt.isBlank()) {
+            return null;
+        }
+        Jws<Claims> c = getClaims(jwt);
+        if (c == null) {
+            // failed
+            return null;
+        }
+        return c.getBody().getSubject();
+    }
+
+    /**
+     * Advanced API, returns the underlying claims from the JWT.
+     * @param jwt the jwt
+     * @return the claims object
+     */
+    public Jws<Claims> getClaims(String jwt) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwt);
+            return claims;
+        } catch(JwtException e) {
+            logger.log(Level.FINE, "Error parsing JWT", e);
+            return null;
+        }
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -334,6 +334,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     // ======= query fields
     public static final String QUERY_PASSWORD = "pw";
     public static final String QUERY_EMAIL = "email";
+    public static final String COOKIE_SAVELOGIN = "stayloggedin";
     public static final String QUERY_PASSWORD_ALT = "uid";
     public static final String QUERY_SESSION = "s";
     public static final String QUERY_LOCALE = "_";
@@ -437,11 +438,14 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             ensureCldrToolsIsFunctioning();
             getDbInstance();
             SurveyThreadManager.getExecutorService().submit(this::doStartup);
+            klm = new KeepLoggedInManager(null);
         } catch (Throwable t) {
             SurveyLog.logException(logger, t, "Initializing SurveyTool");
             SurveyMain.busted("Error initializing SurveyTool.", t);
         }
     }
+
+    public KeepLoggedInManager klm = null;
 
     private void verifyConfigSanity() {
         CLDRConfig cconfig = CLDRConfigImpl.getInstance();
@@ -676,8 +680,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             registeredUser.printPasswordLink(ctx);
             ctx.println("<br><br><br><br><i>Note: this is a test account, and may be removed at any time.</i>");
             if (stayLoggedIn) {
-                ctx.addCookie(QUERY_EMAIL, u.email, TWELVE_WEEKS);
-                ctx.addCookie(QUERY_PASSWORD, u.getPassword(), TWELVE_WEEKS);
+                WebContext.loginRemember(response, u);
             } else {
                 WebContext.removeLoginCookies(request, response);
             }

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestKeepLoggedInManager.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestKeepLoggedInManager.java
@@ -1,0 +1,74 @@
+package org.unicode.cldr.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.Test;
+
+public class TestKeepLoggedInManager {
+    @Test
+    public void TestSaveKey() throws IOException {
+        final File dir = Files.createTempDirectory(TestKeepLoggedInManager.class.getSimpleName()).toFile();
+        dir.deleteOnExit();
+
+        KeepLoggedInManager klm = new KeepLoggedInManager(dir);
+
+        // create key.
+        SecretKey k1 = klm.getKey();
+        assertNotNull(k1);
+
+        // reset it
+        klm.resetKey();
+        SecretKey k2 = klm.getKey();
+        assertNotNull(k2);
+        assertNotEquals(k1, k2);
+
+        KeepLoggedInManager klm2 = new KeepLoggedInManager(dir);
+
+        assertEquals(klm.getKey(), klm2.getKey());
+    }
+
+    @Test
+    public void TestRandomJwt() throws IOException {
+        // test that we can generate a JWT using the 'usual' method and verify it
+        final File dir = Files.createTempDirectory(TestKeepLoggedInManager.class.getSimpleName()+"2").toFile();
+        dir.deleteOnExit();
+        // Will generate a random key. Check round trip.
+        KeepLoggedInManager klm = new KeepLoggedInManager(dir);
+
+        final String SUBJECT = "1234";
+        final String jwt = klm.createJwtForSubject(SUBJECT);
+        assertNotNull(jwt);
+        assertEquals(SUBJECT, klm.getSubject(jwt));
+    }
+
+    @Test
+    public void TestBadJwt() throws IOException {
+        // test that we can generate a JWT using the 'usual' method and verify it
+        final File dir = Files.createTempDirectory(TestKeepLoggedInManager.class.getSimpleName()+"3").toFile();
+        dir.deleteOnExit();
+        // Will generate a random key. Check round trip.
+        KeepLoggedInManager klm = new KeepLoggedInManager(dir);
+
+        // JWT with some other key
+        assertNull(klm.getSubject("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0IiwiaWF0IjoxNjgxNDEyODU4fQ.qYdLAYGPZUBGFaCZ4F4CP5erNPyU8EF8yrg2ONm1SRY"));
+
+        // JWT with a bad key
+        assertNull(klm.getSubject("not a real key"));
+        assertNull(klm.getSubject("≈"));
+
+        final String SUBJECT = "1234";
+        final String expiredJwt = klm.createExpiredJwtForSubject(SUBJECT);
+
+        // long expired JWT
+        assertNull(klm.getSubject(expiredJwt));
+    }
+}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -29,6 +29,8 @@
 		<httpcomponents-version>5.0.3</httpcomponents-version>
 		<!--  web-specific properties are under cldr-apps -->
 		<mysql.version>8.0.30</mysql.version>
+		<!-- jsonwebtoken.io -->
+		<jjwt.version>0.11.5</jjwt.version>
 	</properties>
 
 	<modules>
@@ -155,6 +157,23 @@
 				<groupId>org.mybatis</groupId>
 				<artifactId>mybatis</artifactId>
 				<version>3.5.6</version>
+			</dependency>
+
+			<!-- jwt -->
+			<dependency>
+				<groupId>io.jsonwebtoken</groupId>
+				<artifactId>jjwt-api</artifactId>
+				<version>${jjwt.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.jsonwebtoken</groupId>
+				<artifactId>jjwt-impl</artifactId>
+				<version>${jjwt.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.jsonwebtoken</groupId>
+				<artifactId>jjwt-gson</artifactId>
+				<version>${jjwt.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
- does not replace or modify the X-SurveyTool-Session
- JWT payload is just the subject with the user's id
- secret key is managed automatically

CLDR-16570

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
