### PR TITLE
CLDR-16577 fix typo in markdown

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -8,7 +8,6 @@
 |Date|2023-04-12|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-69/tr35.html">https://www.unicode.org/reports/tr35/tr35-68/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-68/tr35.html">https://www.unicode.org/reports/tr35/tr35-67/tr35.html</a>|
-=======
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|
 |Corrigenda|<a href="https://cldr.unicode.org/index/corrigenda">https://cldr.unicode.org/index/corrigenda</a>|
 |Latest Proposed Update|<a href="https://www.unicode.org/reports/tr35/proposed.html">https://www.unicode.org/reports/tr35/proposed.html</a></td></tr>


### PR DESCRIPTION
- leftover merge conflict marker

CLDR-16577

- [ ] This PR completes the ticket.