### PR TITLE
CLDR-16628 BRS 43.1: update CLDR version, ICU4J libs, readme date

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -42,7 +42,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "43" >
+<!ATTLIST version cldrVersion CDATA #FIXED "43.1" >
     <!--@MATCH:any-->
     <!--@VALUE-->
 <!ATTLIST version draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/dtd/ldmlBCP47.dtd
+++ b/common/dtd/ldmlBCP47.dtd
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "43" >
+<!ATTLIST version cldrVersion CDATA #FIXED "43.1" >
     <!--@MATCH:version-->
     <!--@VALUE-->
 

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "43" >
+<!ATTLIST version cldrVersion CDATA #FIXED "43.1" >
     <!--@MATCH:version-->
     <!--@VALUE-->
 <!ATTLIST version unicodeVersion CDATA #FIXED "15.0.0" >

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -23,7 +23,7 @@ Please view the subcommittee page for the most recent information.
 <!ATTLIST version number CDATA #REQUIRED >
     <!--@MATCH:regex/\$Revision.*\$-->
     <!--@METADATA-->
-<!ATTLIST version cldrVersion CDATA #FIXED "43" >
+<!ATTLIST version cldrVersion CDATA #FIXED "43.1" >
     <!--@MATCH:version-->
     <!--@METADATA-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.unicode.cldr</groupId>
 	<artifactId>cldr-data</artifactId>
-	<version>43.0</version>
+	<version>43.1</version>
 	<name>CLDR Top Level and Data</name>
 	<packaging>pom</packaging>
 	<licenses>

--- a/readme.html
+++ b/readme.html
@@ -11,17 +11,17 @@
 
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
-    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 43</h3>
-    <p>Last updated: 2023-Apr-10</p>
+    <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 43.1</h3>
+    <p>Last updated: 2023-May-03</p>
 
-    <!--<p><b>Note:</b> CLDR 43 is in development and not recommended for use at this stage.</p>-->
-    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 43, intended for those wishing to do pre-release testing.
+    <!--<p><b>Note:</b> CLDR 43.1 is in development and not recommended for use at this stage.</p>-->
+    <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 43.1, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a preliminary version of CLDR 43, intended for those wishing to do pre-release testing.
+    <!--<p><b>Note:</b> This is a preliminary version of CLDR 43.1, intended for those wishing to do pre-release testing.
     It is not recommended for production use.</p>-->
-    <!--<p><b>Note:</b> This is a pre-release candidate version of CLDR 43, intended for testing.
-    It is not recommended for production use.</p>-->
-    <p>This is the final release version of CLDR 43.</p>
+   <p><b>Note:</b> This is a pre-release candidate version of CLDR 43.1, intended for testing.
+    It is not recommended for production use.</p>
+     <!--<p>This is the final release version of CLDR 43.1.</p>-->
 
     <p><strong>Important notes for CLDR 36 and later:</strong></p>
     <ul>

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.unicode.cldr</groupId>
 		<artifactId>cldr-all</artifactId>
-		<version>43.0</version>
+		<version>43.1</version>
 	</parent>
 
 	<dependencies>

--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.unicode.cldr</groupId>
 		<artifactId>cldr-all</artifactId>
-		<version>43.0</version>
+		<version>43.1</version>
 	</parent>
 
 	<dependencies>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -123,7 +123,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     public static final String SUPPLEMENTAL_NAME = "supplementalData";
     public static final String SUPPLEMENTAL_METADATA = "supplementalMetadata";
     public static final String SUPPLEMENTAL_PREFIX = "supplemental";
-    public static final String GEN_VERSION = "43";
+    public static final String GEN_VERSION = "43.1";
     public static final List<String> SUPPLEMENTAL_NAMES = Arrays.asList("characters", "coverageLevels", "dayPeriods", "genderList", "grammaticalFeatures",
         "languageInfo",
         "languageGroup", "likelySubtags", "metaZones", "numberingSystems", "ordinals", "pluralRanges", "plurals", "postalCodeData", "rgScope",

--- a/tools/cldr-rdf/pom.xml
+++ b/tools/cldr-rdf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.unicode.cldr</groupId>
         <artifactId>cldr-all</artifactId>
-        <version>43.0</version>
+        <version>43.1</version>
     </parent>
 
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.unicode.cldr</groupId>
 	<artifactId>cldr-all</artifactId>
-	<version>43.0</version>
+	<version>43.1</version>
 	<name>CLDR All Tools</name>
 	<packaging>pom</packaging>
 	<licenses>
@@ -22,7 +22,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>73.1-cldr-2023-04-10</icu4j.version>
+		<icu4j.version>73.1-release-73-1</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-16628

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Update maint/maint-43 branch to use version 43.1 (except that spec stays at 43). Update ICU4J libs to latest. Update readme.html date and status.

ALLOW_MANY_COMMITS=true
