### PR TITLE
CLDR-16882 check: fail on emoji annotations using the root codes

### DIFF
--- a/common/annotations/ku.xml
+++ b/common/annotations/ku.xml
@@ -61,7 +61,5 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍆" type="tts">balîcan</annotation>
 		<annotation cp="🥔">kartol</annotation>
 		<annotation cp="🥔" type="tts">kartol</annotation>
-		<annotation cp="🏠">E416</annotation>
-		<annotation cp="🏠" type="tts">E416</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/sr.xml
+++ b/common/annotations/sr.xml
@@ -429,8 +429,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∩" type="tts">пресек</annotation>
 		<annotation cp="∪">скуп | унија</annotation>
 		<annotation cp="∪" type="tts">унија</annotation>
-		<annotation cp="∫" draft="contributed">E13.1–305</annotation>
-		<annotation cp="∫" type="tts" draft="contributed">E13.1–305</annotation>
 		<annotation cp="∬" draft="contributed">двоструки интеграл</annotation>
 		<annotation cp="∬" type="tts" draft="contributed">двоструки интеграл</annotation>
 		<annotation cp="∮" draft="contributed">контурни интеграл</annotation>

--- a/common/annotations/sr_Latn.xml
+++ b/common/annotations/sr_Latn.xml
@@ -428,8 +428,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="∩" type="tts">presek</annotation>
 		<annotation cp="∪">skup | unija</annotation>
 		<annotation cp="∪" type="tts">unija</annotation>
-		<annotation cp="∫" draft="contributed">E13.1–305</annotation>
-		<annotation cp="∫" type="tts" draft="contributed">E13.1–305</annotation>
 		<annotation cp="∬" draft="contributed">dvostruki integral</annotation>
 		<annotation cp="∬" type="tts" draft="contributed">dvostruki integral</annotation>
 		<annotation cp="∮" draft="contributed">konturni integral</annotation>

--- a/common/annotations/zu.xml
+++ b/common/annotations/zu.xml
@@ -131,22 +131,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="§" type="tts">i-section</annotation>
 		<annotation cp="¶">alinea | isigaba | paragraph | paragraph mark | pilcrow | uphawu lwesigaba</annotation>
 		<annotation cp="¶" type="tts">uphawu lwesigaba</annotation>
-		<annotation cp="@">at-sign | E13.1–132</annotation>
+		<annotation cp="@">at-sign</annotation>
 		<annotation cp="@" type="tts">at-sign</annotation>
-		<annotation cp="*">E13.1–133</annotation>
-		<annotation cp="*" type="tts">E13.1–133</annotation>
 		<annotation cp="/">isleshi | isthrokhi | oblique | slash | solidus | virgule | whack</annotation>
 		<annotation cp="/" type="tts">isleshi</annotation>
 		<annotation cp="\">backslash | reverse solidus | whack</annotation>
 		<annotation cp="\" type="tts">backslash</annotation>
-		<annotation cp="&amp;">ampersand | E13.1–125</annotation>
+		<annotation cp="&amp;">ampersand</annotation>
 		<annotation cp="&amp;" type="tts">ampersand</annotation>
 		<annotation cp="#">hash | hash sign | hashtag | inamba | lb | pound | uphawu lwe-hash</annotation>
 		<annotation cp="#" type="tts">uphawu lwe-hash</annotation>
-		<annotation cp="%">E13.1–127 | iphesenti</annotation>
+		<annotation cp="%">iphesenti</annotation>
 		<annotation cp="%" type="tts">iphesenti</annotation>
-		<annotation cp="‰">E13.1–128</annotation>
-		<annotation cp="‰" type="tts">E13.1–128</annotation>
 		<annotation cp="†">dagger | obelisk | obelus | uphawu lwe-dagger</annotation>
 		<annotation cp="†" type="tts">uphawu lwe-dagger</annotation>
 		<annotation cp="‡">i-dagger | obelisk | obelus | phinda kabili | uphawu lwe-dagger oluphindeke kabili</annotation>
