### PR TITLE
CLDR-16622 add SimpleXPathParts and abstract parser, for deadlock

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXPathParts.java
@@ -1,0 +1,66 @@
+package org.unicode.cldr.util;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/** Like {@link XPathParts} but does not depend on DTDs, etc. Safe for use at startup. */
+public class SimpleXPathParts extends XPathParser {
+
+    private final class Element {
+        public final String name;
+        public final Map<String, String> attributes = new TreeMap<>();
+
+        public Element(String name) {
+            this.name = name;
+        }
+    }
+
+    final List<Element> elements = new LinkedList<>();
+
+    @Override
+    public String getElement(int i) {
+        if (i < 0) {
+            i = elements.size() + i;
+        }
+        return elements.get(i).name;
+    }
+
+    @Override
+    public String getAttributeValue(int i, String attribute) {
+        if (i < 0) {
+            i = elements.size() + i;
+        }
+        return elements.get(i).attributes.get(attribute);
+    }
+
+    @Override
+    protected void handleClearElements() {
+        elements.clear();
+    }
+
+    @Override
+    protected void handleAddElement(String element) {
+        elements.add(new Element(element));
+    }
+
+    @Override
+    protected void handleAddAttribute(String attribute, String value) {
+        elements.get(elements.size() - 1).attributes.put(attribute, value);
+    }
+
+    SimpleXPathParts(String xpath) {
+        handleParse(xpath, true);
+    }
+
+    /**
+     * for API compatibility
+     *
+     * @param xpath
+     * @return
+     */
+    static SimpleXPathParts getFrozenInstance(String xpath) {
+        return new SimpleXPathParts(xpath);
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Validity.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Validity.java
@@ -79,7 +79,7 @@ public class Validity {
 
             XMLFileReader.loadPathValues(basePath + file, lineData, true);
             for (Pair<String, String> item : lineData) {
-                XPathParts parts = XPathParts.getFrozenInstance(item.getFirst());
+                XPathValue parts = SimpleXPathParts.getFrozenInstance(item.getFirst());
                 if (!"id".equals(parts.getElement(-1))) {
                     continue;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParser.java
@@ -1,0 +1,120 @@
+package org.unicode.cldr.util;
+
+/** This class implements the parsing for XPaths */
+public abstract class XPathParser implements XPathValue {
+    /**
+     * Parse a string component. Will call handleXX() functions when parsed.
+     *
+     * @param xPath the path string
+     * @param initial boolean, if true, will call clearElements() before adding, and make
+     *     requiredPrefix // instead of /
+     */
+    protected void handleParse(String xPath, boolean initial) {
+        String lastAttributeName = "";
+        String requiredPrefix = "/";
+        if (initial) {
+            handleClearElements();
+            requiredPrefix = "//";
+        }
+        if (!xPath.startsWith(requiredPrefix)) {
+            parseError(xPath, 0);
+        }
+        int stringStart = requiredPrefix.length(); // skip prefix
+        char state = 'p';
+        // since only ascii chars are relevant, use char
+        int len = xPath.length();
+        for (int i = 2; i < len; ++i) {
+            char cp = xPath.charAt(i);
+            if (cp != state && (state == '\"' || state == '\'')) {
+                continue; // stay in quotation
+            }
+            switch (cp) {
+                case '/':
+                    if (state != 'p' || stringStart >= i) {
+                        parseError(xPath, i);
+                    }
+                    if (stringStart > 0) {
+                        handleAddElement(xPath.substring(stringStart, i));
+                    }
+                    stringStart = i + 1;
+                    break;
+                case '[':
+                    if (state != 'p' || stringStart >= i) {
+                        parseError(xPath, i);
+                    }
+                    if (stringStart > 0) {
+                        handleAddElement(xPath.substring(stringStart, i));
+                    }
+                    state = cp;
+                    break;
+                case '@':
+                    if (state != '[') {
+                        parseError(xPath, i);
+                    }
+                    stringStart = i + 1;
+                    state = cp;
+                    break;
+                case '=':
+                    if (state != '@' || stringStart >= i) {
+                        parseError(xPath, i);
+                    }
+                    lastAttributeName = xPath.substring(stringStart, i);
+                    state = cp;
+                    break;
+                case '\"':
+                case '\'':
+                    if (state == cp) { // finished
+                        if (stringStart > i) {
+                            parseError(xPath, i);
+                        }
+                        handleAddAttribute(lastAttributeName, xPath.substring(stringStart, i));
+                        state = 'e';
+                        break;
+                    }
+                    if (state != '=') {
+                        parseError(xPath, i);
+                    }
+                    stringStart = i + 1;
+                    state = cp;
+                    break;
+                case ']':
+                    if (state != 'e') {
+                        parseError(xPath, i);
+                    }
+                    state = 'p';
+                    stringStart = -1;
+                    break;
+            }
+        }
+        // check to make sure terminated
+        if (state != 'p' || stringStart >= xPath.length()) {
+            parseError(xPath, xPath.length());
+        }
+        if (stringStart > 0) {
+            handleAddElement(xPath.substring(stringStart, xPath.length()));
+        }
+    }
+
+    /**
+     * Standardized code for throwing a parse error
+     *
+     * @param s
+     * @param i
+     */
+    protected void parseError(String s, int i) {
+        throw new IllegalArgumentException("Malformed xPath '" + s + "' at " + i);
+    }
+
+    /** Subclass implementation */
+    protected abstract void handleClearElements();
+
+    /**
+     * Subclass implementation
+     *
+     * @param element
+     */
+    protected abstract void handleAddElement(String element);
+
+    /** Subclass implementation */
+    protected abstract void handleAddAttribute(String attribute, String value);
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathValue.java
@@ -1,0 +1,14 @@
+package org.unicode.cldr.util;
+
+/** This is an interface for a read-only XPath. */
+public interface XPathValue {
+
+    /** Get the nth element. Negative values are from end */
+    String getElement(int i);
+
+    /**
+     * Get the attributeValue for the attrbute at the nth element (negative index is from end).
+     * Returns null if there's nothing.
+     */
+    String getAttributeValue(int i, String string);
+}


### PR DESCRIPTION
CLDR-16622

Note:
- #2888 fixed the SurveyTool part that exacerbated this
- this implements a minimal SimpleXPathParts class needed for Validity. There may be other clients and improvements.
- There is not a conformance test between XPathParts and SimpleXPathParts.  That should be done before the ticket is closed.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
