### PR TITLE
CLDR-15371 Fix broken links, wrap long URLs

### DIFF
--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -3322,3 +3322,7 @@ div.thinUser {
      color: red;
      background-color: lightgoldenrodyellow !important;
  }
+
+.sidebyside-narrow a[href] {
+	word-wrap: break-word;
+}


### PR DESCRIPTION
-In the Info Panel, wrap links with long URLs to avoid horizontal scrollbar

-Apply the style word-wrap: break-word to a[href] within class sidebyside-narrow

CLDR-15371

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
