### PR TITLE
CLDR-9102 Use NNBSP for grouping non-currency numbers in German language

### DIFF
--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -5896,7 +5896,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<minimumGroupingDigits>↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
-			<group>.</group>
+			<group> </group>
+			<currencyGroup>.</currencyGroup>
 			<list>↑↑↑</list>
 			<percentSign>↑↑↑</percentSign>
 			<plusSign>↑↑↑</plusSign>


### PR DESCRIPTION
CLDR-9102

According to DIN 5008, a thin space (U+2009) should be used as the group character, but because a line break must never occur in a group of characters structured by narrow spaces, the narrow no-break space (U+202F) is typographically correct.

If there is any reason (e.g. overall compatibility) to use NBSP (U+00A0) instead of NNBSP (U+202F), I am happy to use that instead. The main purpose of this PR is to switch from the period to space character.

During review, you might want to check if the number format in `de_IT` should then explicitly be changed back to the period character and/or if the rule in `de_AT` can be removed as a result of this change, as it also specifies the no-break space (U+00A0) for groups.

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
