### PR TITLE
CLDR-16654 Add tool and code for downgrading <locale, path, value> matches

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DowngradePaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DowngradePaths.java
@@ -1,0 +1,17 @@
+package org.unicode.cldr.util;
+
+import java.nio.file.Paths;
+import org.unicode.cldr.draft.FileUtilities;
+
+public class DowngradePaths {
+
+    static LocalePathValueListMatcher data =
+            LocalePathValueListMatcher.load(
+                    Paths.get(
+                            FileUtilities.getRelativeFileName(
+                                    DowngradePaths.class, "downgrade.txt")));
+
+    public static boolean lookingAt(String locale, String path, String value) {
+        return data.lookingAt(locale, path, value);
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocalePathValueListMatcher.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocalePathValueListMatcher.java
@@ -1,0 +1,89 @@
+package org.unicode.cldr.util;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class LocalePathValueListMatcher {
+
+    private static final Splitter SPLIT_SEMI_COLON = Splitter.on(';');
+
+    public static class LocalePathValueMatcher {
+        final Pattern localePattern;
+        final Pattern pathPattern;
+        final Pattern valuePattern;
+
+        public LocalePathValueMatcher(List<String> parts) {
+            localePattern =
+                    parts.size() < 1 || parts.get(0).isEmpty()
+                            ? null
+                            : Pattern.compile(parts.get(0));
+            pathPattern =
+                    parts.size() < 2 || parts.get(1).isEmpty()
+                            ? null
+                            : Pattern.compile(parts.get(1).replace("[@", "\\[@"));
+            valuePattern =
+                    parts.size() < 3 || parts.get(1).isEmpty()
+                            ? null
+                            : Pattern.compile(parts.get(2));
+        }
+
+        public boolean lookingAt(String locale, String path, String value) {
+            return (localePattern == null || localePattern.matcher(locale).lookingAt())
+                    && (pathPattern == null || pathPattern.matcher(path).lookingAt())
+                    && (valuePattern == null || valuePattern.matcher(value).lookingAt());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s\t%s\t%s", localePattern, pathPattern, valuePattern);
+        }
+    }
+
+    final List<LocalePathValueListMatcher.LocalePathValueMatcher> matchData;
+
+    public LocalePathValueListMatcher(
+            List<LocalePathValueListMatcher.LocalePathValueMatcher> _matchData) {
+        matchData = ImmutableList.copyOf(_matchData);
+    }
+
+    public static LocalePathValueListMatcher load(Path path) {
+        try {
+            return load(Files.lines(path));
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    public static LocalePathValueListMatcher load(Stream<String> lines) {
+        List<LocalePathValueListMatcher.LocalePathValueMatcher> _matchData = new ArrayList<>();
+        lines.forEach(line -> load(line, _matchData));
+        return new LocalePathValueListMatcher(_matchData);
+    }
+
+    public boolean lookingAt(String locale, String path, String value) {
+        for (LocalePathValueListMatcher.LocalePathValueMatcher lpv : matchData) {
+            if (!lpv.lookingAt(locale, path, value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void load(
+            String line, List<LocalePathValueListMatcher.LocalePathValueMatcher> _matchData) {
+        line = line.trim();
+        if (line.startsWith("#")) {
+            return;
+        }
+        _matchData.add(
+                new LocalePathValueMatcher(SPLIT_SEMI_COLON.trimResults().splitToList(line)));
+    }
+}

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/downgrade.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/downgrade.txt
@@ -1,0 +1,11 @@
+# Format is 
+#    locale-regex ; path-regex ; value-regex
+# Where a field is missing, it matches all values
+# The match uses 'looking at', equivalent to starting with ^ — so don't start with that
+# If you need to match to the end, follow with $
+# For the path, [@ is automatically escaped
+
+# The following will match anything starting with graphics-dot, thus include graphics-dot-per-centimeter, etc.
+ ; //ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot
+
+# The rest of the paths from https://unicode-org.atlassian.net/browse/CLDR-16503 need to be included

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
@@ -228,6 +228,7 @@ public class TestAll extends TestGroup {
                     "org.unicode.cldr.unittest.TestLocaleCanonicalizer",
                     "org.unicode.cldr.unittest.TestPersonNameFormatter",
                     "org.unicode.cldr.unittest.TestCompactNumbers",
+                    "org.unicode.cldr.unittest.TestPathLookup",
                     //            "org.unicode.cldr.unittest.TestCollators" See Ticket #8288
                     "org.unicode.cldr.api.AllTests",
                 },

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathLookup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathLookup.java
@@ -1,0 +1,66 @@
+package org.unicode.cldr.unittest;
+
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.DowngradePaths;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.LocalePathValueListMatcher;
+
+public class TestPathLookup extends TestFmwkPlus {
+    public static void main(String[] args) {
+        new TestPathLookup().run(args);
+    }
+
+    final CLDRConfig config = CLDRConfig.getInstance();
+    final Factory factory = config.getCldrFactory();
+
+    public void testLocalePathValueListMatcher() {
+        LocalePathValueListMatcher matcher =
+                LocalePathValueListMatcher.load(
+                        Arrays.asList("f.* ; //ldml/units/unitLength[@type=\"long\"]/foobar ; k.*")
+                                .stream());
+
+        String[][] tests = {
+            {"fr", "//ldml/units/unitLength[@type=\"long\"]/foobar", "kg", "true"},
+            {"de", "//ldml/units/unitLength[@type=\"long\"]/foobar", "kg", "false"},
+            {"fr", "//ldml/units/unitLength[@type=\"long\"]/foobar", "meter", "false"},
+            {"fr", "//ldml/units/unitLength[@type=\"long\"]/fii", "kg", "false"},
+        };
+        for (String[] test : tests) {
+            String locale = test[0];
+            String path = test[1];
+            String value = test[2];
+            boolean expected = Boolean.valueOf(test[3]);
+            boolean actual = matcher.lookingAt(locale, path, value);
+            assertEquals(Joiner.on(" , ").join(test), expected, actual);
+        }
+    }
+
+    /** These tests need to be updated whenever the downgrade.txt file changes */
+    public void testDowngrade() {
+        assertTrue(
+                "Downgrade according to current data file",
+                DowngradePaths.lookingAt(
+                        "en",
+                        "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"graphics-dot\"]/displayName",
+                        null));
+
+        int count = countMatches(factory.make("cs", false));
+        assertEquals("Count of matches in cs.xml", 15, count);
+    }
+
+    public int countMatches(CLDRFile cldrFile) {
+        String locale = cldrFile.getLocaleID();
+        int count = 0;
+        for (String path : cldrFile) {
+            String value = cldrFile.getStringValue(path);
+            if (DowngradePaths.lookingAt("en", path, value)) {
+                logln(String.format("%s\t%s\t%s", locale, path, value));
+                ++count;
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
CLDR-16654

tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
- add a new option, -fD for downgrade

tools/cldr-code/src/main/java/org/unicode/cldr/util/DowngradePaths.java
- simple API for calling from CLDRModify, and later while importing votes

tools/cldr-code/src/main/java/org/unicode/cldr/util/LocalePathValueListMatcher.java
- regex matcher for <locale, path, value>
- doesn't need to be highly optimized, because it isn't on critical paths. 

tools/cldr-code/src/main/resources/org/unicode/cldr/util/downgrade.txt
- a data file read by DowngradePaths.java

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathLookup.java
tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
- adds basic unit tests for LocalePathValueListMatcher and Downgrade

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