@@ -167,12 +163,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="※" type="tts">uphawu lwereferensi</annotation>
 		<annotation cp="⁂">i-asterism | i-dinkus | izinkanyezi</annotation>
 		<annotation cp="⁂" type="tts">i-asterism</annotation>
-		<annotation cp="`">E13.1–137</annotation>
-		<annotation cp="`" type="tts">E13.1–137</annotation>
 		<annotation cp="´">i-acute | isimangalo | isimangalo esibi | ithoni</annotation>
 		<annotation cp="´" type="tts">isimangalo esibi</annotation>
-		<annotation cp="^">amandla | circumflex | control | E13.1–139 | I-chevron | inkomba | isibonakaliso se-xor | isigqoko | isimangalo | ukunakekelwa | wedge</annotation>
-		<annotation cp="^" type="tts">E13.1–139</annotation>
+		<annotation cp="^">amandla | circumflex | control | I-chevron | inkomba | isibonakaliso se-xor | isigqoko | isimangalo | ukunakekelwa | wedge</annotation>
 		<annotation cp="¨">i-diaeresis | i-tréma | i-umlaut</annotation>
 		<annotation cp="¨" type="tts">i-diaeresis</annotation>
 		<annotation cp="°">i-degree | ihora | ubufakazi</annotation>
@@ -387,10 +380,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="◯" type="tts">indilinga enkulu engenalutho</annotation>
 		<annotation cp="♪">inothi | umculo | yesishiyagalombili</annotation>
 		<annotation cp="♪" type="tts">inothi yesishiyagalombili</annotation>
-		<annotation cp="♭">E13.1–135</annotation>
-		<annotation cp="♭" type="tts">E13.1–135</annotation>
-		<annotation cp="♯">E13.1–136 | Vote E13.1–136</annotation>
-		<annotation cp="♯" type="tts">Vote E13.1–136</annotation>
 		<annotation cp="😀">osinekile | ubuso obusinekile</annotation>
 		<annotation cp="😀" type="tts">ubuso obusinekile</annotation>
 		<annotation cp="😃">moyizela | ubuso | ubuso obumoyizelayo obuvule umlomo | umlomo | vula</annotation>
@@ -2367,8 +2356,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🎆" type="tts">amakhrikhethi</annotation>
 		<annotation cp="🎇">amakhrikhethi | okuqhumayo | umbungazo</annotation>
 		<annotation cp="🎇" type="tts">okuqhumayo</annotation>
-		<annotation cp="🧨">E11:050</annotation>
-		<annotation cp="🧨" type="tts">E11:050</annotation>
 		<annotation cp="✨">inkanyezi | okukhazimulayo | ukukhazimula</annotation>
 		<annotation cp="✨" type="tts">okukhazimulayo</annotation>
 		<annotation cp="🎈">ibhaluni | umbungazo</annotation>
@@ -2389,8 +2376,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🎐" type="tts">ichime yomoya</annotation>
 		<annotation cp="🎑">inyanga | umbungazo | umcimbi | umcimbi wenyanga</annotation>
 		<annotation cp="🎑" type="tts">umcimbi wenyanga</annotation>
-		<annotation cp="🧧">E11:049</annotation>
-		<annotation cp="🧧" type="tts">E11:049</annotation>
 		<annotation cp="🎀">iribhini | umbungazo</annotation>
 		<annotation cp="🎀" type="tts">iribhini</annotation>
 		<annotation cp="🎁">ibhokisi | iprezenti | isipho | isipho esigoqiwe | okugoqiwe | umbungazo</annotation>
@@ -2429,8 +2414,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🏉" type="tts">ibhola lomboxo</annotation>
 		<annotation cp="🎾">ibhalo | irekhethi | ithenisi</annotation>
 		<annotation cp="🎾" type="tts">ithenisi</annotation>
-		<annotation cp="🥏">E11:007</annotation>
-		<annotation cp="🥏" type="tts">E11:007</annotation>
 		<annotation cp="🎳">ibhola | ukubhowla | umdlalo</annotation>
 		<annotation cp="🎳" type="tts">ukubhowla</annotation>
 		<annotation cp="🏏">ibhethi | ibhola | umdlalo | umdlalo wekhilikithi</annotation>
