### PR TITLE
CLDR-16384 add grammatical modifiers

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -171,7 +171,8 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
 
     public enum GrammaticalScope {
         general,
-        units
+        units,
+        personNames
     }
 
     private Map<GrammaticalTarget, Map<GrammaticalFeature, Map<GrammaticalScope, Set<String>>>>


### PR DESCRIPTION
CLDR-16384

tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
- In setCldrFileToCheck, compute the Modifiers that are allowed in this locale (depending on grammar) and cache.
-  checkPersonNamePatterns adds some parameters, and now checks for the allowed Modifiers
- changed \" to «, etc. Makes dealing with test easier.

tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
- Added the capability to have personNames as a scope for grammar. Unused right now, but will add in release.

tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
- added constants and utilities to Modifier. For now, just two grammatical categories; may add more later (We need to tell vetters that if they need more than these, they need to communicate with us.
- have 'fake' fallbacks to let people know that that sample names would be modified to be genitive or vocative

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
- add fake fallbacks to test
- modify the CheckAccessorStub so we can get the allowed modifiers
- TestCheckPatterns: added two tests that fr disallows -vocative and ru allows it.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
