### PR TITLE
CLDR-16663 Fix production tagger

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -66,14 +66,13 @@ jobs:
         with:
           name: cldr-apps-server
           path: tools/cldr-apps/target/cldr-apps.zip
- #     - name: Tag Production Commit
- #       uses: simpleactions/create-tag@d5c32a2d86b1f96142bbe1ebe8b3b62b0a0587ff
-  #      with:
-   #       sha: ${{ github.event.inputs.git-ref }}
-   #       tag: "${{ steps.tagname.outputs.tag }}"
-  #        message: "Deployed via GitHub by @${{ github.actor }}"
- #       env:
- #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release for Production
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          commit: ${{ github.event.inputs.git-ref }}
+          prerelease: true
+          tag: "${{ steps.tagname.outputs.tag }}"
+          body: "Automated release from ’production’ Action"
   deploy:
     name: Deploy to Production
     needs:


### PR DESCRIPTION
CLDR-16663

- [ ] This PR completes the ticket.

Example tag: https://github.com/unicode-org/cldr/releases/tag/production%2F2023-05-27-1924z
Example run: https://github.com/unicode-org/cldr/actions/runs/5100418543



ALLOW_MANY_COMMITS=true
