### PR TITLE
CLDR-16390 Bailey explainer

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInheritance.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInheritance.mjs
@@ -9,13 +9,14 @@ import * as cldrLoad from "./cldrLoad.js";
 let reasonStrings = null;
 
 /**
- * @returns Promise<Map<String,String>> map from reason enum to string
+ * @returns Promise<Map<String,Object>> map from reason enum to object
  */
 function getInheritanceReasonStrings() {
   if (reasonStrings === null) {
     reasonStrings = cldrAjax
       .doFetch(`api/xpath/inheritance/reasons`)
-      .then((v) => v.json());
+      .then((v) => v.json())
+      .then((r) => r.reduce((p, v) => ((p[v.reason] = v), p), {}));
   }
   return reasonStrings;
 }
@@ -33,7 +34,6 @@ async function explainInheritance(itemLocale, itemXpath) {
   const { items } = await r.json();
   let lastLocale = null;
   let lastPath = null;
-  let firstNone = false;
   for (let i = 0; i < items.length; i++) {
     const { locale, xpath, reason } = items[i];
     if (reason !== "none") {

--- a/tools/cldr-apps/js/src/esm/cldrInheritance.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInheritance.mjs
@@ -48,7 +48,7 @@ async function explainInheritance(itemLocale, itemXpath) {
       lastLocale = locale;
     }
     if (xpath && lastPath !== xpath) {
-      if (i !== 0 || xpath !== itemXpath) {
+      if (i === 0 || xpath !== itemXpath) {
         // Don't set newXpath for the first (current) xpath.
         items[i].newXpath = xpath;
       }

--- a/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
+++ b/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
@@ -118,14 +118,15 @@ export default {
     colorForReason(reason) {
       return (
         {
-          none: "gray",
-          value: "green",
-          itemAlias: "teal",
+          changedAttribute: "yellow",
           codeFallback: "red",
           constructed: "purple",
-          removedAttribute: "blue",
-          changedAttribute: "yellow",
+          fallback: "brown",
           inheritanceMarker: "orange",
+          itemAlias: "teal",
+          none: "gray",
+          removedAttribute: "blue",
+          value: "green",
         }[reason] || null
       );
     },

--- a/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
+++ b/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
@@ -21,6 +21,10 @@
           } in inheritance"
           v-bind:color="colorForReason(reason)"
         >
+          <template #dot v-if="!isTerminal(reason)">
+            <!-- nonterminal show as a down arrow -->
+            <i class="glyphicon glyphicon-circle-arrow-down" />
+          </template>
           <p v-bind:title="reason">
             <b class="locale" v-if="newLocale">{{ newLocale }}</b>
             <span class="reason" v-if="showReason">{{
@@ -37,9 +41,9 @@
           </p>
           <!-- only show on change -->
           <!-- <b v-if="locale" v-bind:title="Locale ID">{{ locale }}</b> -->
-          <p v-if="newXpath" class="xpath">
+          <div v-if="newXpath" class="xpath">
             {{ xpathFull }}
-          </p>
+          </div>
         </a-timeline-item>
       </a-timeline>
     </template>
@@ -125,12 +129,15 @@ export default {
         }[reason] || null
       );
     },
+    isTerminal(reason) {
+      return this.reasons[reason]?.terminal;
+    },
     go(locale, xpath) {
       const href = `#/${locale}//${xpath}`;
       window.location.assign(href);
     },
     getReason(reason, attribute) {
-      const r = this.reasons[reason] || reason;
+      const r = this.reasons[reason].description || reason;
       return cldrText.subTemplate(r, { attribute });
     },
   },
@@ -138,9 +145,9 @@ export default {
 </script>
 
 <style scoped>
-/* .inheritanceTimeline {
-  overflow-y: scroll;
-} */
+.xpath {
+  font-size: smaller;
+}
 
 .locale {
   padding-right: 0.5em;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Inheritance.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Inheritance.java
@@ -2,9 +2,8 @@ package org.unicode.cldr.web.api;
 
 import static org.unicode.cldr.web.CookieSession.sm;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -28,6 +27,30 @@ import org.unicode.cldr.util.StringId;
 @Path("/xpath/inheritance")
 @Tag(name = "xpath", description = "APIs for XPath info")
 public class Inheritance {
+    public static final class ReasonInfo {
+        ReasonInfo(LocaleInheritanceInfo.Reason v) {
+            this.reason = v.name();
+            this.terminal = v.isTerminal();
+            this.description = v.getDescription();
+        }
+
+        @Schema(description = "reason id", example = "codeFallback")
+        public final String reason;
+
+        @Schema(description = "true if a terminal reason", example = "true")
+        public final boolean terminal;
+
+        @Schema(
+                description =
+                        "Description for reason. String substitution of 'attribute' may be required.")
+        public final String description;
+    }
+
+    public static final ReasonInfo[] reasons =
+            Arrays.stream(LocaleInheritanceInfo.Reason.values())
+                    .map(v -> new ReasonInfo(v))
+                    .toArray(l -> new ReasonInfo[l]);
+
     @GET
     @Path("/reasons")
     @Produces(MediaType.APPLICATION_JSON)
@@ -36,18 +59,17 @@ public class Inheritance {
             value = {
                 @APIResponse(
                         responseCode = "200",
-                        description = "Array of possible alt values",
+                        description = "Array of possible reasons",
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = Map.class)))
+                                        schema =
+                                                @Schema(
+                                                        type = SchemaType.ARRAY,
+                                                        implementation = ReasonInfo.class)))
             })
     public Response getReasons() {
-        Map<String, String> map = new TreeMap<>();
-        for (final LocaleInheritanceInfo.Reason r : LocaleInheritanceInfo.Reason.values()) {
-            map.put(r.name(), r.getDescription());
-        }
-        return Response.ok(map).build();
+        return Response.ok(reasons).build();
     }
 
     @GET

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -570,10 +570,8 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         LinkedList<LocaleInheritanceInfo> list = new LinkedList<>();
         // first, call getSourceLocaleIdExtended to populate the list
         Status status = new Status();
-        final String locale1 = // for debugging
-                getSourceLocaleIdExtended(xpath, status, false, list);
+        getSourceLocaleIdExtended(xpath, status, false, list);
         final String path1 = status.pathWhereFound;
-        System.out.println("Path: " + path1 + ", loc: " + locale1);
         // For now, the only special case is Glossonym
         if (path1.equals(GlossonymConstructor.PSEUDO_PATH)) {
             // it's a Glossonym, so as the GlossonymConstructor what the paths are.  Sort paths in
@@ -712,6 +710,11 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         if (result == XMLSource.CODE_FALLBACK_ID && dataSource.isResolving()) {
             final String fallbackPath = getFallbackPath(distinguishedXPath, false, true);
             if (fallbackPath != null && !fallbackPath.equals(distinguishedXPath)) {
+                if (list != null) {
+                    list.add(
+                            new LocaleInheritanceInfo(
+                                    getLocaleID(), distinguishedXPath, Reason.fallback, null));
+                }
                 result =
                         dataSource.getSourceLocaleIdExtended(
                                 fallbackPath, status, skipInheritanceMarker, list);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleInheritanceInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleInheritanceInfo.java
@@ -25,9 +25,12 @@ public final class LocaleInheritanceInfo {
         constructed("Constructed value", false),
         none("The value was not found in this locale.", true),
         inheritanceMarker("Found: Inheritance marker", false),
-        removedAttribute("Removed attribute: ${attribute}", false), // such as alt
-        changedAttribute("Changed attribute: ${attribute}", false), // such as count
-        ;
+        removedAttribute("Removed attribute: ${attribute}", false),
+        changedAttribute("Changed attribute: ${attribute}", false),
+        /**
+         * @see CLDRFile#getFallbackPath - used for other fallback paths
+         */
+        fallback("Other fallback path", false);
 
         private String description;
         private boolean terminal;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleInheritanceInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleInheritanceInfo.java
@@ -1,23 +1,53 @@
 package org.unicode.cldr.util;
 
-/** A triple with information about why an inheritance worked the way it did */
+/** A class with information about why an inheritance worked the way it did */
 public final class LocaleInheritanceInfo {
     /** Reason this entry is there */
     public enum Reason {
-        value("Found: explicit value"),
-        codeFallback("Found: code fallback"),
-        alias("An alias was found at this location"),
-        constructed("Constructed value"),
-        none("The value was not found in this locale."),
-        inheritanceMarker("Found: Inheritance marker"),
-        removedAttribute("Removed attribute: ${attribute}"), // such as alt
-        changedAttribute("Changed attribute: ${attribute}"), // such as count
+        /**
+         * An actual value was found in the XML source. This is never returned for constructed or
+         * other synthesized values.
+         */
+        value("Found: explicit value", true),
+        /**
+         * codeFallback does not have a locale, it is effectively the parent of 'root'. A value was
+         * calculated according to the specification.
+         */
+        codeFallback("Found: code fallback", true),
+        /**
+         * This shows the location where an alias was found which affected the inheritance chain.
+         */
+        alias("An alias was found at this location", false),
+        /**
+         * Constructed entries form a block. All such values are in place of the actual constructed
+         * value.
+         */
+        constructed("Constructed value", false),
+        none("The value was not found in this locale.", true),
+        inheritanceMarker("Found: Inheritance marker", false),
+        removedAttribute("Removed attribute: ${attribute}", false), // such as alt
+        changedAttribute("Changed attribute: ${attribute}", false), // such as count
         ;
 
         private String description;
+        private boolean terminal;
 
-        Reason(String description) {
+        /**
+         * An entry is 'terminal' if it represents the end of a successful look up chain. A
+         * nonterminal entry merely contributes to the look up. Only terminal entries will
+         * correspond to a return value from {@link CLDRFile#getSourceLocaleIdExtended(String,
+         * org.unicode.cldr.util.CLDRFile.Status, boolean)} for example. Entries following a
+         * terminal entry are the start of a bailey value.
+         *
+         * @return
+         */
+        public boolean isTerminal() {
+            return terminal;
+        }
+
+        Reason(String description, boolean terminal) {
             this.description = description;
+            this.terminal = terminal;
         }
 
         public String getDescription() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -1115,11 +1115,17 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                         if (list == null) {
                             return new AliasLocation(xpath, localeID);
                         }
-                        list.add(new LocaleInheritanceInfo(localeID, xpath, Reason.value));
+                        if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
+                            list.add(
+                                    new LocaleInheritanceInfo(
+                                            localeID, xpath, Reason.inheritanceMarker));
+                        } else {
+                            list.add(new LocaleInheritanceInfo(localeID, xpath, Reason.value));
+                        }
                         // Now, keep looping to add additional Bailey values.
                         // Note that we will typically exit the recursion (terminal state)
                         // with Reason.codeFallback or Reason.none
-                        if (firstValue != null) {
+                        if (firstValue == null) {
                             // Save this, this will eventually be the function return.
                             firstValue = new AliasLocation(xpath, localeID);
                             // Everything else is only for Bailey.


### PR DESCRIPTION
- update the implementations behind getPathsForValue to keep going when a hard value is hit. Won't affect getSourceLocale, etc, return values,
but will populate the tracing list with additional values.

- [ ] This PR completes the ticket

CLDR-16390

ALLOW_MANY_COMMITS=true

-----
Example output:

```
• //ldml/localeDisplayNames/territories/territory[@type="PM"]
• 576f1c82a03a22a8
• Value: Saint-Pierre-et-Miquelon
• Inheritance chain:
  • value: en_CA://ldml/localeDisplayNames/territories/territory[@type="PM"]
  • value: en://ldml/localeDisplayNames/territories/territory[@type="PM"]
  • none: root://ldml/localeDisplayNames/territories/territory[@type="PM"]
  • codeFallback: //ldml/localeDisplayNames/territories/territory[@type="PM"]
```

