### PR TITLE
CLDR-16385 Added a new "retain" modifier that, when used with "initia…

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -155,6 +155,7 @@ public class PersonNameFormatter {
         allCaps,
         initialCap,
         initial,
+        retain,
         monogram,
         prefix,
         core,
@@ -559,6 +560,7 @@ public class PersonNameFormatter {
         private final String formatterLanguage;
         private final String formatterScript;
         private final BreakIterator characterBreakIterator;
+        private final BreakIterator wordBreakIterator;
         private final MessageFormat initialFormatter;
         private final MessageFormat initialSequenceFormatter;
         private final String foreignSpaceReplacement;
@@ -585,6 +587,7 @@ public class PersonNameFormatter {
             formatterLanguage = ltp.getLanguage();
             formatterScript = ltp.getScript();
             characterBreakIterator = BreakIterator.getCharacterInstance(uLocale);
+            wordBreakIterator = BreakIterator.getWordInstance();
             initialFormatter = new MessageFormat(initialPattern);
             initialSequenceFormatter = new MessageFormat(initialSequencePattern);
             this.foreignSpaceReplacement =
@@ -633,7 +636,11 @@ public class PersonNameFormatter {
             for (Modifier modifier : remainingModifers) {
                 switch (modifier) {
                     case initial:
-                        bestValue = formatInitial(bestValue, nameFormatParameters);
+                        boolean retainPunctuation = remainingModifers.contains(Modifier.retain);
+                        bestValue = formatInitial(bestValue, nameFormatParameters, retainPunctuation);
+                        break;
+                    case retain:
+                        // do nothing-- this is handled by "initial" above
                         break;
                     case monogram:
                         bestValue = formatMonogram(bestValue, nameFormatParameters);
@@ -674,21 +681,41 @@ public class PersonNameFormatter {
                     : bestValue;
         }
 
-        public String formatInitial(String bestValue, FormatParameters nameFormatParameters) {
+        public String formatInitial(String bestValue, FormatParameters nameFormatParameters, boolean retainPunctuation) {
             // It is probably unusual to have multiple name fields, so this could be optimized for
             // the simpler case.
 
             // Employ both the initialFormatter and initialSequenceFormatter
 
             String result = null;
-            for (String part : SPLIT_SPACE.split(bestValue)) {
-                String partFirst = getFirstGrapheme(part);
-                bestValue = initialFormatter.format(new String[] {partFirst});
-                if (result == null) {
-                    result = bestValue;
-                } else {
-                    result = initialSequenceFormatter.format(new String[] {result, bestValue});
+            String separator = null;
+            wordBreakIterator.setText(bestValue);
+            int lastBound = wordBreakIterator.first();
+            int curBound = wordBreakIterator.next();
+            while (curBound != BreakIterator.DONE) {
+                String part = bestValue.substring(lastBound, curBound);
+                if (Character.isLetter(part.codePointAt(0))) {
+                    String partFirst = getFirstGrapheme(part);
+                    String partFormatted = initialFormatter.format(new String[] { partFirst } );
+                    if (separator != null) {
+                        if (result == null) {
+                            result = "";
+                        }
+                        result = result + separator + partFormatted;
+                    } else if (result == null) {
+                        result = partFormatted;
+                    } else {
+                        result = initialSequenceFormatter.format(new String[] { result, partFormatted } );
+                    }
+                } else if (retainPunctuation && !Character.isWhitespace(part.codePointAt(0))) {
+                    if (separator == null) {
+                        separator = part;
+                    } else {
+                        separator = separator + part;
+                    }
                 }
+                lastBound = curBound;
+                curBound = wordBreakIterator.next();
             }
             return result;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -637,7 +637,8 @@ public class PersonNameFormatter {
                 switch (modifier) {
                     case initial:
                         boolean retainPunctuation = remainingModifers.contains(Modifier.retain);
-                        bestValue = formatInitial(bestValue, nameFormatParameters, retainPunctuation);
+                        bestValue =
+                                formatInitial(bestValue, nameFormatParameters, retainPunctuation);
                         break;
                     case retain:
                         // do nothing-- this is handled by "initial" above
@@ -681,7 +682,10 @@ public class PersonNameFormatter {
                     : bestValue;
         }
 
-        public String formatInitial(String bestValue, FormatParameters nameFormatParameters, boolean retainPunctuation) {
+        public String formatInitial(
+                String bestValue,
+                FormatParameters nameFormatParameters,
+                boolean retainPunctuation) {
             // It is probably unusual to have multiple name fields, so this could be optimized for
             // the simpler case.
 
@@ -696,7 +700,7 @@ public class PersonNameFormatter {
                 String part = bestValue.substring(lastBound, curBound);
                 if (Character.isLetter(part.codePointAt(0))) {
                     String partFirst = getFirstGrapheme(part);
-                    String partFormatted = initialFormatter.format(new String[] { partFirst } );
+                    String partFormatted = initialFormatter.format(new String[] {partFirst});
                     if (separator != null) {
                         if (result == null) {
                             result = "";
@@ -705,7 +709,9 @@ public class PersonNameFormatter {
                     } else if (result == null) {
                         result = partFormatted;
                     } else {
-                        result = initialSequenceFormatter.format(new String[] { result, partFormatted } );
+                        result =
+                                initialSequenceFormatter.format(
+                                        new String[] {result, partFormatted});
                     }
                 } else if (retainPunctuation && !Character.isWhitespace(part.codePointAt(0))) {
                     if (separator == null) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -71,6 +71,8 @@ import org.unicode.cldr.util.personname.PersonNameFormatter.SampleType;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Usage;
 import org.unicode.cldr.util.personname.SimpleNameObject;
 
+import static org.unicode.cldr.util.personname.PersonNameFormatter.Modifier.retain;
+
 public class TestPersonNameFormatter extends TestFmwk {
 
     public static final boolean DEBUG = System.getProperty("TestPersonNameFormatter.DEBUG") != null;
@@ -731,6 +733,10 @@ public class TestPersonNameFormatter extends TestFmwk {
                     break;
                 case initial:
                     expected = "v.B.";
+                    break;
+                case retain:
+                    // "retain" is a no-op except when used in conjunction with "initial"
+                    expected = "van Berk";
                     break;
                 case initialCap:
                     expected = "Van Berk";
@@ -1616,5 +1622,28 @@ public class TestPersonNameFormatter extends TestFmwk {
             String flattened = Joiner.on("|").join(statusList);
             assertEquals(path + "=" + value, expected, flattened);
         }
+    }
+
+    public void TestRetainModifier() {
+        NameObject testName =
+                SimpleNameObject.from("locale=fr, given=Jean-Michel, surname=Basquiat");
+        FallbackFormatter fallbackFormatter =
+                new FallbackFormatter(ULocale.ENGLISH, "{0}.", "{0} {1}", null, null, null, false);
+
+        FormatParameters parameters = FormatParameters.from("length=medium; formality=formal");
+        NamePattern namePattern;
+        String actual;
+
+        namePattern = NamePattern.from(0, "{given} {surname}");
+        actual = namePattern.format(testName, parameters, fallbackFormatter);
+        assertEquals("Sanity check", "Jean-Michel Basquiat", actual);
+
+        namePattern = NamePattern.from(0, "{given-initial} {surname}");
+        actual = namePattern.format(testName, parameters, fallbackFormatter);
+        assertEquals("given-initial", "J. M. Basquiat", actual);
+
+        namePattern = NamePattern.from(0, "{given-initial-retain} {surname}");
+        actual = namePattern.format(testName, parameters, fallbackFormatter);
+        assertEquals("given-initial-retain", "J.-M. Basquiat", actual);
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.unittest;
 
+import static org.unicode.cldr.util.personname.PersonNameFormatter.Modifier.retain;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
@@ -70,8 +72,6 @@ import org.unicode.cldr.util.personname.PersonNameFormatter.Order;
 import org.unicode.cldr.util.personname.PersonNameFormatter.SampleType;
 import org.unicode.cldr.util.personname.PersonNameFormatter.Usage;
 import org.unicode.cldr.util.personname.SimpleNameObject;
-
-import static org.unicode.cldr.util.personname.PersonNameFormatter.Modifier.retain;
 
 public class TestPersonNameFormatter extends TestFmwk {
 


### PR DESCRIPTION
…l", preserves any punctuation that might go

between the initials when a field contains multiple words (i.e., "Jean-Michel" would initialize to "J.-M." rather than "J. M.").

CLDR-16385

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
