### PR TITLE
CLDR-16758 Too many abstained votes; fix bug in import votes

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -1626,7 +1626,7 @@ public class SurveyAjax extends HttpServlet {
                 }
                 String curValue = diskData.getValueAtDPath(xpathString);
                 boolean isWinning =
-                        diskData.equalsOrInheritsCurrentValue(value, curValue, xpathString);
+                        cldrFile.equalsOrInheritsCurrentValue(value, curValue, xpathString);
                 if (oldvotes != null) {
                     String xpathStringHash = sm.xpt.getStringIDString(xp);
                     JSONObject aRow =
@@ -2231,10 +2231,10 @@ public class SurveyAjax extends HttpServlet {
         if (value == null) {
             return true;
         }
-        if (!diskData.equalsOrInheritsCurrentValue(value, curValue, xpathString)) {
+        CLDRFile cldrFile = fac.make(loc, true, true);
+        if (!cldrFile.equalsOrInheritsCurrentValue(value, curValue, xpathString)) {
             return false;
         }
-        CLDRFile cldrFile = fac.make(loc, true, true);
         if (CheckForCopy.sameAsCode(value, xpathString, cldrFile.getUnresolved(), cldrFile)) {
             return false;
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyBulkClosePosts.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyBulkClosePosts.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 import org.json.JSONException;
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.XMLSource;
 
 public class SurveyBulkClosePosts {
@@ -110,10 +111,12 @@ public class SurveyBulkClosePosts {
     }
 
     private boolean matchesWinning(String loc, Integer xpath, String value) {
-        XMLSource diskData = sm.getDiskFactory().makeSource(loc).freeze();
+        STFactory stf = sm.getSTFactory();
+        XMLSource diskData = stf.makeSource(loc).freeze();
         String xpathString = sm.xpt.getById(xpath);
         String curValue = diskData.getValueAtDPath(xpathString);
-        return diskData.equalsOrInheritsCurrentValue(value, curValue, xpathString);
+        CLDRFile cldrFile = stf.make(loc, true, true);
+        return cldrFile.equalsOrInheritsCurrentValue(value, curValue, xpathString);
     }
 
     private void doExecute() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -167,6 +167,41 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
 
     private File supplementalDirectory;
 
+    /**
+     * Does the value in question either match or inherent the current value?
+     *
+     * <p>To match, the value in question and the current value must be non-null and equal.
+     *
+     * <p>To inherit the current value, the value in question must be INHERITANCE_MARKER and the
+     * current value must equal the bailey value.
+     *
+     * <p>This CLDRFile is only used here for getBaileyValue, not to get curValue
+     *
+     * @param value the value in question
+     * @param curValue the current value, that is, XMLSource.getValueAtDPath(xpathString)
+     * @param xpathString the path identifier
+     * @return true if it matches or inherits, else false
+     */
+    public boolean equalsOrInheritsCurrentValue(String value, String curValue, String xpathString) {
+        if (value == null || curValue == null) {
+            return false;
+        }
+        if (value.equals(curValue)) {
+            return true;
+        }
+        if (value.equals(CldrUtility.INHERITANCE_MARKER)) {
+            String baileyValue = getBaileyValue(xpathString, null, null);
+            if (baileyValue == null) {
+                /* This may happen for Invalid XPath; InvalidXPathException may be thrown. */
+                return false;
+            }
+            if (curValue.equals(baileyValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public enum DraftStatus {
         unconfirmed,
         provisional,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -1996,39 +1996,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
     }
 
     /**
-     * Does the value in question either match or inherent the current value in this XMLSource?
-     *
-     * <p>To match, the value in question and the current value must be non-null and equal.
-     *
-     * <p>To inherit the current value, the value in question must be INHERITANCE_MARKER and the
-     * current value must equal the bailey value.
-     *
-     * @param value the value in question
-     * @param curValue the current value, that is, getValueAtDPath(xpathString)
-     * @param xpathString the path identifier
-     * @return true if it matches or inherits, else false
-     */
-    public boolean equalsOrInheritsCurrentValue(String value, String curValue, String xpathString) {
-        if (value == null || curValue == null) {
-            return false;
-        }
-        if (value.equals(curValue)) {
-            return true;
-        }
-        if (value.equals(CldrUtility.INHERITANCE_MARKER)) {
-            String baileyValue = getBaileyValue(xpathString, null, null);
-            if (baileyValue == null) {
-                /* This may happen for Invalid XPath; InvalidXPathException may be thrown. */
-                return false;
-            }
-            if (curValue.equals(baileyValue)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Add a SourceLocation to this full XPath. Base implementation does nothing.
      *
      * @param currentFullXPath


### PR DESCRIPTION
-Move equalsOrInheritsCurrentValue from XMLSource to CLDRFile

-The callers had non-resolving XMLSource for which getBaileyValue is always null

CLDR-16758

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
