### PR TITLE
CLDR-16482 Add core data for mic, change English name to Mi'kmaw

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -408,7 +408,7 @@ annotations.
 			<language type="mgo">Metaʼ</language>
 			<language type="mh">Marshallese</language>
 			<language type="mi">Māori</language>
-			<language type="mic">Mi'kmaq</language>
+			<language type="mic">Mi'kmaw</language>
 			<language type="min">Minangkabau</language>
 			<language type="mk">Macedonian</language>
 			<language type="ml">Malayalam</language>

--- a/common/main/mic.xml
+++ b/common/main/mic.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2023 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="mic"/>
+	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="mic" draft="contributed">Lʼnuiʼsuti</language>
+		</languages>
+		<scripts>
+			<script type="Latn" draft="provisional">Latin</script>
+		</scripts>
+	</localeDisplayNames>
+	<characters>
+		<exemplarCharacters>[a á e é i ɨ j k l m n o ó p q s t u ú w y ʼ]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[b c d f g h r v x z]</exemplarCharacters>
+		<exemplarCharacters type="index">[A Á E É I Ɨ J K L M N O Ó P Q S T U Ú W Y]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[\- ‑ , . % ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[\- ‐ ‑ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
+	</characters>
+	<dates>
+		<calendars>
+			<calendar type="gregorian">
+				<dateFormats>
+					<dateFormatLength type="full">
+						<dateFormat>
+							<pattern draft="provisional">EEEE, MMMM d, y</pattern>
+							<datetimeSkeleton draft="provisional">yMMMMEEEEd</datetimeSkeleton>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="long">
+						<dateFormat>
+							<pattern draft="provisional">MMMM d, y</pattern>
+							<datetimeSkeleton draft="provisional">yMMMMd</datetimeSkeleton>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="medium">
+						<dateFormat>
+							<pattern draft="provisional">MMM d, y</pattern>
+							<datetimeSkeleton draft="provisional">yMMMd</datetimeSkeleton>
+						</dateFormat>
+					</dateFormatLength>
+					<dateFormatLength type="short">
+						<dateFormat>
+							<pattern draft="provisional">y-MM-dd</pattern>
+							<datetimeSkeleton draft="provisional">yMMdd</datetimeSkeleton>
+						</dateFormat>
+					</dateFormatLength>
+				</dateFormats>
+				<timeFormats>
+					<timeFormatLength type="full">
+						<timeFormat>
+							<pattern draft="provisional">h:mm:ss a zzzz</pattern>
+							<datetimeSkeleton draft="provisional">ahmmsszzzz</datetimeSkeleton>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="long">
+						<timeFormat>
+							<pattern draft="provisional">h:mm:ss a z</pattern>
+							<datetimeSkeleton draft="provisional">ahmmssz</datetimeSkeleton>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="medium">
+						<timeFormat>
+							<pattern draft="provisional">h:mm:ss a</pattern>
+							<datetimeSkeleton draft="provisional">ahmmss</datetimeSkeleton>
+						</timeFormat>
+					</timeFormatLength>
+					<timeFormatLength type="short">
+						<timeFormat>
+							<pattern draft="provisional">h:mm a</pattern>
+							<datetimeSkeleton draft="provisional">ahmm</datetimeSkeleton>
+						</timeFormat>
+					</timeFormatLength>
+				</timeFormats>
+			</calendar>
+		</calendars>
+	</dates>
+</ldml>

--- a/common/main/mic_CA.xml
+++ b/common/main/mic_CA.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2021 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="mic"/>
+		<territory type="CA"/>
+	</identity>
+</ldml>

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -1657,7 +1657,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="mi" to="mi_Latn_NZ"/>
 		<!--{ Māori; ?; ? } => { Māori; Latin; New Zealand }-->
 		<likelySubtag from="mic" to="mic_Latn_CA"/>
-		<!--{ Mi'kmaq; ?; ? } => { Mi'kmaq; Latin; Canada }-->
+		<!--{ Mi'kmaw; ?; ? } => { Mi'kmaw; Latin; Canada }-->
 		<likelySubtag from="mif" to="mif_Latn_ZZ"/>
 		<!--{ Mofu-Gudur; ?; ? } => { Mofu-Gudur; Latin; Unknown Region }-->
 		<likelySubtag from="min" to="min_Latn_ID"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2670,7 +2670,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="chp" populationPercent="0.034" officialStatus="official_regional" references="R1329"/>	<!--Chipewyan-->
 			<languagePopulation type="moe" populationPercent="0.032" references="R1329"/>	<!--Innu-aimun-->
 			<languagePopulation type="cr" populationPercent="0.024" officialStatus="official_regional" references="R1329"/>	<!--Cree-->
-			<languagePopulation type="mic" populationPercent="0.021" references="R1329"/>	<!--Mi'kmaq-->
+			<languagePopulation type="mic" populationPercent="0.021" references="R1329"/>	<!--Mi'kmaw-->
 			<languagePopulation type="atj" populationPercent="0.017" references="R1329"/>	<!--Atikamekw-->
 			<languagePopulation type="bla" populationPercent="0.013" references="R1329"/>	<!--Siksiká-->
 			<languagePopulation type="crk" populationPercent="0.011" references="R1329"/>	<!--Plains Cree-->

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1820,7 +1820,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			ks_Deva_IN ksb_TZ ksf_CM ksh_DE ku_TR kw_GB ky_KG
 			la_VA lag_TZ lb_LU lg_UG lij_IT lkt_US lmo_IT ln_CD lo_LA lrc_IR lt_LT lu_CD
 			luo_KE luy_KE lv_LV
-			mai_IN mas_KE mdf_RU mer_KE mfe_MU mg_MG mgh_MZ mgo_CM mi_NZ mk_MK ml_IN mn_MN
+			mai_IN mas_KE mdf_RU mer_KE mfe_MU mg_MG mgh_MZ mgo_CM mi_NZ mic_CA mk_MK ml_IN mn_MN
 			mn_Mong_CN mni_Beng mni_Beng_IN mni_Mtei_IN moh_CA mr_IN ms_Arab_MY ms_MY mt_MT
 			mua_CM mus_US my_MM myv_RU mzn_IR
 			naq_NA nb nb_NO nd_ZW nds_DE ne_NP nl_NL nmg_CM nn_NO nnh_CM nqo_GN nr_ZA

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -190,7 +190,7 @@ public class DisplayAndInputProcessor {
             new HashSet<>(
                     Arrays.asList(
                             "br", "bss", "cad", "cic", "cch", "gn", "ha", "ha_Latn", "lkt", "mgo",
-                            "moh", "mus", "nnh", "qu", "quc", "uk", "uz", "uz_Latn"));
+                            "mic", "moh", "mus", "nnh", "qu", "quc", "uk", "uz", "uz_Latn"));
 
     // Ş ş Ţ ţ  =>  Ș ș Ț ț
     private static final char[][] ROMANIAN_CONVERSIONS = {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -515,7 +515,7 @@ mgp	Eastern Magar	primary	Deva	Devanagari
 mgy	Mbunga	primary	Latn	Latin
 mh	Marshallese	primary	Latn	Latin
 mi	Maori	primary	Latn	Latin
-mic	Mi'kmaq	primary	Latn	Latin
+mic	Mi'kmaw	primary	Latn	Latin
 min	Minangkabau	primary	Latn	Latin
 mk	Macedonian	primary	Cyrl	Cyrillic
 ml	Malayalam	primary	Mlym	Malayalam


### PR DESCRIPTION
CLDR-16482

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add core data for `mic`. Change the English name from Mi'kmaq to Mi'kmaw (note that English uses a straight quote, while `mic` itself uses 02BC for instance in its autonym Lʼnuiʼsuti). Data from Alla Shashkina and Dragan Bešević (with input from Mi'kmaw Kina'matnewey), I just made the CLDR PR.

Also note:
- We already included the display name for `mic` in modern coverage.
- It was also already in attributeValueValidity.xml
- We also already had territoryInfo data for `mic` in Canada.

ALLOW_MANY_COMMITS=true