@@ -2439,8 +2422,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🏑" type="tts">ihokhi</annotation>
 		<annotation cp="🏒">ihokhi | ihokhi yaseqhweni | induku | iqhwa | umdlalo</annotation>
 		<annotation cp="🏒" type="tts">ihokhi yaseqhweni</annotation>
-		<annotation cp="🥍">E11:005</annotation>
-		<annotation cp="🥍" type="tts">E11:005</annotation>
 		<annotation cp="🏓">ibhethi | ibhola | ithenisi yetafula | ping pong | umdlalo</annotation>
 		<annotation cp="🏓" type="tts">ping pong</annotation>
 		<annotation cp="🏸">ibadminton | irekhethi | umdlalo</annotation>
@@ -2507,8 +2488,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="♦" type="tts">okumise okwedayimane</annotation>
 		<annotation cp="♣">ikhadi | izimpukane | umdlalo | umpukane</annotation>
 		<annotation cp="♣" type="tts">umpukane</annotation>
-		<annotation cp="♟">E11:001</annotation>
-		<annotation cp="♟" type="tts">E11:001</annotation>
 		<annotation cp="🃏">ikhadi | ujokha | ukudlala | umdlalo</annotation>
 		<annotation cp="🃏" type="tts">ujokha</annotation>
 		<annotation cp="🀄">imajongi | okubomvu | umajongi oyidragoni ebomvu | umdlalo</annotation>
@@ -2521,12 +2500,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🖼" type="tts">ifulemu enesithombe</annotation>
 		<annotation cp="🎨">ibhodi lengcweti yokupenda | imyuziyemu | isithombe esipendiwe | ubuciko</annotation>
 		<annotation cp="🎨" type="tts">ibhodi lengcweti yokupenda</annotation>
-		<annotation cp="🧵">E11:063</annotation>
-		<annotation cp="🧵" type="tts">E11:063</annotation>
 		<annotation cp="🪡">inaliti | inaliti yokuthunga | izihlungo | izitishi | ukufeketha | ukuthunga</annotation>
 		<annotation cp="🪡" type="tts">inaliti yokuthunga</annotation>
-		<annotation cp="🧶">E11:064</annotation>
-		<annotation cp="🧶" type="tts">E11:064</annotation>
 		<annotation cp="🪢">bopha | hlanganisa | ifindo | intambo | ithandelwe | sonta</annotation>
 		<annotation cp="🪢" type="tts">ifindo</annotation>
 		<annotation cp="👓">ihlo | impahla yokugqoka | izibuko | izibuko zamehlo | ukugqokisa amehlo</annotation>
@@ -3041,8 +3016,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🪦" type="tts">ikhanda eliyinhloko</annotation>
 		<annotation cp="⚱">isitsha somngcwabo | ukufa | umlotha | umngcwabo</annotation>
 		<annotation cp="⚱" type="tts">isitsha somngcwabo</annotation>
-		<annotation cp="🧿">bead | charm | E11:073 | evil-eye | nazar | talisman</annotation>
-		<annotation cp="🧿" type="tts">E11:073</annotation>
+		<annotation cp="🧿">bead | charm | evil-eye | nazar | talisman</annotation>
 		<annotation cp="🪬">amulet | Fatima | hamsa | hand | i-hamsa | Mary | Miriam | protection</annotation>
 		<annotation cp="🪬" type="tts">i-hamsa</annotation>
 		<annotation cp="🗿">i-moai | isichuthe | moyai | ubuso</annotation>
@@ -3171,7 +3145,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🕎" type="tts">imenora</annotation>
 		<annotation cp="🔯">inhlanhla | inkanyezi | intanyezi enechashazi ekhombe kasithupha</annotation>
 		<annotation cp="🔯" type="tts">intanyezi enechashazi ekhombe kasithupha</annotation>
