### PR TITLE
CLDR-7536 New cldrNotify to replace showWithRow and encapsulate notification

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAddAlt.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddAlt.mjs
@@ -3,13 +3,12 @@
  */
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 
 import AddAlt from "../views/AddAlt.vue";
 
 import { createCldrApp } from "../cldrVueRouter.mjs";
-
-import { notification } from "ant-design-vue";
 
 function addButton(containerEl, xpstrid) {
   try {
@@ -21,11 +20,11 @@ function addButton(containerEl, xpstrid) {
     addAltWrapper.setXpathStringId(xpstrid);
   } catch (e) {
     console.error("Error loading Add Alt vue " + e.message + " / " + e.name);
-    notification.open({
-      message: `${e.name} while loading AddAlt.vue`,
-      description: `${e.message}`,
-      duration: 0,
-    });
+    cldrNotify.open(
+      `${e.name} while loading AddAlt.vue`,
+      e.message,
+      cldrNotify.NO_TIMEOUT
+    );
   }
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrCoverageReset.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrCoverageReset.mjs
@@ -5,9 +5,8 @@ import * as cldrCoverage from "./cldrCoverage.mjs";
 import * as cldrGui from "./cldrGui.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrMenu from "./cldrMenu.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrText from "./cldrText.mjs";
-
-import { notification } from "ant-design-vue";
 
 const TEST_DANGER = false && cldrStatus.getIsUnofficial(); // false for production, true only when testing
 
@@ -27,11 +26,11 @@ function resetIfLongSinceAction(millisSinceAction) {
         cldrLoad.handleCoverageChanged();
         cldrGui.updateWithStatus();
         cldrGui.updateWidgetsWithCoverage();
-        notification.open({
-          message: cldrText.get("coverage_reset_msg"),
-          description: cldrText.get("coverage_reset_desc"),
-          duration: 10,
-        });
+        cldrNotify.open(
+          cldrText.get("coverage_reset_msg"),
+          cldrText.get("coverage_reset_desc"),
+          cldrNotify.MEDIUM_DURATION
+        );
       }
     }
   }

--- a/tools/cldr-apps/js/src/esm/cldrDash.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDash.mjs
@@ -170,7 +170,7 @@ function getSinglePathFromUpdate(json) {
       return row.xpstrid;
     }
   }
-  throw "Missing path in getSinglePathFromUpdate";
+  throw new Error("Missing path in getSinglePathFromUpdate");
 }
 
 function updateEntry(updater, category) {

--- a/tools/cldr-apps/js/src/esm/cldrForumPanel.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForumPanel.mjs
@@ -6,7 +6,7 @@ import * as cldrCache from "./cldrCache.mjs";
 import * as cldrDom from "./cldrDom.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrForum from "./cldrForum.mjs";
-import * as cldrInfo from "./cldrInfo.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrRetry from "./cldrRetry.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
@@ -161,12 +161,11 @@ function updatePosts(tr) {
 
   function errorHandler(err) {
     console.log("Error in updatePosts: " + err);
-    const message =
-      cldrStatus.stopIcon() +
-      " Couldn't load forum post for this row- please refresh the page. <br>Error: " +
-      err +
-      "</td>";
-    cldrInfo.showWithRow(message, tr);
+    cldrNotify.error(
+      "Error updating posts, please refresh the page",
+      err,
+      cldrNotify.NO_TIMEOUT
+    );
     cldrRetry.handleDisconnect("Could not load for updatePosts:" + err, null);
   }
 
@@ -187,9 +186,7 @@ function updatePosts(tr) {
     } catch (e) {
       console.log("Error in ajax forum read ", e.message);
       console.log(" response: " + json);
-      const message =
-        cldrStatus.stopIcon() + " exception in ajax forum read: " + e.message;
-      cldrInfo.showWithRow(message, tr);
+      cldrNotify.error("Forum error", e.message, cldrNotify.NO_TIMEOUT);
     }
   }
 

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -8,6 +8,7 @@ import * as cldrForum from "./cldrForum.mjs";
 import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrMenu from "./cldrMenu.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrProgress from "./cldrProgress.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
@@ -16,8 +17,6 @@ import DashboardWidget from "../views/DashboardWidget.vue";
 import MainHeader from "../views/MainHeader.vue";
 
 import { createCldrApp } from "../cldrVueRouter.mjs";
-
-import { notification } from "ant-design-vue";
 
 const GUI_DEBUG = true;
 
@@ -147,11 +146,11 @@ function insertHeader() {
     console.error(
       "Error mounting main header vue " + e.message + " / " + e.name
     );
-    notification.error({
-      message: `${e.name} while loading MainHeader.vue`,
-      description: `${e.message}`,
-      duration: 0,
-    });
+    cldrNotify.error(
+      `${e.name} while loading MainHeader.vue`,
+      e.message,
+      cldrNotify.NO_TIMEOUT
+    );
   }
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -6,6 +6,7 @@ import * as cldrDom from "./cldrDom.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrForumPanel from "./cldrForumPanel.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrSideways from "./cldrSideways.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
@@ -60,11 +61,11 @@ function insertWidget() {
     insertLegacyElement(containerEl);
   } catch (e) {
     console.error("Error loading InfoPanel vue " + e.message + " / " + e.name);
-    notification.error({
-      message: `${e.name} while loading InfoPanel.vue`,
-      description: `${e.message}`,
-      duration: 0,
-    });
+    cldrNotify.error(
+      `${e.name} while loading InfoPanel.vue`,
+      e.message,
+      cldrNotify.NO_TIMEOUT
+    );
   }
 }
 
