### PR TITLE
CLDR-16680 Fix bug preventing voting for aliased values

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -853,8 +853,22 @@ public class DataPage {
                 String ourVote = ballotBox.getVoteValue(userForVotelist, xpath);
                 if (ourVote != null) {
                     CandidateItem voteItem = items.get(ourVote);
+                    if (voteItem == null) {
+                        // inherited value matches inheritance marker and vice-versa
+                        if (ourVote.equals(inheritedValue)) {
+                            voteItem = items.get(CldrUtility.INHERITANCE_MARKER);
+                        } else if (ourVote.equals(CldrUtility.INHERITANCE_MARKER)) {
+                            voteItem = items.get(inheritedValue);
+                        }
+                    }
                     if (voteItem != null) {
                         voteVhash = voteItem.getValueHash();
+                    } else {
+                        logger.severe(
+                                "Found ourVote = "
+                                        + ourVote
+                                        + " but did not find voteItem for xpath = "
+                                        + xpath);
                     }
                 }
             }


### PR DESCRIPTION
-In DataRow.getVoteVHash inherited value matches inheritance marker and vice-versa

CLDR-16680

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
