### PR TITLE
CLDR-16490 Using "Kanton" as the exemplary city for `Pacific/Enderbury`

### DIFF
--- a/common/bcp47/timezone.xml
+++ b/common/bcp47/timezone.xml
@@ -229,7 +229,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="kgfru" description="Bishkek, Kyrgyzstan" alias="Asia/Bishkek"/>
             <type name="khpnh" description="Phnom Penh, Cambodia" alias="Asia/Phnom_Penh"/>
             <type name="kicxi" description="Kiritimati, Kiribati" alias="Pacific/Kiritimati"/>
-            <type name="kipho" description="Enderbury Island, Kiribati" alias="Pacific/Enderbury Pacific/Kanton" iana="Pacific/Kanton"/>
+            <type name="kipho" description="Kanton Island, Kiribati" alias="Pacific/Enderbury Pacific/Kanton" iana="Pacific/Kanton"/>
             <type name="kitrw" description="Tarawa, Kiribati" alias="Pacific/Tarawa"/>
             <type name="kmyva" description="Comoros" alias="Indian/Comoro"/>
             <type name="knbas" description="Saint Kitts" alias="America/St_Kitts"/>

--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -2337,7 +2337,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity draft="unconfirmed">Пномпен</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity draft="unconfirmed">Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -3195,9 +3195,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -4207,9 +4207,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ፍኖም ፔንህ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ኢንደርበሪ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ካንቶን</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -4455,9 +4455,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>بنوم بنه</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>اندربيرج</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>كانتون</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -3138,9 +3138,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>নোম পেন্‌হ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>এণ্ডৰবাৰী</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>কেণ্টন</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -3561,9 +3561,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Pnom Pen</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderböri</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -3530,9 +3530,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пнампень</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Эндэрберы</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -3501,9 +3501,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пном Пен</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Ендърбъри</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="contributed">Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -4473,9 +4473,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>নম পেন</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>এন্ডারবারি</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ক্যান্টন</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -3298,9 +3298,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>नॉम पेन</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>एन्डारबारी</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>केन्ट’न</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -9352,9 +9352,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Pnom Pen</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -4071,9 +4071,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Canton</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -1964,9 +1964,6 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -3043,9 +3043,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>ᎿᎻ ᏇᏂ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ᎡᏂᏇᎵ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ᎧᏛᏂ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -8262,9 +8262,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Phnompenh</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -1936,7 +1936,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>Пномпень</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -3651,9 +3651,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -3774,9 +3774,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -4237,9 +4237,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -3321,9 +3321,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -4126,9 +4126,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Πνομ Πενχ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Έντερμπερι</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Καντών</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -4319,9 +4319,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -3903,7 +3903,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -4449,9 +4449,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -3886,9 +3886,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -4222,9 +4222,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -3624,9 +3624,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -3264,9 +3264,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -3291,9 +3291,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -3691,9 +3691,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="contributed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -9158,9 +9158,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -4551,9 +4551,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>پنوم‌پن</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>اندربری</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>کانتون</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -8735,9 +8735,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>𞤆𞤢𞤲𞤮𞤥-𞤆𞤫𞤲</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>𞤉𞤲𞤣𞤫𞤪𞤦𞤵𞥅𞤪𞤭</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>𞤑𞤢𞤲𞤼𞤮𞤲</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -4469,9 +4469,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -5322,9 +5322,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -6081,9 +6081,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Canton</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -4160,9 +4160,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -2879,7 +2879,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -3848,9 +3848,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -5052,9 +5052,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -3190,9 +3190,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -4060,9 +4060,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ફ્નોમ પેન્હ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>એંડર્બરી</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>કેન્ટન</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -3187,9 +3187,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -3188,9 +3188,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -5217,9 +5217,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>פנום פן</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>אנדרבורי</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>קנטון</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -4110,9 +4110,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>नॉम पेन्ह</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>एंडरबरी</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>कैंटन</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -3756,9 +3756,6 @@ annotations.
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -4355,9 +4355,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -4091,9 +4091,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -3190,9 +3190,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Պնոմպեն</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Էնդերբերի կղզի</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Կանտոն</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -5404,9 +5404,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -2947,9 +2947,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -5719,9 +5719,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -3658,9 +3658,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Canton</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -5606,9 +5606,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>プノンペン</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>エンダーベリー島</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>カントン島</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -3085,9 +3085,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -3654,9 +3654,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>პნომპენი</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ენდერბური</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>კანტონი</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -4144,9 +4144,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пномпень</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Эндербери</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="contributed">Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -3078,9 +3078,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ភ្នំពេញ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>អ៊ីនដឺប៊ូរី</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>កាន់តុន</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -4043,9 +4043,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ನೋಮ್ ಪೆನ್</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ಎಂಡರ್ಬರಿ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ಕ್ಯಾಂಟನ್</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -4944,9 +4944,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>프놈펜</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>엔더베리</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>칸톤</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -3036,9 +3036,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>फ्नोम पेन्ह</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>इंडरबरी</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>कांटोन</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -3126,9 +3126,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пномпень</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Эндербери</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -3053,7 +3053,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -4425,9 +4425,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ພະນົມເປັນ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ເອັນເດີເບີລີ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ແຄນຕອນ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -5470,9 +5470,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Pnompenis</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderburis</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -3889,9 +3889,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Pnompeņa</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderberija</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Kantona</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -4717,9 +4717,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пном Пен</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Ендербери</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -4829,9 +4829,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ഫെനോം പെൻ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>എൻഡബറി</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>കാൻട്ടൻ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -3664,9 +3664,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пномпень</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Эндербери</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -4069,9 +4069,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>प्नोम पेन्ह</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>एंडरबरी</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>कँटन</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -5293,9 +5293,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -3067,9 +3067,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ဖနွမ်ပင်</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>အန်ဒါဘူရီ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ကန်တွန်</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -3568,9 +3568,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>फेनोम फेन</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>एन्डरबरी</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>कान्टोन</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -9381,9 +9381,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -4162,9 +4162,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -8251,9 +8251,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Kantonøya</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -1988,7 +1988,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -3336,9 +3336,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ଫନୋମ୍‌ ପେନହ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ଏଣ୍ଡେରବୁରି</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>କ୍ୟାଣ୍ଟନ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -3927,9 +3927,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ਫਨੋਮ ਪੇਨਹ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ਏਂਡਰਬਰੀ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ਕੈਂਟੋਨ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -3011,9 +3011,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Fnọ́m Pẹn</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Ẹ́ndábẹ́ri</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -4257,9 +4257,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -3397,9 +3397,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>پنوم پن</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>انډربري</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -4327,9 +4327,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -3589,9 +3589,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="contributed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -2936,9 +2936,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -4791,9 +4791,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -4756,9 +4756,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пномпень</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>о-в Эндербери</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -8996,9 +8996,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Canton</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -3465,9 +3465,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>فنام پينه</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>اينڊربري</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ڪانٽن</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -3134,9 +3134,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>නොම් පෙන්</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>එන්ඩර්බරි</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>කැන්ටන්</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -4034,9 +4034,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Phnom Pénh</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -4286,9 +4286,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -7584,9 +7584,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Benom Ben</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderburi</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Kantoon</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -3470,9 +3470,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Pnom-Pen</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbur</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -4049,9 +4049,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пном Пен</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Ендербери</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -4048,9 +4048,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Pnom Pen</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderberi</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Kanton</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -5054,9 +5054,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -3212,9 +3212,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -3135,9 +3135,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -2643,7 +2643,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>ܦܢܘܡ ܦܢ</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity>ܟܐܢܬܘܢ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -2760,9 +2760,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity draft="unconfirmed">Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -4124,9 +4124,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>ஃப்னோம் பென்</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>எண்டர்பரி</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>கேன்டன்</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -4047,9 +4047,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>నోమ్‌పెన్హ్</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ఎండర్బెరీ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>కాంతోన్</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -5246,9 +5246,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>พนมเปญ</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>เอนเดอร์เบอรี</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>แคนทอน</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -3180,9 +3180,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>ፕኖም ፐን</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>ኤንደርበሪ</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>ካንቶን</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -3237,9 +3237,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Pnompen</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderberi</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="contributed">↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -4131,9 +4131,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -4472,9 +4472,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Пномпень</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Ендербері</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>Кантон</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -3793,9 +3793,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>پنوم پن</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>اینڈربری</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>کانٹن</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -3334,9 +3334,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Pnompen</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderberi oroli</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -5933,9 +5933,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -2024,7 +2024,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
+			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -2942,9 +2942,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -2943,9 +2943,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Pacific/Enderbury">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Kanton">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -5227,9 +5227,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>金邊</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>恩得伯理島</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>坎頓</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -5228,9 +5228,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>金边</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>恩得伯理岛</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>坎顿</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -6606,9 +6606,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>金边</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>恩德伯里</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>坎顿岛</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -8641,9 +8641,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>金邊</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>恩得伯理島</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity draft="contributed">坎頓島</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -8689,9 +8689,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>恩德伯里島</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -3717,9 +3717,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>i-Phnom Penh</exemplarCity>
 			</zone>
 			<zone type="Pacific/Enderbury">
-				<exemplarCity>i-Enderbury</exemplarCity>
-			</zone>
-			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Pacific/Kiritimati">


### PR DESCRIPTION
CLDR-16490

- [x] This PR completes the ticket.


ALLOW_MANY_COMMITS=true


This is achieved by using the current exemplar cities of `Pacific/Kanton` (we already have this data) for `Pacific/Enderbury` (the canonical but deprecated tzdb name that we're stuck with). 