@@ -195,16 +196,6 @@ function listen(str, tr, theObj, fn) {
 function showMessage(str) {
   if (panelShouldBeShown()) {
     show(str, null, null, null);
-  }
-}
-
-// Called twice by cldrForumPanel.mjs and twice by cldrVote.mjs, always with
-// an error message. TODO: use another mechanism such as notifications.error(),
-// to reduce dependencies on legacy code and to facilitate improvement.
-// Reference: https://unicode-org.atlassian.net/browse/CLDR-7536
-function showWithRow(str, tr) {
-  if (panelShouldBeShown()) {
-    show(str, tr, null, null);
   }
 }
 
@@ -999,6 +990,5 @@ export {
   showItemInfoFn,
   showMessage,
   showRowObjFunc,
-  showWithRow,
   updateRowVoteInfo,
 };

--- a/tools/cldr-apps/js/src/esm/cldrLoad.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.mjs
@@ -23,6 +23,7 @@ import { LocaleMap } from "./cldrLocaleMap.mjs";
 import * as cldrLocales from "./cldrLocales.mjs";
 import * as cldrMail from "./cldrMail.mjs";
 import * as cldrMenu from "./cldrMenu.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrOldVotes from "./cldrOldVotes.mjs";
 import * as cldrRecentActivity from "./cldrRecentActivity.mjs";
 import * as cldrReport from "./cldrReport.mjs";
@@ -33,7 +34,6 @@ import * as cldrTable from "./cldrTable.mjs";
 import * as cldrText from "./cldrText.mjs";
 import * as cldrVettingParticipation from "./cldrVettingParticipation.mjs";
 import { isVueSpecial } from "../specialToComponentMap.mjs";
-import { notification } from "ant-design-vue";
 import { h } from "vue";
 
 const CLDR_LOAD_DEBUG = false;
@@ -347,11 +347,11 @@ function goToRowId(curId) {
   if (!xtr) {
     if (CLDR_LOAD_DEBUG) {
       console.log("Warning could not load id " + rowId + " does not exist");
-      notification.warning({
-        message: "Could not load XPath",
-        description: `The XPath ID ${curId} does not exist.`,
-        duration: 8,
-      });
+      cldrNotify.warning(
+        "Could not load XPath",
+        `The XPath ID ${curId} does not exist.`,
+        cldrNotify.MEDIUM_DURATION
+      );
     }
     updateCurrentId(null);
   } else {
@@ -676,11 +676,7 @@ function handleMissingSpecial(curSpecial) {
       `Return to the SurveyTool`
     ),
   ]);
-  notification.warning({
-    message: "Page not found",
-    description,
-    duration: 0,
-  });
+  cldrNotify.warning("Page not found", description, cldrNotify.NO_TIMEOUT);
 }
 
 /**
@@ -804,11 +800,11 @@ function loadAllRowsFromJson(json, theDiv) {
     const surveyCurrentId = cldrStatus.getCurrentId();
     const surveyCurrentPage = cldrStatus.getCurrentPage();
     const surveyCurrentLocale = cldrStatus.getCurrentLocale();
-    notification.error({
-      message: "Error loading data",
-      description: `There was a problem loading data to display for ${surveyCurrentLocale}/${surveyCurrentPage}/${surveyCurrentId}`,
-      duration: 0,
-    });
+    cldrNotify.error(
+      "Error loading data",
+      `There was a problem loading data to display for ${surveyCurrentLocale}/${surveyCurrentPage}/${surveyCurrentId}`,
+      cldrNotify.NO_TIMEOUT
+    );
     cldrStatus.setCurrentSection("");
     let msg = "";
     if (json.code) {
@@ -915,11 +911,11 @@ function myLoad(url, message, handler, postData, headers) {
   console.log("MyLoad: " + url + " for " + message);
   const errorHandler = function (err, request) {
     console.log("Error: " + err);
-    notification.error({
-      message: `Could not fetch ${message}`,
-      description: `Error: ${err.toString()}`,
-      duration: 8,
-    });
+    cldrNotify.error(
+      `Could not fetch ${message}`,
+      `Error: ${err.toString()}`,
+      cldrNotify.MEDIUM_DURATION
+    );
     handler(null);
   };
   const loadHandler = function (json) {

--- a/tools/cldr-apps/js/src/esm/cldrNotify.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrNotify.mjs
@@ -1,0 +1,74 @@
+/*
+ * cldrNotify: encapsulate notifications, i.e., pop-up windows that notify the user
+ * what's going on, either staying open until dismissed by the user or disappearing
+ * automatically after a fixed number of seconds.
+ *
+ * Although it's possible for any .mjs file to import notification from ant-design-vue,
+ * it's preferable to encapsulate the dependency here, to facilitate switching to a different
+ * library if and when necessary or appropriate. For example, ant-design-vue might not work
+ * for us anymore when we switch from Vue 3 to Vue 4 or stop using Vue entirely. Within our
+ * Vue components, such encapsulation might also be beneficial, but to a lesser extent given
+ * that those components are already heavily dependent on Vue 3 and ant-design-vue anyway.
+ *
+ * Encapsulation here can also facilitate consistency rather than arbitrary differences
+ * such as 8 seconds here, 10 seconds there; top-left here and top-right there; ...
+ */
+
+// Reference: https://www.antdv.com/components/notification
+import { notification } from "ant-design-vue";
+
+/**
+ * Callers should use one of these constants rather than a literal number.
+ *
+ * Note: possibly it would be better (more consistent) to enforce NO_TIMEOUT for errors, and MEDIUM_DURATION
+ * for warnings and general notifications.
+ */
+const NO_TIMEOUT = 0; // stay open until dismissed by the user
+const MEDIUM_DURATION = 8; // automatically close after this many seconds
+
+/**
+ * Display a general notification
+ *
+ * @param {String} message the title, displayed at the top
+ * @param {String} description the more detailed description
+ * @param {Number} duration how many seconds to display, or NO_TIMEOUT
+ */
+function open(message, description, duration) {
+  notification.open({
+    message: message,
+    description: description,
+    duration: duration,
+  });
+}
+
+/**
+ * Display a warning notification
+ *
+ * @param {String} message the title, displayed at the top
+ * @param {String} description the more detailed description
+ * @param {Number} duration how many seconds to display, or NO_TIMEOUT
+ */
+function warning(message, description, duration) {
+  notification.warning({
+    message: message,
+    description: description,
+    duration: duration,
+  });
+}
+
+/**
+ * Display an error notification
+ *
+ * @param {String} message the title, displayed at the top
+ * @param {String} description the more detailed description
+ * @param {Number} duration how many seconds to display, or NO_TIMEOUT
+ */
+function error(message, description, duration) {
+  notification.error({
+    message: message,
+    description: description,
+    duration: duration,
+  });
+}
+
+export { NO_TIMEOUT, MEDIUM_DURATION, error, open, warning };

