### PR TITLE
CLDR-16786 make languages in CLDR locales' ids available

### DIFF
--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -7,10 +7,40 @@
 	<metadata>
 		<validity>
 			<!-- BCP 47 contains many more language codes than we are interested in maintaining as a part of the CLDR -->
-			<!-- This list contains ONLY those languages considered to be 'of interest' as part of CLDR, -->
-			<!-- and is maintained manually by the CLDR TC -->
-			<!-- The following are in $language but not in common/main or in modern coverage: cu lij prg vo -->
+			<!-- This $language list contains ONLY those languages that are in the CLDR locales' IDs (after maximizing with LikelySubtags) -->
 			<variable id='$language' type='choice'>
+                aa ab af agq ak am an ann apc ar arn as asa ast az
+                ba bal bas be bem bew bez bg bgc bgn bho blo blt bm bn bo br brx bs bss byn
+                ca cad cch ccp ce ceb cgg cho chr cic ckb co cs csw cu cv cy
+                da dav de dje doi dsb dua dv dyo dz
+                ebu ee el en eo es et eu ewo
+                fa ff fi fil fo fr frr fur fy
+                ga gaa gd gez gl gn gsw gu guz gv
+                ha haw he hi hnj hr hsb hu hy
+                ia id ie ig ii io is it iu
+                ja jbo jgo jmc jv
+                ka kab kaj kam kcg kde kea ken kgp khq ki kk kkj kl kln km kn ko kok kpe ks ksb ksf ksh ku kw kxv ky
+                la lag lb lg lij lkt lmo ln lo lrc lt lu luo luy lv
+                mai mas mdf mer mfe mg mgh mgo mi mic mk ml mn mni moh mr ms mt mua mus my myv mzn
+                naq nb nd nds ne nl nmg nn nnh no nqo nr nso nus nv ny nyn
+                oc om or os osa
+                pa pap pcm pis pl prg ps pt
+                qu quc
+                raj rhg rif rm rn ro rof ru rw rwk
+                sa sah saq sat sbp sc scn sd sdh se seh ses sg shi shn si sid sk skr sl sma smj smn sms sn so sq sr ss ssy st su sv sw syr szl
+                ta te teo tg th ti tig tk tn to tok tpi tr trv trw ts tt twq tyv tzm
+                ug uk ur uz
+                vai ve vec vi vmw vo vun
+                wa wae wal wbp wo
+                xh xnr xog
+                yav yi yo yrl yue
+                zgh zh zu
+			</variable>
+			<!-- The following are exceptional cases.
+				In v44 this contains a copy of the previous $language list to make review of CLDR-16789 easier;
+				this should be rationalized later. 
+			  -->
+			<variable id='$languageExceptions' type='choice'>
 				af agq ak am ann apc ar as asa ast az
 				bas be bem bez bg bgc bho bm bn bo br brx bs
 				ca ccp ce ceb cgg chr ckb cs cu cv cy
@@ -39,8 +69,7 @@
 				xh xog
 				yav yi yo yrl yue
 				zgh zh zu
-			</variable>
-			<variable id='$languageExceptions' type='choice'>
+
 				mul root zxx
 				ab ace ada ady ain ale alt an anp arn arp ars atj av awa ay
 				ba ban bi bin bla bug byn

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -1,39 +1,27 @@
 package org.unicode.cldr.unittest;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.ibm.icu.impl.Row;
-import com.ibm.icu.impl.Row.R4;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.unicode.cldr.test.CoverageLevel2;
-import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CoreCoverageInfo;
 import org.unicode.cldr.util.CoreCoverageInfo.CoreItems;
 import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
-import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
 import org.unicode.cldr.util.XMLSource;
