### PR TITLE
CLDR-16888 for barometric pressure, remove IN from regions that use inHg to use default hPa

### DIFF
--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -501,7 +501,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         </unitPreferences>
         <unitPreferences category="pressure" usage="baromtrc">
             <unitPreference regions="001">hectopascal</unitPreference>
-            <unitPreference regions="IN US">inch-ofhg</unitPreference>
+            <unitPreference regions="US">inch-ofhg</unitPreference>
             <unitPreference regions="BR EG GB IL TH">millibar</unitPreference>
             <unitPreference regions="MX RU">millimeter-ofhg</unitPreference>
         </unitPreferences>


### PR DESCRIPTION
CLDR-16888

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

For barometric pressure, remove IN from the list of regions that use inch-ofhg so it falls back to the default (for region 001) hectopascal.

ALLOW_MANY_COMMITS=true
