### PR TITLE
CLDR-16437 lock prettier to version 2.8.8

### DIFF
--- a/tools/cldr-apps/js/test/pretty.sh
+++ b/tools/cldr-apps/js/test/pretty.sh
@@ -1,4 +1,4 @@
-npx prettier --no-error-on-unmatched-pattern --write \
+npx prettier@2.8.8 --no-error-on-unmatched-pattern --write \
     tools/cldr-apps/js/src/*.{js,mjs} \
     tools/cldr-apps/js/src/css/*.css \
     tools/cldr-apps/js/src/esm/*.{js,mjs} \


### PR DESCRIPTION
- v3.0 is interesting but changes a lot of source lines
- this locks down the Javascript prettier version to 2.8.8

CLDR-16437

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
