### PR TITLE
CLDR-13962 Announcements: show in header if unread; fix db; fix locales

### DIFF
--- a/tools/cldr-apps/js/src/views/AnnounceForm.vue
+++ b/tools/cldr-apps/js/src/views/AnnounceForm.vue
@@ -43,6 +43,7 @@
       <a-input
         v-model:value="formState.locs"
         placeholder="Optional list of locales (like: aa fr zh) (fr implies fr_CA/etc.) (empty for all locales)"
+        @blur="validateLocales()"
       />
     </a-form-item>
     <a-form-item
@@ -81,6 +82,7 @@
 </template>
 
 <script>
+import * as cldrAnnounce from "../esm/cldrAnnounce.mjs";
 import { defineComponent, reactive } from "vue";
 
 export default defineComponent({
@@ -164,10 +166,25 @@ export default defineComponent({
     },
 
     describeLocs() {
-      // TODO: api/locales/normalize -- see validateLocales in AddUser.vue
       return this.formState.locs === "" || this.formState.locs === "*"
         ? "all locales"
         : "the following locale(s): " + this.formState.locs;
+    },
+
+    validateLocales() {
+      cldrAnnounce.combineAndValidateLocales(
+        this.formState.locs,
+        this.updateValidatedLocales
+      );
+    },
+
+    updateValidatedLocales(locs, messages) {
+      this.formState.locs = locs;
+      if (messages) {
+        for (let key of Object.keys(messages)) {
+          console.log("Validating locales: " + key + " -- " + messages[key]);
+        }
+      }
     },
   },
 });

--- a/tools/cldr-apps/js/src/views/AnnouncePost.vue
+++ b/tools/cldr-apps/js/src/views/AnnouncePost.vue
@@ -13,9 +13,7 @@
         To: {{ announcement.audience }} •
         {{ announcement.orgsAll ? "All organizations" : "Your organization" }} •
         {{
-          announcement.locales
-            ? "Locale(s): " + announcement.locales
-            : "All locales"
+          announcement.locs ? "Locale(s): " + announcement.locs : "All locales"
         }}
       </section>
       <section class="announcementSubject">

--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -3,7 +3,13 @@
     <ul>
       <li>{{ stVersionPhase }}</li>
       <li>
-        <a href="#menu///"><span class="main-menu-icon">☰</span> Menu</a>
+        <a href="#menu///"><span class="main-menu-icon">☰</span></a>
+      </li>
+      <li v-if="unreadAnnouncementCount">
+        <a href="#announcements///" v-bind:title="announcementsTitle"
+          ><span class="attention-icon">🎈</span>
+          {{ unreadAnnouncementCount }}</a
+        >
       </li>
       <li v-if="coverageLevel">
         <label for="coverageLevel">Coverage:</label>
@@ -71,6 +77,7 @@
 </template>
 
 <script>
+import * as cldrAnnounce from "../esm/cldrAnnounce.mjs";
 import * as cldrCoverage from "../esm/cldrCoverage.mjs";
 import * as cldrMenu from "../esm/cldrMenu.mjs";
 import * as cldrStatus from "../esm/cldrStatus.mjs";
@@ -80,6 +87,7 @@ import * as cldrVote from "../esm/cldrVote.mjs";
 export default {
   data() {
     return {
+      announcementsTitle: null,
       coverageLevel: null,
       coverageMenu: [],
       coverageTitle: null,
@@ -89,6 +97,7 @@ export default {
       sessionMessage: null,
       specialHeader: null,
       stVersionPhase: null,
+      unreadAnnouncementCount: 0,
       userName: null,
       voteCountMenu: null,
       voteLevelChanged: 0,
@@ -151,6 +160,7 @@ export default {
         cldrStatus.getNewVersion() +
         " " +
         cldrStatus.getPhase();
+      cldrAnnounce.getUnreadCount(this.setUnreadCount);
     },
 
     setCoverageLevel() {
@@ -159,6 +169,13 @@ export default {
 
     setVoteLevel() {
       cldrVote.setVoteLevelChanged(this.voteLevelChanged);
+    },
+
+    setUnreadCount(n) {
+      this.unreadAnnouncementCount = n;
+      this.announcementsTitle = n
+        ? "You have " + n + " unread announcement(s)"
+        : "";
     },
   },
 };
@@ -212,6 +229,27 @@ label {
 
 .main-menu:hover {
   background-color: white;
+}
+
+.attention-icon {
+  width: 2rem;
+  margin-top: -1em;
+  margin-bottom: -1em;
+  display: inline-block;
+  vertical-align: -15%;
+  animation-name: announcements;
+  animation-duration: 3s;
+  animation-direction: alternate;
+  animation-iteration-count: infinite;
+}
+
+@keyframes announcements {
+  from {
+    font-size: 1em;
+  }
+  to {
+    font-size: 2em;
+  }
 }
 
 #st-special-header {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
@@ -11,6 +11,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.unicode.cldr.util.LocaleNormalizer;
+import org.unicode.cldr.util.LocaleSet;
 import org.unicode.cldr.web.*;
 
 @ApplicationScoped
@@ -181,6 +183,7 @@ public class Announcements {
         }
         final AnnouncementSubmissionResponse response = new AnnouncementSubmissionResponse();
         try {
+            request.normalize();
             AnnouncementData.submit(request, response, session.user);
         } catch (SurveyException e) {
             throw new RuntimeException(e);
@@ -215,6 +218,15 @@ public class Announcements {
 
         public boolean isValid() {
             return validAudiences.contains(audience) && validOrgs.contains(orgs);
+        }
+
+        public void normalize() {
+            if (locs != null) {
+                String normalized = LocaleNormalizer.normalizeQuietly(locs);
+                LocaleSet locSet = LocaleNormalizer.setFromStringQuietly(normalized, null);
+                LocaleSet langSet = locSet.combineRegionalVariants();
+                locs = langSet.toString();
+            }
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleSet.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleSet.java
@@ -81,4 +81,25 @@ public class LocaleSet {
         }
         return !Sets.intersection(getSet(), otherSet.getSet()).isEmpty();
     }
+
+    /**
+     * Given a set that may include regional variants (sublocales) for the same language, return a
+     * set in which such sublocales have been combined under the main language name. For example,
+     * given "aa fr_BE fr_CA zh", return "aa fr zh"
+     *
+     * <p>This method is intended to combined regional variants in the same way they are combined
+     * for SurveyForum.java.
+     *
+     * @return the set in which regional variants have been combined
+     */
+    public LocaleSet combineRegionalVariants() {
+        if (isAllLocales || isEmpty()) {
+            return this;
+        }
+        Set<String> languageSet = new TreeSet<>();
+        for (CLDRLocale locale : getSet()) {
+            languageSet.add(locale.getLanguage());
+        }
+        return new LocaleSet(languageSet);
+    }
 }


### PR DESCRIPTION
-New pulsating balloon 🎈 emoji link in main header with unread count, if nonzero

-Remove the word Menu adjacent to ☰ icon in main header to make more room

-New cldrAnnounce.getUnreadCount, etc.

-Fix db bugs: no DB_SQL_IDENTITY for ANNOUNCE_READ; skip add/deleteCheckRow when superfluous

-Add primary key for ANNOUNCE_READ on announce_id,user_id

-New api/locales/combine-variants converts fr_CA to fr (etc), and normalizes

-Form for entering locales calls combine-variants automatically

CLDR-13962

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
