### PR TITLE
CLDR-16973 kxv_Deva exemplars: enclose sequence {ड़}; update punct exemplars (not main) per CLDRModify -fP

### DIFF
--- a/common/main/kxv_Deva.xml
+++ b/common/main/kxv_Deva.xml
@@ -41,10 +41,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[अ {अऽ} आ {आऽ} इ ई उ ऊ ए {एऽ} ओ {ओऽ} क ग ङ च ज ञ ट ड ण त द न प ब म र ळ व स ह य ल ड़ ँ ं ा ि ी ु ू े ो ः ् ऽ]</exemplarCharacters>
+		<exemplarCharacters>[अ {अऽ} आ {आऽ} इ ई उ ऊ ए {एऽ} ओ {ओऽ} क ग ङ च ज ञ ट ड ण त द न प ब म र ळ व स ह य ल {ड़} ँ ं ा ि ी ु ू े ो ः ् ऽ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">↑↑↑</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\- ‑ , . % ‰ + 0 १ २ ३ ४ ५ ६ ७ ८ ९]</exemplarCharacters>
-		<exemplarCharacters type="punctuation">[\- ‐ ‑ – — , ; \: ! ? . … ' ‘ ’ &quot; “ ” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[\- ‐‑ – — , ; \: ! ? . … '‘’ &quot;“” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
 	</characters>
 	<delimiters>
 		<quotationStart>↑↑↑</quotationStart>


### PR DESCRIPTION
CLDR-16973

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16973)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

For locale kxv_Deva: This adds curly braces around the nukta sequence {ड़} (U+0921U+093C) in the main exemplars. It also updates the punctuation exemplars per CLDRModify -fP. It does *not* update the main exemplars per CLDRModify -fP because that still causes a unit test failure, see https://unicode-org.atlassian.net/browse/CLDR-16980

ALLOW_MANY_COMMITS=true
