### PR TITLE
CLDR-16560 Requirements for storing inheritance marker

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -565,9 +565,7 @@ public class DataPage {
             if (value == null) {
                 return null;
             }
-            if (VoteResolver.DROP_HARD_INHERITANCE
-                    && value.equals(inheritedValue)
-                    && !inheritsFromRootOrFallback()) {
+            if (VoteResolver.DROP_HARD_INHERITANCE && value.equals(inheritedValue)) {
                 value = CldrUtility.INHERITANCE_MARKER;
             }
             CandidateItem item = items.get(value);
@@ -585,15 +583,13 @@ public class DataPage {
             if (winningValue != null && winningValue.equals(value)) {
                 winningItem = item;
             }
-            if (baselineValue != null && baselineValue.equals(value)) {
+            if (baselineValue != null
+                    && (baselineValue.equals(value)
+                            || (CldrUtility.INHERITANCE_MARKER.equals(value)
+                                    && baselineValue.equals(inheritedValue)))) {
                 item.isBaselineValue = true;
             }
             return item;
-        }
-
-        private boolean inheritsFromRootOrFallback() {
-            String loc = inheritedLocale.getBaseName();
-            return XMLSource.ROOT_ID.equals(loc) || XMLSource.CODE_FALLBACK_ID.equals(loc);
         }
 
         /** Calculate the hash used for HTML forms for this DataRow. */
@@ -1914,10 +1910,6 @@ public class DataPage {
          * baselineValue, or because it has votes), then "add" it again here so that we have myItem and
          * will call setTests.
          *
-         * Also, if inherited value is from root or code-fallback, then we still need a candidate item that's
-         * non-inherited to avoid errors about inheriting from root/fallback, and to match the winning value
-         * which might be not be INHERITANCE_MARKER even though it matches the bailey value.
-         *
          * TODO: It would be better to consolidate where setTests is called for all items, to ensure
          * it's called once and only once for each item that needs it.
          */
@@ -1925,8 +1917,7 @@ public class DataPage {
         if (ourValue != null) {
             if (!VoteResolver.DROP_HARD_INHERITANCE
                     || !ourValue.equals(row.inheritedValue)
-                    || row.items.get(ourValue) != null
-                    || row.inheritsFromRootOrFallback()) {
+                    || row.items.get(ourValue) != null) {
                 myItem = row.addItem(ourValue, "our");
                 if (DEBUG) {
                     System.err.println(

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -1059,6 +1059,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 VoteType voteType)
                 throws BallotBox.InvalidXPathException, BallotBox.VoteNotAcceptedException {
             makeSureInPathsForFile(distinguishingXpath, user, value);
+            value = reviseInheritanceAsNeeded(distinguishingXpath, value);
             SurveyLog.debug(
                     "V4v: "
                             + locale
@@ -1135,6 +1136,26 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             if (newVal != null && !newVal.equals(oldVal)) {
                 xmlsource.notifyListeners(distinguishingXpath);
             }
+        }
+
+        /**
+         * Get the possibly modified value. If value matches the bailey value or inheritance marker,
+         * possibly change it from bailey value to inheritance marker, or vice-versa, as needed to
+         * meet requirements described and implemented in VoteResolver.
+         *
+         * @param path the path
+         * @param value the input value
+         * @return the possibly modified value
+         */
+        private String reviseInheritanceAsNeeded(String path, String value) {
+            if (value != null) {
+                CLDRFile cldrFile = getFile(true);
+                if (cldrFile == null) {
+                    throw new InternalCldrException("getFile failure in reviseInheritanceAsNeeded");
+                }
+                value = VoteResolver.reviseInheritanceAsNeeded(path, value, cldrFile);
+            }
+            return value;
         }
 
         /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.util;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.text.Collator;
+import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
 import java.sql.Timestamp;
 import java.util.*;
@@ -53,7 +54,7 @@ import org.unicode.cldr.util.VettingViewer.VoteStatus;
  * </pre>
  */
 public class VoteResolver<T> {
-    public static final boolean DROP_HARD_INHERITANCE = false;
+    public static final boolean DROP_HARD_INHERITANCE = true;
 
     private final VoterInfoList voterInfoList;
 
@@ -2206,5 +2207,55 @@ public class VoteResolver<T> {
             }
         }
         return status;
+    }
+    /**
+     * Get the possibly modified value. If value matches the bailey value or inheritance marker,
+     * possibly change it from bailey value to inheritance marker, or vice-versa, as needed to meet
+     * these requirements: 1. If the path changes when getting bailey, then we are inheriting
+     * sideways. We need to use a hard value. 2. If the value is different from the bailey value,
+     * can't use inheritance; we need a hard value. 3. Otherwise we use inheritance marker.
+     *
+     * <p>These requirements are pragmatic, to work around limitations of the current inheritance
+     * algorithm, which is hyper-sensitive to the distinction between inheritance marker and bailey,
+     * which, depending on that distinction, unintentionally tends to change lateral inheritance to
+     * vertical inheritance, or vice-versa.
+     *
+     * <p>This method has consequences affecting vote resolution. For example, assume
+     * DROP_HARD_INHERITANCE is true. If a user votes for what is currently the inherited value, and
+     * these requirements call for using inheritance marker, then their vote is stored as
+     * inheritance marker in the db; if the parent value then changes (even during same release
+     * cycle), the vote is still a vote for inheritance -- that is how soft inheritence has long
+     * been intended to work. In the cases where this method returns the hard value matching bailey,
+     * the user's vote is stored in the db as that hard value; if the parent value then changes, the
+     * user's vote does not change -- this differs from what we'd like ideally (which is for all
+     * inh. votes to be "soft"). If and when the inheritance algorithm changes to reduce or
+     * eliminate the problematic aspects of the hard/soft distinction, this method might no longer
+     * be needed.
+     *
+     * <p>Reference: https://unicode-org.atlassian.net/browse/CLDR-16560
+     *
+     * @param path the path
+     * @param value the input value
+     * @param cldrFile the CLDRFile for determining inheritance
+     * @return the possibly modified value
+     */
+    public static String reviseInheritanceAsNeeded(String path, String value, CLDRFile cldrFile) {
+        if (!DROP_HARD_INHERITANCE) {
+            return value;
+        }
+        if (!cldrFile.isResolved()) {
+            throw new InternalCldrException("must be resolved");
+        }
+        Output<String> pathWhereFound = new Output<>();
+        Output<String> localeWhereFound = new Output<>();
+        String baileyValue = cldrFile.getBaileyValue(path, pathWhereFound, localeWhereFound);
+        if (baileyValue != null
+                && (CldrUtility.INHERITANCE_MARKER.equals(value) || baileyValue.equals(value))) {
+            value =
+                    pathWhereFound.value.equals(path)
+                            ? CldrUtility.INHERITANCE_MARKER
+                            : baileyValue;
+        }
+        return value;
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.ibm.icu.util.Output;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.unittest.TestUtilities;
 import org.unicode.cldr.util.VoteResolver.Status;
@@ -42,5 +43,95 @@ public class TestVoteResolver {
 
     private VoteResolver<String> getStringResolver() {
         return new VoteResolver<String>(TestUtilities.getTestVoterInfoList());
+    }
+
+    /**
+     * Test VoteResolver.reviseInheritanceAsNeeded
+     *
+     * <p>Inheritance marker should remain unchanged if pathWhereFound.value.equals(path).
+     *
+     * <p>Bailey should change to inheritance marker if pathWhereFound.value.equals(path).
+     *
+     * <p>Inheritance marker should change to bailey if !pathWhereFound.value.equals(path).
+     *
+     * <p>Bailey should remain unchanged if !pathWhereFound.value.equals(path).
+     *
+     * <p>Any other value should remain unchanged no matter what.
+     */
+    @Test
+    public void testReviseInheritance() {
+        if (!VoteResolver.DROP_HARD_INHERITANCE) {
+            return;
+        }
+        final String localeId = "fr_CA";
+        final CLDRFile cldrFile = CLDRConfig.getInstance().getCLDRFile(localeId, true);
+
+        // Go through all paths until we have tested one for which pathWhereFound is the same,
+        // and another one for which pathWhereFound is different
+        boolean gotSamePath = false, gotDifferentPath = false;
+        for (String path : cldrFile.fullIterable()) {
+            Output<String> pathWhereFound = new Output<>();
+            String baileyValue = cldrFile.getBaileyValue(path, pathWhereFound, null);
+            if (baileyValue == null) {
+                continue;
+            }
+            String anyOtherValue = "x" + baileyValue; // anything but bailey or inheritance marker
+            if (pathWhereFound.value.equals(path)) {
+                if (!gotSamePath) {
+                    gotSamePath = true;
+                    testSamePath(path, baileyValue, anyOtherValue, cldrFile);
+                }
+            } else {
+                if (!gotDifferentPath) {
+                    gotDifferentPath = true;
+                    testDifferentPath(path, baileyValue, anyOtherValue, cldrFile);
+                }
+            }
+            if (gotSamePath && gotDifferentPath) {
+                return;
+            }
+        }
+        assertTrue(gotSamePath);
+        assertTrue(gotDifferentPath);
+    }
+
+    private void testSamePath(
+            String path, String baileyValue, String anyOtherValue, CLDRFile cldrFile) {
+        String value1 =
+                VoteResolver.reviseInheritanceAsNeeded(
+                        path, CldrUtility.INHERITANCE_MARKER, cldrFile);
+        assertEquals(
+                CldrUtility.INHERITANCE_MARKER,
+                value1,
+                "inheritance marker should remain unchanged");
+
+        String value2 = VoteResolver.reviseInheritanceAsNeeded(path, baileyValue, cldrFile);
+        assertEquals(
+                CldrUtility.INHERITANCE_MARKER,
+                value2,
+                "bailey should change to inheritance marker");
+
+        String value3 = VoteResolver.reviseInheritanceAsNeeded(path, anyOtherValue, cldrFile);
+        assertEquals(
+                anyOtherValue,
+                value3,
+                "any other value should remain unchanged when paths are same");
+    }
+
+    private void testDifferentPath(
+            String path, String baileyValue, String anyOtherValue, CLDRFile cldrFile) {
+        String value1 =
+                VoteResolver.reviseInheritanceAsNeeded(
+                        path, CldrUtility.INHERITANCE_MARKER, cldrFile);
+        assertEquals(baileyValue, value1, "inheritance marker should change to bailey");
+
+        String value2 = VoteResolver.reviseInheritanceAsNeeded(path, baileyValue, cldrFile);
+        assertEquals(baileyValue, value2, "bailey should remain unchanged");
+
+        String value3 = VoteResolver.reviseInheritanceAsNeeded(path, anyOtherValue, cldrFile);
+        assertEquals(
+                anyOtherValue,
+                value3,
+                "any other value should remain unchanged when paths are different");
     }
 }


### PR DESCRIPTION
-Change VoteResolver.DROP_HARD_INHERITANCE to true

-When needed to meet requirements, change INHERITANCE_MARKER to Bailey or vice-versa

-New method STFactory.PerLocaleData.reviseInheritanceAsNeeded called by setValueFromResolver

-New method VoteResolver.reviseInheritanceAsNeeded called by STFactory.PerLocaleData.reviseInheritanceAsNeeded

-New unit test TestVoteResolver.testReviseInheritance for VoteResolver.reviseInheritanceAsNeeded

-Remove DataPage.DataRow.inheritsFromRootOrFallback, no longer necessary or appropriate

-Make isBaselineValue true for inheritance marker in DataPage.DataRow.addItem when appropriate to display star

-Comments

CLDR-16560

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
