### PR TITLE
CLDR-16841 Tweek the formatting

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -1249,8 +1249,10 @@ public class ExampleGenerator {
                 relation = "≈";
                 relatedValueDisplay = relatedValueDisplay.substring(1);
             }
-            if (!examples.isEmpty() && first) {
-                examples.add(""); // add blank line
+            if (first) {
+                if (!examples.isEmpty()) {
+                    examples.add(""); // add blank line
+                }
                 first = false;
             }
             examples.add(
@@ -1382,7 +1384,7 @@ public class ExampleGenerator {
     @SuppressWarnings("deprecation")
     public String handleCompoundUnit(UnitLength unitLength, String compoundType, Count count) {
         /*
-         *  <units>
+             *  <units>
         <unitLength type="long">
             <alias source="locale" path="../unitLength[@type='short']"/>
         </unitLength>
@@ -1391,7 +1393,7 @@ public class ExampleGenerator {
                 <unitPattern count="other">{0}/{1}</unitPattern>
             </compoundUnit>
 
-         *  <compoundUnit type="per">
+             *  <compoundUnit type="per">
                 <unitPattern count="one">{0}/{1}</unitPattern>
                 <unitPattern count="other">{0}/{1}</unitPattern>
             </compoundUnit>
@@ -1400,7 +1402,7 @@ public class ExampleGenerator {
                 <unitPattern count="other">{0} meters</unitPattern>
             </unit>
 
-         */
+             */
 
         // we want to get a number that works for the count passed in.
         DecimalQuantity amount = getBest(count);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.util;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.math.BigIntegerMath;
 import com.ibm.icu.number.LocalizedNumberFormatter;
 import com.ibm.icu.number.Notation;
 import com.ibm.icu.number.NumberFormatter;
@@ -15,6 +16,7 @@ import com.ibm.icu.util.Output;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -44,6 +46,7 @@ public final class Rational implements Comparable<Rational> {
 
     public static final Rational ZERO = Rational.of(0);
     public static final Rational ONE = Rational.of(1);
+    public static final Rational TWO = Rational.of(2);
     public static final Rational NEGATIVE_ONE = ONE.negate();
 
     public static final Rational INFINITY = Rational.of(1, 0);
@@ -54,6 +57,7 @@ public final class Rational implements Comparable<Rational> {
     public static final Rational TENTH = TEN.reciprocal();
 
     public static final char REPTEND_MARKER = '˙';
+    public static final String APPROX = "~";
 
     public static class RationalParser implements Freezable<RationalParser> {
 
@@ -101,6 +105,9 @@ public final class Rational implements Comparable<Rational> {
                     return INFINITY;
                 case "-INF":
                     return NEGATIVE_INFINITY;
+            }
+            if (input.startsWith(APPROX)) {
+                input = input.substring(1);
             }
             List<String> comps =
                     slashSplitter.splitToList(input.replace(",", "")); // allow commas anywhere
@@ -336,35 +343,54 @@ public final class Rational implements Comparable<Rational> {
         return toString(FormatStyle.plain);
     }
 
-    private static final BigInteger BASIC_LIMIT = BigInteger.valueOf(20);
+    private static final BigInteger NUM_OR_DEN_LIMIT = BigInteger.valueOf(10000000);
+    private static final BigInteger NUM_TIMES_DEN_LIMIT = BigInteger.valueOf(10000000);
+    private static final BigInteger BIG_HIGH = BigInteger.valueOf(10000000);
+    private static final double DOUBLE_HIGH = 10000000d;
+    private static final double DOUBLE_LOW = 0.001d;
+
+    static final String THIN_SPACE = "\u2009";
+    static final String DIVIDER = THIN_SPACE + "/" + THIN_SPACE;
 
     public String toString(FormatStyle style) {
+        boolean denIsOne = denominator.equals(BigInteger.ONE);
+        BigInteger absNumerator = numerator.abs();
         switch (style) {
             case plain:
-                return numerator + (denominator.equals(BigInteger.ONE) ? "" : " / " + denominator);
+                return numerator + (denIsOne ? "" : DIVIDER + denominator);
             case basic:
-                if (denominator.equals(BigInteger.ONE)) {
-                    return numerator.toString();
-                } else if (denominator.compareTo(BASIC_LIMIT) <= 0
-                        || numerator.compareTo(BASIC_LIMIT) <= 0) {
-                    return nf.format(numerator) + "/" + nf.format(denominator);
-                } else {
-                    String result =
-                            nf2.format(numerator.doubleValue() / denominator.doubleValue())
-                                    .toString();
-                    Rational roundtrip = Rational.of(result);
-                    if (roundtrip.equals(this)) {
-                        return result;
+                if (denIsOne) {
+                    if (absNumerator.compareTo(BIG_HIGH) < 0) {
+                        return format.format(numerator).toString();
+                    } else {
+                        return replaceE(formatSciSigDig5.format(numerator).toString());
                     }
-                    return "~" + result;
+                } else {
+                    int log10num = BigIntegerMath.log10(absNumerator, RoundingMode.UP);
+                    int log10den = BigIntegerMath.log10(denominator, RoundingMode.UP);
+                    if ((log10num <= 1 && log10den <= 4) || (log10num <= 4 && log10den <= 1)) {
+                        return format.format(numerator) + DIVIDER + format.format(denominator);
+                    } else {
+                        final double doubleValue =
+                                numerator.doubleValue() / denominator.doubleValue();
+                        double absDoubleValue = Math.abs(doubleValue);
+                        String result;
+                        if (DOUBLE_LOW < absDoubleValue && absDoubleValue < DOUBLE_HIGH) {
+                            result = formatSigDig5.format(doubleValue).toString();
+                        } else {
+                            result = formatSciSigDig5.format(doubleValue).toString();
+                        }
+                        Rational roundtrip = Rational.of(result);
+                        return replaceE(roundtrip.equals(this) ? result : APPROX + result);
+                    }
                 }
             default:
         }
         Output<BigDecimal> newNumerator = new Output<>(new BigDecimal(numerator));
         final BigInteger newDenominator = minimalDenominator(newNumerator, denominator);
         final String numStr = format(newNumerator.value);
-        final String denStr = nf.format(newDenominator).toString();
-        final boolean denIsOne = newDenominator.equals(BigInteger.ONE);
+        final String denStr = formatNoGroup.format(newDenominator).toString();
+        denIsOne = newDenominator.equals(BigInteger.ONE);
         int limit = 1000;
 
         switch (style) {
@@ -379,7 +405,7 @@ public final class Rational implements Comparable<Rational> {
                 }
                 // otherwise drop through to simple
             case simple:
-                return denIsOne ? numStr : numStr + "/" + denStr;
+                return denIsOne ? numStr : numStr + DIVIDER + denStr;
             case html:
                 return denIsOne
                         ? numStr
@@ -389,25 +415,38 @@ public final class Rational implements Comparable<Rational> {
         }
     }
 
-    static final LocalizedNumberFormatter nf =
-            NumberFormatter.with()
-                    .precision(Precision.unlimited())
-                    .grouping(GroupingStrategy.OFF)
-                    .locale(Locale.ENGLISH);
+    private String replaceE(String format2) {
+        return format2.replace("E", THIN_SPACE + "×" + THIN_SPACE + "10ˆ");
+    }
 
-    static final LocalizedNumberFormatter nf2 =
-            NumberFormatter.with()
-                    .precision(Precision.fixedSignificantDigits(5))
-                    .locale(Locale.ENGLISH);
+    static final LocalizedNumberFormatter format =
+            NumberFormatter.with().precision(Precision.unlimited()).locale(Locale.ENGLISH);
 
-    static final LocalizedNumberFormatter snf =
+    static final LocalizedNumberFormatter formatSci =
             NumberFormatter.with()
                     .precision(Precision.unlimited())
                     .notation(Notation.engineering())
                     .locale(Locale.ENGLISH);
 
+    static final LocalizedNumberFormatter formatNoGroup =
+            NumberFormatter.with()
+                    .precision(Precision.unlimited())
+                    .grouping(GroupingStrategy.OFF)
+                    .locale(Locale.ENGLISH);
+
+    static final LocalizedNumberFormatter formatSigDig5 =
+            NumberFormatter.with()
+                    .precision(Precision.maxSignificantDigits(5))
+                    .locale(Locale.ENGLISH);
+
+    static final LocalizedNumberFormatter formatSciSigDig5 =
+            NumberFormatter.with()
+                    .precision(Precision.maxSignificantDigits(4))
+                    .notation(Notation.engineering())
+                    .locale(Locale.ENGLISH);
+
     static String format(BigDecimal value) {
-        return nf.format(value).toString();
+        return formatNoGroup.format(value).toString();
         /*
          * TODO Change 1000000 to 1×10<sup>-6</sup>, etc.
          * Only for large/small numbers, eg:
@@ -574,7 +613,7 @@ public final class Rational implements Comparable<Rational> {
     }
 
     public Rational symmetricDiff(Rational b) {
-        return this.subtract(b).divide(this.abs().add(b.abs())).multiply(Rational.of(2));
+        return this.subtract(b).divide(this.abs().add(b.abs())).multiply(TWO);
     }
 
     /** Return repeating fraction, as long as the length is reasonable */
@@ -600,7 +639,7 @@ public final class Rational implements Comparable<Rational> {
             return s.toString();
         } else if (pToq > 0) {
             BigInteger intPart = p.divide(q);
-            s.append(nf.format(intPart));
+            s.append(formatNoGroup.format(intPart));
             p = p.remainder(q);
             if (p.compareTo(BigInteger.ZERO) == 0) {
                 return s.toString();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -345,6 +345,18 @@ public class TestExampleGenerator extends TestFmwk {
 
     public void TestUnits() {
         ExampleGenerator exampleGenerator = getExampleGenerator("en");
+        String staticMeterExample =
+                "〖1 meter ≡ 1,000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1 / 1,000 kilometer〗〖1 meter ≈ 621.4 × 10ˆ-6 mile (US/UK)〗";
+        String staticMeterExampleJp =
+                "〖1 meter ≡ 1,000 millimeter〗〖1 meter ≡ 3.025 jo-jp (JP)〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≈ 0.0023341 ri-jp (JP)〗〖1 meter ≡ 1 / 1,000 kilometer〗〖1 meter ≈ 621.4 × 10ˆ-6 mile (US/UK)〗";
+        String staticMeterExampleRi =
+                "〖1 ri-jp (JP) ≡ 1,296 jo-jp (JP)〗〖1 ri-jp (JP) ≈ 468.54 yard (US/UK)〗〖1 ri-jp (JP) ≈ 428.43 meter〗〖1 ri-jp (JP) ≈ 0.42843 kilometer〗〖1 ri-jp (JP) ≈ 0.26621 mile (US/UK)〗";
+
+        checkValue(
+                "Length m",
+                staticMeterExample,
+                exampleGenerator,
+                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/displayName");
         checkValue(
                 "Duration hm",
                 "〖5:37〗",
@@ -352,22 +364,22 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/units/durationUnit[@type=\"hm\"]/durationUnitPattern");
         checkValue(
                 "Length m",
-                "〖❬1❭ meter〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1❭ meter〗〖〗" + staticMeterExample,
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"one\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭ meters〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭ meters〗〖〗" + staticMeterExample,
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭ m〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭ m〗〖〗" + staticMeterExample,
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"short\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length m",
-                "〖❬1.5❭m〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭m〗〖〗" + staticMeterExample,
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
 
@@ -375,7 +387,7 @@ public class TestExampleGenerator extends TestFmwk {
         // non-winning value
         checkValue(
                 "Length m",
-                "〖❬1.5❭ badmeter〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭ badmeter〗〖〗" + staticMeterExample,
                 exampleGenerator,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]",
                 "{0} badmeter");
@@ -383,7 +395,8 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGeneratorDe = getExampleGenerator("de");
         checkValue(
                 "Length m",
-                "〖❬1,5❭ badmeter〗〖❬Anstatt 1,5❭ badmeter❬ …❭〗〖❌  ❬… für 1,5❭ badmeter❬ …❭〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1,5❭ badmeter〗〖❬Anstatt 1,5❭ badmeter❬ …❭〗〖❌  ❬… für 1,5❭ badmeter❬ …❭〗〖〗"
+                        + staticMeterExample,
                 exampleGeneratorDe,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"][@case=\"genitive\"]",
                 "{0} badmeter");
@@ -391,20 +404,14 @@ public class TestExampleGenerator extends TestFmwk {
         ExampleGenerator exampleGeneratorJa = getExampleGenerator("ja");
         checkValue(
                 "Length m",
-                "〖❬1.5❭m〗〖〗〖1 meter ≡ 1000 millimeter〗〖1 meter ≡ 3.0250 jo-jp (JP)〗〖1 meter ≈ 1.0936 yard (US/UK)〗〖1 meter ≈ 0.0023341 ri-jp (JP)〗〖1 meter ≡ 1/1000 kilometer〗〖1 meter ≈ 0.00062137 mile (US/UK)〗",
+                "〖❬1.5❭m〗〖〗" + staticMeterExampleJp,
                 exampleGeneratorJa,
                 "//ldml/units/unitLength[@type=\"narrow\"]/unit[@type=\"length-meter\"]/unitPattern[@count=\"other\"]");
         checkValue(
                 "Length ri",
-                "〖❬1.5❭ 里〗〖〗〖1 ri-jp (JP) ≡ 1296 jo-jp (JP)〗〖1 ri-jp (JP) ≈ 468.54 yard (US/UK)〗〖1 ri-jp (JP) ≈ 428.43 meter〗〖1 ri-jp (JP) ≈ 0.42843 kilometer〗〖1 ri-jp (JP) ≈ 0.26621 mile (US/UK)〗",
+                "〖❬1.5❭ 里〗〖〗" + staticMeterExampleRi,
                 exampleGeneratorJa,
                 "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-ri-jp\"]/unitPattern[@count=\"other\"]");
-
-        checkValue(
-                "Length ri",
-                "〖1 ri-jp (JP) ≡ 1296 jo-jp (JP)〗〖〗〖1 ri-jp (JP) ≈ 468.54 yard (US/UK)〗〖1 ri-jp (JP) ≈ 428.43 meter〗〖1 ri-jp (JP) ≈ 0.42843 kilometer〗〖1 ri-jp (JP) ≈ 0.26621 mile (US/UK)〗",
-                exampleGeneratorJa,
-                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-ri-jp\"]/displayName");
     }
 
     /**
@@ -1094,42 +1101,42 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "one",
                 "accusative",
-                "〖❬1❭ Tag〗〖❬… für 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ Tag〗〖❬… für 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "one",
                 "dative",
-                "〖❬1❭ Tag〗〖❬… mit 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ Tag〗〖❬… mit 1❭ Tag❬ …❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "one",
                 "genitive",
-                "〖❬1❭ Tages〗〖❬Anstatt 1❭ Tages❬ …❭〗〖❌  ❬… für 1❭ Tages❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ Tages〗〖❬Anstatt 1❭ Tages❬ …❭〗〖❌  ❬… für 1❭ Tages❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "one",
                 "nominative",
-                "〖❬1❭ Tag〗〖❬1❭ Tag❬ kostet (kosten) € 3,50.❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ Tag〗〖❬1❭ Tag❬ kostet (kosten) € 3,50.❭〗〖❌  ❬Anstatt 1❭ Tag❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "accusative",
-                "〖❬1,5❭ Tage〗〖❬… für 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1,5❭ Tage〗〖❬… für 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "dative",
-                "〖❬1,5❭ Tagen〗〖❬… mit 1,5❭ Tagen❬ …❭〗〖❌  ❬… für 1,5❭ Tagen❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1,5❭ Tagen〗〖❬… mit 1,5❭ Tagen❬ …❭〗〖❌  ❬… für 1,5❭ Tagen❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "genitive",
-                "〖❬1,5❭ Tage〗〖❬Anstatt 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1,5❭ Tage〗〖❬Anstatt 1,5❭ Tage❬ …❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "nominative",
-                "〖❬1,5❭ Tage〗〖❬1,5❭ Tage❬ kostet (kosten) € 3,50.❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1,5❭ Tage〗〖❬1,5❭ Tage❬ kostet (kosten) € 3,50.❭〗〖❌  ❬… mit 1,5❭ Tage❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
         };
         checkInflectedUnitExamples("de", deTests);
@@ -1137,32 +1144,32 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "one",
                 "accusative",
-                "〖❬1❭ ημέρα〗〖❬… ανά 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ ημέρα〗〖❬… ανά 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "one",
                 "genitive",
-                "〖❬1❭ ημέρας〗〖❬… αξίας 1❭ ημέρας❬ …❭〗〖❌  ❬… ανά 1❭ ημέρας❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ ημέρας〗〖❬… αξίας 1❭ ημέρας❬ …❭〗〖❌  ❬… ανά 1❭ ημέρας❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "one",
                 "nominative",
-                "〖❬1❭ ημέρα〗〖❬Η απόσταση είναι 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬1❭ ημέρα〗〖❬Η απόσταση είναι 1❭ ημέρα❬ …❭〗〖❌  ❬… αξίας 1❭ ημέρα❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "accusative",
-                "〖❬0,9❭ ημέρες〗〖❬… ανά 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬0,9❭ ημέρες〗〖❬… ανά 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "genitive",
-                "〖❬0,9❭ ημερών〗〖❬… αξίας 0,9❭ ημερών❬ …❭〗〖❌  ❬… ανά 0,9❭ ημερών❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬0,9❭ ημερών〗〖❬… αξίας 0,9❭ ημερών❬ …❭〗〖❌  ❬… ανά 0,9❭ ημερών❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
             {
                 "other",
                 "nominative",
-                "〖❬0,9❭ ημέρες〗〖❬Η απόσταση είναι 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1/7 week〗"
+                "〖❬0,9❭ ημέρες〗〖❬Η απόσταση είναι 0,9❭ ημέρες❬ …❭〗〖❌  ❬… αξίας 0,9❭ ημέρες❬ …❭〗〖〗〖1 day ≡ 24 hour〗〖1 day ≡ 1 / 7 week〗"
             },
         };
         checkInflectedUnitExamples("el", elTests);


### PR DESCRIPTION
CLDR-16841

The formatting of some values lead to overly long numbers, and sometimes hard to read, so modified to avoid that. 
Also modified the chart generation to use that, and use a better sort. The tests were modified to suit, and also simplified to make them easier to read and update.

Examples:

![Screenshot 2023-07-11 at 16 17 35](https://github.com/unicode-org/cldr/assets/9613872/2b859ed3-4eea-4a31-b419-c53497ba4008)

(This is just interim improvements, and don't yet move the examples into the blue pane.)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
