### PR TITLE
CLDR-4903 Correct ordering etc

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -536,14 +536,22 @@ public class ExampleGenerator {
                     CodePointEscaper.FORCE_ESCAPE_WITH_NONSPACING);
     static final String LRM = "\u200E";
     static final UnicodeSet NEEDS_LRM = new UnicodeSet("[:BidiClass=R:]").freeze();
+    private static final boolean SHOW_NON_SPACING_IN_UNICODE_SET = false;
+
     /**
      * Add examples for UnicodeSets. First, show a hex format of non-spacing marks if there are any,
      * then show delta to the winning value if there are any.
      */
     private String handleUnicodeSet(XPathParts parts, String xpath, String value) {
         ArrayList<String> examples = new ArrayList<>();
-        final UnicodeSet valueSet = new UnicodeSet(value);
-        if (valueSet.containsSome(CodePointEscaper.NON_SPACING)) {
+        UnicodeSet valueSet;
+        try {
+            valueSet = new UnicodeSet(value);
+        } catch (Exception e) {
+            return null;
+        }
+        if (SHOW_NON_SPACING_IN_UNICODE_SET
+                && valueSet.containsSome(CodePointEscaper.NON_SPACING)) {
             StringBuilder result = new StringBuilder();
             for (String nsm : new UnicodeSet(valueSet).retainAll(CodePointEscaper.NON_SPACING)) {
                 result.append("  ").append(nsm);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateIndexCharacters.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateIndexCharacters.java
@@ -6,7 +6,6 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import org.unicode.cldr.draft.FileUtilities;
@@ -17,7 +16,6 @@ import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.SimpleFactory;
-import org.unicode.cldr.util.SimpleUnicodeSetFormatter;
 
 public class GenerateIndexCharacters {
     public static void main(String[] args) throws IOException {
@@ -55,15 +53,8 @@ public class GenerateIndexCharacters {
         for (String item : items) {
             uset.add(item);
         }
-        SimpleUnicodeSetFormatter pp = new SimpleUnicodeSetFormatter((Comparator) collator);
-        //        new UnicodeSetPrettyPrinter()
-        //            .setCompressRanges(true)
-        //            .setToQuote(DisplayAndInputProcessor.TO_QUOTE)
-        //            .setOrdering(collator)
-        //            .setSpaceComparator(collator);
-
-        String cleanedSet =
-                DisplayAndInputProcessor.getCleanedUnicodeSet(uset, pp, ExemplarType.index);
+        DisplayAndInputProcessor daip = new DisplayAndInputProcessor(cFile);
+        String cleanedSet = daip.getCleanedUnicodeSet(uset, ExemplarType.index);
         return cleanedSet;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2473,7 +2473,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         if (v == null) {
             return UnicodeSet.EMPTY;
         }
-        UnicodeSet result = new UnicodeSet(v);
+        UnicodeSet result = SimpleUnicodeSetFormatter.parseLenient(v);
         UnicodeSet toNuke = new UnicodeSet(HACK_CASE_CLOSURE_SET).removeAll(result);
         result.closeOver(UnicodeSet.CASE);
         result.removeAll(toNuke);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -26,7 +26,7 @@ public enum CodePointEscaper {
     ZWJ(0x200D, "zero-width joiner"),
 
     ZWSP(0x200B, "word non-joiner", "zero-width space"),
-    ZWNBSP(0x2060, "word joiner (zero-width no-break space)"),
+    ZWNBSP(0x2060, "word joiner", "zero-width no-break space"),
 
     ALM(0x061C, "Arabic letter mark"),
     LRM(0x200E, "left-right mark"),

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/FormatterParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/FormatterParser.java
@@ -1,0 +1,7 @@
+package org.unicode.cldr.util;
+
+public interface FormatterParser<T> {
+    public String format(T source);
+
+    public T parse(String formattedString);
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
@@ -759,7 +759,14 @@ public abstract class MatchValue implements Predicate<String> {
         final UnicodeSet uset;
 
         public UnicodeSpanMatchValue(String key) {
-            uset = new UnicodeSet(key);
+            UnicodeSet temp;
+            try {
+                temp = new UnicodeSet(key);
+            } catch (Exception e) {
+                temp = UnicodeSet.EMPTY;
+                int debug = 0;
+            }
+            uset = temp.freeze();
             sample = new StringBuilder().appendCodePoint(uset.getRangeStart(0)).toString();
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
  *
  * @author markdavis
  */
-public class SimpleUnicodeSetFormatter {
+public class SimpleUnicodeSetFormatter implements FormatterParser<UnicodeSet> {
     public static Normalizer2 nfc = Normalizer2.getNFCInstance();
 
     public static final Comparator<String> BASIC_COLLATOR =
@@ -89,6 +89,28 @@ public class SimpleUnicodeSetFormatter {
         this(null, null, 255);
     }
 
+    static class Lazy {
+        static SimpleUnicodeSetFormatter SINGLETON = new SimpleUnicodeSetFormatter();
+
+        static SimpleUnicodeSetFormatter getSingleton() {
+            return SINGLETON;
+        }
+    }
+
+    public static SimpleUnicodeSetFormatter getDefault() {
+        return Lazy.getSingleton();
+    }
+
+    /** Parse as UnicodeSet if of the form […], else parse with default SimpleUnicodeSetFormatter */
+    public static UnicodeSet parseLenient(String source) {
+        if (source.startsWith("[") && source.endsWith("]")) {
+            return new UnicodeSet(source);
+        } else {
+            return getDefault().parse(source);
+        }
+    }
+
+    @Override
     public String format(UnicodeSet input) {
         final boolean allowRanges = input.size() >= maxDisallowRanges;
         StringBuilder result = new StringBuilder();
@@ -158,6 +180,7 @@ public class SimpleUnicodeSetFormatter {
 
     static final Splitter SPACE_SPLITTER = Splitter.on(' ').omitEmptyStrings();
 
+    @Override
     public UnicodeSet parse(String input) {
         UnicodeSet result = new UnicodeSet();
         // Note: could be optimized but probably not worth the effort

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
@@ -20,7 +20,7 @@ import java.util.Comparator;
 import java.util.TreeSet;
 
 /** Provides more flexible formatting of UnicodeSet patterns. */
-public class UnicodeSetPrettyPrinter {
+public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
     private static final StringComparator CODEPOINT_ORDER =
             new UTF16.StringComparator(true, false, 0);
     private static final UnicodeSet PATTERN_WHITESPACE =
@@ -123,6 +123,7 @@ public class UnicodeSetPrettyPrinter {
      * @param uset
      * @return formatted UnicodeSet
      */
+    @Override
     public String format(UnicodeSet uset) {
         first = true;
         UnicodeSet putAtEnd =
@@ -299,5 +300,10 @@ public class UnicodeSetPrettyPrinter {
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
+    }
+
+    @Override
+    public UnicodeSet parse(String formattedString) {
+        return new UnicodeSet(formattedString);
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1482,18 +1482,18 @@ public class TestExampleGenerator extends TestFmwk {
                 "de",
                 "//ldml/characters/parseLenients[@scope=\"date\"][@level=\"lenient\"]/parseLenient[@sample=\"-\"]",
                 "[\\u200B \\- . ๎ ็]",
-                "〖  ็ = U+0E47  ๎ = U+0E4E〗〖‎➕ ⦕ZWSP⦖ ๎ ็〗〖‎➖ /〗〖❬internal: ❭[\\-.็๎​]〗"
+                "〖‎➕ ⦕ZWSP⦖ ๎ ็〗〖‎➖ /〗〖❬internal: ❭[\\-.็๎​]〗"
             },
             {
                 "de",
                 "//ldml/characters/exemplarCharacters",
                 "[\\u200B a-z ๎ ็]",
-                "〖  ็ = U+0E47  ๎ = U+0E4E〗〖‎➕ ⦕ZWSP⦖ ๎ ็〗〖‎➖ ä ö ß ü〗〖❬internal: ❭[a-z็๎​]〗"
+                "〖‎➕ ⦕ZWSP⦖ ๎ ็〗〖‎➖ ä ö ß ü〗〖❬internal: ❭[a-z็๎​]〗"
             },
+            {"de", "//ldml/characters/exemplarCharacters", "a-z ⦕ZWSP⦖", null},
         };
 
         for (String[] test : tests) {
-
             final String locale = test[0];
             final String path = test[1];
             final String value = test[2];


### PR DESCRIPTION
CLDR-4903
This is to handle the 3 changes listed in https://unicode-org.atlassian.net/browse/CLDR-4903?focusedCommentId=169687

Some more notes:

This clearly separates the three different string forms of UnicodeSet
- the plain form coming from calling unicodeSet.toString() or .toPattern(), and produced by new UnicodeSet()
- the prettier form used internally to XML. This is valid UnicodeSet, but is formatted to group the elements differently, eg in sorting order according to the locale. This is handled by UnicodeSetPrettyPrinter, with parse and format methods. (The parse method just calls new UnicodeSet, since the prettier form is still valid UnicodeSet input.)
- a new display form for vetters, that simplifies the syntax to help prevent them from making mistakes, handled by SimpleUnicodeSetFormatter with parse and format methods.

SimpleUnicodeSetFormatter.parseLenient(value) is a new method that tries parsing the value in two ways:
1. If the format […], then with new UnicodeSet()
2. Otherwise with SimpleUnicodeSetFormatter.parse()

Example:
DAIP.processInput() uses SimpleUnicodeSetFormatter.parseLenient(value) to parse the value coming from the vetter, and UnicodeSetPrettyPrinter.format() to then put it in the right format for internal use. This might throw an exception if the content is not valid according to UnicodeSet, _and_ not valid according  to SimpleUnicodeSetFormatter. The exceptions have messages that are suitable for showing to vetters.

DAIP.formatForDisplay() displays the value using SimpleUnicodeSetFormatter, with a simpler format.

Various places in the code needed to change to use SimpleUnicodeSetFormatter.parseLenient

------
This was #2906; I had to change that PR because the branch name was illegal (had a comma in it). 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
4. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
