### PR TITLE
CLDR-16634 revert #2256 which included @ in ALetter for wordbreak

### DIFF
--- a/common/segments/root.xml
+++ b/common/segments/root.xml
@@ -348,7 +348,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<!-- Now normal variables -->
 				<variable id="$Format">\p{Word_Break=Format}</variable>
 				<variable id="$Katakana">\p{Word_Break=Katakana}</variable>
-				<variable id="$ALetter">[\p{Word_Break=ALetter}@]</variable>
+				<variable id="$ALetter">\p{Word_Break=ALetter}</variable>
 				<variable id="$MidLetter">[[\p{Word_Break=MidLetter}] - [\u003A \uFE55 \uFF1A]]</variable>
 				<variable id="$MidNum">\p{Word_Break=MidNum}</variable>
 				<variable id="$MidNumLet">\p{Word_Break=MidNumLet}</variable>


### PR DESCRIPTION
CLDR-16634

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Revert the change which included '@' in ALetter for wordbreak, i.e. revert #2256.

ALLOW_MANY_COMMITS=true
