### PR TITLE
CLDR-16811 fix unicode set variables

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2862,13 +2862,13 @@ Element content whose display may be affected in this way should include an expl
 #### <a name="Unicode_Sets" href="#Unicode_Sets">Unicode Sets</a>
 
 Some attribute values or element contents use _UnicodeSet_ notation.
-A UnicodeSet represents a finite set of Unicode code points and strings, and is defined by lists of code points and strings, Unicode property sets, and set operators, all bounded by square brackets.
+A UnicodeSet represents a finite set of Unicode code points and strings, and is defined by lists of code points and strings, Unicode property sets, and set operators, with square brackets for groupings.
 In this context, a code point means a string consisting of exactly one code point.
 
 A UnicodeSet implements the semantics in _UTS #18: Unicode Regular Expressions_ [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)] Levels 1 & 2 that are relevant to determining sets of characters.
 Note however that it may deviate from the syntax provided in [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)].
-There is one exception to the supported semantics, Section [RL2.6](https://www.unicode.org/reports/tr18/#RL2.6) _Wildcards in Property Values_.
-That feature can be supported in clients such as ICU by implementing a “hook” as is done in the [online UnicodeSet utilities](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bname%3D%2FAPPLE%2F%7D).
+In particular, Section [RL2.6](https://www.unicode.org/reports/tr18/#RL2.6) _Wildcards in Property Values_ is not supported.
+However, that feature can be supported in clients such as ICU by implementing a “hook” as is done in the [online UnicodeSet utilities](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bname%3D%2FAPPLE%2F%7D).
 
 A UnicodeSet may be cited in specifications outside of the domain of LDML.
 In such a case, that specification may specify a subset or superset of the syntax provided here.

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2921,7 +2921,7 @@ The syntax characters are listed in the table below:
 |  $   | U+0024 | DOLLAR SIGN          | Equivalent of \\uFFFF when followed by ']', or initiator for a variable identifier. |
 |  &   | U+0026 | AMPERSAND            | Intersecting UnicodeSets                   |
 |  -  | U+002D | HYPHEN-MINUS          | Ranges of characters; also set difference. |
-|  :   | U+003A | COLON                | POSIX-style property syntax. Note that [:di:] is a valid property expression, [di:] = [\: d i], and [:di] is an error |
+|  :   | U+003A | COLON                | POSIX-style property syntax. Note that [:di:] is a valid property expression, [di:] = [\\: d i], and [:di] is an error |
 |  [  | U+005B | LEFT SQUARE BRACKET   | Grouping; POSIX property syntax            |
 |  ]  | U+005D | RIGHT SQUARE BRACKET  | Grouping; POSIX property syntax            |
 |  \\  | U+005C | REVERSE SOLIDUS      | Escaping                                   |

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2861,45 +2861,71 @@ Element content whose display may be affected in this way should include an expl
 
 #### <a name="Unicode_Sets" href="#Unicode_Sets">Unicode Sets</a>
 
-Some attribute values or element contents use _UnicodeSet_ notation. A UnicodeSet represents a finite set of Unicode code points and strings, and is defined by lists of code points and strings, Unicode property sets, and set operators, all bounded by square brackets. In this context, a code point means a string consisting of exactly one code point.
+Some attribute values or element contents use _UnicodeSet_ notation.
+A UnicodeSet represents a finite set of Unicode code points and strings, and is defined by lists of code points and strings, Unicode property sets, and set operators, all bounded by square brackets.
+In this context, a code point means a string consisting of exactly one code point.
 
-A UnicodeSet implements the semantics in _UTS #18: Unicode Regular Expressions_ [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)] Levels 1 & 2 that are relevant to determining sets of characters. Note however that it may deviate from the syntax provided in [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)], which is illustrative rather than a requirement. There is one exception to the supported semantics, Section [RL2.6](https://www.unicode.org/reports/tr18/#RL2.6) _Wildcards in Property Values_. That feature can be supported in clients such as ICU by implementing a “hook” as is done in the [online UnicodeSet utilities](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bname%3D%2FAPPLE%2F%7D).
+A UnicodeSet implements the semantics in _UTS #18: Unicode Regular Expressions_ [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)] Levels 1 & 2 that are relevant to determining sets of characters.
+Note however that it may deviate from the syntax provided in [[UTS18](https://www.unicode.org/reports/tr41/#UTS18)].
+There is one exception to the supported semantics, Section [RL2.6](https://www.unicode.org/reports/tr18/#RL2.6) _Wildcards in Property Values_.
+That feature can be supported in clients such as ICU by implementing a “hook” as is done in the [online UnicodeSet utilities](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7Bname%3D%2FAPPLE%2F%7D).
 
-A UnicodeSet may be cited in specifications outside of the domain of LDML. In such a case, the specification may specify a subset of the syntax provided here.
+A UnicodeSet may be cited in specifications outside of the domain of LDML.
+In such a case, that specification may specify a subset or superset of the syntax provided here.
 
-The following provides EBNF syntax for a UnicodeSet:
+##### UnicodeSet syntax #####
 
 | Symbol         | Expression                                                     | Examples                                |
 | -------------- | -------------------------------------------------------------- | --------------------------------------- |
-| `root`         | <pre>= prop<br/>\| '[-]'<br/>\| '[' [\\-\\^]? s seq+ ']'</pre> | \\p{x=y},<br/>[abc]                     |
+| `root`         | <pre>= prop<br/>\| '[-]'<br/>\| '[' [\\-\\^]? s seq+ ']'<br/>\| var</pre> | \\p{x=y},<br/>[abc]          |
 | `seq`          | <pre>= root (s [\\&\\-] s root)* s<br/>\| range s</pre>        | [abc]-[cde], a                          |
-| `range`        | <pre>= char ('-' char)?<br/>\| '{' (s char)+ s '}'</pre>       | a, a-c, \{abc}                          |
+| `range`        | <pre>= char ('-' char)?<br/>\| string</pre>                    | a, a-c, \{abc}                          |
+| `string`       | <pre>= '{' (s char)+ s '}'<br/>\| var</pre>                    | \{abc}, {}                              |
 | `prop`         | <pre>= '\\' [pP] '{' propName ([≠=] s value1+)? '}'<br/>\| '[:' '^'? propName ([≠=] s value2+)? ':]'</pre> | \\p\{x=y}, [:x=y:]<br/> |
-| `propName`     | <pre>= s [A-Za-z0-9] [A-Za-z0-9_\\x20]* s</pre>                | General_Category,<br/>General Category  |
+| `propName`     | <pre>= s [A-Za-z0-9] [A-Za-z0-9_\\x20]* s</pre>                | General_Category,<br/>general category  |
 | `value1`       | <pre>= [^\\}]<br/>\| '\\' quoted</pre>                         | Lm,<br/>\\n,<br/>\\}                    |
 | `value2`       | <pre>= [^:]<br/>\| '\\' quoted</pre>                           | Lm,<br/>\\n,<br/>\\:                    |
-| `char`         | <pre>= [^\\& \\- \\[ \\[ \\] \\\\ \\} \\{ [:Pat_WS:]]<br/>\| '\\' quoted</pre> | a, b, c, \\n                            |
+| `char`         | <pre>= [^\\& \\- \\[ \\[ \\] \\\\ \\} \\{ [:Pat_WS:]]<br/>\| '\\' quoted<br/>\| var</pre> | a, b, c, \\n |
 | `quoted`       | <pre>= 'u' (hex{4} \| bracketedHex)<br/>\| 'x' (hex{2} \| bracketedHex)<br/>\| 'U00' ('0' hex{5} \| '10' hex{4})<br/>\| 'N{' propName '}'<br/>\| [[\u0000-\U00010FFFF]-[uxUN]]</pre> | _**error** if lengths not exact_ |
 | `charName`     | <pre>= s [A-Za-z0-9] [-A-Za-z0-9_\x20]* s</pre>                | TIBETAN LETTER -A                       |
 | `bracketedHex` | <pre>= '{' s hexCodePoint (s hexCodePoint)* s '}'</pre>        | \{61 2019 62}                           |
 | `hexCodePoint` | <pre>= hex{1,5} \| '10' hex{4}</pre>                           |                                         |
 | `hex`          | <pre>= [0-9A-Fa-f]</pre>                                       |                                         |
+| `var`          | <pre>= '$' [:XID_Start:] [:XID_Continue:]*</pre>               | variable (optional support)             |
 | `s`            | <pre>= [:Pattern_White_Space:]*</pre>                          | optional whitespace                     |
 
-Some constraints on UnicodeSet syntax are not captured by this EBNF. Notably, property names and values are restricted to those supported by the implementation, and have additional constraints imposed by [[UAX44](https://www.unicode.org/reports/tr41/#UAX44)]. In addition, quoted values that resolve to more than one code point are disallowed in ranges of the form `char '-' char`.
+Some constraints on UnicodeSet syntax are not captured by this EBNF.
+In particular:
+1. Property names and values are restricted to those supported by the implementation, and have additional constraints imposed by [[UAX44](https://www.unicode.org/reports/tr41/#UAX44)].
+2. Quoted values that resolve to more than one code point are disallowed in ranges of the form `char '-' char`.
 
+##### Variable identifiers #####
+Support for variable identifiers (var) is optional, used in certain contexts such as in [https://cldr-smoke.unicode.org/spec/main/ldml/tr35-general.html#Transforms](Transforms).
+When supported, a mapping from variable identifiers to strings is provided when parsing a UnicodeSet.
+Whenever an unescaped '$' is encountered outside of a property expression and followed immdicate, and there is a mapping, it is checked for the longest match.
+If there is such a match, then the value for that is substituted for the '$' and the variable identifier.
+If there is no such match, or if the subsitution causes a syntax error, then the parse operation returns an **error**.
+
+Notes: 
+1. The 'type' of a variable value is not specified. Thus [$a-$b] can resolve whether $a and $b are chars ($a=δ, $b=θ) or roots ($a=\p{script=greek}, $b=\p{general_category=letter}).
+The only restriction is that the result be syntactic; thus ($a=w, $b=xy) would raise an error or exception.
+2. Variable substitution is currently disallowed inside of prop expressions; thus \p{gc=$blah} raises an error.
+3. '$' when followed by ']' is interpreted as \\uFFFF, and is used to match before the start of a string or after the end. Thus [ab$] matches "a" or "b" or "".
+4. If '$' is neither followed by a character of type [:XID_Start:] or a ']', it is a syntax error.
+
+##### UnicodeSet syntax characters #####
 The syntax characters are listed in the table below:
 
 | Char | Hex    | Name                 | Usage                                      |
 | ---- | ------ | -------------------- | ------------------------------------------ |
-|  $   | U+0024 | DOLLAR SIGN          | Equivalent of \\uFFFF (This is for implementations that return \\uFFFF when accessing before the first or after the last character) |
+|  $   | U+0024 | DOLLAR SIGN          | Equivalent of \\uFFFF when followed by ']', or initiator for a variable identifier. |
 |  &   | U+0026 | AMPERSAND            | Intersecting UnicodeSets                   |
-|  -  | U+002D | HYPHEN-MINUS         | Ranges of characters; also set difference. |
-|  :   | U+003A | COLON                | POSIX-style property syntax                |
-|  [  | U+005B | LEFT SQUARE BRACKET  | Grouping; POSIX property syntax            |
-|  ]  | U+005D | RIGHT SQUARE BRACKET | Grouping; POSIX property syntax            |
+|  -  | U+002D | HYPHEN-MINUS          | Ranges of characters; also set difference. |
+|  :   | U+003A | COLON                | POSIX-style property syntax. Note that [:di:] is a valid property expression, [di:] = [\: d i], and [:di] is an error |
+|  [  | U+005B | LEFT SQUARE BRACKET   | Grouping; POSIX property syntax            |
+|  ]  | U+005D | RIGHT SQUARE BRACKET  | Grouping; POSIX property syntax            |
 |  \\  | U+005C | REVERSE SOLIDUS      | Escaping                                   |
-|  ^   | U+005E | CIRCUMFLEX ACCENT    | Posix negation syntax                      |
+|  ^   | U+005E | CIRCUMFLEX ACCENT    | Complement syntax                      |
 |  {   | U+007B | LEFT CURLY BRACKET   | Strings in set; Perl property syntax       |
 |  }   | U+007D | RIGHT CURLY BRACKET  | Strings in set; Perl property syntax       |
 |      | U+0020 U+0009..U+000D U+0085<br/>U+200E U+200F<br/>U+2028 U+2029 | ASCII whitespace,<br/>LRM, RLM,<br/>LINE/PARAGRAPH SEPARATOR | Ignored except when escaped |

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2885,7 +2885,7 @@ In such a case, that specification may specify a subset or superset of the synta
 | `propName`     | <pre>= s [A-Za-z0-9] [A-Za-z0-9_\\x20]* s</pre>                | General_Category,<br/>general category  |
 | `value1`       | <pre>= [^\\}]<br/>\| '\\' quoted</pre>                         | Lm,<br/>\\n,<br/>\\}                    |
 | `value2`       | <pre>= [^:]<br/>\| '\\' quoted</pre>                           | Lm,<br/>\\n,<br/>\\:                    |
-| `char`         | <pre>= [^\\& \\- \\[ \\[ \\] \\\\ \\} \\{ [:Pat_WS:]]<br/>\| '\\' quoted<br/>\| var</pre> | a, b, c, \\n |
+| `char`         | <pre>= [^\\& \\- \\[ \\[ \\] \\\\ \\} \\{ [:Pat_WS:]]<br/>\| '\\' quoted<br/>\| string</pre> | a, b, c, \\n |
 | `quoted`       | <pre>= 'u' (hex{4} \| bracketedHex)<br/>\| 'x' (hex{2} \| bracketedHex)<br/>\| 'U00' ('0' hex{5} \| '10' hex{4})<br/>\| 'N{' propName '}'<br/>\| [[\u0000-\U00010FFFF]-[uxUN]]</pre> | _**error** if lengths not exact_ |
 | `charName`     | <pre>= s [A-Za-z0-9] [-A-Za-z0-9_\x20]* s</pre>                | TIBETAN LETTER -A                       |
 | `bracketedHex` | <pre>= '{' s hexCodePoint (s hexCodePoint)* s '}'</pre>        | \{61 2019 62}                           |
@@ -2898,6 +2898,9 @@ Some constraints on UnicodeSet syntax are not captured by this EBNF.
 In particular:
 1. Property names and values are restricted to those supported by the implementation, and have additional constraints imposed by [[UAX44](https://www.unicode.org/reports/tr41/#UAX44)].
 2. Quoted values that resolve to more than one code point are disallowed in ranges of the form `char '-' char`.
+Thus [{ab}-{c}] raises an error, while [{a}-{c}] is equivalent to [a-c].
+3. If […] starts with [:, then it begins a prop, and must terminate with :]. 
+Thus [:di:] is a valid property expression, [di:] is a 3 code-point set, and [:di] raises an error.
 
 ##### Variable identifiers #####
 Support for variable identifiers (var) is optional, used in certain contexts such as in [https://cldr-smoke.unicode.org/spec/main/ldml/tr35-general.html#Transforms](Transforms).
@@ -2907,11 +2910,14 @@ If there is such a match, then the value for that is substituted for the '$' and
 If there is no such match, or if the subsitution causes a syntax error, then the parse operation returns an **error**.
 
 Notes: 
-1. The 'type' of a variable value is not specified. Thus [$a-$b] can resolve whether $a and $b are chars ($a=δ, $b=θ) or roots ($a=\p{script=greek}, $b=\p{general_category=letter}).
-The only restriction is that the result be syntactic; thus ($a=w, $b=xy) would raise an error or exception.
-2. Variable substitution is currently disallowed inside of prop expressions; thus \p{gc=$blah} raises an error.
-3. '$' when followed by ']' is interpreted as \\uFFFF, and is used to match before the start of a string or after the end. Thus [ab$] matches "a" or "b" or "".
-4. If '$' is neither followed by a character of type [:XID_Start:] or a ']', it is a syntax error.
+1. The 'type' of a variable value is not specified. 
+Thus [$a-$b] can resolve whether $a and $b are chars (eg, $a=δ, $b=θ) or roots (eg, $a=\p{script=greek}, $b=\p{general_category=letter}).
+The only restriction is that the result be syntactic; thus ($a=w, $b=xy) would raise an error.
+2. Variable substitution is currently disallowed inside of prop expressions. 
+Thus \p{gc=$blah} raises an error.
+3. '$' when followed by ']' is interpreted as \\uFFFF, and is used to match before the start of a string or after the end.
+Thus [ab$] matches "a" or "b" or "".
+4. If an unescaped '$' is neither followed by a character of type [:XID_Start:] nor a ']', it is a syntax error.
 
 ##### UnicodeSet syntax characters #####
 The syntax characters are listed in the table below:
@@ -2921,7 +2927,7 @@ The syntax characters are listed in the table below:
 |  $   | U+0024 | DOLLAR SIGN          | Equivalent of \\uFFFF when followed by ']', or initiator for a variable identifier. |
 |  &   | U+0026 | AMPERSAND            | Intersecting UnicodeSets                   |
 |  -  | U+002D | HYPHEN-MINUS          | Ranges of characters; also set difference. |
-|  :   | U+003A | COLON                | POSIX-style property syntax. Note that [:di:] is a valid property expression, [di:] = [\\: d i], and [:di] is an error |
+|  :   | U+003A | COLON                | POSIX-style property syntax.|
 |  [  | U+005B | LEFT SQUARE BRACKET   | Grouping; POSIX property syntax            |
 |  ]  | U+005D | RIGHT SQUARE BRACKET  | Grouping; POSIX property syntax            |
 |  \\  | U+005C | REVERSE SOLIDUS      | Escaping                                   |


### PR DESCRIPTION
CLDR-16811

The main change is to add variables as an optional part of the semantics. That is reflected in the EBNF table, and in a new section below that. In so doing, a few other clarifications were included, such as the syntax and semantics of '$', and that [: is an error if not terminated with :], but that : can otherwise occur within a set without escaping.

Following https://sembr.org/, also added linebreaks to paragraphs touched in this section.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
