### PR TITLE
CLDR-14380 Follow-up refactoring and no Info Panel for forum help

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrForumFilter.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForumFilter.mjs
@@ -1,6 +1,7 @@
 /*
  * cldrForumFilter: encapsulate filtering of forum threads.
  */
+import * as cldrForumType from "./cldrForumType.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 
 /**
@@ -212,7 +213,10 @@ function passIfNeedingAction(threadPosts) {
   if (!rootPost?.open) {
     return false;
   }
-  if (rootPost.postType === "Request" || rootPost.postType === "Discuss") {
+  if (
+    rootPost.postType === cldrForumType.REQUEST ||
+    rootPost.postType === cldrForumType.DISCUSS
+  ) {
     if (!rootPost.poster || rootPost.poster === filterUserId) {
       return false; // not "from others"
     }
@@ -232,12 +236,12 @@ function passIfOpenRequestYouStarted(threadPosts) {
   return (
     rootPost?.open &&
     rootPost.poster === filterUserId &&
-    rootPost.postType === "Request"
+    rootPost.postType === cldrForumType.REQUEST
   );
 }
 
 /**
- * Is the thread open and of type "Request", started by other than the current user?
+ * Is the thread open and of type cldrForumType.REQUEST, started by other than the current user?
  *
  * Open Requests By Others should include all open Requests regardless of whether they need action
  * from you or not, and regardless of whether you have replied or not
@@ -250,20 +254,20 @@ function passIfOpenRequestByOther(threadPosts) {
   if (!rootPost.poster || rootPost.poster === filterUserId) {
     return false; // not "by other"
   }
-  return rootPost?.open && rootPost.postType === "Request";
+  return rootPost?.open && rootPost.postType === cldrForumType.REQUEST;
 }
 
 /**
- * Is the thread open and of type "Discuss"?
+ * Is the thread open and of type cldrForumType.DISCUSS?
  *
- * Open Discussions should include all Open forum threads of type "Discuss"".
+ * Open Discussions should include all Open forum threads of type cldrForumType.DISCUSS".
  *
  * @param {Array} threadPosts the array of posts in the thread
  * @return {Boolean} true if it passes, else false
  */
 function passIfOpenDiscuss(threadPosts) {
   const rootPost = getRootPost(threadPosts);
-  return rootPost?.open && rootPost.postType === "Discuss";
+  return rootPost?.open && rootPost.postType === cldrForumType.DISCUSS;
 }
 
 /**

--- a/tools/cldr-apps/js/src/esm/cldrForumType.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForumType.mjs
@@ -1,0 +1,8 @@
+const AGREE = "Agree";
+const CLOSE = "Close";
+const COMMENT = "Comment";
+const DECLINE = "Decline";
+const DISCUSS = "Discuss";
+const REQUEST = "Request";
+
+export { AGREE, CLOSE, COMMENT, DECLINE, DISCUSS, REQUEST };

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -327,7 +327,12 @@ const strings = {
   forum_reply: "Reply",
   forum_msg: "Showing posts for ${forum} and all sublocales.",
   forumGuidance:
-    "This is the Forum page. This page will not reload when new posts come in, but you can use your browser's Refresh button to load new posts.",
+    "This page will not reload automatically when new posts come in. You can use your browser's Refresh button to load new posts.",
+  forum_prefill_agree: "I agree. I am changing my vote to the requested “${0}”",
+  forum_prefill_close: "I'm closing this thread",
+  forum_prefill_decline:
+    "I decline changing my vote to the requested “${0}”. My reasons are:\n",
+  forum_prefill_request: "Please consider voting for “${0}”. My reasons are:\n",
   forum_remember_vote:
     "⚠️ Please remember to vote – submitting a forum post does NOT cause any actual vote to be made.",
 


### PR DESCRIPTION
-New cldrForumType.mjs encapsulates constants DISCUSS, REQUIRE, etc.

-Move prefill messages to cldrText.mjs

-Do not use Info Panel for the brief guidance message, show it inline instead

CLDR-14380

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
