### PR TITLE
CLDR-16390 inh explainer: add 'hidden' property

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInheritance.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInheritance.mjs
@@ -35,7 +35,10 @@ async function explainInheritance(itemLocale, itemXpath) {
   let lastLocale = null;
   let lastPath = null;
   for (let i = 0; i < items.length; i++) {
-    const { locale, xpath, reason } = items[i];
+    const { locale, xpath, reason, hidden } = items[i];
+    if (hidden) {
+      items[i].hidden = true;
+    }
     if (reason !== "none") {
       // hide 'none'
       items[i].showReason = true;

--- a/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
+++ b/tools/cldr-apps/js/src/views/InheritanceExplainer.vue
@@ -18,6 +18,7 @@
             showReason,
             xpath,
             xpathFull,
+            hidden,
           } in inheritance"
           v-bind:color="colorForReason(reason)"
         >
@@ -35,6 +36,7 @@
             <button
               class="cldr-nav-btn"
               v-if="
+                !hidden &&
                 locale &&
                 xpath &&
                 (locale != currentLocale || xpath != currentId)
@@ -45,7 +47,7 @@
             </button>
           </p>
           <!-- only show on change -->
-          <div v-if="newXpath" class="xpath">
+          <div v-if="newXpath" :class="xpathClass(hidden)">
             {{ xpathFull }}
           </div>
         </a-timeline-item>
@@ -87,6 +89,13 @@ export default {
     };
   },
   methods: {
+    xpathClass(hidden) {
+      if (hidden) {
+        return "xpath xpath-hidden";
+      } else {
+        return "xpath";
+      }
+    },
     explain(locale, xpath) {
       // clear this first in case something happens
       this.visible = false;
@@ -162,6 +171,10 @@ export default {
 <style scoped>
 .xpath {
   font-size: smaller;
+}
+
+.xpath-hidden {
+  opacity: 0.4;
 }
 
 .locale {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -2362,4 +2362,34 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 .forVersion(SurveyMain.getLastVoteVersion(), false)
                 .toString();
     }
+
+    /** Somewhat expensive operation. Query whether an XPath is visible. */
+    public boolean isVisibleInSurveyTool(String locale, String x) {
+        return isVisibleInSurveyTool(
+                CLDRLocale.getInstance(locale), CLDRFile.getDistinguishingXPath(x, null));
+    }
+
+    /** Somewhat expensive operation. Query whether an XPath is visible. */
+    public boolean isVisibleInSurveyTool(CLDRLocale l, String dPath) {
+        // see also {@link #isValidSurveyToolVote}
+        if (!getAvailableCLDRLocales().contains(l)) {
+            return false; // bad locale ID
+        }
+
+        PathHeader ph = getPathHeader(dPath);
+        if (ph == null) return false; // out of scope
+        if (ph.shouldHide()) return false; // PH says hide it
+
+        if (sm.getSupplementalDataInfo().getCoverageValue(dPath, l.getBaseName())
+                > org.unicode.cldr.util.Level.COMPREHENSIVE.getLevel()) {
+            return false; // out of coverage
+        }
+
+        if (!get(l).getPathsForFile().contains(dPath)) {
+            return false; // not in file paths.
+            // Note: Not sure why it wasn't caught before!
+        }
+
+        return true; // OK.
+    }
 }


### PR DESCRIPTION
- routine on STFactory to calculate if an xpath is hidden
- also, add generated XPaths to the XPathTable

CLDR-16390

- [ ] This PR completes the ticket.


Half (back end) implementation for the issue of the broken jump button.  Adds a `hidden: true/false` property to the API. 

Update:  including Front End  also, see image

<img width="757" alt="image" src="https://github.com/unicode-org/cldr/assets/855219/62ce5c08-b58c-4087-908f-342531d27eeb">


for path `/cldr-apps/v#/de/Duration/1aab94512d97c3fd`

ALLOW_MANY_COMMITS=true
