### PR TITLE
CLDR-15034 DTD @MATCH: add validity/bcp47 and semver match types

### DIFF
--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -62,6 +62,11 @@
 			<groupId>org.relaxng</groupId>
 			<artifactId>trang</artifactId>
 		</dependency>
+		<!-- for semver -->
+		<dependency>
+			<groupId>com.vdurmont</groupId>
+			<artifactId>semver4j</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
@@ -114,6 +114,7 @@ public abstract class MatchValue implements Predicate<String> {
         }
     }
 
+    /** Check that a bcp47 locale ID is well-formed */
     public static class BCP47LocaleMatchValue extends MatchValue {
         static final UnicodeSet basechars = new UnicodeSet("[A-Za-z0-9_]");
 
@@ -131,10 +132,14 @@ public abstract class MatchValue implements Predicate<String> {
             try {
                 ULocale l = ULocale.forLanguageTag(item);
                 if (l == null || l.getBaseName().isEmpty()) {
-                    return false;
+                    return false; // failed to parse
                 }
+
+                // check with lstr parser
+                LanguageTagParser ltp = new LanguageTagParser();
+                ltp.set(item);
             } catch (Throwable t) {
-                return false;
+                return false; // string failed
             }
             return true;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
@@ -122,7 +122,7 @@ public abstract class MatchValue implements Predicate<String> {
 
         @Override
         public String getName() {
-            return "validity/bcp47";
+            return "validity/bcp47-wellformed";
         }
 
         @Override
@@ -325,7 +325,7 @@ public abstract class MatchValue implements Predicate<String> {
             if (typeName.equals("locale")) {
                 return new LocaleMatchValue();
             }
-            if (typeName.equals("bcp47")) {
+            if (typeName.equals("bcp47-wellformed")) {
                 return new BCP47LocaleMatchValue();
             }
             int slashPos = typeName.indexOf('/');

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
@@ -114,11 +114,11 @@ public abstract class MatchValue implements Predicate<String> {
         }
     }
 
-    /** Check that a bcp47 locale ID is well-formed */
-    public static class BCP47LocaleMatchValue extends MatchValue {
+    /** Check that a bcp47 locale ID is well-formed. Does not check validity. */
+    public static class BCP47LocaleWellFormedMatchValue extends MatchValue {
         static final UnicodeSet basechars = new UnicodeSet("[A-Za-z0-9_]");
 
-        public BCP47LocaleMatchValue() {}
+        public BCP47LocaleWellFormedMatchValue() {}
 
         @Override
         public String getName() {
@@ -326,7 +326,7 @@ public abstract class MatchValue implements Predicate<String> {
                 return new LocaleMatchValue();
             }
             if (typeName.equals("bcp47-wellformed")) {
-                return new BCP47LocaleMatchValue();
+                return new BCP47LocaleWellFormedMatchValue();
             }
             int slashPos = typeName.indexOf('/');
             Set<Status> statuses = null;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestMatchValue.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestMatchValue.java
@@ -46,7 +46,8 @@ public class TestMatchValue {
                 is_bcp47.stream().map(v -> () -> assertTrue(m.is(v), v + ": Should be bcp47")));
 
         ImmutableSet<String> not_bcp47 =
-                ImmutableSet.of("de_DE@PREEURO", "en_US_POSIX", "a b c", "a");
+                ImmutableSet.of(
+                        "de_DE@PREEURO", "en_US_POSIX", "a b c", "a", "aa-BB-CCC-DDDD-EEEEE-u-u-u");
         assertAll(
                 "is=true",
                 not_bcp47.stream()

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestMatchValue.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestMatchValue.java
@@ -1,0 +1,60 @@
+package org.unicode.cldr.util;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.util.MatchValue.SemverMatchValue;
+import org.unicode.cldr.util.MatchValue.ValidityMatchValue;
+
+public class TestMatchValue {
+    @Test
+    void TestSemverMatchValue() {
+        // assert that no keyword is allowed
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    SemverMatchValue.of("Not Allowed");
+                });
+
+        final SemverMatchValue m = SemverMatchValue.of(null);
+
+        ImmutableSet<String> is_semver = ImmutableSet.of("0.0.0", "1.0.0", "42.0.0-BETA3");
+        assertAll(
+                "is=true",
+                is_semver.stream().map(v -> () -> assertTrue(m.is(v), v + ": Should be a semver")));
+
+        ImmutableSet<String> not_semver = ImmutableSet.of("0.0", "v1.0", "Some Version", "");
+        assertAll(
+                "is=true",
+                not_semver.stream()
+                        .map(v -> () -> assertFalse(m.is(v), v + ": Should NOT be a semver")));
+    }
+
+    @Test
+    void TestBcp47MatchValue() {
+        // assert that no keyword is allowed
+        final MatchValue m = ValidityMatchValue.of("bcp47");
+
+        ImmutableSet<String> is_bcp47 =
+                ImmutableSet.of("und", "mt-Latn", "und-US-u-rg-ustx-tz-uschi");
+        assertAll(
+                "is=true",
+                is_bcp47.stream().map(v -> () -> assertTrue(m.is(v), v + ": Should be bcp47")));
+
+        ImmutableSet<String> not_bcp47 =
+                ImmutableSet.of("de_DE@PREEURO", "en_US_POSIX", "a b c", "a");
+        assertAll(
+                "is=true",
+                not_bcp47.stream()
+                        .map(
+                                v ->
+                                        () ->
+                                                assertFalse(
+                                                        m.is(v),
+                                                        v + ": Should NOT be a bcp47 version")));
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestMatchValue.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestMatchValue.java
@@ -37,7 +37,7 @@ public class TestMatchValue {
     @Test
     void TestBcp47MatchValue() {
         // assert that no keyword is allowed
-        final MatchValue m = ValidityMatchValue.of("bcp47");
+        final MatchValue m = ValidityMatchValue.of("bcp47-wellformed");
 
         ImmutableSet<String> is_bcp47 =
                 ImmutableSet.of("und", "mt-Latn", "und-US-u-rg-ustx-tz-uschi");

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -184,6 +184,13 @@
 				<artifactId>jjwt-gson</artifactId>
 				<version>${jjwt.version}</version>
 			</dependency>
+
+			<!-- for semver -->
+			<dependency>
+				<groupId>com.vdurmont</groupId>
+				<artifactId>semver4j</artifactId>
+				<version>3.1.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
For the Keyboard spec, we needed to match two additional `@MATCH` types to the DTD.

- `@MATCH:semver` matches a semantic version ([semver.org](https://semver.org)) such as `1.0.0` or `1.2.3-BETA`  - this is used for the keyboard version   
- `@MATCH:validity/bcp47` matches any valid bcp47 id, such as `nod-Lana` or `de-CH-t-k0-windows-extended-var` - this is used for the keyboard locale id
- plus tests

(cherry picked from commit 632c286d8abd7c20a082e749cf67c3b0b264816a)

CLDR-15034

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
