### PR TITLE
CLDR-15622 Add more examples for date-time combo formats (std, atTime)

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -768,6 +768,25 @@ public class TestExampleGenerator extends TestFmwk {
         assertEquals("Currency format example faulty", "【٥‏/٩‏/١٩٩٩〗【⃪٥‏/٩‏/١٩٩٩〗", actual);
     }
 
+    public void TestDateTimeComboFormats() {
+        ExampleGenerator exampleGenerator = getExampleGenerator("en");
+        checkValue(
+                "DateTimeCombo long std",
+                "〖❬September 5, 1999❭, ❬1:25:59 PM Eastern Standard Time❭〗〖❬September 5, 1999❭, ❬1:25 PM❭〗〖❬September 5, 1999❭, ❬7:00 AM – 1:25 PM❭〗〖❬today❭, ❬7:00 AM – 1:25 PM❭〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/dateTimeFormatLength[@type=\"long\"]/dateTimeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
+        checkValue(
+                "DateTimeCombo short std",
+                "〖❬9/5/99❭, ❬1:25:59 PM Eastern Standard Time❭〗〖❬9/5/99❭, ❬1:25 PM❭〗〖❬9/5/99❭, ❬7:00 AM – 1:25 PM❭〗〖❬today❭, ❬7:00 AM – 1:25 PM❭〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/dateTimeFormatLength[@type=\"short\"]/dateTimeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
+        checkValue(
+                "DateTimeCombo long std",
+                "〖❬September 5, 1999❭ at ❬1:25:59 PM Eastern Standard Time❭〗〖❬September 5, 1999❭ at ❬1:25 PM❭〗〖❬today❭ at ❬1:25 PM❭〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/dateTimeFormatLength[@type=\"long\"]/dateTimeFormat[@type=\"atTime\"]/pattern[@type=\"standard\"]");
+    }
+
     public void TestSymbols() {
         CLDRFile english = info.getEnglish();
         ExampleGenerator exampleGenerator = new ExampleGenerator(english, english);


### PR DESCRIPTION
CLDR-15622

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Add more examples for date-time combining formats. Previously we showed examples of combining a date and a time, each of the length matching the length of the combination format. But that does not illustrate all of the grammatical issues, nor the different between the standard combining formats and the new "atTime" version. So chnage the examples as follows:

- For all types, show
    - date (of same length as combo format) with a single full time
    - date (of same length as combo format) with a single short time
- For the standard patterns, add
    - date (of same length as combo format) with a short time range
    - relative date with a short time range
- For the atTime patterns, add
    - relative date with a single short time

This gets a little complex because
- We have to get winning values for all of the different date-time items. We simplify a bit by just using the intervalFormatFalback pattern to make the short time range, should be reasonable for a short time range from morning to evening.
- We have to treat the date-time-combining format as a date format, not purely as a message pattern (for handling quoted literal text for example).