### PR TITLE
CLDR-15034 add @ALLOWS_UESC DTD Annotation

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3204,6 +3204,7 @@ and are included below the !ELEMENT or !ATTLIST line that they apply to. The cur
 | ---------------------| ----------- |
 | `<!--@VALUE-->`      | The attribute is not distinguishing, and is treated like an element value |
 | `<!--@METADATA-->`   | The attribute is a “comment” on the data, like the draft status. It is not typically used in implementations. |
+| `<!--@ALLOWS_UESC-->`   | The attribute value can be escaped using the `\u` notation. Does not require this notation to be used. |
 | `<!--@ORDERED-->`    | The element's children are ordered, and do not inherit. |
 | `<!--@DEPRECATED-->` | The element or attribute is deprecated, and should not be used. |
 | `<!--@DEPRECATED: attribute-value1, attribute-value2-->` | The attribute values are deprecated, and should not be used. Spaces between tokens are not significant. |

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -160,6 +160,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         private final Set<String> commentsPre;
         private Set<String> commentsPost;
         private boolean isDeprecatedAttribute;
+        private boolean isUEscapedAttribute = false;
         public AttributeStatus attributeStatus =
                 AttributeStatus.distinguished; // default unless reset by annotations, or for xml:
         // attributes
@@ -294,6 +295,10 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                     case "@DEPRECATED":
                         isDeprecatedAttribute = true;
                         break;
+                    case "@ALLOWS_UESC":
+                        isUEscapedAttribute = true;
+                        break;
+
                     default:
                         int colonPos = commentIn.indexOf(':');
                         if (colonPos < 0) {
@@ -374,6 +379,10 @@ public class DtdData extends XMLFileReader.SimpleHandler {
 
         public boolean isDeprecated() {
             return isDeprecatedAttribute;
+        }
+
+        public boolean isUEscaped() {
+            return isUEscapedAttribute;
         }
 
         public boolean isDeprecatedValue(String value) {
@@ -1233,7 +1242,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             seen.seenAttributes.add(a);
             boolean attributeDeprecated =
                     elementDeprecated || isDeprecated(current.name, a.name, "*");
-
+            boolean attributeUEscaped = isUEscaped(current.name, a.name, "*");
             deprecatedValues.clear();
 
             showComments(b, a.commentsPre, true);
@@ -1283,6 +1292,9 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                                 + "<!--@DEPRECATED:"
                                 + Joiner.on(", ").join(deprecatedValues)
                                 + "-->");
+            }
+            if (attributeUEscaped) {
+                b.append(COMMENT_PREFIX + "<!--@ALLOWS_UESC-->");
             }
         }
         if (current.children.size() > 0) {
@@ -1400,6 +1412,17 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         }
         return attribute.deprecatedValues.contains(
                 attributeValue); // don't need special test for "*"
+    }
+
+    public boolean isUEscaped(String elementName, String attributeName, String attributeValue) {
+        Element element = getElementThrowingIfNull(elementName, null, null);
+        Attribute attribute = element.getAttributeNamed(attributeName);
+        if (attribute == null) {
+            throw new IllegalByDtdException(elementName, attributeName, attributeValue);
+        } else if (attribute.isUEscaped()) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -160,7 +160,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
         private final Set<String> commentsPre;
         private Set<String> commentsPost;
         private boolean isDeprecatedAttribute;
-        private boolean isUEscapedAttribute = false;
+        private boolean attributeAllowsUEscape = false;
         public AttributeStatus attributeStatus =
                 AttributeStatus.distinguished; // default unless reset by annotations, or for xml:
         // attributes
@@ -296,7 +296,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                         isDeprecatedAttribute = true;
                         break;
                     case "@ALLOWS_UESC":
-                        isUEscapedAttribute = true;
+                        attributeAllowsUEscape = true;
                         break;
 
                     default:
@@ -381,8 +381,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             return isDeprecatedAttribute;
         }
 
-        public boolean isUEscaped() {
-            return isUEscapedAttribute;
+        public boolean allowsUEscape() {
+            return attributeAllowsUEscape;
         }
 
         public boolean isDeprecatedValue(String value) {
@@ -1242,7 +1242,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             seen.seenAttributes.add(a);
             boolean attributeDeprecated =
                     elementDeprecated || isDeprecated(current.name, a.name, "*");
-            boolean attributeUEscaped = isUEscaped(current.name, a.name, "*");
+            boolean attributeUEscaped = allowsUEscape(current.name, a.name, "*");
             deprecatedValues.clear();
 
             showComments(b, a.commentsPre, true);
@@ -1414,12 +1414,12 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                 attributeValue); // don't need special test for "*"
     }
 
-    public boolean isUEscaped(String elementName, String attributeName, String attributeValue) {
+    public boolean allowsUEscape(String elementName, String attributeName, String attributeValue) {
         Element element = getElementThrowingIfNull(elementName, null, null);
         Attribute attribute = element.getAttributeNamed(attributeName);
         if (attribute == null) {
             throw new IllegalByDtdException(elementName, attributeName, attributeValue);
-        } else if (attribute.isUEscaped()) {
+        } else if (attribute.allowsUEscape()) {
             return true;
         }
         return false;


### PR DESCRIPTION
This adds the `@ALLOWS_UESC` DTD annotation, used in the proposed Keyboard DTD.

This annotation on an attribute value indicates that an attribute value MAY contain the `\u{0127}` Unicode escaped format in the attribute.  For example,

```xml
<!ATTLIST key to CDATA #IMPLIED >
    <!--@MATCH:any-->
    <!--@VALUE-->
    <!--@ALLOWS_UESC-->
```

and then:

```xml
<key id="quote" to="\u{22}"/>
```

- Originally #2642 734b93461ff567458d58e0cd1cb9b679d8cbc506

(cherry picked from commit 38d093341c5205a8523aa3882a800a275072a387)

CLDR-15034

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
