### PR TITLE
CLDR-16885 Fix `&amp;` and `&quot;` usage in transforms

### DIFF
--- a/common/transforms/Any-Accents.xml
+++ b/common/transforms/Any-Accents.xml
@@ -9,7 +9,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<version number="$Revision$"/>
 	<transforms>
 		<transform source="Any" target="Accents" direction="both" alias="und-t-d0-accents" backwardAlias="und-t-s0-accents">
-			<tRule>
+			<tRule><![CDATA[
 :: NFD (NFC) ;
 # to do: make reversible
 # define special conversion characters.
@@ -278,7 +278,7 @@ $pre v $post ↔ ʌ ; # LATIN SMALL LETTER TURNED V
 # $pre YYY $post ↔ ẚ ; # LATIN SMALL LETTER A WITH RIGHT HALF RING
 # $pre YYY $post ↔ ⁿ ; # SUPERSCRIPT LATIN SMALL LETTER N
 :: NFC (NFD) ;
-			</tRule>
+			]]></tRule>
 		</transform>
 	</transforms>
 </supplementalData>

--- a/common/transforms/Any-Accents.xml
+++ b/common/transforms/Any-Accents.xml
@@ -22,7 +22,7 @@ $pre \' $post ↔ ́ ; # COMBINING ACUTE ACCENT
 $pre \^ $post ↔ ̂ ; # COMBINING CIRCUMFLEX ACCENT
 $pre \~ $post ↔ ̃ ; # COMBINING TILDE
 $pre \- $post ↔ ̄ ; # COMBINING MACRON
-$pre \&quot; $post ↔ ̈ ; # COMBINING DIAERESIS
+$pre \" $post ↔ ̈ ; # COMBINING DIAERESIS
 $pre \* $post ↔ ̊ ; # COMBINING RING ABOVE
 $pre \, $post ↔ ̧ ; # COMBINING CEDILLA
 $pre '/' $post ↔ ̸ ; # COMBINING LONG SOLIDUS OVERLAY

--- a/common/transforms/Cyrillic-Latin.xml
+++ b/common/transforms/Cyrillic-Latin.xml
@@ -9,7 +9,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<version number="$Revision$"/>
 	<transforms>
 		<transform source="Cyrl" target="Latn" direction="both" alias="Cyrillic-Latin und-Latn-t-und-cyrl" backwardAlias="Latin-Cyrillic und-Cyrl-t-und-latn">
-			<tRule>
+			<tRule><![CDATA[
 # TODO: add remaining characters
 # Should add variants for Russian-English, Russian-German
 # Those can use this as a base, and then remap cases
@@ -296,7 +296,7 @@ $ignore = [[:Mark:]''] * ;
 # :: ([\u0000-\u007E ʹ ʺ [:Cyrillic:] [:Latin:] [:nonspacing mark:] ‧]);
 # MINIMAL FILTER: Latin-Cyrillic
 :: ( [‧ˌ̈A-Za-zÀ-ÏÑ-ÖÙ-Ýà-ïñ-öù-ýÿ-ĥĨ-İĴ-ķĹ-ľŃ-ňŌ-őŔ-ťŨ-žƏƠ-ơƯ-ưǍ-ǜǞ-ǣǦ-ǰǴ-ǵǸ-țȞ-ȟȦ-ȳəʹ-ʺ̀-̂̆-̦̱̇̌̀-́̈́ʹ΅-ΆΈ-ΊΌΎ-ΐά-ΰό-ώϓЀЃЌ-ЎЙйѐѓќ-ўӁ-ӂӐ-ӑӖ-ӗḀ-ẙẛẠ-ỹἂ-ἅἊ-Ἅἒ-ἕἚ-Ἕἢ-ἥἪ-Ἥἲ-ἵἺ-Ἵὂ-ὅὊ-Ὅὒ-ὕὛὝὢ-ὥὪ-Ὥὰ-ώᾂ-ᾅᾊ-ᾍᾒ-ᾕᾚ-ᾝᾢ-ᾥᾪ-ᾭᾰᾲᾴᾸᾺ-ΆῂῄῈ-Ή῍-῎ῐῒ-ΐῘῚ-Ί῝-῞ῠῢ-ΰῨῪ-Ύ῭-΅ῲῴῸ-ΏK-Å] ) ;
-			</tRule>
+			]]></tRule>
 		</transform>
 	</transforms>
 </supplementalData>

--- a/common/transforms/Cyrillic-Latin.xml
+++ b/common/transforms/Cyrillic-Latin.xml
@@ -35,7 +35,7 @@ $macron = \u0304 ;
 $breveBelow = \u032E;
 
 $ignoreForCase = [‧[:Mn:][:Me:]] ;
-$lower = [[:Latin:][:Cyrillic:] &amp; [:Ll:]];
+$lower = [[:Latin:][:Cyrillic:] & [:Ll:]];
 $beforeLower = $ignoreForCase * $lower ;
 
 # Move up so not masked


### PR DESCRIPTION
CLDR-16885

Changes `&amp;` to `&` and `&quot;` to `"`. 

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
