### PR TITLE
CLDR-16763 Reduce deadlocks

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
@@ -116,6 +116,15 @@ public interface BallotBox<T> {
     VoteResolver<String> getResolver(String path);
 
     /**
+     * Get the vote resolver for this path.
+     *
+     * @param path
+     * @param r resolver to reuse (must be from a prior call)
+     * @return
+     */
+    VoteResolver<String> getResolver(String path, VoteResolver<String> r);
+
+    /**
      * Whether the user voted at all. Returns false if user voted for null (no opinion).
      *
      * @param myUser

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -83,7 +83,7 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
     }
 
     private String getFullPathWithResolver(String path, VoteResolver<String> resolver) {
-        String diskFullPath = ballotBox.diskData.getFullPathAtDPath(path);
+        String diskFullPath = diskData.getFullPathAtDPath(path);
         if (diskFullPath == null) {
             /*
              * If the disk didn't have a full path, just use the inbound path.

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -1,0 +1,137 @@
+package org.unicode.cldr.web;
+
+import java.util.Date;
+import java.util.logging.Logger;
+import org.unicode.cldr.util.CLDRFile.DraftStatus;
+import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.util.VoteResolver.Status;
+import org.unicode.cldr.util.XMLSource;
+
+/**
+ * Formerly DataBackedSource. This XMLSource is not modifiable by the user (putFullPathAtDPath), but
+ * only responds to changes via votes.
+ */
+public class BallotBoxXMLSource<T> extends DelegateXMLSource {
+    static final Logger logger = SurveyLog.forClass(BallotBoxXMLSource.class);
+
+    BallotBox<T> ballotBox;
+    /** original data before any votes */
+    XMLSource diskData;
+
+    /** Writeable XMLSource to delegate to */
+    BallotBoxXMLSource(XMLSource diskData, BallotBox<T> makeFrom) {
+        super(diskData.cloneAsThawed());
+        this.diskData = diskData;
+        ballotBox = makeFrom;
+    }
+
+    @Override
+    public Date getChangeDateAtDPath(String path) {
+        return ballotBox.getLastModDate(path);
+    }
+
+    /**
+     * Set the value for the given path for this DataBackedSource, using the given VoteResolver.
+     * This is the bottleneck for processing values.
+     *
+     * @param path the xpath
+     * @param resolver the VoteResolver (for recycling), or null
+     * @param voteLoadingContext the VoteLoadingContext
+     * @return the VoteResolver
+     */
+    VoteResolver<String> setValueFromResolver(
+            String path,
+            VoteResolver<String> resolver,
+            STFactory.VoteLoadingContext voteLoadingContext,
+            STFactory.PerLocaleData.PerXPathData xpd) {
+        String value;
+        String fullPath;
+        /*
+         * If there are no votes, it may be more efficient (or anyway expected) to skip vote resolution
+         * and use diskData instead. This has far-reaching effects and should be better documented.
+         * When and how does it change the outcome and/or performance?
+         * Currently only skip for VoteLoadingContext.ORDINARY_LOAD_VOTES with null/empty xpd.
+         *
+         * Do not skip vote resolution if VoteLoadingContext.SINGLE_VOTE, even for empty xpd. Otherwise an Abstain can
+         * result in "no votes", "skip vote resolution", failure to get the right winning value, possibly inherited.
+         *
+         * Do not skip vote resolution if VoteLoadingContext.VXML_GENERATION, even for empty xpd. We may need to call
+         * getWinningValue for vote resolution for a larger set of paths to get baseline, etc.
+         */
+
+        /**
+         * TODO: move this into the caller somehow. Maybe just use a special resolver that just
+         * calls into diskData.
+         */
+        if (voteLoadingContext == STFactory.VoteLoadingContext.ORDINARY_LOAD_VOTES
+                && (xpd == null || xpd.isEmpty())) {
+            /*
+             * Skip vote resolution
+             */
+            value = diskData.getValueAtDPath(path);
+            fullPath = diskData.getFullPathAtDPath(path);
+        } else {
+            resolver = ballotBox.getResolver(path, resolver);
+            value = resolver.getWinningValue();
+            fullPath = getFullPathWithResolver(path, resolver);
+        }
+        delegate.removeValueAtDPath(path);
+        if (value != null) {
+            delegate.putValueAtPath(fullPath, value);
+        }
+        return resolver;
+    }
+
+    private String getFullPathWithResolver(String path, VoteResolver<String> resolver) {
+        String diskFullPath = ballotBox.diskData.getFullPathAtDPath(path);
+        if (diskFullPath == null) {
+            /*
+             * If the disk didn't have a full path, just use the inbound path.
+             */
+            diskFullPath = path;
+        }
+        /*
+         * Remove JUST draft alt proposed. Leave 'numbers=' etc.
+         */
+        String baseXPath = XPathTable.removeDraftAltProposed(diskFullPath);
+        Status win = resolver.getWinningStatus();
+        /*
+         * Catch Status.missing, or it will trigger an exception in draftStatusFromWinningStatus
+         * since there is no "missing" in DraftStatus.
+         * This may happen especially for VoteLoadingContext.VXML_GENERATION.
+         *
+         * Status.missing can also occur for VoteLoadingContext.SINGLE_VOTE, when a user abstains
+         * after submitting a new value. Then, delegate.removeValueAtDPath and/or delegate.putValueAtPath
+         * is required to clear out the submitted value; then possibly res = inheritance marker
+         */
+        if (win == Status.missing || win == Status.approved) {
+            return baseXPath;
+        } else {
+            DraftStatus draftStatus = draftStatusFromWinningStatus(win);
+            return baseXPath + "[@draft=\"" + draftStatus.toString() + "\"]";
+        }
+    }
+
+    /**
+     * Map the given VoteResolver.Status to a CLDRFile.DraftStatus
+     *
+     * @param win the VoteResolver.Status (winning status)
+     * @return the DraftStatus
+     *     <p>As a rule, the name of each VoteResolver.Status is also the name of a DraftStatus. Any
+     *     exceptions to that rule should be handled explicitly in this function. However,
+     *     VoteResolver.Status.missing is currently NOT handled and will cause an exception to be
+     *     logged. The caller should check for VoteResolver.Status.missing and avoid calling this
+     *     function with it.
+     *     <p>References: https://unicode.org/cldr/trac/ticket/11721
+     *     https://unicode.org/cldr/trac/ticket/11766 https://unicode.org/cldr/trac/ticket/11103
+     */
+    private static final DraftStatus draftStatusFromWinningStatus(VoteResolver.Status win) {
+        try {
+            return DraftStatus.forString(win.toString());
+        } catch (IllegalArgumentException e) {
+            SurveyLog.logException(
+                    logger, e, "Exception in draftStatusFromWinningStatus of " + win);
+            return DraftStatus.unconfirmed;
+        }
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DelegateXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DelegateXMLSource.java
@@ -1,0 +1,138 @@
+package org.unicode.cldr.web;
+
+import com.ibm.icu.util.VersionInfo;
+import java.util.Iterator;
+import java.util.Set;
+import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.util.XPathParts.Comments;
+
+/**
+ * An XMLSource that acts as a delegate for another XMLSource. This is the parent for STFactory's
+ * DataBackedSource, which overrides with database content. The base class is readonly, but the
+ * subclass may mutate the delegate
+ *
+ * @author srl
+ */
+class DelegateXMLSource extends XMLSource {
+    /** May be mutated by subclass. */
+    protected XMLSource delegate;
+
+    public DelegateXMLSource(XMLSource source) {
+        setLocaleID(source.getLocaleID());
+        delegate = source;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.icu.util.Freezable#freeze()
+     */
+    @Override
+    public XMLSource freeze() {
+        readonly();
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.unicode.cldr.util.XMLSource#getFullPathAtDPath(java.lang.String)
+     */
+    @Override
+    public String getFullPathAtDPath(String path) {
+        return delegate.getFullPathAtDPath(path);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.unicode.cldr.util.XMLSource#getValueAtDPath(java.lang.String)
+     */
+    @Override
+    public String getValueAtDPath(String path) {
+        return delegate.getValueAtDPath(path);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.unicode.cldr.util.XMLSource#getXpathComments()
+     */
+    @Override
+    public Comments getXpathComments() {
+        return delegate.getXpathComments();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.unicode.cldr.util.XMLSource#iterator()
+     */
+    @Override
+    public Iterator<String> iterator() {
+        return delegate.iterator();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.unicode.cldr.util.XMLSource#putFullPathAtDPath(java.lang.String,
+     * java.lang.String)
+     */
+    @Override
+    public void putFullPathAtDPath(String distinguishingXPath, String fullxpath) {
+        readonly();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.unicode.cldr.util.XMLSource#putValueAtDPath(java.lang.String,
+     * java.lang.String)
+     */
+    @Override
+    public void putValueAtDPath(String distinguishingXPath, String value) {
+        readonly();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.unicode.cldr.util.XMLSource#removeValueAtDPath(java.lang.String)
+     */
+    @Override
+    public void removeValueAtDPath(String distinguishingXPath) {
+        readonly();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.unicode.cldr.util.XMLSource#setXpathComments(org.unicode.cldr
+     * .util.XPathParts.Comments)
+     */
+    @Override
+    public void setXpathComments(Comments comments) {
+        readonly();
+    }
+
+    @Override
+    public void getPathsWithValue(String valueToMatch, String pathPrefix, Set<String> result) {
+        delegate.getPathsWithValue(valueToMatch, pathPrefix, result);
+    }
+
+    @Override
+    public VersionInfo getDtdVersionInfo() {
+        return delegate.getDtdVersionInfo();
+    }
+
+    private static void readonly() {
+        throw new InternalError("This is a readonly instance.");
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/LocaleMaxSizer.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/LocaleMaxSizer.java
@@ -1,0 +1,70 @@
+package org.unicode.cldr.web;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.unicode.cldr.util.CLDRLocale;
+
+/**
+ * This class tracks the expected maximum size of strings in the locale.
+ *
+ * @author srl
+ */
+public class LocaleMaxSizer {
+    public static final int EXEMPLAR_CHARACTERS_MAX = 8192;
+
+    public static final String EXEMPLAR_CHARACTERS = "//ldml/characters/exemplarCharacters";
+
+    Map<CLDRLocale, Map<String, Integer>> sizeExceptions;
+
+    TreeMap<String, Integer> exemplars_prefix = new TreeMap<>();
+    Set<CLDRLocale> exemplars_set = new TreeSet<>();
+
+    /** Construct a new sizer. */
+    public LocaleMaxSizer() {
+        // set up the map
+        sizeExceptions = new TreeMap<>();
+        exemplars_prefix.put(EXEMPLAR_CHARACTERS, EXEMPLAR_CHARACTERS_MAX);
+        String[] locs = {"ja", "ko", "zh", "zh_Hant" /*because of cross-script inheritance*/};
+        for (String loc : locs) {
+            exemplars_set.add(CLDRLocale.getInstance(loc));
+        }
+    }
+
+    /**
+     * It's expected that this is called with EVERY locale, so we do not recurse into parents.
+     *
+     * @param l
+     */
+    public void add(CLDRLocale l) {
+        if (l == null) return; // attempt to add null
+        CLDRLocale hnr = l.getHighestNonrootParent();
+        if (hnr == null) return; // Exit if l is root
+        if (exemplars_set.contains(hnr)) { // are we a child of ja, ko, zh?
+            sizeExceptions.put(l, exemplars_prefix);
+        }
+    }
+
+    /**
+     * For the specified locale, what is the expected string size?
+     *
+     * @param locale
+     * @param xpath
+     * @return
+     */
+    public int getSize(CLDRLocale locale, String xpath) {
+        Map<String, Integer> prefixes = sizeExceptions.get(locale);
+        if (prefixes != null) {
+            for (Map.Entry<String, Integer> e : prefixes.entrySet()) {
+                if (xpath.startsWith(e.getKey())) {
+                    return e.getValue();
+                }
+            }
+        }
+        return MAX_VAL_LEN;
+    }
+
+    /** The max string length accepted of any value. */
+    public static final int MAX_VAL_LEN = 4096;
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -661,6 +661,11 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             return r;
         }
 
+        @Override
+        public VoteResolver<String> getResolver(String path) {
+            return getResolver(peekXpathData(path), path, null);
+        }
+
         /**
          * called by getResolver()
          *
@@ -684,11 +689,6 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 }
             }
             return r;
-        }
-
-        @Override
-        public VoteResolver<String> getResolver(String path) {
-            return getResolver(peekXpathData(path), path, null);
         }
 
         @Override

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -635,8 +635,9 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             r.setBaseline(currentValue, currentStatus);
             r.add(currentValue);
 
-            CLDRFile cf = make(locale, true);
-            r.setBaileyValue(cf.getBaileyValue(path, null, null));
+            /** Note that rFile may not have all votes filled in yet as we're in startup phase */
+            final CLDRFile baseFile = (rFile != null) ? rFile : diskFile;
+            r.setBaileyValue(baseFile.getBaileyValue(path, null, null));
 
             // add each vote
             if (perXPathData != null && !perXPathData.isEmpty()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -2959,8 +2959,8 @@ public class SurveyAjax extends HttpServlet {
                     sm.getRelatedLocs(topLocale); // sublocales of the 'top' locale
             for (CLDRLocale ol : relatedLocs) {
                 String baseName = ol.getBaseName();
-                XMLSource src = sm.getSTFactory().makeSource(baseName, true /* resolved */);
-                String ov = src.getValueAtDPath(xpathString);
+                CLDRFile src = sm.getSTFactory().make(baseName, true /* resolved */);
+                String ov = src.getStringValue(xpathString);
                 if (ov != null) {
                     JSONArray other;
                     if (others.has(ov)) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -2484,11 +2484,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
      * @author srl
      */
     public class UserLocaleStuff implements AutoCloseable {
-        public CLDRFile cldrfile = null;
-        public XMLSource dbSource = null;
-        public XMLSource resolvedSource = null;
         private int use;
-        CLDRFile resolvedFile = null;
 
         public void open() {
             use++;
@@ -2517,11 +2513,10 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         }
 
         public void internalClose() {
-            this.dbSource = null;
         }
 
         public boolean isClosed() {
-            return this.dbSource == null;
+            return(use == 0);
         }
 
         public UserLocaleStuff(CLDRLocale locale) {
@@ -2529,22 +2524,9 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                 allUserLocaleStuffs.add(this);
             }
 
-            // TODO: refactor.
-            if (cldrfile == null) {
-                resolvedSource = getSTFactory().makeSource(locale.getBaseName(), true);
-                dbSource = resolvedSource.getUnresolving();
-                cldrfile =
-                        getSTFactory()
-                                .make(locale, true)
-                                .setSupplementalDirectory(getSupplementalDirectory());
-                resolvedFile = cldrfile;
-            }
         }
 
         public void clear() {
-            // TODO: try just kicking these instead of clearing?
-            cldrfile = null;
-            dbSource = null;
         }
     }
 
@@ -3305,7 +3287,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     private static Set<CLDRLocale> localeListSet = null;
     private static Set<CLDRLocale> roLocales = null;
 
-    protected static STFactory.LocaleMaxSizer localeSizer;
+    protected static LocaleMaxSizer localeSizer;
 
     /**
      * Get the list of locales which are read only for some reason. These won't be generated, and
@@ -3335,7 +3317,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         Set<CLDRLocale> s = new TreeSet<>();
         Set<CLDRLocale> ro = new TreeSet<>();
         Set<CLDRLocale> w = new TreeSet<>();
-        STFactory.LocaleMaxSizer lms = new STFactory.LocaleMaxSizer();
+        LocaleMaxSizer lms = new LocaleMaxSizer();
 
         String onlyLocales = CLDRConfig.getInstance().getProperty("CLDR_ONLY_LOCALES", null);
         Set<String> onlySet = null;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -2522,8 +2522,6 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                 allUserLocaleStuffs.add(this);
             }
         }
-
-        public void clear() {}
     }
 
     /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -88,7 +88,6 @@ import org.unicode.cldr.util.SpecialLocales;
 import org.unicode.cldr.util.SpecialLocales.Type;
 import org.unicode.cldr.util.StackTracker;
 import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.web.UserRegistry.User;
 import org.unicode.cldr.web.WebContext.HTMLDirection;
 import org.unicode.cldr.web.api.Summary;
@@ -2512,22 +2511,19 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             }
         }
 
-        public void internalClose() {
-        }
+        public void internalClose() {}
 
         public boolean isClosed() {
-            return(use == 0);
+            return (use == 0);
         }
 
         public UserLocaleStuff(CLDRLocale locale) {
             synchronized (allUserLocaleStuffs) {
                 allUserLocaleStuffs.add(this);
             }
-
         }
 
-        public void clear() {
-        }
+        public void clear() {}
     }
 
     /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
@@ -29,7 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.PathHeader;
@@ -1215,10 +1214,6 @@ public class WebContext implements Cloneable, Appendable {
         if (uf != null) {
             uf.close();
         }
-    }
-
-    public CLDRFile getCLDRFile() {
-        return getUserFile().cldrfile;
     }
 
     public void no_js_warning() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletion.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletion.java
@@ -179,7 +179,10 @@ public class LocaleCompletion {
         // we need an XML Source to receive notification.
         // This causes LocaleCompletionHelper.INSTANCE.valueChanged(...) to be called
         // whenever a vote happens.
-        stFactory.get(cldrLocale).getSource().addListener(LocaleCompletion.LocaleCompletionHelper.INSTANCE);
+        stFactory
+                .get(cldrLocale)
+                .getSource()
+                .addListener(LocaleCompletion.LocaleCompletionHelper.INSTANCE);
         return new LocaleCompletionCounter(cldrLocale, stFactory).getResponse();
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletion.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletion.java
@@ -179,8 +179,7 @@ public class LocaleCompletion {
         // we need an XML Source to receive notification.
         // This causes LocaleCompletionHelper.INSTANCE.valueChanged(...) to be called
         // whenever a vote happens.
-        final XMLSource mySource = stFactory.makeSource(cldrLocale.toString(), false);
-        mySource.addListener(LocaleCompletion.LocaleCompletionHelper.INSTANCE);
+        stFactory.get(cldrLocale).getSource().addListener(LocaleCompletion.LocaleCompletionHelper.INSTANCE);
         return new LocaleCompletionCounter(cldrLocale, stFactory).getResponse();
     }
 

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestMisc.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestMisc.java
@@ -4,7 +4,7 @@ package org.unicode.cldr.unittest.web;
 import com.ibm.icu.dev.test.TestFmwk;
 import java.util.Set;
 import org.unicode.cldr.util.*;
-import org.unicode.cldr.web.STFactory;
+import org.unicode.cldr.web.LocaleMaxSizer;
 import org.unicode.cldr.web.SurveyMain;
 import org.unicode.cldr.web.WebContext;
 
@@ -18,7 +18,7 @@ public class TestMisc extends TestFmwk {
 
     public void TestLocaleMaxSizer() {
         logln("Creating new sizer..");
-        STFactory.LocaleMaxSizer lms = new STFactory.LocaleMaxSizer();
+        LocaleMaxSizer lms = new LocaleMaxSizer();
 
         Factory f = CLDRConfig.getInstance().getCldrFactory();
         logln("Populating sizer..");
@@ -27,18 +27,18 @@ public class TestMisc extends TestFmwk {
         }
 
         final String TESTCASES[] = {
-            "root", "//foo/bar", Integer.toString(STFactory.LocaleMaxSizer.MAX_VAL_LEN),
-            "zh", "//foo/bar", Integer.toString(STFactory.LocaleMaxSizer.MAX_VAL_LEN),
+            "root", "//foo/bar", Integer.toString(LocaleMaxSizer.MAX_VAL_LEN),
+            "zh", "//foo/bar", Integer.toString(LocaleMaxSizer.MAX_VAL_LEN),
             "zh", "//ldml/characters/exemplarCharacters",
-                    Integer.toString(STFactory.LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
+                    Integer.toString(LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
             "zh_Hans_CN", "//ldml/characters/exemplarCharacters",
-                    Integer.toString(STFactory.LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
+                    Integer.toString(LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
             "zh_Hans_CN", "//ldml/characters/exemplarCharacters",
-                    Integer.toString(STFactory.LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
+                    Integer.toString(LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
             "zh_Hant", "//ldml/characters/exemplarCharacters[@type=\"auxiliary\"]",
-                    Integer.toString(STFactory.LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
+                    Integer.toString(LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
             "zh_Hant_HK", "//ldml/characters/exemplarCharacters",
-                    Integer.toString(STFactory.LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
+                    Integer.toString(LocaleMaxSizer.EXEMPLAR_CHARACTERS_MAX),
         };
 
         for (int i = 0; i < TESTCASES.length; i += 3) {


### PR DESCRIPTION
CLDR-16763

- [ ] This PR completes the ticket.

Initial work:

- use a real cache instead of homegrown
- initialize the non-resolved XMLSource / CLDRFile in the Per-Locale c'tor instead of deferring

I think initializing the resolved XMLSource might be more challenging because it's reentrant, needs to construct other PerLocaleDatas. 

But perhaps, when, say, French or French in Canada is hit, ST should grab a lock  and initialize ALL `fr*` sublocales right there. That way if  say `fr_FR` and `fr_CA` both got hit at the same time, they wouldn't deadlock on adding `fr` . 

ALLOW_MANY_COMMITS=true
