### PR TITLE
CLDR-13962 Announcements: bug fix, orgs not orgsAll; improve email

### DIFF
--- a/tools/cldr-apps/js/src/views/AnnouncePost.vue
+++ b/tools/cldr-apps/js/src/views/AnnouncePost.vue
@@ -11,7 +11,7 @@
       </section>
       <section class="announcementToFrom">
         To: {{ announcement.audience }} •
-        {{ announcement.orgsAll ? "All organizations" : "Your organization" }} •
+        {{ "Organization(s): " + announcement.orgs }} •
         {{
           announcement.locs ? "Locale(s): " + announcement.locs : "All locales"
         }}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AnnouncementData.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AnnouncementData.java
@@ -138,6 +138,7 @@ public class AnnouncementData {
             return;
         }
         String subject = "CLDR Survey Tool announcement: " + request.subject;
+        String locs = (request.locs == null || request.locs.isEmpty()) ? "All" : request.locs;
         String body =
                 "From: "
                         + poster.name
@@ -149,8 +150,8 @@ public class AnnouncementData {
                         + request.orgs
                         + "\n"
                         + "Locale(s): "
-                        + request.locs
-                        + "\n"
+                        + locs
+                        + "\n\n"
                         + request.body
                         + "\n\n"
                         + "Do not reply to this message, instead please go to the Survey Tool.\n\n"


### PR DESCRIPTION
-Fix message display, no boolean orgsAll, instead Organization(s): Mine/TC/All

-Improve display of Locale(s) line in the email, put All if null/empty; two newlines

CLDR-13962

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
