### PR TITLE
CLDR-16630 Further cleanup of unicode set escaping

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
@@ -793,5 +793,21 @@ public class ExampleDependencies {
                             "//ldml/personNames/nativeSpaceReplacement",
                             "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/personNames/nativeSpaceReplacement",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@formality=\"*\"]/namePattern")
+
+                    // For UnicodeSet examples, need to clear this path's value if the winning value
+                    // changes
+                    .putAll(
+                            "//ldml/characters/exemplarCharacters",
+                            "//ldml/characters/exemplarCharacters")
+                    .putAll(
+                            "//ldml/characters/exemplarCharacters[@type=\"*\"]",
+                            "//ldml/characters/exemplarCharacters[@type=\"*\"]")
+                    .putAll(
+                            "//ldml/characters/parseLenients[@scope=\"*\"][@level=\"*\"]/parseLenient[@sample=\"*\"]",
+                            "//ldml/characters/parseLenients[@scope=\"*\"][@level=\"*\"]/parseLenient[@sample=\"*\"]")
                     .build();
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -536,7 +536,7 @@ public class ExampleGenerator {
                     CodePointEscaper.FORCE_ESCAPE_WITH_NONSPACING);
     static final String LRM = "\u200E";
     static final UnicodeSet NEEDS_LRM = new UnicodeSet("[:BidiClass=R:]").freeze();
