### PR TITLE
CLDR-16862 Upgrade sw and zh_Hant_HK to 8-vote minimum

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -36,7 +36,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<approvalRequirement votes="=HIGH_BAR" locales="tr" paths="//ldml/localeDisplayNames/territories/territory\[@type=.CY.\]"/>
 			<approvalRequirement votes="=HIGH_BAR" locales="kea pt_CV" paths="//ldml/numbers/currencies/currency\[@type=.CVE.\]/(symbol|decimal)"/>
 			<!--  established locales - http://cldr.unicode.org/index/process#TOC-Draft-Status-of-Optimal-Field-Value -->
-			<approvalRequirement votes="=LOWER_BAR" locales="ar bn bg ca cs da de el en en_AU es es_419 en_GB es_MX et fa fi fil fr fr_CA gu he hi hr hu id is it ja kk kn ko lt lv mk ml mr ms nl no pa pl pt pt_PT ro ru sk sl sr sv ta te th tr ur uk vi zh zh_Hant" paths=""/>
+			<approvalRequirement votes="=LOWER_BAR" locales="ar bn bg ca cs da de el en en_AU es es_419 en_GB es_MX et fa fi fil fr fr_CA gu he hi hr hu id is it ja kk kn ko lt lv mk ml mr ms nl no pa pl pt pt_PT ro ru sk sl sr sv sw ta te th tr ur uk vi zh zh_Hant zh_Hant_HK" paths=""/>
 			<!--  all other items -->
 			<approvalRequirement votes="=vetter" locales="*" paths=""/>
 		</approvalRequirements>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Level.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Level.java
@@ -138,6 +138,9 @@ public enum Level {
      * @return level with the minimal getLevel() value
      */
     public static Level max(Level a, Level b) {
+        if (a == null) {
+            return b;
+        }
         return Level.fromLevel(Math.max(a.getLevel(), b.getLevel()));
     }
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -243,6 +243,7 @@ Google	;	yo	;	modern	;	Yoruba
 Google	;	yue	;	modern	;	T5	Cantonese
 Google	;	zh	;	modern	;	T1	Simplified Chinese
 Google	;	zh_Hant	;	modern	;	T1	Traditional Chinese
+Google  ; zh_Hant  ; modern 
 Google	;	zu	;	modern	;	T5	Zulu
 Google ; * ; moderate ; All Others, provisionally
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -243,7 +243,7 @@ Google	;	yo	;	modern	;	Yoruba
 Google	;	yue	;	modern	;	T5	Cantonese
 Google	;	zh	;	modern	;	T1	Simplified Chinese
 Google	;	zh_Hant	;	modern	;	T1	Traditional Chinese
-Google  ; zh_Hant  ; modern 
+Google	;	zh_Hant_HK	;	modern
 Google	;	zu	;	modern	;	T5	Zulu
 Google ; * ; moderate ; All Others, provisionally
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -57,7 +57,7 @@ public class TestUtilities extends TestFmwkPlus {
     private static final int STRING_ID_TEST_COUNT = 1024 * 16;
 
     final int ONE_VETTER_BAR = Level.vetter.getVotes(Organization.unaffiliated);
-    final int TWO_VETTER_BAR = 2 * ONE_VETTER_BAR;
+    final int TWO_VETTER_BAR = VoteResolver.LOWER_BAR;
 
     public static void main(String[] args) {
         new TestUtilities().run(args);
@@ -730,7 +730,7 @@ public class TestUtilities extends TestFmwkPlus {
         final Set<String> eightVoteSublocales =
                 new HashSet<>(
                         Arrays.asList(
-                                "pt_PT", "zh_Hant", "en_AU", "en_GB", "es_MX", "fr_CA", "es_419"));
+                    "pt_PT", "zh_Hant", "zh_Hant_HK", "en_AU", "en_GB", "es_MX", "fr_CA", "es_419"));
         final VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         final String path = "//ldml/annotations/annotation[@cp=\"🌏\"][@type=\"tts\"]";
         for (String locale : SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -730,7 +730,14 @@ public class TestUtilities extends TestFmwkPlus {
         final Set<String> eightVoteSublocales =
                 new HashSet<>(
                         Arrays.asList(
-                    "pt_PT", "zh_Hant", "zh_Hant_HK", "en_AU", "en_GB", "es_MX", "fr_CA", "es_419"));
+                                "pt_PT",
+                                "zh_Hant",
+                                "zh_Hant_HK",
+                                "en_AU",
+                                "en_GB",
+                                "es_MX",
+                                "fr_CA",
+                                "es_419"));
         final VoteResolver<String> resolver = new VoteResolver<>(getTestVoterInfoList());
         final String path = "//ldml/annotations/annotation[@cp=\"🌏\"][@type=\"tts\"]";
         for (String locale : SubmissionLocales.CLDR_OR_HIGH_LEVEL_LOCALES) {


### PR DESCRIPTION
CLDR-16862

Upgrade sw and zh_Hant_HK to 8-vote minimum

It looks like bg and is had already been upgraded in https://github.com/unicode-org/cldr/pull/2098

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
