### PR TITLE
CLDR-7536 Info Panel not for specials; preliminary refactoring

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrBulkClosePosts.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrBulkClosePosts.mjs
@@ -2,7 +2,6 @@
  * cldrBulkClosePosts: Survey Tool feature for bulk-closing forum posts
  */
 import * as cldrAjax from "./cldrAjax.mjs";
-import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrRetry from "./cldrRetry.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
@@ -15,7 +14,6 @@ let contentDiv = null;
  * Fetch the Bulk Close Posts data from the server, and "load" it
  */
 function load() {
-  cldrInfo.showMessage(cldrText.get("bulk_close_postsGuidance"));
   const url = getBulkClosePostsUrl();
   const xhrArgs = {
     url: url,
@@ -107,6 +105,7 @@ function getBulkClosePostsUrl() {
  */
 function makeHtmlFromJson(json) {
   let html = "<div>\n";
+  html += "<p><i>" + cldrText.get("bulk_close_postsGuidance") + "</i></p>";
   if (
     typeof json.threadCount === "undefined" ||
     typeof json.status === "undefined" ||

--- a/tools/cldr-apps/js/src/esm/cldrFlagged.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrFlagged.mjs
@@ -3,7 +3,6 @@
  */
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrCsvFromTable from "./cldrCsvFromTable.mjs";
-import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrRetry from "./cldrRetry.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
@@ -18,7 +17,6 @@ const flaggedCsvId = "flaggedCsv";
  * Fetch the Flagged Items data from the server, and "load" it
  */
 function load() {
-  cldrInfo.showMessage(cldrText.get("flaggedGuidance"));
   const xhrArgs = {
     url: getFlaggedUrl(),
     handleAs: "json",
@@ -54,6 +52,9 @@ function errorHandler(err) {
 }
 
 function populateFromJson(div, json) {
+  const guidance = document.createElement("p");
+  guidance.innerHTML = "<i>" + cldrText.get("flaggedGuidance") + "</i>";
+  div.appendChild(guidance);
   const header = json.flagged.header;
   const rows = json.flagged.data;
   let lastLocale = undefined;

--- a/tools/cldr-apps/js/src/esm/cldrForumParticipation.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForumParticipation.mjs
@@ -3,7 +3,6 @@
  */
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrCsvFromTable from "./cldrCsvFromTable.mjs";
-import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrRetry from "./cldrRetry.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
@@ -19,8 +18,6 @@ const fileName = "participation.csv";
  * Called as special.load
  */
 function load() {
-  cldrInfo.showMessage(cldrText.get("forum_participationGuidance"));
-
   const url = getForumParticipationUrl();
   const xhrArgs = {
     url: url,
@@ -50,7 +47,7 @@ function loadHandler(json) {
 }
 
 function errorHandler(err) {
-  cldrRetry.handleDisconnect(err, json, "", "Loading forum participation data");
+  cldrRetry.handleDisconnect(err, null, "", "Loading forum participation data");
 }
 
 /**

--- a/tools/cldr-apps/js/src/esm/cldrListEmails.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrListEmails.mjs
@@ -2,9 +2,8 @@
  * cldrListEmails: encapsulate "List email addresses of participating users"
  */
 import * as cldrAjax from "./cldrAjax.mjs";
-import * as cldrDom from "./cldrDom.mjs";
-import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
+import * as cldrRetry from "./cldrRetry.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
 
@@ -23,7 +22,6 @@ const gotNone = "<p>No data, or no users participated.</p>";
  * Called as special.load
  */
 function load() {
-  cldrInfo.showMessage(help + cldrStatus.getNewVersion());
   const xhrArgs = {
     url: getAjaxUrl(),
     handleAs: "json",
@@ -48,11 +46,12 @@ function loadHandler(json) {
 }
 
 function errorHandler(err) {
-  cldrRetry.handleDisconnect(err, json, "", "Loading email data");
+  cldrRetry.handleDisconnect(err, null, "", "Loading email data");
 }
 
 function getHtml(json) {
   let html = header;
+  html += "<p><i>" + help + cldrStatus.getNewVersion() + "</i></p>";
   if (!json.participating_users) {
     html += gotNone;
   } else {

--- a/tools/cldr-apps/js/src/esm/cldrLoad.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.mjs
@@ -804,9 +804,11 @@ function loadAllRowsFromJson(json, theDiv) {
     const surveyCurrentId = cldrStatus.getCurrentId();
     const surveyCurrentPage = cldrStatus.getCurrentPage();
     const surveyCurrentLocale = cldrStatus.getCurrentLocale();
-    cldrInfo.showMessage(
-      `There was a problem loading data to display for ${surveyCurrentLocale}/${surveyCurrentPage}/${surveyCurrentId}`
-    );
+    notification.error({
+      message: "Error loading data",
+      description: `There was a problem loading data to display for ${surveyCurrentLocale}/${surveyCurrentPage}/${surveyCurrentId}`,
+      duration: 0,
+    });
     cldrStatus.setCurrentSection("");
     let msg = "";
     if (json.code) {

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -398,7 +398,6 @@ const strings = {
   vsStop: "Stop",
   vsContent_initial: "Click Recalculate to calculate the summary",
 
-  forum_participationGuidance: "This is the Forum Participation page.",
   forum_participation_TOTAL: "Posts in this release",
   forum_participation_ORG: "Posts by my org.",
   forum_participation_REQUEST: "Open Requests",

--- a/tools/cldr-apps/js/src/esm/cldrVettingParticipation.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVettingParticipation.mjs
@@ -134,8 +134,6 @@ let nf = null; // Intl.NumberFormat initialized later
  * Called as special.load
  */
 function load() {
-  cldrInfo.showMessage(cldrText.get("vetting_participationGuidance"));
-
   const url = getAjaxUrl();
   const xhrArgs = {
     url: url,
@@ -318,6 +316,11 @@ function loadVettingParticipation(json, ourDiv) {
   const div = $(ourDiv);
 
   // Front matter
+  div.append(
+    $("<p/>", {
+      text: cldrText.get("vetting_participationGuidance"),
+    })
+  );
   div.append($("<h3>Locales and Vetting Participation</h3>"));
   div.append(
     $("<p/>", {

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -490,9 +490,7 @@ function appendItem(div, value, pClass) {
   var text = document.createTextNode(value);
   var span = document.createElement("span");
   span.appendChild(text);
-  if (!value) {
-    span.className = "selected";
-  } else if (pClass) {
+  if (pClass) {
     span.className = pClass;
   } else {
     span.className = "value";


### PR DESCRIPTION
-Do not use the Info Panel for specials; instead, show guidance inline for Bulk Close Posts, Flagged Items, List Emails, Vetting Participation

-Remove Forum Participation guidance, was useless: This is the Forum Participation page

-Usage of Info Panel for specials needlessly complicated the code; simplification facilitates modernization

-Refactor cldrInfo.mjs slightly to facilitate further changes and modernization

-Rename pucontent to itemInfoElement for clarity

-In cldrLoad, use notification.error instead of cldrInfo.showMessage to report problem loading data

-Fix bug in cldrForumParticipation.mjs discovered while testing: no json in error handler

-Fix bugs in cldrListEmails.mjs discovered while testing: import cldrRetry; no json in error handler

-Remove dead code in cldrVote.mjs (!value is impossible here)

-TODO comments

CLDR-7536

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
