### PR TITLE
CLDR-13180 st: use DAIP for English, Root, Others

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.js
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.js
@@ -513,7 +513,7 @@ function updateRowVoteInfo(tr, theRow) {
        * theRow.inheritedValue can be undefined here; then do not append
        */
       if (theRow.inheritedValue) {
-        cldrVote.appendItem(valdiv, theRow.inheritedValue, item.pClass);
+        cldrVote.appendItem(valdiv, theRow.inheritedDisplayValue, item.pClass);
         valdiv.appendChild(
           cldrDom.createChunk(cldrText.get("voteInfo_votesForInheritance"), "p")
         );
@@ -787,7 +787,7 @@ function showItemInfoFn(theRow, item) {
     var h3 = document.createElement("div");
     var displayValue = item.value;
     if (item.value === cldrSurvey.INHERITANCE_MARKER) {
-      displayValue = theRow.inheritedValue;
+      displayValue = theRow.inheritedDisplayValue;
     }
 
     cldrVote.appendItem(h3, displayValue, item.pClass);

--- a/tools/cldr-apps/js/src/esm/cldrTable.js
+++ b/tools/cldr-apps/js/src/esm/cldrTable.js
@@ -864,7 +864,7 @@ function updateRowOthersCell(tr, theRow, cell, protoButton, formAdd) {
     copyWinning.onclick = function (e) {
       let theValue = getValidWinningValue(theRow);
       if (theValue === cldrSurvey.INHERITANCE_MARKER || theValue === null) {
-        theValue = theRow.inheritedValue;
+        theValue = theRow.inheritedDisplayValue;
       }
       input.value = theValue || null;
       input.focus();
@@ -995,7 +995,7 @@ function updateRowOthersCell(tr, theRow, cell, protoButton, formAdd) {
 function addVitem(td, tr, theRow, item, newButton) {
   let displayValue = item.value;
   if (displayValue === cldrSurvey.INHERITANCE_MARKER) {
-    displayValue = theRow.inheritedValue;
+    displayValue = theRow.inheritedDisplayValue;
   }
   if (!displayValue && displayValue !== "") {
     return;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
@@ -53,13 +53,22 @@ public interface BallotBox<T> {
         }
     }
 
+    /**
+     * @param value raw (non-display) value
+     */
     public void voteForValue(T user, String distinguishingXpath, String value)
             throws InvalidXPathException, VoteNotAcceptedException;
 
+    /**
+     * @param value raw (non-display) value
+     */
     public void voteForValueWithType(
             T user, String distinguishingXpath, String value, VoteType voteType)
             throws VoteNotAcceptedException, InvalidXPathException;
 
+    /**
+     * @param value raw (non-display) value
+     */
     public void voteForValueWithType(
             T user, String distinguishingXpath, String value, Integer withVote, VoteType voteType)
             throws InvalidXPathException, VoteNotAcceptedException;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -408,7 +408,11 @@ public class DataPage {
             return coverageValue;
         }
 
+        /** the displayName is the value of the 'English' column. */
         private final String displayName;
+
+        /** Same as displayName, but unprocessed */
+        private final String rawEnglish;
 
         // these apply to the 'winning' item, if applicable
         boolean hasErrors = false;
@@ -437,6 +441,13 @@ public class DataPage {
 
         public String getInheritedValue() {
             return inheritedValue;
+        }
+
+        private String inheritedDisplayValue = null;
+
+        /** like getInheritedValue(), but processed */
+        public String getInheritedDisplayValue() {
+            return inheritedDisplayValue;
         }
 
         /** The winning item for this DataRow. */
@@ -520,7 +531,8 @@ public class DataPage {
             baselineValue = resolver.getBaselineValue();
             baselineStatus = resolver.getBaselineStatus();
 
-            this.displayName = comparisonValueFile.getStringValue(xpath);
+            rawEnglish = comparisonValueFile.getStringValue(xpath);
+            displayName = getProcessor().processForDisplay(xpath, rawEnglish);
         }
 
         /**
@@ -608,6 +620,10 @@ public class DataPage {
 
         public String getDisplayName() {
             return displayName;
+        }
+
+        public String getRawEnglish() {
+            return rawEnglish;
         }
 
         /** Get the locale for this DataRow */
@@ -759,6 +775,7 @@ public class DataPage {
                  */
                 // System.out.println("Warning: no inherited value in updateInheritedValue; xpath =
                 // " + xpath);
+                inheritedDisplayValue = null;
             } else {
                 /*
                  * Unless this DataRow already has an item with value INHERITANCE_MARKER,
@@ -783,6 +800,7 @@ public class DataPage {
                         System.err.println("@@3:" + (System.currentTimeMillis() - lastTime));
                     }
                 }
+                inheritedDisplayValue = getProcessor().processForDisplay(xpath, inheritedValue);
             }
             if ((checkCldr != null) && (inheritedItem != null) && (inheritedItem.tests == null)) {
                 if (TRACE_TIME) {
@@ -848,15 +866,14 @@ public class DataPage {
         }
 
         public String getHelpHTML() {
-            return nativeExampleGenerator.getHelpHtml(xpath, this.displayName);
+            return nativeExampleGenerator.getHelpHtml(xpath, rawEnglish);
         }
 
         public String getDisplayExample() {
             String displayExample = null;
             if (displayName != null) {
                 displayExample =
-                        sm.getComparisonValuesExample()
-                                .getNonTrivialExampleHtml(xpath, displayName);
+                        sm.getComparisonValuesExample().getNonTrivialExampleHtml(xpath, rawEnglish);
             }
             return displayExample;
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -175,12 +175,14 @@ public class VoteAPI {
             public String dir;
             public String displayExample;
             public String displayName;
+            public String rawEnglish;
             public Map<String, String> extraAttributes;
             public boolean flagged;
             public boolean hasVoted;
             public String helpHtml;
             public String inheritedLocale;
             public String inheritedValue;
+            public String inheritedDisplayValue;
             public String inheritedXpid;
             public Map<String, Candidate> items;
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -221,12 +221,14 @@ public class VoteAPIHelper {
         // situations.
         row.displayExample = r.getDisplayExample();
         row.displayName = r.getDisplayName();
+        row.rawEnglish = r.getRawEnglish();
         row.extraAttributes = r.getNonDistinguishingAttributes();
         row.flagged = r.isFlagged();
         row.hasVoted = r.userHasVoted();
         row.helpHtml = r.getHelpHTML();
         row.inheritedLocale = r.getInheritedLocaleName();
         row.inheritedValue = r.getInheritedValue();
+        row.inheritedDisplayValue = r.getInheritedDisplayValue();
         row.inheritedXpid = r.getInheritedXPath();
         row.items = calculateItems(r);
         row.placeholderInfo = placeholders.get(xpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -354,6 +354,9 @@ public class DisplayAndInputProcessor {
      * @return
      */
     public synchronized String processForDisplay(String path, String value) {
+        if (value == null) {
+            return null;
+        }
         if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
             return value;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PathInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PathInfo.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
+import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRFile.Status;
@@ -20,7 +21,9 @@ public class PathInfo {
             new Options(PathInfo.class)
                     .add("locale", ".*", "und", "Locale ID for the path info")
                     .add("infile", ".*", null, "File to read paths from or '--infile=-' for stdin")
-                    .add("nosource", "Don’t print the XML Source line");
+                    .add("nosource", "Don’t print the XML Source line")
+                    .add("OutputDaip", ".*", "run a string through DAIP for output")
+                    .add("InputDaip", ".*", "run a string through DAIP for input");
 
     public static void main(String args[]) throws IOException {
         final Set<String> paths = options.parse(args, true);
@@ -66,7 +69,7 @@ public class PathInfo {
                 if (!prePopulated && file != null) {
                     // scan all possible XPaths
                     System.err.println("INFO: Scanning all possible xpaths for hex IDs...");
-                    // TODO: include fullpath, etc etc...
+                    file.getExtraPaths().forEach(x -> StringId.getHexId(x));
                     file.fullIterable().forEach(x -> StringId.getHexId(x));
                     prePopulated = true;
                 }
@@ -106,9 +109,11 @@ public class PathInfo {
         }
         System.out.println("• Value: " + file.getStringValue(dPath));
         // File lookup
-        SourceLocation source = file.getSourceLocation(path);
-        if (source != null) {
-            System.out.println(source + " XML Source Location");
+        if (!nosource) {
+            SourceLocation source = file.getSourceLocation(path);
+            if (source != null) {
+                System.out.println(source + " XML Source Location");
+            }
         }
         // Inheritance lookup
         final String fullPath = file.getFullXPath(path);
@@ -117,6 +122,32 @@ public class PathInfo {
             System.out.println("• Full path: " + StringId.getHexId(fullPath));
         }
 
+        Option inputDaip = options.get("InputDaip");
+        Option outputDaip = options.get("OutputDaip");
+        if (inputDaip.doesOccur() || outputDaip.doesOccur()) {
+            DisplayAndInputProcessor daip = new DisplayAndInputProcessor(file);
+            if (inputDaip.doesOccur()) {
+                String input = inputDaip.getValue();
+                System.out.println("INPUT: " + input);
+                Exception[] e = new Exception[1];
+                final String raw = daip.processInput(path, input, e);
+                System.out.println("RAW<<: " + raw);
+                if (e.length > 0) {
+                    for (final Exception ex : e) {
+                        System.err.println(ex);
+                    }
+                }
+            }
+            if (outputDaip.doesOccur()) {
+                String output = outputDaip.getValue();
+                System.out.println("RAW   : " + output);
+                final String disp = daip.processForDisplay(path, output);
+                System.out.println("DISP>>: " + disp);
+            }
+            return; // skip inheritance chain
+        }
+
+        // inheritance
         Status status = new Status();
         if (false) {
             // For debugging: compare the below to calling getSourceLocaleIdExtended directly.


### PR DESCRIPTION
- add rawEnglish field to DataPage for what was formerly the displayName
- displayName in the voting data is now DAIP processed
- remove DAIP normalization from STFactory, it should be done by callers, and not done on DB values. CLDR-16105
- PathInfo CLI tooling to test DAIP

Still some rough edges:

1. ST doesn't always recognize the display value as the one you were voting for, so vote 'jumps' unnecessarily.
2. raw UnicodeSet in the info panel. 

CLDR-13180

- [ ] This PR completes the ticket.


ALLOW_MANY_COMMITS=true
