### PR TITLE
CLDR-16681 Enable gettings stats and deleting votes for downgraded paths

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDowngradedVotes.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDowngradedVotes.mjs
@@ -1,0 +1,73 @@
+/*
+ * cldrDowngradedVotes: Survey Tool feature for counting/deleting votes for downgraded paths
+ */
+import * as cldrAjax from "./cldrAjax.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
+import * as cldrStatus from "./cldrStatus.mjs";
+import * as cldrText from "./cldrText.mjs";
+
+/**
+ * URL used with GET for getting statistics, or with DELETE for deleting votes
+ */
+const DOWNGRADE_URL = "voting/downgraded";
+
+let callbackSetData = null;
+
+async function refresh(viewCallbackSetData) {
+  if (!hasPermission()) {
+    viewCallbackSetData(null);
+    return;
+  }
+  callbackSetData = viewCallbackSetData;
+  const url = cldrAjax.makeApiUrl(DOWNGRADE_URL);
+  return await cldrAjax
+    .doFetch(url)
+    .then(cldrAjax.handleFetchErrors)
+    .then((r) => r.json())
+    .then(setData)
+    .catch(handleRefreshError);
+}
+
+function setData(json) {
+  if (callbackSetData) {
+    callbackSetData(json);
+  }
+  return json;
+}
+
+function handleRefreshError(e) {
+  cldrNotify.exception(e, "loading stats about votes for downgraded paths");
+}
+
+function hasPermission() {
+  return cldrStatus.getPermissions()?.userIsAdmin;
+}
+
+async function deleteAllImported() {
+  const url = cldrAjax.makeApiUrl(DOWNGRADE_URL);
+  const init = {
+    method: "DELETE",
+  };
+  return await cldrAjax
+    .doFetch(url, init)
+    .then(cldrAjax.handleFetchErrors)
+    .then((r) => r.json())
+    .then(handleDeletionSuccess)
+    .catch(handleDeletionError);
+}
+
+function handleDeletionSuccess(json) {
+  cldrNotify.open(
+    cldrText.get("downgradedDeletionSuccessHeader"),
+    cldrText.get("downgradedDeletionSuccessDetail")
+  );
+  refresh(callbackSetData);
+  return json;
+}
+
+function handleDeletionError(e) {
+  cldrNotify.exception(e, "trying to delete votes for downgraded paths");
+  refresh(callbackSetData);
+}
+
+export { deleteAllImported, hasPermission, refresh };

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -4,6 +4,23 @@
 const CLDR_TEXT_DEBUG = false;
 
 const strings = {
+  downgradedDeletionSuccessHeader: "Success",
+  downgradedDeletionSuccessDetail:
+    "The imported votes for downgraded paths were successfully deleted",
+  downgradedPleaseLogIn: "To view, please log in as Admin.",
+  downgradedPathsExist:
+    "Votes for downgraded paths exist with the following type(s) of vote:",
+  downgradedHeaderVoteType: "Vote Type",
+  downgradedHeaderImported: "Imported",
+  downgradedHeaderCount: "Count",
+  downgradedTotal: "Total",
+  downgradedTotalImported: "Total imported",
+  downgradedNote:
+    "Note: only vote types with “true” in the “Imported” column can be deleted by this utility. If other types are shown, they are for informational purposes only.",
+  downgradedCurrentlyNone:
+    "There are currently no imported votes for downgraded paths 🎉",
+  downgradedDeleteAll: "Delete all imported votes for downgraded paths!",
+
   git_commit_url_prefix: "https://github.com/unicode-org/cldr/commit/",
   git_compare_url_prefix: "https://github.com/unicode-org/cldr/compare/",
   git_compare_url_main: "main",
@@ -461,6 +478,7 @@ const strings = {
   special_createAndLogin: "Create and Login",
   special_default: "Missing Page",
   special_dashboard: "Dashboard",
+  special_downgraded: "Votes for Downgraded Paths",
   special_error_subtypes: "Error Subtypes",
   special_flagged: "Flagged Items",
   special_forum: "Forum Posts",

--- a/tools/cldr-apps/js/src/esm/cldrVueMap.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVueMap.mjs
@@ -2,6 +2,7 @@ import AboutPanel from "../views/AboutPanel.vue";
 import AnnouncePanel from "../views/AnnouncePanel.vue";
 import AddUser from "../views/AddUser.vue";
 import AutoImport from "../views/AutoImport.vue";
+import DowngradedVotes from "../views/DowngradedVotes.vue";
 import GeneralInfo from "../views/GeneralInfo.vue";
 import LockAccount from "../views/LockAccount.vue";
 import LookUp from "../views/LookUp.vue";
@@ -21,6 +22,7 @@ const specialToComponentMap = {
   announcements: AnnouncePanel,
   add_user: AddUser,
   auto_import: AutoImport,
+  downgraded: DowngradedVotes,
   general: GeneralInfo,
   lock_account: LockAccount,
   lookup: LookUp,

--- a/tools/cldr-apps/js/src/views/DowngradedVotes.vue
+++ b/tools/cldr-apps/js/src/views/DowngradedVotes.vue
@@ -1,0 +1,138 @@
+<template>
+  <!-- spinner shows if there's a delay -->
+  <a-spin tip="Loading" v-if="!downgradeData && !pleaseLogIn" :delay="500" />
+  <p v-if="pleaseLogIn">{{ text("downgradedPleaseLogIn") }}</p>
+  <template v-if="downgradeData && !pleaseLogIn">
+    <section v-if="downgradeData.cats?.length">
+      <p>{{ text("downgradedPathsExist") }}</p>
+      <table>
+        <th>{{ text("downgradedHeaderVoteType") }}</th>
+        <th>{{ text("downgradedHeaderImported") }}</th>
+        <th>{{ text("downgradedHeaderCount") }}</th>
+        <tr v-for="cat of downgradeData.cats" :key="cat">
+          <td>{{ cat.voteType }}</td>
+          <td>{{ cat.isImported }}</td>
+          <td>{{ cat.count }}</td>
+        </tr>
+        <tr>
+          <td>{{ text("downgradedTotal") }}</td>
+          <td></td>
+          <td>{{ voteCountTotal }}</td>
+        </tr>
+        <tr>
+          <td>{{ text("downgradedTotalImported") }}</td>
+          <td></td>
+          <td>{{ voteCountImported }}</td>
+        </tr>
+      </table>
+      <p class="note">
+        {{ text("downgradedNote") }}
+      </p>
+    </section>
+    <section class="nothingToShow" v-if="voteCountImported === 0">
+      {{ text("downgradedCurrentlyNone") }}
+    </section>
+    <section v-if="canDelete">
+      <a-button @click="deleteAllImported" class="deleteButton">
+        {{ text("downgradedDeleteAll") }}
+      </a-button>
+    </section>
+  </template>
+</template>
+
+<script>
+import * as cldrDowngradedVotes from "../esm/cldrDowngradedVotes.mjs";
+import * as cldrNotify from "../esm/cldrNotify.mjs";
+import * as cldrText from "../esm/cldrText.mjs";
+
+export default {
+  data() {
+    return {
+      canDelete: false,
+      downgradeData: null,
+      pleaseLogIn: false,
+      voteCountImported: 0,
+      voteCountTotal: 0,
+      texts: {},
+    };
+  },
+
+  created() {
+    cldrDowngradedVotes.refresh(this.setData);
+  },
+
+  methods: {
+    setData(data) {
+      if (data == null) {
+        this.pleaseLogIn = true;
+      } else {
+        this.downgradeData = data;
+        this.countVotes();
+        this.canDelete = this.voteCountImported > 0;
+      }
+    },
+
+    countVotes() {
+      let imported = 0;
+      let total = 0;
+      for (let cat of this.downgradeData.cats) {
+        total += cat.count;
+        if (cat.isImported) {
+          imported += cat.count;
+        }
+      }
+      this.voteCountImported = imported;
+      this.voteCountTotal = total;
+    },
+
+    deleteAllImported() {
+      cldrDowngradedVotes.deleteAllImported();
+    },
+
+    text(key) {
+      return this.texts[key] || (this.texts[key] = cldrText.get(key));
+    },
+  },
+};
+</script>
+
+<style scoped>
+.nothingToShow {
+  font-weight: bold;
+  font-size: 24px;
+  color: #40a9ff;
+  background-color: #f5f5f5;
+  border: 1px solid #e3e3e3;
+  border-radius: 3px;
+  padding: 1em;
+  margin: 1em;
+}
+
+.deleteButton {
+  margin: 1em;
+  background-color: yellow; /* danger! */
+}
+
+.note {
+  font-style: italic;
+}
+
+table {
+  margin: 1em;
+  padding: 1ex;
+}
+
+th {
+  background-color: lightgray;
+}
+
+td,
+th {
+  border: 1px solid black;
+  padding: 1ex;
+}
+
+td {
+  text-align: right;
+}
+</style>

--- a/tools/cldr-apps/js/src/views/MainMenu.vue
+++ b/tools/cldr-apps/js/src/views/MainMenu.vue
@@ -61,6 +61,13 @@
       <li v-if="accountLocked" class="emphatic">
         LOCKED: Note: your account is currently locked
       </li>
+      <li v-if="isAdmin">
+        <ul>
+          <li>
+            <a href="#downgraded///">Votes for downgraded paths</a>
+          </li>
+        </ul>
+      </li>
       <li class="section-header">Forum</li>
       <li>
         <ul>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/DowngradedVotes.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/DowngradedVotes.java
@@ -1,0 +1,210 @@
+package org.unicode.cldr.web.api;
+
+import java.sql.*;
+import java.util.*;
+import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.unicode.cldr.util.DowngradePaths;
+import org.unicode.cldr.util.VoteType;
+import org.unicode.cldr.web.*;
+
+@ApplicationScoped
+@Path("/voting/downgraded")
+@Tag(name = "Downgraded votes", description = "APIs for Survey Tool downgraded votes")
+public class DowngradedVotes {
+    private static final Logger logger = SurveyLog.forClass(DowngradedVotes.class);
+
+    /**
+     * The submitter column must be included even though it isn't used explicitly, since it is a
+     * primary key, and the query must select all primary keys in order to call
+     * ResultSet.deleteRow() successfully
+     */
+    private static final String SELECT_SQL =
+            "SELECT locale,xpath,value,vote_type,submitter FROM " + DBUtils.Table.VOTE_VALUE;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Get statistics",
+            description = "Get statistics about votes for downgraded paths")
+    @APIResponses(
+            value = {
+                @APIResponse(
+                        responseCode = "200",
+                        description = "Downgraded Stats",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                DowngradedStatsResponse.class))),
+                @APIResponse(responseCode = "403", description = "Forbidden"),
+                @APIResponse(
+                        responseCode = "500",
+                        description = "Internal Server Error",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = STError.class))),
+                @APIResponse(responseCode = "503", description = "Not ready yet"),
+            })
+    public Response getStats(@HeaderParam(Auth.SESSION_HEADER) String sessionString) {
+        CookieSession session = Auth.getSession(sessionString);
+        if (session == null) {
+            return Auth.noSessionResponse();
+        }
+        if (!UserRegistry.userIsAdmin(session.user)) {
+            return Response.status(403, "Forbidden").build();
+        }
+        session.userDidAction();
+        if (SurveyMain.isBusted() || !SurveyMain.wasInitCalled() || !SurveyMain.triedToStartUp()) {
+            return STError.surveyNotQuiteReady();
+        }
+        DowngradedStatsResponse response = new DowngradedStatsResponse();
+        return Response.ok(response).build();
+    }
+
+    @Schema(description = "Stats of downgraded paths")
+    public static final class DowngradedStatsResponse {
+        @Schema(description = "Number of votes for downgraded paths, categorized by vote type")
+        public DowngradeCategory[] cats;
+
+        public DowngradedStatsResponse() {
+            Map<VoteType, Integer> catMap = new HashMap<>();
+            loopThroughAllVotes(catMap);
+            cats = new DowngradeCategory[catMap.size()];
+            int i = 0;
+            for (Map.Entry<VoteType, Integer> entry : catMap.entrySet()) {
+                cats[i++] = new DowngradeCategory(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    @Schema(description = "Single category of votes for downgraded paths")
+    public static class DowngradeCategory {
+        @Schema(description = "The vote type")
+        public VoteType voteType;
+
+        @Schema(description = "The number of downgraded votes with this type")
+        public int count;
+
+        @Schema(description = "Whether this type of vote is classified as being imported")
+        public boolean isImported;
+
+        public DowngradeCategory(VoteType voteType, int count) {
+            this.voteType = voteType;
+            this.count = count;
+            this.isImported = this.voteType.isImported();
+        }
+    }
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Delete", description = "Delete imported votes for downgraded paths")
+    @APIResponses(
+            value = {
+                @APIResponse(
+                        responseCode = "200",
+                        description = "Successful deletion",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                DowngradedStatsResponse.class))),
+                @APIResponse(responseCode = "403", description = "Forbidden"),
+                @APIResponse(
+                        responseCode = "500",
+                        description = "Internal Server Error",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = STError.class))),
+            })
+    public Response deleteImported(@HeaderParam(Auth.SESSION_HEADER) String sessionString) {
+        CookieSession session = Auth.getSession(sessionString);
+        if (session == null) {
+            return Auth.noSessionResponse();
+        }
+        if (!UserRegistry.userIsAdmin(session.user)) {
+            return Response.status(403, "Forbidden").build();
+        }
+        session.userDidAction();
+        DeletionResponse response;
+        try {
+            response = new DeletionResponse();
+        } catch (Exception e) {
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+        return Response.ok(response).build();
+    }
+
+    @Schema(description = "Report on status of deletion request")
+    public static final class DeletionResponse {
+        public DeletionResponse() {
+            loopThroughAllVotes(null /* delete */);
+        }
+    }
+
+    /**
+     * Loop through all the votes, and fill in the given map with info about votes for downgraded
+     * paths; or, if the map is null, delete all imported votes for downgraded paths.
+     *
+     * @param catMap the category map, or null for deletion
+     */
+    private static void loopThroughAllVotes(Map<VoteType, Integer> catMap) {
+        Connection conn;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            conn = DBUtils.getInstance().getAConnection();
+            if (conn == null) {
+                return;
+            }
+            ps = DBUtils.prepareForwardUpdateable(conn, SELECT_SQL);
+            rs = ps.executeQuery();
+            while (rs.next()) {
+                handleVote(rs, catMap /* if catMap is null, it means DELETE */);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            DBUtils.close(rs, ps);
+        }
+    }
+
+    private static void handleVote(ResultSet rs, Map<VoteType, Integer> catMap)
+            throws SQLException {
+        String localeId = rs.getString(1);
+        int xp = rs.getInt(2);
+        String xpath = CookieSession.sm.xpt.getById(xp);
+        String value = DBUtils.getStringUTF8(rs, 3);
+        VoteType voteType = VoteType.fromId(rs.getInt(4));
+        if (voteType == null || voteType == VoteType.NONE) {
+            logger.warning("DowngradedVotes got vote type " + voteType + "; changed to UNKNOWN");
+            voteType = VoteType.UNKNOWN;
+        }
+        if (catMap != null) {
+            if (DowngradePaths.lookingAt(localeId, xpath, value)) {
+                Integer n = catMap.get(voteType);
+                catMap.put(voteType, (n == null) ? 1 : n + 1);
+            }
+        } else {
+            /* if catMap is null and the vote is imported and the path is downgraded, delete the vote */
+            if (voteType.isImported() && DowngradePaths.lookingAt(localeId, xpath, value)) {
+                rs.deleteRow();
+            }
+        }
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DowngradePaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DowngradePaths.java
@@ -2,7 +2,7 @@ package org.unicode.cldr.util;
 
 public class DowngradePaths {
 
-    static LocalePathValueListMatcher data =
+    private static LocalePathValueListMatcher data =
             LocalePathValueListMatcher.load(CldrUtility.getUTF8Data("downgrade.txt").lines());
 
     public static boolean lookingAt(String locale, String path, String value) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteType.java
@@ -46,4 +46,8 @@ public enum VoteType {
     public int id() {
         return integerId;
     }
+
+    public boolean isImported() {
+        return this == AUTO_IMPORT || this == MANUAL_IMPORT;
+    }
 }


### PR DESCRIPTION
-New cldrDowngradedVotes.mjs, DowngradedVotes.vue, DowngradedVotes.java

-New item in main menu for Admin only: Votes for Downgraded Paths

-The new page shows how many votes for downgraded paths, categorized by vote type

-The new page has a button for deleting the imported votes for downgraded paths

-Revise DowngradePaths.java to make data private

-Revise VoteType.java with added method isImported

CLDR-16681

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
