### PR TITLE
CLDR-16534 Downgrade paths for islamic calendar display names (renaming to use Hijri)

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/downgrade.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/downgrade.txt
@@ -12,6 +12,10 @@
 
 # The rest of the paths from https://unicode-org.atlassian.net/browse/CLDR-16503 need to be included
 
+# CLDR-16534 Downgrade paths for renaming Islamic Calendar to Hijri Calendar
+
+	;	 //ldml/localeDisplayNames/types/type[@key="calendar"][@type="islamic
+
 # CLDR-16228 Add the paths where spaces changed in cjk+ person names
 # CLDR-16568 Require checking of questionable PNF data
 


### PR DESCRIPTION
CLDR-16534

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

One part of changing the islamic calendar display names to use Hijri: Downgrade the relevant paths.

ALLOW_MANY_COMMITS=true
