### PR TITLE
CLDR-16863 no longer treat org-disputes as disputed

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
@@ -125,7 +125,7 @@ public final class SurveyJSONWrapper {
                                         .toString()) /* "raw" is only used for debugging (stdebug_enabled) */
                         .put("requiredVotes", r.getRequiredVotes());
 
-        Map<String, Long> valueToVote = r.getResolvedVoteCounts();
+        Map<String, Long> valueToVote = r.getResolvedVoteCountsIncludingIntraOrgDisputes();
 
         JSONObject orgs = new JSONObject();
         for (Organization o : Organization.values()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
@@ -260,7 +260,8 @@ public class ReportAPI {
             } else {
                 votersForNotAcceptable = 0;
             }
-            Map<ReportAcceptability, Long> rvc = res.getResolvedVoteCountsIncludingIntraOrgDisputes();
+            Map<ReportAcceptability, Long> rvc =
+                    res.getResolvedVoteCountsIncludingIntraOrgDisputes();
             acceptableScore = rvc.get(ReportAcceptability.acceptable);
             notAcceptableScore = rvc.get(ReportAcceptability.notAcceptable);
             // serialize the voteResolver

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/ReportAPI.java
@@ -260,12 +260,12 @@ public class ReportAPI {
             } else {
                 votersForNotAcceptable = 0;
             }
-            Map<ReportAcceptability, Long> rvc = res.getResolvedVoteCounts();
+            Map<ReportAcceptability, Long> rvc = res.getResolvedVoteCountsIncludingIntraOrgDisputes();
             acceptableScore = rvc.get(ReportAcceptability.acceptable);
             notAcceptableScore = rvc.get(ReportAcceptability.notAcceptable);
             // serialize the voteResolver
             transcript = res.getTranscript();
-            resolvedVoteCounts = res.getResolvedVoteCounts();
+            resolvedVoteCounts = res.getResolvedVoteCountsIncludingIntraOrgDisputes();
             votingResults = VoteAPIHelper.getVotingResults(res);
             this.votes = votes;
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -273,7 +273,7 @@ public class VoteAPIHelper {
         final EnumSet<Organization> conflictedOrgs = resolver.getConflictedOrganizations();
         /** array of Key, Value, Key, Value… */
         final List<Object> valueToVoteA = new ArrayList<>();
-        final Map<T, Long> valueToVote = resolver.getResolvedVoteCounts();
+        final Map<T, Long> valueToVote = resolver.getResolvedVoteCountsIncludingIntraOrgDisputes();
         for (Map.Entry<T, Long> e : valueToVote.entrySet()) {
             valueToVoteA.add(e.getKey());
             valueToVoteA.add(String.valueOf(e.getValue()));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -547,7 +547,9 @@ public class VoteResolver<T> {
     private class OrganizationToValueAndVote<T> {
         private final Map<Organization, MaxCounter<T>> orgToVotes =
                 new EnumMap<>(Organization.class);
-        /** All votes, even those that aren't any org's vote because they lost an intra-org dispute */
+        /**
+         * All votes, even those that aren't any org's vote because they lost an intra-org dispute
+         */
         private final Counter<T> allVotesIncludingIntraOrgDispute = new Counter<>();
 
         private final Map<Organization, Integer> orgToMax = new EnumMap<>(Organization.class);
@@ -619,11 +621,13 @@ public class VoteResolver<T> {
             if (DROP_HARD_INHERITANCE) {
                 value = changeBaileyToInheritance(value);
             }
-            /** All votes are added here, even if they will later lose an intra-org dispute.  */
+            /** All votes are added here, even if they will later lose an intra-org dispute. */
             allVotesIncludingIntraOrgDispute.add(value, votes, time.getTime());
             nameTime.put(info.getName(), time.getTime());
             if (DEBUG) {
-                System.out.println("allVotesIncludingIntraOrgDispute Info: " + allVotesIncludingIntraOrgDispute);
+                System.out.println(
+                        "allVotesIncludingIntraOrgDispute Info: "
+                                + allVotesIncludingIntraOrgDispute);
             }
             if (DEBUG) {
                 System.out.println("VoteInfo: " + info.getName() + info.getOrganization());
@@ -2031,7 +2035,7 @@ public class VoteResolver<T> {
      * Returns a map from value to resolved vote count, in descending order. If the winning item is
      * not there, insert at the front. If the baseline (trunk) item is not there, insert at the end.
      *
-     * This map includes intra-org disputes.
+     * <p>This map includes intra-org disputes.
      *
      * @return the map
      */
@@ -2049,7 +2053,8 @@ public class VoteResolver<T> {
         if (baselineValue != null && !totals.containsKey(baselineValue)) {
             result.put(baselineValue, 0L);
         }
-        for (T value : organizationToValueAndVote.allVotesIncludingIntraOrgDispute.getMap().keySet()) {
+        for (T value :
+                organizationToValueAndVote.allVotesIncludingIntraOrgDispute.getMap().keySet()) {
             if (!result.containsKey(value)) {
                 result.put(value, 0L);
             }
@@ -2074,9 +2079,7 @@ public class VoteResolver<T> {
             return VoteStatus.provisionalOrWorse;
         }
         final int itemsWithVotes =
-                DROP_HARD_INHERITANCE
-                        ? totals.size()
-                        : countDistinctValuesWithVotes();
+                DROP_HARD_INHERITANCE ? totals.size() : countDistinctValuesWithVotes();
         if (itemsWithVotes > 1) {
             // If there are votes for two "distinct" items, we should look at them.
             return VoteStatus.disputed;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -551,7 +551,7 @@ public class VoteResolver<T> {
         private final Counter<T> totalVotes = new Counter<>();
 
         private final Map<Organization, Integer> orgToMax = new EnumMap<>(Organization.class);
-        /** All disctinct values, excluding intra-org disputes */
+        /** All distinct values, excluding intra-org disputes */
         private final Counter<T> totals = new Counter<>(true);
 
         private Map<String, Long> nameTime = new LinkedHashMap<>();
@@ -778,11 +778,7 @@ public class VoteResolver<T> {
                 annotateTranscript(
                         "--- %s vote is for '%s' with strength %d",
                         org.getDisplayName(), considerItem, considerCount);
-                // Now that we know exactly what this org's final vote is, add it to the total
-                // counter
                 orgToAdd.put(org, considerItem);
-                // This vote isn't in an org dispute, so add it to totalUndisputedVotes
-                totalUndisputedVotes.add(considerItem, considerCount);
                 totals.add(considerItem, considerCount, considerTime);
 
                 if (DEBUG) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -567,7 +567,7 @@ public class TestUtilities extends TestFmwkPlus {
         resolver.add("apple", toVoterId("appleV"));
 
         // check that alphabetical wins when votes are equal
-        Map<String, Long> counts = resolver.getResolvedVoteCounts();
+        Map<String, Long> counts = resolver.getResolvedVoteCountsIncludingIntraOrgDisputes();
         logln(counts.toString());
         assertEquals("", "foo", new ArrayList<>(counts.keySet()).get(2));
 
@@ -577,7 +577,7 @@ public class TestUtilities extends TestFmwkPlus {
         resolver.setBaseline("foo", Status.approved);
         resolver.add("zebra", toVoterId("googleV"));
         resolver.add("apple", toVoterId("appleV"));
-        counts = resolver.getResolvedVoteCounts();
+        counts = resolver.getResolvedVoteCountsIncludingIntraOrgDisputes();
         logln(counts.toString());
         assertEquals("", "foo", new ArrayList<>(counts.keySet()).get(0));
 
@@ -586,7 +586,7 @@ public class TestUtilities extends TestFmwkPlus {
         resolver.setLocale(CLDRLocale.getInstance("de"), null);
         resolver.setBaseline("foo", Status.approved);
         resolver.add("zebra", toVoterId("googleS"));
-        counts = resolver.getResolvedVoteCounts();
+        counts = resolver.getResolvedVoteCountsIncludingIntraOrgDisputes();
         logln(counts.toString());
         assertEquals("", "foo", new ArrayList<>(counts.keySet()).get(0));
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Date;
+
 import com.ibm.icu.util.Output;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.unittest.TestUtilities;
@@ -23,26 +25,31 @@ public class TestVoteResolver {
                 CLDRLocale.getInstance("fr"), null); // NB: pathHeader is needed for annotations
         vr.setBaseline("Bouvet", Status.unconfirmed);
         vr.setBaileyValue("BV");
-        // Vote with a date in the past, this wil l lose the org dispute
-        vr.add(
-                "Bouvet",
+
+        // A date in 2017
+        final Date t0 = new Date(1500000000000L);
+        // A date in 2020
+        final Date t1 = new Date(1600000000000L);
+
+        assertTrue(t0.before(t1));
+
+        // Vote with a date in the past, this will lose the org dispute
+        vr.add( "Bouvet",
                 TestUtilities.TestUser.googleV.voterId,
                 null,
-                DateConstants.RECENT_HISTORY);
+                t0);
 
-        vr.add("Illa Bouvet", TestUtilities.TestUser.googleV2.voterId, null, DateConstants.NOW);
-        vr.add("Illa Bouvet", TestUtilities.TestUser.appleV.voterId, null, DateConstants.NOW);
-        vr.add(
-                "Illa Bouvet",
+        vr.add("Illa Bouvet", TestUtilities.TestUser.googleV2.voterId, null, t1);
+        vr.add("Illa Bouvet", TestUtilities.TestUser.appleV.voterId, null, t1);
+        vr.add("Illa Bouvet",
                 TestUtilities.TestUser.unaffiliatedS.voterId,
                 null,
-                DateConstants.NOW);
+                t1);
         assertAll(
                 "Verify the outcome",
                 () -> assertEquals("Illa Bouvet", vr.getWinningValue()),
-                () ->
-                        assertEquals(
-                                VoteStatus.ok, vr.getStatusForOrganization(Organization.google)));
+                () -> assertEquals(
+                        VoteStatus.ok, vr.getStatusForOrganization(Organization.google)));
     }
 
     @Test

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.ibm.icu.util.Output;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.unittest.TestUtilities;
+import org.unicode.cldr.util.VettingViewer.VoteStatus;
 import org.unicode.cldr.util.VoteResolver.Status;
 
 /**
@@ -14,6 +15,26 @@ import org.unicode.cldr.util.VoteResolver.Status;
  * @see org.unicode.cldr.unittest.TestUtilities#TestUser
  */
 public class TestVoteResolver {
+
+    @Test
+    void testDisputed() {
+        final VoteResolver<String> vr = getStringResolver();
+        vr.setLocale(
+                CLDRLocale.getInstance("fr"), null); // NB: pathHeader is needed for annotations
+        vr.setBaseline("Bouvet", Status.unconfirmed);
+        vr.setBaileyValue("BV");
+        vr.add("Bouvet", TestUtilities.TestUser.googleV.voterId);
+        vr.add("Illa Bouvet", TestUtilities.TestUser.googleV2.voterId);
+        vr.add("Illa Bouvet", TestUtilities.TestUser.appleV.voterId);
+        vr.add("Illa Bouvet", TestUtilities.TestUser.unaffiliatedS.voterId);
+        assertAll(
+                "Verify the outcome",
+                () -> assertEquals("Illa Bouvet", vr.getWinningValue()),
+                () ->
+                        assertEquals(
+                                VoteStatus.ok, vr.getStatusForOrganization(Organization.google)));
+    }
+
     @Test
     void testExplanations() {
         // Example from https://st.unicode.org/cldr-apps/v#/fr/Languages_A_D/54dc38b9b6c86cac

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
@@ -23,10 +23,20 @@ public class TestVoteResolver {
                 CLDRLocale.getInstance("fr"), null); // NB: pathHeader is needed for annotations
         vr.setBaseline("Bouvet", Status.unconfirmed);
         vr.setBaileyValue("BV");
-        vr.add("Bouvet", TestUtilities.TestUser.googleV.voterId);
-        vr.add("Illa Bouvet", TestUtilities.TestUser.googleV2.voterId);
-        vr.add("Illa Bouvet", TestUtilities.TestUser.appleV.voterId);
-        vr.add("Illa Bouvet", TestUtilities.TestUser.unaffiliatedS.voterId);
+        // Vote with a date in the past, this wil l lose the org dispute
+        vr.add(
+                "Bouvet",
+                TestUtilities.TestUser.googleV.voterId,
+                null,
+                DateConstants.RECENT_HISTORY);
+
+        vr.add("Illa Bouvet", TestUtilities.TestUser.googleV2.voterId, null, DateConstants.NOW);
+        vr.add("Illa Bouvet", TestUtilities.TestUser.appleV.voterId, null, DateConstants.NOW);
+        vr.add(
+                "Illa Bouvet",
+                TestUtilities.TestUser.unaffiliatedS.voterId,
+                null,
+                DateConstants.NOW);
         assertAll(
                 "Verify the outcome",
                 () -> assertEquals("Illa Bouvet", vr.getWinningValue()),

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
@@ -4,9 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
-
 import com.ibm.icu.util.Output;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.unittest.TestUtilities;
 import org.unicode.cldr.util.VettingViewer.VoteStatus;
@@ -34,22 +33,17 @@ public class TestVoteResolver {
         assertTrue(t0.before(t1));
 
         // Vote with a date in the past, this will lose the org dispute
-        vr.add( "Bouvet",
-                TestUtilities.TestUser.googleV.voterId,
-                null,
-                t0);
+        vr.add("Bouvet", TestUtilities.TestUser.googleV.voterId, null, t0);
 
         vr.add("Illa Bouvet", TestUtilities.TestUser.googleV2.voterId, null, t1);
         vr.add("Illa Bouvet", TestUtilities.TestUser.appleV.voterId, null, t1);
-        vr.add("Illa Bouvet",
-                TestUtilities.TestUser.unaffiliatedS.voterId,
-                null,
-                t1);
+        vr.add("Illa Bouvet", TestUtilities.TestUser.unaffiliatedS.voterId, null, t1);
         assertAll(
                 "Verify the outcome",
                 () -> assertEquals("Illa Bouvet", vr.getWinningValue()),
-                () -> assertEquals(
-                        VoteStatus.ok, vr.getStatusForOrganization(Organization.google)));
+                () ->
+                        assertEquals(
+                                VoteStatus.ok, vr.getStatusForOrganization(Organization.google)));
     }
 
     @Test


### PR DESCRIPTION
- update VoteResolver to add OrganizationToValueAndVote.totalUndisputedVotes which excludes intra-org disputes.
- add a test

CLDR-16863

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