-import org.unicode.cldr.util.XPathParts;
 
 public class TestCoverage extends TestFmwkPlus {
     private static final boolean DEBUG = false;
@@ -173,241 +161,6 @@ public class TestCoverage extends TestFmwkPlus {
         diff.removeAll(coreCoverage);
         if (diff.size() != 0) {
             errln("\t" + title + ": " + diff);
-        }
-    }
-
-    static class CoverageStatus {
-
-        private Level level;
-        private boolean inRoot;
-        private boolean inId;
-        private Level languageLevel;
-        private String displayName;
-
-        public CoverageStatus(
-                Level level,
-                boolean inRoot,
-                boolean inId,
-                Level languageLevel,
-                String displayName) {
-            this.level = level;
-            this.inRoot = inRoot;
-            this.inId = inId;
-            this.languageLevel = languageLevel == null ? Level.UNDETERMINED : languageLevel;
-            this.displayName = displayName;
-        }
-
-        @Override
-        public String toString() {
-            return (inRoot ? "root" : "x")
-                    + "\t"
-                    + (inId ? "ids" : "x")
-                    + "\t"
-                    + stringForm(languageLevel)
-                    + "\t"
-                    + stringForm(level)
-                    + "\t"
-                    + displayName;
-        }
-
-        private String stringForm(Level level2) {
-            if (level == null) {
-                return "υnd";
-            }
-            switch (level2) {
-                case UNDETERMINED:
-                    return "υnd";
-                case COMPREHENSIVE:
-                    return "ϲomp";
-                default:
-                    return level2.toString();
-            }
-        }
-    }
-
-    public void testLSR() {
-        SupplementalDataInfo supplementalData = testInfo.getSupplementalDataInfo();
-        Factory factory = testInfo.getCldrFactory();
-        CLDRFile root = factory.make("root", true);
-        CoverageLevel2 coverageLevel =
-                CoverageLevel2.getInstance(supplementalData, "yyy"); // non-existant locale
-
-        Set<String> langsRoot = new TreeSet<>();
-        Set<String> scriptsRoot = new TreeSet<>();
-        Set<String> regionsRoot = new TreeSet<>();
-
-        // Get root LSR codes
-
-        for (String path : root) {
-            if (!path.startsWith("//ldml/localeDisplayNames/")) {
-                continue;
-            }
-            XPathParts parts = XPathParts.getFrozenInstance(path);
-            String code = parts.getAttributeValue(3, "type");
-            if (code == null || code.contains("_")) {
-                continue;
-            }
-            switch (parts.getElement(3)) {
-                case "language":
-                    langsRoot.add(code);
-                    break;
-                case "script":
-                    scriptsRoot.add(code);
-                    break;
-                case "territory":
-                    regionsRoot.add(code);
-                    break;
-            }
-        }
-        langsRoot = ImmutableSet.copyOf(langsRoot);
-        scriptsRoot = ImmutableSet.copyOf(scriptsRoot);
-        regionsRoot = ImmutableSet.copyOf(regionsRoot);
-
-        // get CLDR locale IDs' codes
-
-        Map<String, Level> langs = new TreeMap<>();
-        Map<String, Level> scripts = new TreeMap<>();
-        Map<String, Level> regions = new TreeMap<>();
-        LikelySubtags likely = new LikelySubtags();
-
-        LanguageTagParser ltp = new LanguageTagParser();
-        for (String locale : factory.getAvailable()) {
-            Level languageLevel = sc.getLocaleCoverageLevel(Organization.cldr, locale);
-            if (languageLevel == null || languageLevel == Level.UNDETERMINED) {
-                languageLevel = Level.CORE;
-            }
-            ltp.set(locale);
-            likely.maximize(ltp);
-            addBestLevel(langs, ltp.getLanguage(), languageLevel);
-            addBestLevel(scripts, ltp.getScript(), languageLevel);
-            addBestLevel(regions, ltp.getRegion(), languageLevel);
-        }
-        regions.remove("");
-        scripts.remove("");
-
-        // get the data
-
-        Map<String, CoverageStatus> data = new TreeMap<>();
-
-        ImmutableMap<Integer, R4<String, Map<String, Level>, Set<String>, Level>> typeToInfo =
-                ImmutableMap.of(
-                        CLDRFile.LANGUAGE_NAME,
-                        Row.of("language", langs, langsRoot, Level.MODERN),
-                        CLDRFile.SCRIPT_NAME,
-                        Row.of("script", scripts, scriptsRoot, Level.MODERATE),
-                        CLDRFile.TERRITORY_NAME,
-                        Row.of("region", regions, regionsRoot, Level.MODERATE));
-
-        for (Entry<Integer, R4<String, Map<String, Level>, Set<String>, Level>> typeAndInfo :
-                typeToInfo.entrySet()) {
-            int type = typeAndInfo.getKey();
-            String name = typeAndInfo.getValue().get0();
-            Map<String, Level> idPartMap = typeAndInfo.getValue().get1();
-            Set<String> setRoot = typeAndInfo.getValue().get2();
-            Level targetLevel = typeAndInfo.getValue().get3();
-            for (String code : Sets.union(idPartMap.keySet(), setRoot)) {
-                String displayName = testInfo.getEnglish().getName(type, code);
-                String path = CLDRFile.getKey(type, code);
-                Level level = coverageLevel.getLevel(path);
-                data.put(
-                        name + "\t" + code,
-                        new CoverageStatus(
-                                level,
-                                setRoot.contains(code),
-                                idPartMap.containsKey(code),
-                                idPartMap.get(code),
-                                displayName));
-            }
-        }
-        if (SHOW_LSR_DATA) {
-
-            System.out.println(
-                    "\nType\tCode\tIn Root\tIn CLDR Locales\tCLDR TargeLevel\tRoot Path Level\tCombinations");
-            for (Entry<String, CoverageStatus> entry : data.entrySet()) {
-                System.out.println(entry.getKey() + "\t" + entry.getValue());
-            }
-            System.out.println();
-            for (Entry<String, CoverageStatus> entry : data.entrySet()) {
-                final String key = entry.getKey();
-                if (!key.startsWith("language")) {
-                    continue;
-                }
-                final CoverageStatus value = entry.getValue();
-                if (value.inId) {
-                    continue;
-                }
-                String[] parts = key.split("\t");
-                PopulationData population = sdi.getBaseLanguagePopulationData(parts[1]);
-                if (population == null) {
-                    System.out.println(key + "\t" + value.displayName + "\t" + value + "\t-1\t-1");
-                } else {
-                    System.out.println(
-                            key
-                                    + "\t"
-                                    + value.displayName
-                                    + "\t"
-                                    + value
-                                    + "\t"
-                                    + population.getPopulation()
-                                    + "\t"
-                                    + population.getLiteratePopulation());
-                }
-            }
-        }
-
-        Set<String> ids = new TreeSet<>();
-        Set<String> missing = new TreeSet<>();
-        for (Entry<String, CoverageStatus> entry : data.entrySet()) {
-            final String key = entry.getKey();
-            if (!key.startsWith("language")) {
-                continue;
-            }
-            final CoverageStatus value = entry.getValue();
-            if (value.inId) {
-                String[] parts = key.split("\t");
-                ids.add(parts[1]);
-                if (!value.inRoot) {
-                    missing.add(parts[1]);
-                }
-            }
-        }
-        if (!assertEquals(
-                "Language subtags that are in a CLDR locale's ID are in root ("
-                        + missing.size()
-                        + ")",
-                "",
-                Joiner.on(' ').join(missing))) {
-            warnln(
-                    "Full set for resetting $language in attributeValueValidity.xml ("
-                            + ids.size()
-                            + "):"
-                            + breakLines(ids, "\n                "));
-        }
-    }
-
-    private String breakLines(Set<String> ids, String indent) {
-        StringBuilder result = new StringBuilder();
-        int lastFirstChar = 0;
-        for (String id : ids) {
-            int firstChar = id.codePointAt(0);
-            result.append(firstChar == lastFirstChar ? " " : indent);
-            result.append(id);
-            lastFirstChar = firstChar;
-        }
-        return result.toString();
-    }
-
-    private void addBestLevel(Map<String, Level> codeToBestLevel, String code, Level level) {
-        if (level != Level.UNDETERMINED) {
-            int debug = 0;
-        }
-        Level old = codeToBestLevel.get(code);
-        if (old == null) {
-            codeToBestLevel.put(code, level);
-        } else if (level.compareTo(old) > 0) {
-            codeToBestLevel.put(code, level);
-        } else if (level != old) {
-            int debug = 0;
         }
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -2,12 +2,16 @@ package org.unicode.cldr.unittest;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Relation;
+import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
+import com.ibm.icu.impl.Row.R4;
 import com.ibm.icu.text.CompactDecimalFormat;
 import com.ibm.icu.text.CompactDecimalFormat.CompactStyle;
 import com.ibm.icu.text.Transform;
@@ -30,6 +34,7 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 import org.unicode.cldr.draft.ScriptMetadata;
 import org.unicode.cldr.test.CoverageLevel2;
+import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
@@ -43,6 +48,7 @@ import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LogicalGrouping;
 import org.unicode.cldr.util.LogicalGrouping.PathType;
 import org.unicode.cldr.util.Organization;
@@ -62,6 +68,8 @@ import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.XPathParts;
 
 public class TestCoverageLevel extends TestFmwkPlus {
+
+    private static final boolean SHOW_LSR_DATA = false;
 
     private static CLDRConfig testInfo = CLDRConfig.getInstance();
     private static final StandardCodes STANDARD_CODES = StandardCodes.make();
@@ -495,6 +503,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
         final Pattern language100 =
                 PatternCache.get(
                         "("
+                                + "blo|kxv|skr|vmw|xnr|"
                                 + "ach|aeb?|afh|ak[kz]|aln|ang|apc|ar[coqswyz]|ase|avk|"
                                 + "ba[lrx]|bb[cj]|be[jw]|bf[dq]|bgc|bgn|bik|bjn|bkm|bpy|bqi|br[ah]|bss|bu[am]|byv|"
                                 + "ca[dry]|cch|ch[bgnp]|cic|cop|cps|crh?|csb|"
@@ -1076,5 +1085,240 @@ public class TestCoverageLevel extends TestFmwkPlus {
         bMinusA.removeAll(expected);
         result.putAll("actual-expected", bMinusA);
         return result;
+    }
+
+    static class CoverageStatus {
+
+        private Level level;
+        private boolean inRoot;
+        private boolean inId;
+        private Level languageLevel;
+        private String displayName;
+
+        public CoverageStatus(
+                Level level,
+                boolean inRoot,
+                boolean inId,
+                Level languageLevel,
+                String displayName) {
+            this.level = level;
+            this.inRoot = inRoot;
+            this.inId = inId;
+            this.languageLevel = languageLevel == null ? Level.UNDETERMINED : languageLevel;
+            this.displayName = displayName;
+        }
+
+        @Override
+        public String toString() {
+            return (inRoot ? "root" : "x")
+                    + "\t"
+                    + (inId ? "ids" : "x")
+                    + "\t"
+                    + stringForm(languageLevel)
+                    + "\t"
+                    + stringForm(level)
+                    + "\t"
+                    + displayName;
+        }
+
+        private String stringForm(Level level2) {
+            if (level == null) {
+                return "υnd";
+            }
+            switch (level2) {
+                case UNDETERMINED:
+                    return "υnd";
+                case COMPREHENSIVE:
+                    return "ϲomp";
+                default:
+                    return level2.toString();
+            }
+        }
+    }
+
+    public void testLSR() {
+        SupplementalDataInfo supplementalData = testInfo.getSupplementalDataInfo();
+        org.unicode.cldr.util.Factory factory = testInfo.getCldrFactory();
+        CLDRFile root = factory.make(LocaleNames.ROOT, true);
+        CoverageLevel2 coverageLevel =
+                CoverageLevel2.getInstance(supplementalData, "qtz"); // non-existent locale
+
+        Set<String> langsRoot = new TreeSet<>();
+        Set<String> scriptsRoot = new TreeSet<>();
+        Set<String> regionsRoot = new TreeSet<>();
+
+        // Get root LSR codes
+
+        for (String path : root) {
+            if (!path.startsWith("//ldml/localeDisplayNames/")) {
+                continue;
+            }
+            XPathParts parts = XPathParts.getFrozenInstance(path);
+            String code = parts.getAttributeValue(3, "type");
+            if (code == null || code.contains("_")) {
+                continue;
+            }
+            switch (parts.getElement(3)) {
+                case "language":
+                    langsRoot.add(code);
+                    break;
+                case "script":
+                    scriptsRoot.add(code);
+                    break;
+                case "territory":
+                    regionsRoot.add(code);
+                    break;
+            }
+        }
+        langsRoot = ImmutableSet.copyOf(langsRoot);
+        scriptsRoot = ImmutableSet.copyOf(scriptsRoot);
+        regionsRoot = ImmutableSet.copyOf(regionsRoot);
+
+        // get CLDR locale IDs' codes
+
+        Map<String, Level> langs = new TreeMap<>();
+        Map<String, Level> scripts = new TreeMap<>();
+        Map<String, Level> regions = new TreeMap<>();
+        LikelySubtags likely = new LikelySubtags();
+
+        LanguageTagParser ltp = new LanguageTagParser();
+        for (String locale : factory.getAvailable()) {
+            Level languageLevel = STANDARD_CODES.getLocaleCoverageLevel(Organization.cldr, locale);
+            if (languageLevel == null || languageLevel == Level.UNDETERMINED) {
+                languageLevel = Level.CORE;
+            }
+            ltp.set(locale);
+            likely.maximize(ltp);
+            addBestLevel(langs, ltp.getLanguage(), languageLevel);
+            addBestLevel(scripts, ltp.getScript(), languageLevel);
+            addBestLevel(regions, ltp.getRegion(), languageLevel);
+        }
+        regions.remove("");
+        scripts.remove("");
+
+        // get the data
+
+        Map<String, CoverageStatus> data = new TreeMap<>();
+
+        ImmutableMap<Integer, R4<String, Map<String, Level>, Set<String>, Level>> typeToInfo =
+                ImmutableMap.of(
+                        CLDRFile.LANGUAGE_NAME,
+                        Row.of("language", langs, langsRoot, Level.MODERN),
+                        CLDRFile.SCRIPT_NAME,
+                        Row.of("script", scripts, scriptsRoot, Level.MODERATE),
+                        CLDRFile.TERRITORY_NAME,
+                        Row.of("region", regions, regionsRoot, Level.MODERATE));
+
+        for (Entry<Integer, R4<String, Map<String, Level>, Set<String>, Level>> typeAndInfo :
+                typeToInfo.entrySet()) {
+            int type = typeAndInfo.getKey();
+            String name = typeAndInfo.getValue().get0();
+            Map<String, Level> idPartMap = typeAndInfo.getValue().get1();
+            Set<String> setRoot = typeAndInfo.getValue().get2();
+            Level targetLevel = typeAndInfo.getValue().get3();
+            for (String code : Sets.union(idPartMap.keySet(), setRoot)) {
+                String displayName = testInfo.getEnglish().getName(type, code);
+                String path = CLDRFile.getKey(type, code);
+                Level level = coverageLevel.getLevel(path);
+                data.put(
+                        name + "\t" + code,
+                        new CoverageStatus(
+                                level,
+                                setRoot.contains(code),
+                                idPartMap.containsKey(code),
+                                idPartMap.get(code),
+                                displayName));
+            }
+        }
+        if (SHOW_LSR_DATA) {
+
+            System.out.println(
+                    "\nType\tCode\tIn Root\tIn CLDR Locales\tCLDR TargeLevel\tRoot Path Level\tCombinations");
+            for (Entry<String, CoverageStatus> entry : data.entrySet()) {
+                System.out.println(entry.getKey() + "\t" + entry.getValue());
+            }
+            System.out.println();
+            for (Entry<String, CoverageStatus> entry : data.entrySet()) {
+                final String key = entry.getKey();
+                if (!key.startsWith("language")) {
+                    continue;
+                }
+                final CoverageStatus value = entry.getValue();
+                if (value.inId) {
+                    continue;
+                }
+                String[] parts = key.split("\t");
+                PopulationData population = SDI.getBaseLanguagePopulationData(parts[1]);
+                if (population == null) {
+                    System.out.println(key + "\t" + value.displayName + "\t" + value + "\t-1\t-1");
+                } else {
+                    System.out.println(
+                            key
+                                    + "\t"
+                                    + value.displayName
+                                    + "\t"
+                                    + value
+                                    + "\t"
+                                    + population.getPopulation()
+                                    + "\t"
+                                    + population.getLiteratePopulation());
+                }
+            }
+        }
+
+        Set<String> ids = new TreeSet<>();
+        Set<String> missing = new TreeSet<>();
+        for (Entry<String, CoverageStatus> entry : data.entrySet()) {
+            final String key = entry.getKey();
+            if (!key.startsWith("language")) {
+                continue;
+            }
+            final CoverageStatus value = entry.getValue();
+            if (value.inId) {
+                String[] parts = key.split("\t");
+                ids.add(parts[1]);
+                if (!value.inRoot) {
+                    missing.add(parts[1]);
+                }
+            }
+        }
+        if (!assertEquals(
+                "Language subtags that are in a CLDR locale's ID are in root ("
+                        + missing.size()
+                        + ")",
+                "",
+                Joiner.on(' ').join(missing))) {
+            warnln(
+                    "Full set for resetting $language in attributeValueValidity.xml ("
+                            + ids.size()
+                            + "):"
+                            + breakLines(ids, "\n                "));
+        }
+    }
+
+    private String breakLines(Set<String> ids, String indent) {
+        StringBuilder result = new StringBuilder();
+        int lastFirstChar = 0;
+        for (String id : ids) {
+            int firstChar = id.codePointAt(0);
+            result.append(firstChar == lastFirstChar ? " " : indent);
+            result.append(id);
+            lastFirstChar = firstChar;
+        }
+        return result.toString();
+    }
+
+    private void addBestLevel(Map<String, Level> codeToBestLevel, String code, Level level) {
+        if (level != Level.UNDETERMINED) {
+            int debug = 0;
+        }
+        Level old = codeToBestLevel.get(code);
+        if (old == null) {
+            codeToBestLevel.put(code, level);
+        } else if (level.compareTo(old) > 0) {
+            codeToBestLevel.put(code, level);
+        } else if (level != old) {
+            int debug = 0;
+        }
     }
 }


### PR DESCRIPTION
CLDR-16786

Note: this adds the missing languages (such as aa and osa). I left some duplication in the attributeValueValidity file to make review easier (while ensuring that nothing else changes).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