-		<annotation cp="🪯">E15–020 | khanda</annotation>
+		<annotation cp="🪯">khanda</annotation>
 		<annotation cp="🪯" type="tts">khanda</annotation>
 		<annotation cp="♈">aries | inkanyezi | isiklabhu</annotation>
 		<annotation cp="♈" type="tts">aries</annotation>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
@@ -27,7 +27,7 @@ public class CheckAnnotations extends CheckCLDR {
                             .setMainType(CheckStatus.errorType)
                             .setSubtype(Subtype.illegalAnnotationCode)
                             .setMessage(
-                                    "The annotation must be a translation and not contain the numeric E- code ({0})",
+                                    "The annotation must be a translation and not contain the E… code from root, or anything like it. ({0})",
                                     ecode));
         }
         return this;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
@@ -1,0 +1,47 @@
+package org.unicode.cldr.test;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.PatternCache;
+
+public class CheckAnnotations extends CheckCLDR {
+    private static final Pattern ANNOTATION_PATH = Pattern.compile("//ldml/annotations/.*");
+
+    @Override
+    public CheckCLDR handleCheck(
+            String path, String fullPath, String value, Options options, List<CheckStatus> result) {
+        if (value == null) {
+            return this;
+        } else if (!ANNOTATION_PATH.matcher(path).matches()
+                || !getCldrFileToCheck().isNotRoot(path)) {
+            return this;
+        }
+        final String ecode = hasAnnotationECode(value);
+
+        if (ecode != null) {
+            result.add(
+                    new CheckStatus()
+                            .setCause(this)
+                            .setMainType(CheckStatus.errorType)
+                            .setSubtype(Subtype.illegalAnnotationCode)
+                            .setMessage(
+                                    "The annotation must be a translation and not contain the numeric E- code ({0})",
+                                    ecode));
+        }
+        return this;
+    }
+
+    static String hasAnnotationECode(String value) {
+        Matcher m = HAS_ANNOTATION_ECODE.matcher(value);
+        if (m.find()) {
+            return m.group();
+        } else {
+            return null;
+        }
+    }
+
+    static final Pattern HAS_ANNOTATION_ECODE =
+            PatternCache.get("E[0-9]{1,3}(?:[-\u2013:—.][0-9]{1,3}){0,2}");
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -595,6 +595,7 @@ public abstract class CheckCLDR implements CheckAccessor {
     public static CompoundCheckCLDR getCheckAll(Factory factory, String nameMatcher) {
         return new CompoundCheckCLDR()
                 .setFilter(Pattern.compile(nameMatcher, Pattern.CASE_INSENSITIVE).matcher(""))
+                .add(new CheckAnnotations())
                 // .add(new CheckAttributeValues(factory))
                 .add(new CheckChildren(factory))
                 .add(new CheckCoverage(factory))
@@ -811,7 +812,8 @@ public abstract class CheckCLDR implements CheckAccessor {
             missingLanguage,
             namePlaceholderProblem,
             missingSpaceBetweenNameFields,
-            illegalParameterValue;
+            illegalParameterValue,
+            illegalAnnotationCode;
 
             @Override
             public String toString() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestCheckAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestCheckAnnotations.java
@@ -1,0 +1,31 @@
+package org.unicode.cldr.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestCheckAnnotations {
+
+    @ParameterizedTest
+    @ValueSource(
+            // all of these should fail
+            strings = {
+                // Soures as noted.
+
+                // zu
+                "E13.1\u2013128",
+                "E13.1\u2013127 | iphesenti",
+                "ampersand | E13.1\u2013125",
+                "E13.1\u2013125",
+                "E13.1\u2013136 | Vote E13.1\u2013136",
+                "E11:005",
+                // sr
+                "E13.1\u2013305",
+                // ku
+                "E416",
+            })
+    public void TestIllegalAnnotationName(final String value) {
+        assertNotNull(CheckAnnotations.hasAnnotationECode(value));
+    }
+}


### PR DESCRIPTION
> `❮Error: The annotation must be a translation and not contain the numeric E- code (E13.1–125)❯`

- Example: E13.1-416
- includes test

CLDR-16882

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true