### PR TITLE
CLDR-16339 Improve inheritance messaging

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -795,16 +795,9 @@ function showItemInfoFn(theRow, item) {
     td.appendChild(h3);
 
     if (item.value) {
-      /*
-       * Strings produced here, used as keys for cldrText.sub(), may include:
-       *  "pClass_winner", "pClass_alias", "pClass_fallback", "pClass_fallback_code", "pClass_fallback_root", "pClass_loser".
-       *  See getPClass in DataPage.java.
-       *
-       *  TODO: why not show stars, etc., here?
-       */
       h3.appendChild(
         cldrDom.createChunk(
-          cldrText.sub("pClass_" + item.pClass, item),
+          getItemDescription(item.pClass, theRow.inheritedLocale),
           "p",
           "pClassExplain"
         )
@@ -828,6 +821,28 @@ function showItemInfoFn(theRow, item) {
       cldrTable.appendExample(td, item.example);
     }
   }; // end function(td)
+}
+
+function getItemDescription(itemClass, inheritedLocale) {
+  /*
+   * itemClass may be "winner, "alias", "fallback", "fallback_code", "fallback_root", or "loser".
+   *  See getPClass in DataPage.java.*
+   */
+  if (itemClass === "fallback") {
+    const locName = cldrLoad.getLocaleName(inheritedLocale);
+    return cldrText.sub("item_description_fallback", [locName]);
+  } else if (itemClass === "alias") {
+    if (inheritedLocale === cldrStatus.getCurrentLocale()) {
+      return cldrText.get("item_description_alias_same_locale");
+    } else {
+      const locName = cldrLoad.getLocaleName(inheritedLocale);
+      return cldrText.sub("item_description_alias_diff_locale", [locName]);
+    }
+  } else {
+    // Strings produced here, used as keys for cldrText.get(), may include:
+    // "item_description_winner", "item_description_fallback_code", "item_description_fallback_root", "item_description_loser".
+    return cldrText.get("item_description_" + itemClass);
+  }
 }
 
 /**

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -142,12 +142,16 @@ const strings = {
   admin_users_action_kick_desc: "Logout this user",
 
   // pClass ( see DataPage.java)
-  pClass_winner: "This item is currently winning.",
-  pClass_alias: "This item is aliased from another location.",
-  pClass_fallback_code: "This item is an untranslated code.",
-  pClass_fallback_root: "This item is inherited from the root locale.",
-  pClass_loser: "This item is currently losing.",
-  pClass_fallback: "This item is inherited.",
+  item_description_winner: "This item is currently winning.",
+  item_description_alias_same_locale:
+    "This item is inherited from another field in this locale.",
+  item_description_alias_diff_locale:
+    "This item is inherited from another field in the ${0} locale.",
+  item_description_fallback_code: "This item is an untranslated code.",
+  item_description_fallback_root:
+    "This item is inherited from the root locale.",
+  item_description_loser: "This item is currently losing.",
+  item_description_fallback: "This item is inherited from the ${0} locale.",
   pClassExplain_desc: "This area shows the item's status.",
   followAlias: "Jump to Original ⇒",
   noFollowAlias: "This item is constructed from other values.",

--- a/tools/cldr-apps/js/src/views/InfoPanel.vue
+++ b/tools/cldr-apps/js/src/views/InfoPanel.vue
@@ -2,35 +2,35 @@
   <div>
     <section id="InfoPanelSection">
       <header class="sidebyside-column-top">
-        <a-button
-          shape="circle"
+        <button
           class="cldr-nav-btn info-panel-closebox"
-          title="Close"
+          title="Close the Info Panel"
           @click="closeInfoPanel"
         >
           ✕
-        </a-button>
-        <a-button
-          shape="circle"
+        </button>
+        <button
           class="cldr-nav-btn"
-          title="Reload"
+          title="Reload the Info Panel"
           @click="reloadInfoPanel"
         >
           ↻
-        </a-button>
+        </button>
         <span class="i-am-info-panel">Info Panel</span>
-        <a-button
-          v-if="locale && id"
-          shape="circle"
-          class="cldr-nav-btn"
-          title="Explain"
-          @click="explain"
-        >
-          ↑
-        </a-button>
+        <span class="explainer">
+          <a-button
+            v-if="locale && id"
+            shape="circle"
+            class="cldr-nav-btn"
+            title="Explain inheritance for this item"
+            @click="explain"
+          >
+            ↑
+          </a-button>
+          <InheritanceExplainer ref="inheritanceExplainer" />
+        </span>
       </header>
     </section>
-    <InheritanceExplainer ref="inheritanceExplainer" />
   </div>
 </template>
 
@@ -99,5 +99,10 @@ header {
   font-weight: bold;
   margin-right: 1ex;
   flex-grow: 1;
+}
+
+.explainer {
+  margin-left: auto !important;
+  margin-right: 1ex;
 }
 </style>

--- a/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
+++ b/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
@@ -30,18 +30,19 @@
             <span class="reason" v-if="showReason">{{
               getReason(reason, attribute)
             }}</span>
-            <!-- show the Go button, only if we have locale AND xpath. Hide if we're already there.  -->
-            <a-button
-              size="small"
-              shape="round"
+            &nbsp;
+            <!-- show the Jump button, only if we have locale AND xpath. Hide if we're already there.  -->
+            <button
+              class="cldr-nav-btn"
               v-if="
                 locale &&
                 xpath &&
                 (locale != currentLocale || xpath != currentId)
               "
               @click="go(locale, xpath)"
-              >Jump</a-button
             >
+              Jump
+            </button>
           </p>
           <!-- only show on change -->
           <div v-if="newXpath" class="xpath">
@@ -49,6 +50,13 @@
           </div>
         </a-timeline-item>
       </a-timeline>
+      <button
+        class="cldr-nav-btn"
+        title="Close the Inheritance Explainer"
+        @click="closeInheritanceExplainer"
+      >
+        Close
+      </button>
     </template>
   </a-popover>
 </template>
@@ -143,6 +151,9 @@ export default {
     getReason(reason, attribute) {
       const r = this.reasons[reason].description || reason;
       return cldrText.subTemplate(r, { attribute });
+    },
+    closeInheritanceExplainer() {
+      this.visible = false;
     },
   },
 };


### PR DESCRIPTION
-Change [This item is inherited] to [This item is inherited from the ... locale]

-Change [This item is aliased from another location] to either [This item is inherited from another field in this locale] or [This item is inherited from another field in the ... locale]

-Rename with item_description_... instead of pClass_... for clarity

-Change styles of some Info Panel buttons to match other buttons (e.g., Dashboard)

-Make some hover titles more descriptive: Close the Info Panel, Reload the Info Panel, Explain inheritance for this item

-Link the Inheritance Explainer window to its button; add a Close button

CLDR-16339

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
