### PR TITLE
CLDR-16815 fix vote-for-inheritance showing up

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -229,7 +229,12 @@ public class DataPage {
              */
             public Set<UserRegistry.User> getVotes() {
                 if (!checkedVotes) {
-                    votes = ballotBox.getVotesForValue(xpath, rawValue);
+                    String valueToCheck = rawValue;
+                    if (valueToCheck.equals(CldrUtility.INHERITANCE_MARKER)) {
+                        // Not so raw as it ought to be.
+                        valueToCheck = inheritedValue;
+                    }
+                    votes = ballotBox.getVotesForValue(xpath, valueToCheck);
                     checkedVotes = true;
                 }
                 return votes;


### PR DESCRIPTION
- CandidateItem.rawValue (sic!) can contain INHERITANCE_MARKER, thus failing to retrieve a list of voters.
- Probably only affects UI. It was showing the vote result for inheritance but no voters.
- Also note that the vote transcript was still correct in this case.

CLDR-16815

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