--- a/tools/cldr-apps/js/src/esm/cldrProgress.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrProgress.mjs
@@ -6,6 +6,7 @@
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrCoverage from "./cldrCoverage.mjs";
 import * as cldrGui from "./cldrGui.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
 import * as cldrText from "./cldrText.mjs";
@@ -13,8 +14,6 @@ import * as cldrText from "./cldrText.mjs";
 import ProgressMeters from "../views/ProgressMeters.vue";
 
 import { createCldrApp } from "../cldrVueRouter.mjs";
-
-import { notification } from "ant-design-vue";
 
 let progressWrapper = null;
 
@@ -123,11 +122,11 @@ function insertWidget(spanId) {
     console.error(
       "Error loading ProgressMeters vue " + e.message + " / " + e.name
     );
-    notification.error({
-      message: `${e.name} while loading ProgressMeters.vue`,
-      description: `${e.message}`,
-      duration: 0,
-    });
+    cldrNotify.error(
+      `${e.name} while loading ProgressMeters.vue`,
+      e.message,
+      cldrNotify.NO_TIMEOUT
+    );
   }
 }
 
@@ -396,7 +395,7 @@ function reallyFetchLocaleData(locale) {
     .then((response) => {
       if (!response.ok) {
         progressWrapper.setHidden(true);
-        throw Error(response.statusText);
+        throw new Error(response.statusText);
       }
       return response;
     })

--- a/tools/cldr-apps/js/src/esm/cldrReport.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrReport.mjs
@@ -99,7 +99,7 @@ async function fetchAllReports() {
  */
 async function getOneLocaleStatus(locale) {
   if (locale === "-") {
-    throw Error(
+    throw new Error(
       "Please call client.apis.voting.getReportLocaleStatus() directly with the “-” parameter."
     );
   }
@@ -108,7 +108,7 @@ async function getOneLocaleStatus(locale) {
     locale,
   });
   if (obj.locales.length !== 1) {
-    throw Error(
+    throw new Error(
       `getOneLocaleStatus(${locale}) expected an array of one item but got ${obj.locales.length}`
     );
   }

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -6,6 +6,7 @@ import * as cldrDom from "./cldrDom.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrRetry from "./cldrRetry.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
@@ -339,30 +340,25 @@ function showProposedItem(inTd, tr, theRow, value, tests, json) {
       if (tr.myProposal) tr.myProposal.style.display = "none";
     }
     if (ourItem || (replaceErrors && value === "") /* Abstain */) {
-      let str = cldrText.sub(
+      const message = cldrText.sub(
         "StatusAction_msg",
         [cldrText.get("StatusAction_" + json.statusAction)],
         "p",
         ""
       );
-      var str2 = cldrText.sub(
+      const description = cldrText.sub(
         "StatusAction_popupmsg",
         [cldrText.get("StatusAction_" + json.statusAction), theRow.code],
         "p",
         ""
       );
-      // show in modal popup (ouch!)
-      alert(str2);
-
-      // show this message in a sidebar also
-      const message = cldrStatus.stopIcon() + str;
-      cldrInfo.showWithRow(message, tr);
+      cldrNotify.error(message, description, cldrNotify.NO_TIMEOUT);
     }
     return;
   } else if (json && json.didNotSubmit) {
     ourDiv.className = "d-item-err";
-    const message = "Did not submit this value: " + json.didNotSubmit;
-    cldrInfo.showWithRow(message, tr);
+    const description = "Did not submit this value: " + json.didNotSubmit;
+    cldrNotify.error("Not submitted", description, cldrNotify.NO_TIMEOUT);
     return;
   } else {
     setDivClass(ourDiv, testKind);

--- a/tools/cldr-apps/js/src/esm/localesTxtGenerator.mjs
+++ b/tools/cldr-apps/js/src/esm/localesTxtGenerator.mjs
@@ -60,7 +60,7 @@ function generateLocalesTxt(data, outFunction) {
         // validate org mapping
         const orgLower = orgMogrify(org2);
         if (!allOrgs[orgLower]) {
-          throw Error(`${ver} has unknown org ${org2}`);
+          throw new Error(`${ver} has unknown org ${org2}`);
         }
 
         if (org !== orgLower) {

--- a/tools/cldr-apps/js/src/views/CldrRows.vue
+++ b/tools/cldr-apps/js/src/views/CldrRows.vue
@@ -52,7 +52,7 @@ export default {
     } else if (this.xpstrid) {
       theUrl = `api/voting/${this.locale}/row/${this.xpstrid}`;
     } else {
-      throw Error(`Need xpstrid= or page= to continue.`);
+      throw new Error(`Need xpstrid= or page= to continue.`);
     }
     fetch(theUrl, {
       headers: {

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -254,7 +254,7 @@ export default {
         .doFetch(url)
         .then((response) => {
           if (!response.ok) {
-            throw Error(response.statusText);
+            throw new Error(response.statusText);
           }
           return response;
         })


### PR DESCRIPTION
-Get rid of cldrInfo.showWithRow to simplify cldrInfo and use more modern notifications

-New cldrNotify.mjs with three methods: show, warning, and error

-In JavaScript, always throw new Error instead of throw string so e.message is defined

-Also throw new Error instead of throw Error, for consistency (although they are equivalent)

CLDR-7536

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
