### PR TITLE
CLDR-16365 Restore Beaufort to root, remove test skips

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5438,6 +5438,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kn</displayName>
 				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
+			<unit type="speed-beaufort">
+				<displayName>Bft</displayName>
+				<unitPattern count="other">B {0}</unitPattern>
+			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
 				<unitPattern count="other">{0}°</unitPattern>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -53,7 +53,7 @@ public class UnitConverter implements Freezable<UnitConverter> {
     static final Splitter SPACE_SPLITTER = Splitter.on(' ').trimResults().omitEmptyStrings();
 
     public static final Set<String> UNTRANSLATED_UNIT_NAMES =
-            ImmutableSet.of("portion", "ofglucose", "100-kilometer", "ofhg", "beaufort");
+            ImmutableSet.of("portion", "ofglucose", "100-kilometer", "ofhg");
 
     public static final Set<String> HACK_SKIP_UNIT_NAMES =
             ImmutableSet.of(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -397,9 +397,7 @@ public class TestCLDRFile extends TestFmwk {
             ) {
                 logln("+" + engName + ", -" + locales + "\t" + path);
             } else {
-                if (!path.contains("speed-beaufort")) {
-                    errln("+" + engName + ", -" + locales + "\t" + path);
-                }
+                errln("+" + engName + ", -" + locales + "\t" + path);
             }
         }
         for (Entry<String, Set<String>> entry : extraPathsToLocales.keyValuesSet()) {


### PR DESCRIPTION
CLDR-16365

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Restore Beaufort to root and undo the test skips added when it was removed from root. This reverts the parts of #2696 related to Beaufort.

ALLOW_MANY_COMMITS=true
