### PR TITLE
CLDR-16700 Correct link to Maven setup in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ All rights reserved. [Terms of use][]
 [Terms of use]: https://www.unicode.org/copyright.html
 [Jira]: https://github.com/unicode-org/cldr/blob/main/docs/requesting_changes.md
 [Tools source]: https://github.com/unicode-org/cldr/tree/main/tools
-[Maven setup]: https://cldr.unicode.org/development/cldr-development-site/maven-setup
+[Maven setup]: https://cldr.unicode.org/development/maven
 [Repository Organization]: https://cldr.unicode.org/index/downloads#h.lf1z45b9du36
 [How to contribute]: https://cldr.unicode.org/#h.vw32p8sealpj
 [Unicode member]: https://home.unicode.org/membership/why-join/


### PR DESCRIPTION
The previous link led to a 404 error.

CLDR-16700 Maven setup link in CONTRIBUTING.md is broken

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
