### PR TITLE
CLDR-16841 add examples for units

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
@@ -370,23 +370,20 @@ public final class Rational implements Comparable<Rational> {
         switch (style) {
             case repeating:
                 limit = 30;
+                // fall through with smaller limit
             case repeatingAll:
+                // if we come directly here, the limit is huge
                 String result = toRepeating(limit);
-                // unreasonable
-                if (result != null) {
+                if (result != null) { // null is returned if we can't fit into the limit
                     return result;
                 }
                 // otherwise drop through to simple
             case simple:
-                {
-                    return denIsOne ? numStr : numStr + "/" + denStr;
-                }
+                return denIsOne ? numStr : numStr + "/" + denStr;
             case html:
-                {
-                    return denIsOne
-                            ? numStr
-                            : "<sup>" + numStr + "</sup>" + "/<sub>" + denStr + "<sub>";
-                }
+                return denIsOne
+                        ? numStr
+                        : "<sup>" + numStr + "</sup>" + "/<sub>" + denStr + "<sub>";
             default:
                 throw new UnsupportedOperationException();
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.lang.UCharacter;
@@ -2019,6 +2020,31 @@ public class UnitConverter implements Freezable<UnitConverter> {
                 baseUnit = getStandardUnit(baseUnit);
             }
             result.put(otherValue, baseUnit);
+        }
+    }
+
+    static final Set<UnitSystem> NO_UK =
+            Set.copyOf(Sets.difference(UnitSystem.ALL, Set.of(UnitSystem.uksystem)));
+    static final Set<UnitSystem> NO_JP =
+            Set.copyOf(Sets.difference(UnitSystem.ALL, Set.of(UnitSystem.jpsystem)));
+    static final Set<UnitSystem> NO_JP_UK =
+            Set.copyOf(
+                    Sets.difference(
+                            UnitSystem.ALL, Set.of(UnitSystem.jpsystem, UnitSystem.uksystem)));
+    /**
+     * Customize the systems according to the locale
+     *
+     * @return
+     */
+    public static Set<UnitSystem> getExampleUnitSystems(String locale) {
+        String language = CLDRLocale.getInstance(locale).getLanguage();
+        switch (language) {
+            case "ja":
+                return NO_UK;
+            case "en":
+                return NO_JP;
+            default:
+                return NO_JP_UK;
         }
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -1,5 +1,6 @@
 package org.unicode.cldr.util;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -20,6 +21,7 @@ import com.ibm.icu.util.ULocale;
 import java.math.BigInteger;
 import java.math.MathContext;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -1617,6 +1619,26 @@ public class UnitConverter implements Freezable<UnitConverter> {
 
         public static Set<String> toStringSet(Collection<UnitSystem> stringUnitSystems) {
             return stringUnitSystems.stream().map(x -> x.toString()).collect(Collectors.toSet());
+        }
+
+        private static final Joiner SLASH_JOINER = Joiner.on("/");
+
+        public static String getSystemsDisplay(Set<UnitSystem> systems) {
+            List<String> result = new ArrayList<>();
+            for (UnitSystem system : systems) {
+                switch (system) {
+                    case ussystem:
+                        result.add("US");
+                        break;
+                    case uksystem:
+                        result.add("UK");
+                        break;
+                    case jpsystem:
+                        result.add("JP");
+                        break;
+                }
+            }
+            return result.isEmpty() ? "" : " (" + SLASH_JOINER.join(result) + ")";
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -352,22 +352,22 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/units/durationUnit[@type=\"hm\"]/durationUnitPattern");
         checkValue(
                 "Length m",
-                "〖❬1❭ meter〗",
+                "〖❬1❭ meter〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"one\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭ meters〗",
+                "〖❬1.5❭ meters〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭ m〗",
+                "〖❬1.5❭ m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭m〗",
+                "〖❬1.5❭m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
 
@@ -375,7 +375,7 @@ public class TestExampleGenerator extends TestFmwk {
         // non-winning value
         checkValue(
                 "Length m",
-                "〖❬1.5❭ badmeter〗",
+                "〖❬1.5❭ badmeter〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]",
                 "{0} badmeter");
@@ -383,10 +383,17 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGeneratorDe = getExampleGenerator("de");
         checkValue(
                 "Length m",
-                "〖❬1,5❭ badmeter〗〖❬Anstatt 1,5❭ badmeter❬ …❭〗〖❌  ❬… für 1,5❭ badmeter❬ …❭〗",
+                "〖❬1,5❭ badmeter〗〖❬Anstatt 1,5❭ badmeter❬ …❭〗〖❌  ❬… für 1,5❭ badmeter❬ …❭〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGeneratorDe,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"][@case=\"genitive\"]",
                 "{0} badmeter");
+
+        ExampleGenerator exampleGeneratorJa = getExampleGenerator("ja");
+        checkValue(
+                "Length m",
+                "〖❬1.5❭m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 3.0250 jo-jp〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 ~0.0023341 ri-jp〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                exampleGeneratorJa,
+                "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
     }
 
     /**
@@ -1073,46 +1080,78 @@ public class TestExampleGenerator extends TestFmwk {
 
     public void TestInflectedUnitExamples() {
         String[][] deTests = {
-            {"one", "accusative", "〖❬1❭ Tag〗〖❬… für 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗"},
-            {"one", "dative", "〖❬1❭ Tag〗〖❬… mit 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗"},
-            {"one", "genitive", "〖❬1❭ Tages〗〖❬Anstatt 1❭ Tages❬ …❭〗〖❌  ❬… für 1❭ Tages❬ …❭〗"},
+            {
+                "one",
+                "accusative",
+                "〖❬1❭ Tag〗〖❬… für 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "one",
+                "dative",
+                "〖❬1❭ Tag〗〖❬… mit 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "one",
+                "genitive",
+                "〖❬1❭ Tages〗〖❬Anstatt 1❭ Tages❬ …❭〗〖❌  ❬… für 1❭ Tages❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
             {
                 "one",
                 "nominative",
-                "〖❬1❭ Tag〗〖❬1❭ Tag❬ kostet (kosten) € 3,50.❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗"
-            },
-            {"other", "accusative", "〖❬1,5❭ Tage〗〖❬… für 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗"},
-            {"other", "dative", "〖❬1,5❭ Tagen〗〖❬… mit 1,5❭ Tagen❬ …❭〗〖❌  ❬… für 1,5❭ Tagen❬ …❭〗"},
-            {"other", "genitive", "〖❬1,5❭ Tage〗〖❬Anstatt 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗"},
-            {
-                "other",
-                "nominative",
-                "〖❬1,5❭ Tage〗〖❬1,5❭ Tage❬ kostet (kosten) € 3,50.❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗"
-            },
-        };
-        checkInflectedUnitExamples("de", deTests);
-        String[][] elTests = {
-            {"one", "accusative", "〖❬1❭ ημέρα〗〖❬… ανά 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗"},
-            {"one", "genitive", "〖❬1❭ ημέρας〗〖❬… αξίας 1❭ ημέρας❬ …❭〗〖❌  ❬… ανά 1❭ ημέρας❬ …❭〗"},
-            {
-                "one",
-                "nominative",
-                "〖❬1❭ ημέρα〗〖❬Η απόσταση είναι 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗"
+                "〖❬1❭ Tag〗〖❬1❭ Tag❬ kostet (kosten) € 3,50.❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
             },
             {
                 "other",
                 "accusative",
-                "〖❬0,9❭ ημέρες〗〖❬… ανά 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗"
+                "〖❬1,5❭ Tage〗〖❬… für 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "other",
+                "dative",
+                "〖❬1,5❭ Tagen〗〖❬… mit 1,5❭ Tagen❬ …❭〗〖❌  ❬… für 1,5❭ Tagen❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
             },
             {
                 "other",
                 "genitive",
-                "〖❬0,9❭ ημερών〗〖❬… αξίας 0,9❭ ημερών❬ …❭〗〖❌  ❬… ανά 0,9❭ ημερών❬ …❭〗"
+                "〖❬1,5❭ Tage〗〖❬Anstatt 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
             },
             {
                 "other",
                 "nominative",
-                "〖❬0,9❭ ημέρες〗〖❬Η απόσταση είναι 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗"
+                "〖❬1,5❭ Tage〗〖❬1,5❭ Tage❬ kostet (kosten) € 3,50.❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+        };
+        checkInflectedUnitExamples("de", deTests);
+        String[][] elTests = {
+            {
+                "one",
+                "accusative",
+                "〖❬1❭ ημέρα〗〖❬… ανά 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "one",
+                "genitive",
+                "〖❬1❭ ημέρας〗〖❬… αξίας 1❭ ημέρας❬ …❭〗〖❌  ❬… ανά 1❭ ημέρας❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "one",
+                "nominative",
+                "〖❬1❭ ημέρα〗〖❬Η απόσταση είναι 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "other",
+                "accusative",
+                "〖❬0,9❭ ημέρες〗〖❬… ανά 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "other",
+                "genitive",
+                "〖❬0,9❭ ημερών〗〖❬… αξίας 0,9❭ ημερών❬ …❭〗〖❌  ❬… ανά 0,9❭ ημερών❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+            },
+            {
+                "other",
+                "nominative",
+                "〖❬0,9❭ ημέρες〗〖❬Η απόσταση είναι 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
             },
         };
         checkInflectedUnitExamples("el", elTests);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -391,9 +391,20 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGeneratorJa = getExampleGenerator("ja");
         checkValue(
                 "Length m",
-                "〖❬1.5❭m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 3.0250 jo-jp〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 ~0.0023341 ri-jp〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 3.0250 jo-jp (JP)〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 ~0.0023341 ri-jp (JP)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
                 exampleGeneratorJa,
                 "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
+        checkValue(
+                "Length ri",
+                "〖❬1.5❭ 里〗〖1 ri-jp (JP) 🟰 1296 jo-jp (JP)〗〖1 ri-jp (JP) 🟰 ~468.54 yard (US/UK)〗〖1 ri-jp (JP) 🟰 ~428.43 meter〗〖1 ri-jp (JP) 🟰 ~0.42843 kilometer〗〖1 ri-jp (JP) 🟰 ~0.26621 mile (US/UK)〗",
+                exampleGeneratorJa,
+                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-ri-jp\"]/unitPattern[@count=\"other\"]");
+
+        checkValue(
+                "Length ri",
+                "〖1 ri-jp (JP) 🟰 1296 jo-jp (JP)〗〖1 ri-jp (JP) 🟰 ~468.54 yard (US/UK)〗〖1 ri-jp (JP) 🟰 ~428.43 meter〗〖1 ri-jp (JP) 🟰 ~0.42843 kilometer〗〖1 ri-jp (JP) 🟰 ~0.26621 mile (US/UK)〗",
+                exampleGeneratorJa,
+                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-ri-jp\"]/displayName");
     }
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -352,22 +352,22 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/units/durationUnit[@type=\"hm\"]/durationUnitPattern");
         checkValue(
                 "Length m",
-                "〖❬1❭ meter〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1❭ meter〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"one\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭ meters〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭ meters〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭ m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭ m〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭m〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
 
@@ -375,7 +375,7 @@ public class TestExampleGenerator extends TestFmwk {
         // non-winning value
         checkValue(
                 "Length m",
-                "〖❬1.5❭ badmeter〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭ badmeter〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]",
                 "{0} badmeter");
@@ -383,7 +383,7 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGeneratorDe = getExampleGenerator("de");
         checkValue(
                 "Length m",
-                "〖❬1,5❭ badmeter〗〖❬Anstatt 1,5❭ badmeter❬ …❭〗〖❌  ❬… für 1,5❭ badmeter❬ …❭〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1,5❭ badmeter〗〖❬Anstatt 1,5❭ badmeter❬ …❭〗〖❌  ❬… für 1,5❭ badmeter❬ …❭〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGeneratorDe,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"][@case=\"genitive\"]",
                 "{0} badmeter");
@@ -391,18 +391,18 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGeneratorJa = getExampleGenerator("ja");
         checkValue(
                 "Length m",
-                "〖❬1.5❭m〗〖1 meter 🟰 1000 millimeter〗〖1 meter 🟰 3.0250 jo-jp (JP)〗〖1 meter 🟰 ~1.0936 yard (US/UK)〗〖1 meter 🟰 ~0.0023341 ri-jp (JP)〗〖1 meter 🟰 1/1000 kilometer〗〖1 meter 🟰 ~0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭m〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≡ 3.0250 jo-jp (JP)〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≈ 0.0023341 ri-jp (JP)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
                 exampleGeneratorJa,
                 "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length ri",
-                "〖❬1.5❭ 里〗〖1 ri-jp (JP) 🟰 1296 jo-jp (JP)〗〖1 ri-jp (JP) 🟰 ~468.54 yard (US/UK)〗〖1 ri-jp (JP) 🟰 ~428.43 meter〗〖1 ri-jp (JP) 🟰 ~0.42843 kilometer〗〖1 ri-jp (JP) 🟰 ~0.26621 mile (US/UK)〗",
+                "〖❬1.5❭ 里〗〖〗〖1 ri-jp (JP) ≡ 1296 jo-jp (JP)〗〖1 ri-jp (JP) ≈ 468.54 yard (US/UK)〗〖1 ri-jp (JP) ≈ 428.43 meter〗〖1 ri-jp (JP) ≈ 0.42843 kilometer〗〖1 ri-jp (JP) ≈ 0.26621 mile (US/UK)〗",
                 exampleGeneratorJa,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-ri-jp\"]/unitPattern[@count=\"other\"]");
 
         checkValue(
                 "Length ri",
-                "〖1 ri-jp (JP) 🟰 1296 jo-jp (JP)〗〖1 ri-jp (JP) 🟰 ~468.54 yard (US/UK)〗〖1 ri-jp (JP) 🟰 ~428.43 meter〗〖1 ri-jp (JP) 🟰 ~0.42843 kilometer〗〖1 ri-jp (JP) 🟰 ~0.26621 mile (US/UK)〗",
+                "〖1 ri-jp (JP) ≡ 1296 jo-jp (JP)〗〖〗〖1 ri-jp (JP) ≈ 468.54 yard (US/UK)〗〖1 ri-jp (JP) ≈ 428.43 meter〗〖1 ri-jp (JP) ≈ 0.42843 kilometer〗〖1 ri-jp (JP) ≈ 0.26621 mile (US/UK)〗",
                 exampleGeneratorJa,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-ri-jp\"]/displayName");
     }
@@ -1094,42 +1094,42 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "one",
                 "accusative",
-                "〖❬1❭ Tag〗〖❬… für 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ Tag〗〖❬… für 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "one",
                 "dative",
-                "〖❬1❭ Tag〗〖❬… mit 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ Tag〗〖❬… mit 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "one",
                 "genitive",
-                "〖❬1❭ Tages〗〖❬Anstatt 1❭ Tages❬ …❭〗〖❌  ❬… für 1❭ Tages❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ Tages〗〖❬Anstatt 1❭ Tages❬ …❭〗〖❌  ❬… für 1❭ Tages❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "one",
                 "nominative",
-                "〖❬1❭ Tag〗〖❬1❭ Tag❬ kostet (kosten) € 3,50.❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ Tag〗〖❬1❭ Tag❬ kostet (kosten) € 3,50.❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "accusative",
-                "〖❬1,5❭ Tage〗〖❬… für 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1,5❭ Tage〗〖❬… für 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "dative",
-                "〖❬1,5❭ Tagen〗〖❬… mit 1,5❭ Tagen❬ …❭〗〖❌  ❬… für 1,5❭ Tagen❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1,5❭ Tagen〗〖❬… mit 1,5❭ Tagen❬ …❭〗〖❌  ❬… für 1,5❭ Tagen❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "genitive",
-                "〖❬1,5❭ Tage〗〖❬Anstatt 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1,5❭ Tage〗〖❬Anstatt 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "nominative",
-                "〖❬1,5❭ Tage〗〖❬1,5❭ Tage❬ kostet (kosten) € 3,50.❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1,5❭ Tage〗〖❬1,5❭ Tage❬ kostet (kosten) € 3,50.❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
         };
         checkInflectedUnitExamples("de", deTests);
@@ -1137,32 +1137,32 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "one",
                 "accusative",
-                "〖❬1❭ ημέρα〗〖❬… ανά 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ ημέρα〗〖❬… ανά 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "one",
                 "genitive",
-                "〖❬1❭ ημέρας〗〖❬… αξίας 1❭ ημέρας❬ …❭〗〖❌  ❬… ανά 1❭ ημέρας❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ ημέρας〗〖❬… αξίας 1❭ ημέρας❬ …❭〗〖❌  ❬… ανά 1❭ ημέρας❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "one",
                 "nominative",
-                "〖❬1❭ ημέρα〗〖❬Η απόσταση είναι 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬1❭ ημέρα〗〖❬Η απόσταση είναι 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "accusative",
-                "〖❬0,9❭ ημέρες〗〖❬… ανά 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬0,9❭ ημέρες〗〖❬… ανά 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "genitive",
-                "〖❬0,9❭ ημερών〗〖❬… αξίας 0,9❭ ημερών❬ …❭〗〖❌  ❬… ανά 0,9❭ ημερών❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬0,9❭ ημερών〗〖❬… αξίας 0,9❭ ημερών❬ …❭〗〖❌  ❬… ανά 0,9❭ ημερών❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
             {
                 "other",
                 "nominative",
-                "〖❬0,9❭ ημέρες〗〖❬Η απόσταση είναι 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖1 day 🟰 24 hour〗〖1 day 🟰 1/7 week〗"
+                "〖❬0,9❭ ημέρες〗〖❬Η απόσταση είναι 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
             },
         };
         checkInflectedUnitExamples("el", elTests);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -3806,4 +3806,38 @@ public class TestUnits extends TestFmwk {
             }
         }
     }
+
+    public void testGetRelated() {
+        Map<Rational, String> related2 =
+                converter.getRelatedExamples(
+                        "meter", Sets.difference(UnitSystem.ALL, Set.of(UnitSystem.jpsystem)));
+        logln(showUnitExamples("meter", related2));
+
+        Set<String> generated = new LinkedHashSet<>();
+        for (String unit : converter.getSimpleUnits()) {
+            Map<Rational, String> related =
+                    converter.getRelatedExamples(
+                            unit, Sets.difference(UnitSystem.ALL, Set.of(UnitSystem.jpsystem)));
+            generated.addAll(related.values());
+            logln(showUnitExamples(unit, related));
+        }
+        logln(generated.toString());
+    }
+
+    public String showUnitExamples(String unit, Map<Rational, String> related) {
+        return "\n"
+                + unit
+                + "\t#"
+                + converter.getSystemsEnum(unit)
+                + "\n= "
+                + related.entrySet().stream()
+                        .map(
+                                x ->
+                                        x.getKey().toString(FormatStyle.basic)
+                                                + " "
+                                                + x.getValue()
+                                                + "\t#"
+                                                + converter.getSystemsEnum(x.getValue()))
+                        .collect(Collectors.joining("\n= "));
+    }
 }


### PR DESCRIPTION
CLDR-16841

tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
- Adds the example to unit/unitPattern and /displayName
- The related units are fetched from the UnitConverter, and displayed with each separate example.
- The format is like **1 ounce-troy (US/UK) 🟰 ~82.943 fun (JP)**, so it shows whether a unit is in a country-system (UK, US, or JP), and what the equivalent amount would be in a related unit

tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
- Add a shorter, simpler way to show units. 
- currently if numerator or denominator are < 20, shows as fraction (or just numerator, if denominator is 1)
- Uses 5 significant digits, and adds ~ if the displayed value is approximate.

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
- Adds some utilities
- Displays the country systems
- getRelatedExamples picks some samples. Currently
  - gets all the simple units that are interconvertable with the source unit
  - adds a few others, and removes some unusual ones
  - always adds metric
  - checks all the systems (except si, and except jp outside of Japanese) to find the closest units, above and below, where possible. Skips units that are far away (current > 10000x or < 1/10000x)
  - skips some more unusual units
  - removes the source unit, if it got added.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
- fixes current tests, and adds a few more

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
- tests the getRelatedExamples codes. Currently the only test is to make sure they don't throw exceptions

Current limitations
- It just handles the simple units, so not, say, square-kilometer
- When it doesn't handle a unit, it should still probably show an example if it is in a country-system
- getExampleUnitSystems should probably be moved to the UnitConverter
- It might be showing too many units, or not the best ones, but I didn't want to spend too much time tuning right now.
- FYI, just filed the related (but independent) https://unicode-org.atlassian.net/browse/CLDR-16851
- Especially if we add more units, we probably want to cache the related units. Right now it filters by locale, but that could be done at runtime.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
