### PR TITLE
CLDR-16322 Make SurveyTool personName pattern ordering as in personName report

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -2051,17 +2051,6 @@ public class PathHeader implements Comparable<PathHeader> {
                             // sampleName item values in desired sort order
                             final List<String> itemValues =
                                     PersonNameFormatter.SampleType.ALL_STRINGS;
-                            // personName attribute values: each group in desired
-                            // sort order, but groups from least important to most
-                            final List<String> pnAttrValues =
-                                    Arrays.asList(
-                                            "long",
-                                            "medium",
-                                            "short", // length values
-                                            "givenFirst",
-                                            "surnameFirst",
-                                            "sorting"); // order values
-
                             if (source.equals("NameOrder")) {
                                 order = 0;
                                 return "NameOrder for Locales";
@@ -2080,16 +2069,24 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (source.startsWith(pnPrefix)) {
                                 String attrValues = source.substring(pnPrefix.length());
                                 List<String> parts = HYPHEN_SPLITTER.splitToList(attrValues);
-                                order = 30;
-                                for (String part : parts) {
-                                    if (pnAttrValues.contains(part)) {
-                                        order += (1 << pnAttrValues.indexOf(part));
-                                    }
+
+                                String nameOrder = parts.get(0);
+                                if (nameOrder.contentEquals("sorting")) {
+                                    order = 40;
+                                    return "PersonName Sorting Patterns (Usage: referring)";
                                 }
-                                attrValues = attrValues.replace("sorting-", "sorting/index-");
-                                return "PersonName Patterns for Order-Length: " + attrValues;
+                                order = 30;
+                                if (nameOrder.contentEquals("surnameFirst")) {
+                                    order += 1;
+                                }
+                                String nameUsage = parts.get(1);
+                                if (nameUsage.contentEquals("monogram")) {
+                                    order += 20;
+                                    return "PersonName Monogram Patterns for Order: " + nameOrder;
+                                }
+                                return "PersonName Main Patterns for Order: " + nameOrder;
                             }
-                            order = 40;
+                            order = 60;
                             return source;
                         }
                     });
@@ -2103,21 +2100,37 @@ public class PathHeader implements Comparable<PathHeader> {
                             // sort order, but groups from least important to most
                             final List<String> attrValues =
                                     Arrays.asList(
+                                            "referring",
+                                            "addressing", // usage values to include
                                             "formal",
                                             "informal", // formality values
-                                            "referring",
-                                            "addressing",
-                                            "monogram"); // usage values
+                                            "long",
+                                            "medium",
+                                            "short"); // length values
                             // order & length values handled in &personNameSection
 
                             List<String> parts = HYPHEN_SPLITTER.splitToList(source);
                             order = 0;
+                            String attributes = "";
+                            boolean skipReferring = false;
                             for (String part : parts) {
                                 if (attrValues.contains(part)) {
                                     order += (1 << attrValues.indexOf(part));
-                                } // anything else like alt="variant" is at order 0
+                                    // anything else like alt="variant" is at order 0
+                                    if (!skipReferring || !part.contentEquals("referring")) {
+                                        // Add this part to display attribute string
+                                        if (attributes.length() == 0) {
+                                            attributes = part;
+                                        } else {
+                                            attributes = attributes + "-" + part;
+                                        }
+                                    }
+                                } else if (part.contentEquals("sorting")) {
+                                    skipReferring = true; // For order=sorting, don't display
+                                    // usage=referring
+                                }
                             }
-                            return source;
+                            return attributes;
                         }
                     });
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -306,8 +306,8 @@
 
 //ldml/personNames/initialPattern[@type=\"%A\"][@alt=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; pattern-$1-$2
 //ldml/personNames/initialPattern[@type=\"%A\"]   ; Misc ; Person Name Formats ; &personNameSection(AuxiliaryItems) ; pattern-$1
-//ldml/personNames/personName[@order=\"%A\"][@length=\"%A\"][@usage=\"%A\"][@formality=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$2) ; &personNameOrder($3-$4-$5)
-//ldml/personNames/personName[@order=\"%A\"][@length=\"%A\"][@usage=\"%A\"][@formality=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$2) ; &personNameOrder($3-$4)
+//ldml/personNames/personName[@order=\"%A\"][@length=\"%A\"][@usage=\"%A\"][@formality=\"%A\"]/namePattern[@alt=\"%A\"]     ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$3) ; &personNameOrder($1-$2-$3-$4-$5)
+//ldml/personNames/personName[@order=\"%A\"][@length=\"%A\"][@usage=\"%A\"][@formality=\"%A\"]/namePattern      ; Misc ; Person Name Formats ; &personNameSection(PersonName:$1-$3) ; &personNameOrder($1-$2-$3-$4)
 //ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"][@alt=\"%A\"]        ; Misc ; Person Name Formats ; &personNameSection(SampleName:$1) ; &sampleNameOrder($2-$3)
 //ldml/personNames/sampleName[@item=\"%A\"]/nameField[@type=\"%A\"]        ; Misc ; Person Name Formats ;  &personNameSection(SampleName:$1) ; &sampleNameOrder($2)
 


### PR DESCRIPTION
CLDR-16322

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

The idea here is to have the SurveyTool show personName patterns with a  grouping and tagging that matches the personName report. So this puts the patterns into 5 groups, in the following order:

1. Main patterns for order givenFirst
2. Main patterns for order surnameFirst
3. Sorting patterns (order is sorting, usage is referring)
4. Monogram patterns for order givenFirst (usage is monogram)
5. Monogram patterns for order surnameFirst (usage is monogram)

Within the first two sections, individual items are tagged with length-usage-formality[-alt], but ordered by length, formality then usage as in the report.

In the other sections, items are only tagged with length-formality[-alt], since usage is implied by the section (for sorting it is referring, for monogram it is monogram).

Will need to verify all of this on smoketest after PR is merged.

ALLOW_MANY_COMMITS=true
