### PR TITLE
CLDR-16699 add modern coverage for beaufort in selected regions, re-enable use of comprehensive

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -1251,7 +1251,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST coverageLevel inTerritory CDATA #IMPLIED >
     <!--@MATCH:any-->
 <!ATTLIST coverageLevel value CDATA #REQUIRED >
-    <!--@MATCH:literal/basic, core, minimal, moderate, modern, posix-->
+    <!--@MATCH:literal/basic, comprehensive, core, minimal, moderate, modern, posix-->
     <!--@VALUE-->
 <!ATTLIST coverageLevel match CDATA #REQUIRED >
     <!--@MATCH:any-->

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -173,6 +173,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%unitsEnglish" value="(length-fathom|length-furlong|mass-stone|volume-bushel|energy-british-thermal-unit)"/>
 		<coverageVariable key="%unitsNonEnglish" value="[a-z]++-(?!(furlong|fathom|stone|bushel|mile-nautical))([a-z]++([-a-z]++)?)"/>
 		<coverageVariable key="%unitsOther" value="(length-(picometer|light-year)|pressure-(hectopascal|inch-ofhg|millibar)|acceleration-g-force|angle-(degree|minute|second)|area-(acre|hectare|square-(foot|kilometer|meter|mile))|power-(horsepower|kilowatt|watt)|speed-meter-per-second|volume-cubic-(mile|kilometer))"/>
+		<coverageVariable key="%unitBeaufortRegions" value="(CN|DE|GB|GR|HK|MO|MT|NL|TW|US)"/>
 		<coverageVariable key="%variantTypes" value="([A-Z0-9]++)"/>
 		<coverageVariable key="%wideAbbr" value="(wide|abbreviated)"/>
 		<coverageVariable key="%yesNo" value="(yes|no)"/>
@@ -898,6 +899,20 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 		<coverageLevel value="modern" match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="numbers/currencyFormats[@numberSystem='latn']/currencyPatternAppendISO"/>
+
+		<!-- Make Beaufort modern for selected regions -->
+		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
+		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute']"/>
+		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/displayName"/>
+		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/gender"/>
+		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/perUnitPattern"/>
+		<!-- Then make Beaufort explicitly  comprehensive for other regions -->
+		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
+		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute']"/>
+		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/displayName"/>
+		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/gender"/>
+		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/perUnitPattern"/>
+		<!-- Then handle other units -->
 
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/displayName"/>


### PR DESCRIPTION
CLDR-16699

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Give unit speed-beaufort modern coverage only for selected regions (where it is known to be used), but make it comprehensive for other regions should they choose to add localized data for it.

To do this I had to re-enable (in the dtd) explicit use of coverage level "comprehensive" in coverageLevels.xml. It already seems to be handled correctly elsewhere (e.g. in tools/cldr-code/src/main/java/org/unicode/cldr/util/Level.java).

ALLOW_MANY_COMMITS=true
