### PR TITLE
CLDR-15296 Fix gasoline-equivalent

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -415,6 +415,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:regex/simple-->
     <!--@VALUE-->
 <!ATTLIST unitQuantity description CDATA #IMPLIED >
+    <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!ELEMENT convertUnits ( convertUnit* ) >
@@ -435,6 +436,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:set/literal/ussystem, uksystem, jpsystem, metric, si, other-->
     <!--@VALUE-->
 <!ATTLIST convertUnit description CDATA #IMPLIED >
+    <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!ELEMENT unitPreferenceData ( unitPreferences* ) >

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -253,8 +253,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         <convertUnit source='pascal' baseUnit='kilogram-per-meter-square-second' systems="metric si"/>
         <convertUnit source='bar' baseUnit='kilogram-per-meter-square-second' factor='100000' systems="metric"/>
         <convertUnit source='atmosphere' baseUnit='kilogram-per-meter-square-second' factor='101325'/>
-        <convertUnit source='gasoline-equivalent' baseUnit='kilogram-per-meter-square-second' factor='33.7 * 3600 * 1000/gal_to_m3'/>
-        
+        <convertUnit source='gasoline-equivalent' baseUnit='kilogram-per-meter-square-second' factor='33.705 * 3600 * 1000/gal_to_m3' description="Constructed so that 1 gallon-gasoline-equivalent = 33.705 kWh as per https://www3.epa.gov/otaq/gvg/learn-more-technology.htm"/>
 
         <!-- pressure-per-length -->
         <convertUnit source='ofhg' baseUnit='kilogram-per-square-meter-square-second' factor='13595.1*gravity'/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -1319,6 +1319,25 @@ public class UnitConverter implements Freezable<UnitConverter> {
             }
             return gender;
         }
+
+        public UnitId times(UnitId id2) {
+            UnitId result = new UnitId(comparator);
+            combine(numUnitsToPowers, id2.numUnitsToPowers, result.numUnitsToPowers);
+            combine(denUnitsToPowers, id2.denUnitsToPowers, result.denUnitsToPowers);
+            return result;
+        }
+
+        public void combine(
+                Map<String, Integer> map1,
+                Map<String, Integer> map2,
+                Map<String, Integer> resultMap) {
+            Set<String> units = Sets.union(map1.keySet(), map2.keySet());
+            for (String unit : units) {
+                Integer int1 = map1.get(unit);
+                Integer int2 = map2.get(unit);
+                resultMap.put(unit, (int1 == null ? 0 : int1) + (int2 == null ? 0 : int2));
+            }
+        }
     }
 
     public enum PlaceholderLocation {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -3890,12 +3890,16 @@ public class TestUnits extends TestFmwk {
         }
     }
 
+    static final Set<String> extras =
+            Set.of("square-meter", "cubic-meter", "square-second", "cubic-second");
+
     public void testRelations() {
         Multimap<String, UnitEquivalence> decomps = TreeMultimap.create();
         Set<UnitId> unitIds =
                 converter.getBaseUnitToQuantity().entrySet().stream()
                         .map(x -> converter.createUnitId(x.getKey()).freeze())
                         .collect(Collectors.toSet());
+        extras.forEach(x -> unitIds.add(converter.createUnitId(x).freeze()));
         for (UnitId id1 : unitIds) {
             String standard1 = converter.getStandardUnit(id1.toString());
             if (skipUnit(standard1)) {
@@ -3955,7 +3959,8 @@ public class TestUnits extends TestFmwk {
     }
 
     private boolean skipUnit(String unit) {
-        return unit == null || unit.contains("-") || unit.equals("becquerel");
+        return !extras.contains(unit)
+                && (unit == null || unit.contains("-") || unit.equals("becquerel"));
     }
 
     public void testEquivalents() {


### PR DESCRIPTION
CLDR-15296

common/dtd/ldmlSupplemental.dtd
There was no `@MATCH` for the description attributes

common/supplemental/units.xml
The report was that the unit was wrong. At first I thought that it was the case. Wrote a test to verify, and rechecked the conversion factor, which was off slightly from EPA definition. Added an explanation why the unit for `gasoline-equivalent` seems so odd. 

description="Constructed so that 1 gallon-gasoline-equivalent = 33.705 kWh as per https://www3.epa.gov/otaq/gvg/learn-more-technology.htm"

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
Added some utilities for testing

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java

Write test to verify that gasoline-equivalent has the right value and unit, and adjust the conversion slightly to match EPA instead of wikipedia. 

The test file contains some additional code for testing units, with the class UnitEquivalence and the method testRelations.

The testRelations takes the "basic" units like newton, watt, meter, second, and find out which of those are related to two others by multiplication or division. It tests a few of them against known cases, but the full printout is available via -v, which can be useful in debugging relationships.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