-    private static final boolean SHOW_NON_SPACING_IN_UNICODE_SET = false;
+    private static final boolean SHOW_NON_SPACING_IN_UNICODE_SET = true;
 
     /**
      * Add examples for UnicodeSets. First, show a hex format of non-spacing marks if there are any,
@@ -550,15 +550,6 @@ public class ExampleGenerator {
         } catch (Exception e) {
             return null;
         }
-        if (SHOW_NON_SPACING_IN_UNICODE_SET
-                && valueSet.containsSome(CodePointEscaper.NON_SPACING)) {
-            StringBuilder result = new StringBuilder();
-            for (String nsm : new UnicodeSet(valueSet).retainAll(CodePointEscaper.NON_SPACING)) {
-                result.append("  ").append(nsm);
-                result.append(" = U+" + Utility.hex(nsm.codePointAt(0)));
-            }
-            examples.add(result.toString());
-        }
         String winningValue = cldrFile.getWinningValue(xpath);
         if (!winningValue.equals(value)) {
             // show delta
@@ -570,6 +561,12 @@ public class ExampleGenerator {
             }
             if (!winning_minus_value.isEmpty()) {
                 examples.add(LRM + "➖ " + SUSF.format(winning_minus_value));
+            }
+        }
+        if (SHOW_NON_SPACING_IN_UNICODE_SET
+                && valueSet.containsSome(CodePointEscaper.NON_SPACING)) {
+            for (String nsm : new UnicodeSet(valueSet).retainAll(CodePointEscaper.FORCE_ESCAPE)) {
+                examples.add(CodePointEscaper.toExample(nsm.codePointAt(0)));
             }
         }
         examples.add(setBackground("internal: ") + valueSet.toPattern(false)); // internal format

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
@@ -173,9 +173,7 @@ public class SimpleUnicodeSetFormatter implements FormatterParser<UnicodeSet> {
         if (!forceHex.contains(cp)) {
             ap.appendCodePoint(cp);
         } else {
-            ap.append(CodePointEscaper.ESCAPE_START)
-                    .append(CodePointEscaper.toAbbreviationOrHex(cp))
-                    .append(CodePointEscaper.ESCAPE_END);
+            ap.append(CodePointEscaper.codePointToEscaped(cp));
         }
         return ap;
     }
@@ -266,7 +264,7 @@ public class SimpleUnicodeSetFormatter implements FormatterParser<UnicodeSet> {
                         "Missing end escape " + CodePointEscaper.ESCAPE_END + ": " + word + "❌");
             }
             result.appendCodePoint(
-                    CodePointEscaper.fromAbbreviationOrHex(
+                    CodePointEscaper.rawEscapedToCodePoint(
                             word.substring(interiorStart, escapeEnd)));
             i = escapeEnd + 1;
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -738,7 +738,7 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
             {
                 "//ldml/characters/exemplarCharacters",
                 "[a-c {def} å \\u200B \\- . ๎ ็]",
-                "❰ZWSP❱ ๎ ็ - . a b c def å",
+                "❰WNJ❱ ๎ ็ - . a b c def å",
                 "[\\u200B ๎ ็ a b c {def} å]",
                 // note: DAIP also adds break/nobreak alternates for
                 // hyphen, and removes some characters if exemplars
@@ -746,7 +746,7 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
             {
                 "//ldml/characters/parseLenients[@scope=\"date\"][@level=\"lenient\"]/parseLenient[@sample=\"-\"]",
                 "[a-c {def} å \\u200B \\- . ๎ ็]",
-                "❰ZWSP❱ ๎ ็ - . a b c def å",
+                "❰WNJ❱ ๎ ็ - . a b c def å",
                 "[\\u200B ๎ ็ \\- ‑ . a b c {def} å]",
                 // note: DAIP also adds break/nobreak alternates
                 // for hyphen, etc.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1486,13 +1486,13 @@ public class TestExampleGenerator extends TestFmwk {
                 "de",
                 "//ldml/characters/parseLenients[@scope=\"date\"][@level=\"lenient\"]/parseLenient[@sample=\"-\"]",
                 "[\\u200B \\- . ๎ ็]",
-                "〖‎➕ ❰ZWSP❱ ๎ ็〗〖‎➖ /〗〖❬internal: ❭[\\-.็๎​]〗"
+                "〖‎➕ ❰WNJ❱ ๎ ็〗〖‎➖ /〗〖❰WNJ❱ allow line wrap after, aka ZWSP〗〖❬internal: ❭[\\-.็๎​]〗"
             },
             {
                 "de",
                 "//ldml/characters/exemplarCharacters",
                 "[\\u200B a-z ๎ ็]",
-                "〖‎➕ ❰ZWSP❱ ๎ ็〗〖‎➖ ä ö ß ü〗〖❬internal: ❭[a-z็๎​]〗"
+                "〖‎➕ ❰WNJ❱ ๎ ็〗〖‎➖ ä ö ß ü〗〖❰WNJ❱ allow line wrap after, aka ZWSP〗〖❬internal: ❭[a-z็๎​]〗"
             },
             {"de", "//ldml/characters/exemplarCharacters", "a-z ❰ZWSP❱", null},
         };

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
@@ -362,4 +362,24 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
             warnln("Use -v to see list of escapes");
         }
     }
+
+    public void TestStringEscaper() {
+        String[][] tests = {
+            {"xyz", "xyz"},
+            {null, "❰WNJ❱xyz❰47❱", "\u200BxyzG"},
+            {"\u200Bxyz\u200B", "❰WNJ❱xyz❰WNJ❱"},
+            {"A\u200B\u00ADB", "A❰WNJ❱❰SHY❱B"},
+        };
+        for (String[] test : tests) {
+            String source = test[0];
+            String expected = test[1];
+            String expectedRoundtrip = test.length < 3 ? test[0] : test[2];
+            if (source != null) {
+                String actual = CodePointEscaper.toEscaped(source);
+                assertEquals(source, expected, actual);
+            }
+            String actualRoundtrip = CodePointEscaper.toUnescaped(expected);
+            assertEquals(expected, expectedRoundtrip, actualRoundtrip);
+        }
+    }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
@@ -250,9 +250,6 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
         }
         final UnicodeSet missing =
                 new UnicodeSet(needsEscape).removeAll(CodePointEscaper.getNamedEscapes());
-        if (logKnownIssue("CLDR-16627", "remove FFFF when the ticket closes")) {
-            missing.remove(0xFFFF);
-        }
         assertEquals("*\tMissing\tNamed Escapes:\t", "", susf.format(missing));
     }
 
@@ -333,32 +330,36 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
         collection.add(new StringBuilder().appendCodePoint(0x10FFFF).toString());
         for (String item : collection) {
             final int cp = item.codePointAt(0);
-            String display = CodePointEscaper.toAbbreviationOrHex(cp);
-            int roundtrip = CodePointEscaper.fromAbbreviationOrHex(display);
+            String display = CodePointEscaper.codePointToEscaped(cp);
+            int roundtrip = CodePointEscaper.escapedToCodePoint(display);
             assertEquals(
                     "\tU+"
                             + Utility.hex(cp, 4)
                             + " "
                             + UCharacter.getExtendedName(cp)
                             + " ⇒ "
-                            + CodePointEscaper.ESCAPE_START
                             + display
-                            + CodePointEscaper.ESCAPE_END
                             + "\t",
                     cp,
                     roundtrip);
         }
         if (isVerbose()) {
+            System.out.println("Abbr.\tCode Point\tName");
             for (CodePointEscaper item : CodePointEscaper.values()) {
                 System.out.println(
-                        item
-                                + "\t"
+                        item.codePointToEscaped()
+                                + "\tU+"
                                 + Utility.hex(item.getCodePoint(), 4)
                                 + "\t"
-                                + UCharacter.getExtendedName(item.getCodePoint())
-                                + "\t"
-                                + Joiner.on('\t').join(item.getLongNames()));
+                                + item.getShortName());
             }
+            System.out.println(
+                    CodePointEscaper.ESCAPE_START
+                            + "…"
+                            + CodePointEscaper.ESCAPE_END
+                            + "\tU+…\tOther; … = hex notation");
+        } else {
+            warnln("Use -v to see list of escapes");
         }
     }
 }


### PR DESCRIPTION
CLDR-16630

tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
- appends the escapes used in the set, and their short names

tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
- more cleanup, changed the ordering to group better, enhanced names
- Also changed ZWSP to WNJ, as per other ticket
- cleaned up API a bit, added utilities, changed names (some of this percolates into other files)

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
- enhanced the verbose option to print a table we can use in the Sites documentation

tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
- Added the paths with UnicodeSet values. The examples need flushing when the winning value changes, since they show differences *from* the winning path 

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
