### PR TITLE
CLDR-16807 vetting viewer for unaffiliated TC+ gets all locales

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1119,6 +1119,14 @@ public class VettingViewer<T> {
 
     private Map<String, String> getSortedNames(Organization org, Level desiredLevel) {
         Map<String, String> sortedNames = new TreeMap<>(CLDRConfig.getInstance().getCollator());
+        // TODO: another hack, unaffiliated gets everything
+        if (org == Organization.unaffiliated) {
+            for (String localeID : cldrFactory.getAvailable()) {
+                sortedNames.put(getName(localeID), localeID);
+            }
+            return sortedNames;
+        }
+
         // TODO Fix HACK
         // We are going to ignore the predicate for now, just using the locales that have explicit
         // coverage.


### PR DESCRIPTION
- to allow error counts for all locales

CLDR-16807

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
