### PR TITLE
CLDR-14380 Remove db backup from production after rsync to corp

### DIFF
--- a/tools/scripts/ansible/templates/cldrbackup/backup_sh.j2
+++ b/tools/scripts/ansible/templates/cldrbackup/backup_sh.j2
@@ -17,4 +17,4 @@ mysqldump ${DATABASE_NAME} --add-drop-table --create-options --default-character
 
 # Wait until mysqldump is finished before running xz, to minimize db disruption (don't use | pipe)
 xz ${FNAME}.sql
-rsync -q ${FNAME}.sql.xz ${RSYNC_DEST}
+rsync --quiet --remove-source-files ${FNAME}.sql.xz ${RSYNC_DEST}


### PR DESCRIPTION
-Add --remove-source-files option to rsync; only removes if successful

-Also change -q to equivalent --quiet for clarity

CLDR-14380

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
