### PR TITLE
CLDR-16669 Update collation root from unihan-index

### DIFF
--- a/common/collation/root.xml
+++ b/common/collation/root.xml
@@ -704,7 +704,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 # Index characters for the unihan sort order in root.
 # Each index character is an ideograph representing a radical,
 # and sorts like the first ideograph in the radical-stroke order.
-# Unicode 13.0.0
+# Unicode 15.1.0
 &一=\uFDD0一 # radical 1
 &丨=\uFDD0丨 # radical 2
 &丶=\uFDD0丶 # radical 3
@@ -899,6 +899,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 &页=\uFDD0页 # radical 181'
 &風=\uFDD0風 # radical 182
 &风=\uFDD0风 # radical 182'
+&𲋄=\uFDD0𲋄 # radical 182''
 &飛=\uFDD0飛 # radical 183
 &飞=\uFDD0飞 # radical 183'
 &食=\uFDD0食 # radical 184
@@ -933,15 +934,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 &鼎=\uFDD0鼎 # radical 206
 &鼓=\uFDD0鼓 # radical 207
 &鼠=\uFDD0鼠 # radical 208
+&鼡=\uFDD0鼡 # radical 208''
 &鼻=\uFDD0鼻 # radical 209
 &齊=\uFDD0齊 # radical 210
 &齐=\uFDD0齐 # radical 210'
 &齒=\uFDD0齒 # radical 211
 &齿=\uFDD0齿 # radical 211'
+&𮮾=\uFDD0歯 # radical 211''
 &龍=\uFDD0龍 # radical 212
 &龙=\uFDD0龙 # radical 212'
+&𬺗=\uFDD0竜 # radical 212''
 &龜=\uFDD0龜 # radical 213
 &龟=\uFDD0龟 # radical 213'
+&𪚲=\uFDD0亀 # radical 213''
 &龠=\uFDD0龠 # radical 214
 				]]></cr>
 			</collation>


### PR DESCRIPTION
CLDR-16669

Update the collation root.xml file with the unihan-index.txt contents which has changes for Unicode 15.1 (new radicals).
@markusicu forgot to update this file in PR #3007.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
