### PR TITLE
CLDR-14883 drop + for unit-gender

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -839,7 +839,7 @@ function updateRowOthersCell(tr, theRow, cell, protoButton, formAdd) {
   cldrDom.removeAllChildNodes(cell); // other
   cldrSurvey.setLang(cell);
 
-  if (tr.canModify) {
+  if (tr.canModify && !tr.theRow.fixedCandidates) {
     formAdd.role = "form";
     formAdd.className = "form-inline";
     const buttonAdd = document.createElement("div");

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -206,6 +206,9 @@ public class VoteAPI {
 
             @Schema(description = "prose description of voting outcome")
             public String voteTranscript;
+
+            @Schema(description = "True if candidates are fixed (disable plus).", example = "false")
+            public boolean fixedCandidates;
         }
 
         public static final class Page {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -15,7 +15,6 @@ import org.unicode.cldr.test.TestCache.TestResultBundle;
 import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.web.*;
 import org.unicode.cldr.web.BallotBox.VoteNotAcceptedException;
@@ -245,6 +244,7 @@ public class VoteAPIHelper {
         row.xpath = xpath;
         row.xpathId = CookieSession.sm.xpt.getByXpath(xpath);
         row.xpstrid = XPathTable.getStringIDString(xpath);
+        row.fixedCandidates = r.fixedCandidates();
         return row;
     }
 


### PR DESCRIPTION
- for the 'gender' element in units, show fixed candidate items where applicable
- hide the + (add) as it's not possible to add a new value.
- capability to add more fixed candidates in the future

CLDR-14883


German
![image](https://github.com/unicode-org/cldr/assets/855219/28bac9f9-e72d-475e-8f51-d4a9a1895c80)

Czech
![image](https://github.com/unicode-org/cldr/assets/855219/fcc2dbf8-7695-4df5-ba3e-2d309a0eab27)



ALLOW_MANY_COMMITS=true
