### PR TITLE
CLDR-16978 restore annotations that were deleted by CLDRModify -fQ in e8697986ac..

### DIFF
--- a/common/annotations/bew.xml
+++ b/common/annotations/bew.xml
@@ -11,63 +11,63 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="bew"/>
 	</identity>
 	<annotations>
-		<annotation cp="😀" draft="unconfirmed">muka girang</annotation>
+		<annotation cp="😀" draft="unconfirmed">girang | muka | nyengir | seneng</annotation>
 		<annotation cp="😀" type="tts" draft="unconfirmed">muka girang</annotation>
-		<annotation cp="😃" draft="unconfirmed">muka nyengir lèbar</annotation>
+		<annotation cp="😃" draft="unconfirmed">lèbar | muka | nyengir | seneng | sumringah</annotation>
 		<annotation cp="😃" type="tts" draft="unconfirmed">muka nyengir lèbar</annotation>
-		<annotation cp="😄" draft="unconfirmed">muka girang mata ketutup</annotation>
+		<annotation cp="😄" draft="unconfirmed">girang | ketawa | mata ketutup | muka | seneng</annotation>
 		<annotation cp="😄" type="tts" draft="unconfirmed">muka girang mata ketutup</annotation>
-		<annotation cp="😁" draft="unconfirmed">muka nyengir</annotation>
+		<annotation cp="😁" draft="unconfirmed">gigi | ketawa | mata seneng | muka | nyengir</annotation>
 		<annotation cp="😁" type="tts" draft="unconfirmed">muka nyengir</annotation>
-		<annotation cp="😆" draft="unconfirmed">muka ketawa merem</annotation>
+		<annotation cp="😆" draft="unconfirmed">ketawa | muka | ngakak | nglèdèk | seneng</annotation>
 		<annotation cp="😆" type="tts" draft="unconfirmed">muka ketawa merem</annotation>
-		<annotation cp="😅" draft="unconfirmed">muka girang keringetan</annotation>
+		<annotation cp="😅" draft="unconfirmed">girang | keringetan | ketawa | muka | seneng | senyum lèbar</annotation>
 		<annotation cp="😅" type="tts" draft="unconfirmed">muka girang keringetan</annotation>
-		<annotation cp="🤣" draft="unconfirmed">ngakak</annotation>
+		<annotation cp="🤣" draft="unconfirmed">bodor | guling-guling | ketawa | ketawa ampé nangis | kocak | lucu | muka | ngakak</annotation>
 		<annotation cp="🤣" type="tts" draft="unconfirmed">ngakak</annotation>
-		<annotation cp="😂" draft="unconfirmed">muka nangis seneng</annotation>
+		<annotation cp="😂" draft="unconfirmed">aèr mata | girang | ketawa | muka | nangis seneng | seneng | senyum lèbar</annotation>
 		<annotation cp="😂" type="tts" draft="unconfirmed">muka nangis seneng</annotation>
-		<annotation cp="🙂" draft="unconfirmed">muka mèsem biasa</annotation>
+		<annotation cp="🙂" draft="unconfirmed">mèsem | muka | senyum | senyum biasa</annotation>
 		<annotation cp="🙂" type="tts" draft="unconfirmed">muka mèsem biasa</annotation>
-		<annotation cp="🙃" draft="unconfirmed">muka kebalik</annotation>
+		<annotation cp="🙃" draft="unconfirmed">kebalik | muka | senyum</annotation>
 		<annotation cp="🙃" type="tts" draft="unconfirmed">muka kebalik</annotation>
-		<annotation cp="🫠" draft="unconfirmed">muka melèlèh</annotation>
+		<annotation cp="🫠" draft="unconfirmed">caèran | ilang | larut | melèlèh | muka | senyum</annotation>
 		<annotation cp="🫠" type="tts" draft="unconfirmed">muka melèlèh</annotation>
-		<annotation cp="😉" draft="unconfirmed">muka ngedip</annotation>
+		<annotation cp="😉" draft="unconfirmed">genit | kedip | muka | ngedip | ngegoda</annotation>
 		<annotation cp="😉" type="tts" draft="unconfirmed">muka ngedip</annotation>
-		<annotation cp="😊" draft="unconfirmed">muka nahan malu girang</annotation>
+		<annotation cp="😊" draft="unconfirmed">bebunga-bunga | girang | kesenengan | malu | mèrah | muka | nahan malu | seneng</annotation>
 		<annotation cp="😊" type="tts" draft="unconfirmed">muka nahan malu girang</annotation>
-		<annotation cp="😇" draft="unconfirmed">muka malaèkat</annotation>
+		<annotation cp="😇" draft="unconfirmed">baè’ | baè’ ati | baèk | iklas | lugu | malaèkat | malaikat | mèsem | muka | polos | senyum</annotation>
 		<annotation cp="😇" type="tts" draft="unconfirmed">muka malaèkat</annotation>
-		<annotation cp="🥰" draft="unconfirmed">muka senyum kedemenan</annotation>
+		<annotation cp="🥰" draft="unconfirmed">ati | cinta | demen | kedemean | muka senyum cinta | seneng | senyum</annotation>
 		<annotation cp="🥰" type="tts" draft="unconfirmed">muka senyum kedemenan</annotation>
-		<annotation cp="😍" draft="unconfirmed">muka cinta</annotation>
+		<annotation cp="😍" draft="unconfirmed">ati | cinta | mata | muka cinta | muka cinta mata ati | senyum</annotation>
 		<annotation cp="😍" type="tts" draft="unconfirmed">muka cinta</annotation>
-		<annotation cp="🤩" draft="unconfirmed">muka seneng mata bintang</annotation>
+		<annotation cp="🤩" draft="unconfirmed">bintang | girang | mata | mèsem | muka seneng | seneng | senyum</annotation>
 		<annotation cp="🤩" type="tts" draft="unconfirmed">muka seneng mata bintang</annotation>
-		<annotation cp="😘" draft="unconfirmed">muka niupin sun</annotation>
+		<annotation cp="😘" draft="unconfirmed">cium | demen | kecup | mulut niup | seneng | suka | sun</annotation>
 		<annotation cp="😘" type="tts" draft="unconfirmed">muka niupin sun</annotation>
-		<annotation cp="😗" draft="unconfirmed">muka ngesun</annotation>
+		<annotation cp="😗" draft="unconfirmed">cium | monyong | mulut | ngesun | nyium | nyosor | sun</annotation>
 		<annotation cp="😗" type="tts" draft="unconfirmed">muka ngesun</annotation>
-		<annotation cp="☺" draft="unconfirmed">muka mèsem seneng</annotation>
+		<annotation cp="☺" draft="unconfirmed">baè’ | baèk | iklas | mèsem | muka | seneng | senyum</annotation>
 		<annotation cp="☺" type="tts" draft="unconfirmed">muka mèsem seneng</annotation>
-		<annotation cp="😚" draft="unconfirmed">muka ngesun merem pipi mèra</annotation>
+		<annotation cp="😚" draft="unconfirmed">cinta | cium | demen | monyong | muka | ngesun | nyium | nyosor | pipi mèra | seneng | suka | sun</annotation>
 		<annotation cp="😚" type="tts" draft="unconfirmed">muka ngesun merem pipi mèra</annotation>
-		<annotation cp="😙" draft="unconfirmed">muka ngesun merem</annotation>
+		<annotation cp="😙" draft="unconfirmed">cinta | cium | demen | monyong | muka | ngesun | nyium | nyosor | seneng | suka | sun</annotation>
 		<annotation cp="😙" type="tts" draft="unconfirmed">muka ngesun merem</annotation>
-		<annotation cp="🥲" draft="unconfirmed">muka haru</annotation>
+		<annotation cp="🥲" draft="unconfirmed">aèr mata | bangga | besukur | haru | kesentu | lega | mèsem | muka seneng | muka senyum | plong | senyum | sukur</annotation>
 		<annotation cp="🥲" type="tts" draft="unconfirmed">muka haru</annotation>
-		<annotation cp="😋" draft="unconfirmed">muka lejat</annotation>
+		<annotation cp="😋" draft="unconfirmed">ènak | gurih | lejat | muka | nyicipin makanan</annotation>
 		<annotation cp="😋" type="tts" draft="unconfirmed">muka lejat</annotation>
-		<annotation cp="😛" draft="unconfirmed">muka mèlèd</annotation>
+		<annotation cp="😛" draft="unconfirmed">lida | lidah | mèlèd | muka | nglèdèk</annotation>
 		<annotation cp="😛" type="tts" draft="unconfirmed">muka mèlèd</annotation>
-		<annotation cp="😜" draft="unconfirmed">muka mèlèd ngedip</annotation>
+		<annotation cp="😜" draft="unconfirmed">kedip | lida | lidah | mèlèd | muka | ngedip | nglèdèk</annotation>
 		<annotation cp="😜" type="tts" draft="unconfirmed">muka mèlèd ngedip</annotation>
-		<annotation cp="🤪" draft="unconfirmed">muka pè’a</annotation>
+		<annotation cp="🤪" draft="unconfirmed">bègo | konyol | mèlèd | muka | nglèdèk | pè’a | sarap | sèdèng | songong</annotation>
 		<annotation cp="🤪" type="tts" draft="unconfirmed">muka pè’a</annotation>
-		<annotation cp="😝" draft="unconfirmed">muka mèlèd merem</annotation>
+		<annotation cp="😝" draft="unconfirmed">jiji’ | ketawa | mèlèd | merem | muka | songong</annotation>
 		<annotation cp="😝" type="tts" draft="unconfirmed">muka mèlèd merem</annotation>
-		<annotation cp="🤑" draft="unconfirmed">muka napsu duit</annotation>
+		<annotation cp="🤑" draft="unconfirmed">duit | mata duitan | muka | napsu</annotation>
 		<annotation cp="🤑" type="tts" draft="unconfirmed">muka napsu duit</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/cv.xml
+++ b/common/annotations/cv.xml
@@ -11,23 +11,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="cv"/>
 	</identity>
 	<annotations>
-		<annotation cp="🏻" draft="unconfirmed">сӑран ҫутӑ тӗсӗ</annotation>
+		<annotation cp="🏻" draft="unconfirmed">сӑран ҫутӑ тӗсӗ | сӑран тонӗ | тип 1–2</annotation>
 		<annotation cp="🏻" type="tts" draft="unconfirmed">сӑран ҫутӑ тӗсӗ</annotation>
-		<annotation cp="🏼" draft="unconfirmed">ӳт-тирӗн вӑтам-ҫутӑ тӗсӗ</annotation>
+		<annotation cp="🏼" draft="unconfirmed">сӑран тонӗ | тип 3 | ӳт-тирӗн вӑтам-ҫутӑ тӗсӗ</annotation>
 		<annotation cp="🏼" type="tts" draft="unconfirmed">ӳт-тирӗн вӑтам-ҫутӑ тӗсӗ</annotation>
-		<annotation cp="🏽" draft="unconfirmed">сӑран вӑтам тонӗ</annotation>
+		<annotation cp="🏽" draft="unconfirmed">сӑран вӑтам тонӗ | сӑран тонӗ | тип 4</annotation>
 		<annotation cp="🏽" type="tts" draft="unconfirmed">сӑран вӑтам тонӗ</annotation>
-		<annotation cp="🏾" draft="unconfirmed">сӑран вӑтам тӗксӗм тонӗ</annotation>
+		<annotation cp="🏾" draft="unconfirmed">сӑран вӑтам тӗксӗм тонӗ | сӑран тонӗ | тип 5</annotation>
 		<annotation cp="🏾" type="tts" draft="unconfirmed">сӑран вӑтам тӗксӗм тонӗ</annotation>
-		<annotation cp="🏿" draft="unconfirmed">сӑран тӗксӗм тонӗ</annotation>
+		<annotation cp="🏿" draft="unconfirmed">сӑран тӗксӗм тонӗ | сӑран тонӗ | тип 6</annotation>
 		<annotation cp="🏿" type="tts" draft="unconfirmed">сӑран тӗксӗм тонӗ</annotation>
-		<annotation cp="🦰" draft="unconfirmed">хӗрлӗ ҫӳҫ</annotation>
+		<annotation cp="🦰" draft="unconfirmed">импир | хӗрлӗ ҫӳҫ | хӗрлӗрех ҫӳҫ</annotation>
 		<annotation cp="🦰" type="tts" draft="unconfirmed">хӗрлӗ ҫӳҫ</annotation>
-		<annotation cp="🦱" draft="unconfirmed">явӑнчӑк ҫӳҫ</annotation>
+		<annotation cp="🦱" draft="unconfirmed">афро | кӑтра | кӑтра ҫӳҫ | ҫӳҫ пайӑркисем</annotation>
 		<annotation cp="🦱" type="tts" draft="unconfirmed">явӑнчӑк ҫӳҫ</annotation>
-		<annotation cp="🦳" draft="unconfirmed">шурӑ ҫӳҫ</annotation>
+		<annotation cp="🦳" draft="unconfirmed">ватӑ | кӑвакарнӑ | ҫӳҫ | шурӑ</annotation>
 		<annotation cp="🦳" type="tts" draft="unconfirmed">шурӑ ҫӳҫ</annotation>
-		<annotation cp="🦲" draft="unconfirmed">кукша пуҫ</annotation>
+		<annotation cp="🦲" draft="unconfirmed">кукша | ҫӳҫсӗр | химиотерапи | хырӑннӑ</annotation>
 		<annotation cp="🦲" type="tts" draft="unconfirmed">кукша пуҫ</annotation>
 		<annotation cp="🎄" draft="unconfirmed">Раштав елки</annotation>
 		<annotation cp="🎄" type="tts" draft="unconfirmed">Раштав елки</annotation>
@@ -47,21 +47,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🖨" type="tts" draft="unconfirmed">принтер</annotation>
 		<annotation cp="🖱" draft="unconfirmed">компьютер шӑшийӗ</annotation>
 		<annotation cp="🖱" type="tts" draft="unconfirmed">компьютер шӑшийӗ</annotation>
-		<annotation cp="🏁" draft="unconfirmed">клеткӑллӑ ялав</annotation>
+		<annotation cp="🏁" draft="unconfirmed">ӑмӑрту | тӑваткал-тӑваткал ялав</annotation>
 		<annotation cp="🏁" type="tts" draft="unconfirmed">клеткӑллӑ ялав</annotation>
-		<annotation cp="🚩" draft="unconfirmed">виҫкӗтеслӗ ялав</annotation>
+		<annotation cp="🚩" draft="unconfirmed">юпа | ялав виҫкӗтеслӗ</annotation>
 		<annotation cp="🚩" type="tts" draft="unconfirmed">виҫкӗтеслӗ ялав</annotation>
-		<annotation cp="🎌" draft="unconfirmed">хӗреслӗ ялавсем</annotation>
+		<annotation cp="🎌" draft="unconfirmed">уявлани | хӗрес | хӗресленнӗ ялавсем | япун</annotation>
 		<annotation cp="🎌" type="tts" draft="unconfirmed">хӗреслӗ ялавсем</annotation>
-		<annotation cp="🏴" draft="unconfirmed">хура ялав</annotation>
+		<annotation cp="🏴" draft="unconfirmed">вӗлкӗшет | хура ялав</annotation>
 		<annotation cp="🏴" type="tts" draft="unconfirmed">хура ялав</annotation>
-		<annotation cp="🏳" draft="unconfirmed">шурӑ ялав</annotation>
+		<annotation cp="🏳" draft="unconfirmed">вӗлкӗшет | шурӑ ялав</annotation>
 		<annotation cp="🏳" type="tts" draft="unconfirmed">шурӑ ялав</annotation>
-		<annotation cp="🏳‍🌈" draft="unconfirmed">асамат кӗперӗ ялавӗ</annotation>
+		<annotation cp="🏳‍🌈" draft="unconfirmed">асамат кӗперӗ | асамат кӗперӗ ялавӗ | мӑнаҫлӑх</annotation>
 		<annotation cp="🏳‍🌈" type="tts" draft="unconfirmed">асамат кӗперӗ ялавӗ</annotation>
-		<annotation cp="🏳‍⚧" draft="unconfirmed">трансгендер ялавӗ</annotation>
+		<annotation cp="🏳‍⚧" draft="unconfirmed">ҫутӑ-сенкер | трансгендер | шупка | шурӑ | ялав</annotation>
 		<annotation cp="🏳‍⚧" type="tts" draft="unconfirmed">трансгендер ялавӗ</annotation>
-		<annotation cp="🏴‍☠" draft="unconfirmed">пират ялавӗ</annotation>
+		<annotation cp="🏴‍☠" draft="unconfirmed">мул | пират | пират ялавӗ | ҫарату | Хаваслӑ Роджер</annotation>
 		<annotation cp="🏴‍☠" type="tts" draft="unconfirmed">пират ялавӗ</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/de.xml
+++ b/common/annotations/de.xml
@@ -2925,7 +2925,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👙" type="tts">Bikini</annotation>
 		<annotation cp="👚">Bluse | Damenmode | Kleidung | Oberbekleidung</annotation>
 		<annotation cp="👚" type="tts">Bluse</annotation>
-		<annotation cp="🪭" draft="contributed">Faltfächer</annotation>
+		<annotation cp="🪭">Fächer | Faltfächer | kühlen | schüchtern | warm</annotation>
 		<annotation cp="🪭" type="tts" draft="contributed">Faltfächer</annotation>
 		<annotation cp="👛">Accessoire | Brieftasche | Geldbörse | Portemonnaie</annotation>
 		<annotation cp="👛" type="tts">Geldbörse</annotation>
@@ -2955,7 +2955,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🩰" type="tts">Ballettschuhe</annotation>
 		<annotation cp="👢">Damen | Damenstiefel | Schuh | Stiefel</annotation>
 		<annotation cp="👢" type="tts">Damenstiefel</annotation>
-		<annotation cp="🪮" draft="contributed">Haarkamm</annotation>
+		<annotation cp="🪮">Afro | Haare | Haarkamm | Kamm</annotation>
 		<annotation cp="🪮" type="tts" draft="contributed">Haarkamm</annotation>
 		<annotation cp="👑">König | Königin | Krone</annotation>
 		<annotation cp="👑" type="tts">Krone</annotation>

--- a/common/annotations/et.xml
+++ b/common/annotations/et.xml
@@ -243,27 +243,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↷" type="tts" draft="contributed">päripäeva ülemise poolkaarega nool</annotation>
 		<annotation cp="↸" draft="contributed">loodesse nool pika ribaga</annotation>
 		<annotation cp="↸" type="tts" draft="contributed">loodesse nool pika ribaga</annotation>
-		<annotation cp="↹" draft="contributed">ribaga vasaknool ribaga paremnoole peal</annotation>
+		<annotation cp="↹" draft="contributed">nool | paremale ribaga nool | riba | vasakule | vasakule ribaga nool</annotation>
 		<annotation cp="↹" type="tts" draft="contributed">ribaga vasaknool ribaga paremnoole peal</annotation>
 		<annotation cp="↺" draft="contributed">vastupäeva avatud ringiga nool</annotation>
 		<annotation cp="↺" type="tts" draft="contributed">vastupäeva avatud ringiga nool</annotation>
 		<annotation cp="↻" draft="contributed">päripäeva avatud ringiga nool</annotation>
 		<annotation cp="↻" type="tts" draft="contributed">päripäeva avatud ringiga nool</annotation>
-		<annotation cp="↼" draft="contributed">vasakule harpuun ülemise kiskuga</annotation>
+		<annotation cp="↼" draft="contributed">kisk | vasakule harpuun ülemise kiskuga</annotation>
 		<annotation cp="↼" type="tts" draft="contributed">vasakule harpuun ülemise kiskuga</annotation>
 		<annotation cp="↽" draft="contributed">vasakule harpuun alumise kiskuga</annotation>
 		<annotation cp="↽" type="tts" draft="contributed">vasakule harpuun alumise kiskuga</annotation>
-		<annotation cp="↾" draft="contributed">üles harpuun parema kiskuga</annotation>
+		<annotation cp="↾" draft="contributed">kisk | üles harpuun parema kiskuga</annotation>
 		<annotation cp="↾" type="tts" draft="contributed">üles harpuun parema kiskuga</annotation>
-		<annotation cp="↿" draft="contributed">üles harpuun vasaku kiskuga</annotation>
+		<annotation cp="↿" draft="contributed">kisk | üles harpuun vasaku kiskuga</annotation>
 		<annotation cp="↿" type="tts" draft="contributed">üles harpuun vasaku kiskuga</annotation>
-		<annotation cp="⇀" draft="contributed">paremale harpuun ülemise kiskuga</annotation>
+		<annotation cp="⇀" draft="contributed">kisk | paremale harpuun ülemise kiskuga</annotation>
 		<annotation cp="⇀" type="tts" draft="contributed">paremale harpuun ülemise kiskuga</annotation>
-		<annotation cp="⇁" draft="contributed">paremale harpuun alumise kiskuga</annotation>
+		<annotation cp="⇁" draft="contributed">kisk | paremale harpuun alumise kiskuga</annotation>
 		<annotation cp="⇁" type="tts" draft="contributed">paremale harpuun alumise kiskuga</annotation>
-		<annotation cp="⇂" draft="contributed">alla harpuun parema kiskuga</annotation>
+		<annotation cp="⇂" draft="contributed">alla harpuun parema kiskuga | kisk</annotation>
 		<annotation cp="⇂" type="tts" draft="contributed">alla harpuun parema kiskuga</annotation>
-		<annotation cp="⇃" draft="contributed">alla harpuun vasaku kiskuga</annotation>
+		<annotation cp="⇃" draft="contributed">alla harpuun vasaku kiskuga | kisk</annotation>
 		<annotation cp="⇃" type="tts" draft="contributed">alla harpuun vasaku kiskuga</annotation>
 		<annotation cp="⇄">paremnool vasaknoole kohal</annotation>
 		<annotation cp="⇄" type="tts">paremnool vasaknoole kohal</annotation>
@@ -343,7 +343,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⇪" type="tts" draft="contributed">seest tühi ülesnool tulbast</annotation>
 		<annotation cp="⇵" draft="contributed">allanool vasakul ülesnool paremal</annotation>
 		<annotation cp="⇵" type="tts" draft="contributed">allanool vasakul ülesnool paremal</annotation>
-		<annotation cp="∀" draft="contributed">kõigi jaoks</annotation>
+		<annotation cp="∀" draft="contributed">antud | kõigi jaoks | kõik | mis tahes | universaalne</annotation>
 		<annotation cp="∀" type="tts" draft="contributed">kõigi jaoks</annotation>
 		<annotation cp="∂" draft="contributed">osatuletis</annotation>
 		<annotation cp="∂" type="tts">osatuletis</annotation>
@@ -507,9 +507,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⊙" type="tts">punkt ringis operaator</annotation>
 		<annotation cp="⊚" draft="contributed">ring ringis operaator</annotation>
 		<annotation cp="⊚" type="tts" draft="contributed">ring ringis operaator</annotation>
-		<annotation cp="⊛" draft="contributed">tärn ringis operaator</annotation>
+		<annotation cp="⊛" draft="contributed">operaator | tärn | tärn ringis operaator</annotation>
 		<annotation cp="⊛" type="tts" draft="contributed">tärn ringis operaator</annotation>
-		<annotation cp="⊞" draft="contributed">pluss ruudus</annotation>
+		<annotation cp="⊞" draft="contributed">matemaatika | pluss ruudus</annotation>
 		<annotation cp="⊞" type="tts" draft="contributed">pluss ruudus</annotation>
 		<annotation cp="⊟">matemaatika | miinus ruudus</annotation>
 		<annotation cp="⊟" type="tts">miinus ruudus</annotation>
@@ -551,7 +551,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⋮" type="tts">vertikaalsed kolm punkti</annotation>
 		<annotation cp="⋯">keskjoone horisontaalsed kolm punkti | kolm punkti</annotation>
 		<annotation cp="⋯" type="tts">keskjoone horisontaalsed kolm punkti</annotation>
-		<annotation cp="⋰">kolm punkti | matemaatika | paremale üles diagonaalsed kolm punkti | paremale üles digonaalsed kolm punkti</annotation>
+		<annotation cp="⋰">kolm punkti | matemaatika | paremale üles diagonaalsed kolm punkti</annotation>
 		<annotation cp="⋰" type="tts">paremale üles digonaalsed kolm punkti</annotation>
 		<annotation cp="⋱">kolm punkti | matemaatika | paremale alla diagonaalsed kolm punkti</annotation>
 		<annotation cp="⋱" type="tts">paremale alla diagonaalsed kolm punkti</annotation>
@@ -635,7 +635,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="◌" type="tts" draft="contributed">katkendlik ring</annotation>
 		<annotation cp="◍" draft="contributed">püstiste triipudega ring</annotation>
 		<annotation cp="◍" type="tts" draft="contributed">püstiste triipudega ring</annotation>
-		<annotation cp="◎" draft="contributed">kontsentrilised ringid</annotation>
+		<annotation cp="◎" draft="contributed">kontsentrilised ringid | märklaud | topeltring</annotation>
 		<annotation cp="◎" type="tts" draft="contributed">kontsentrilised ringid</annotation>
 		<annotation cp="●">ring | täidetud ring</annotation>
 		<annotation cp="●" type="tts">täidetud ring</annotation>

--- a/common/annotations/fil.xml
+++ b/common/annotations/fil.xml
@@ -1873,11 +1873,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">loro</annotation>
 		<annotation cp="🪽">ibon | lumilipad | mala-anghel | metolohiya | paglalayag | pakpak</annotation>
 		<annotation cp="🪽" type="tts">pakpak</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">itim na ibon</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">ibon | itim | rook | uwak</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">itim na ibon</annotation>
 		<annotation cp="🪿">bumubusina | fowl | gansa | hangal | ibon</annotation>
 		<annotation cp="🪿" type="tts">gansa</annotation>
-		<annotation cp="🐦‍🔥" draft="contributed">phoenix</annotation>
+		<annotation cp="🐦‍🔥" draft="contributed">pantasya, firebird, muling pagsilang, reinkarnasyon | phoenix</annotation>
 		<annotation cp="🐦‍🔥" type="tts" draft="contributed">phoenix</annotation>
 		<annotation cp="🐸">hayop | mukha | palaka</annotation>
 		<annotation cp="🐸" type="tts">palaka</annotation>
@@ -2019,7 +2019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🍊" type="tts">dalanghita</annotation>
 		<annotation cp="🍋">citrus | halaman | lemon | prutas</annotation>
 		<annotation cp="🍋" type="tts">lemon</annotation>
-		<annotation cp="🍋‍🟩" draft="contributed">dayap</annotation>
+		<annotation cp="🍋‍🟩" draft="contributed">citrus, prutas, tropikal | dayap</annotation>
 		<annotation cp="🍋‍🟩" type="tts" draft="contributed">dayap</annotation>
 		<annotation cp="🍌">banana | halaman | prutas | saba | saging</annotation>
 		<annotation cp="🍌" type="tts">saging</annotation>
@@ -2083,7 +2083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫚" type="tts">luya</annotation>
 		<annotation cp="🫛">beans | edamame | gisante | gisantes | gulay | munggo | pod</annotation>
 		<annotation cp="🫛" type="tts">gisante</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">kayumanggi na kabute</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">kayumanggi na kabute | pagkain, kabute, kalikasan, gulay</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">kayumanggi na kabute</annotation>
 		<annotation cp="🍞">pagkain | tinapay</annotation>
 		<annotation cp="🍞" type="tts">tinapay</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">baston</annotation>
 		<annotation cp="🔗">kadena | kawing</annotation>
 		<annotation cp="🔗" type="tts">kawing</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">lagot na kadena</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">lagot na kadena | lagot, nalalagot, kadena, posas, kalayaan</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">lagot na kadena</annotation>
 		<annotation cp="⛓">kadena</annotation>
 		<annotation cp="⛓" type="tts">kadena</annotation>

--- a/common/annotations/gu.xml
+++ b/common/annotations/gu.xml
@@ -459,7 +459,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="≌" type="tts">સર્વાંગસમ</annotation>
 		<annotation cp="≒">લગભગ સમાન છબી</annotation>
 		<annotation cp="≒" type="tts">લગભગ સમાન છબી</annotation>
-		<annotation cp="≖" draft="contributed">રીંગ ઈન ઈક્વલ</annotation>
+		<annotation cp="≖" draft="contributed">ગણિત | રીંગ ઈન ઈક્વલ | સમાનતા</annotation>
 		<annotation cp="≖" type="tts" draft="contributed">રીંગ ઈન ઈક્વલ</annotation>
 		<annotation cp="≡">આનાથી સમાન | ચોક્કસ | ત્રણગણું | સમાન</annotation>
 		<annotation cp="≡" type="tts">આનાથી સમાન</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">તપાસ માટેની લાકડી</annotation>
 		<annotation cp="🔗">બે રિંગ્સ | લિંક | લિંકનું ચિહ્ન | લિંક્સ</annotation>
 		<annotation cp="🔗" type="tts">લિંક</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">તૂટેલી સાંકળ</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">તૂટવું, તૂટતી, સાંકળ, હાથકડી, આઝાદી, તૂટેલી સાંકળ</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">તૂટેલી સાંકળ</annotation>
 		<annotation cp="⛓">સાંકળ</annotation>
 		<annotation cp="⛓" type="tts">સાંકળ</annotation>

--- a/common/annotations/he.xml
+++ b/common/annotations/he.xml
@@ -165,7 +165,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="‸" type="tts">קרט</annotation>
 		<annotation cp="※">סימן ייחוס</annotation>
 		<annotation cp="※" type="tts">סימן ייחוס</annotation>
-		<annotation cp="⁂" draft="contributed">כוכביות</annotation>
+		<annotation cp="⁂" draft="contributed">אסטריזם | כוכביות | כוכבים</annotation>
 		<annotation cp="⁂" type="tts" draft="contributed">כוכביות</annotation>
 		<annotation cp="`">הטעמה | סימן דיאקריטי | סימן הטעמה משני</annotation>
 		<annotation cp="`" type="tts">סימן הטעמה משני</annotation>
@@ -191,17 +191,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↑" type="tts">חץ שמצביע למעלה</annotation>
 		<annotation cp="↓">חץ | חץ שמצביע למטה | למטה | מצביע למטה</annotation>
 		<annotation cp="↓" type="tts">חץ שמצביע למטה</annotation>
-		<annotation cp="↜" draft="contributed">חץ גלי שמאלה</annotation>
+		<annotation cp="↜" draft="contributed">חץ גלי | חץ גלי שמאלה | חץ שמאלה</annotation>
 		<annotation cp="↜" type="tts" draft="contributed">חץ גלי שמאלה</annotation>
-		<annotation cp="↝" draft="contributed">חץ גלי ימינה</annotation>
+		<annotation cp="↝" draft="contributed">חץ גלי | חץ גלי ימינה | חץ ימינה</annotation>
 		<annotation cp="↝" type="tts" draft="contributed">חץ גלי ימינה</annotation>
-		<annotation cp="↞" draft="contributed">חץ דו-ראשי שמאלה</annotation>
+		<annotation cp="↞" draft="contributed">חץ דו-ראשי שמאלה | חץ כפול שמאלה</annotation>
 		<annotation cp="↞" type="tts" draft="contributed">חץ דו-ראשי שמאלה</annotation>
-		<annotation cp="↟" draft="contributed">חץ דו-ראשי למעלה</annotation>
+		<annotation cp="↟" draft="contributed">חץ דו-ראשי למעלה | חץ כלפי מעלה | חץ כפול</annotation>
 		<annotation cp="↟" type="tts" draft="contributed">חץ דו-ראשי למעלה</annotation>
-		<annotation cp="↠" draft="contributed">חץ דו-ראשי ימינה</annotation>
+		<annotation cp="↠" draft="contributed">חץ דו-ראשי ימינה | חץ כפול ימינה</annotation>
 		<annotation cp="↠" type="tts" draft="contributed">חץ דו-ראשי ימינה</annotation>
-		<annotation cp="↡" draft="contributed">חץ דו-ראשי למטה</annotation>
+		<annotation cp="↡" draft="contributed">חץ דו-ראשי למטה | חץ כלפי מטה | חץ כפול</annotation>
 		<annotation cp="↡" type="tts" draft="contributed">חץ דו-ראשי למטה</annotation>
 		<annotation cp="↢" draft="contributed">חץ שמאלה עם זנב</annotation>
 		<annotation cp="↢" type="tts" draft="contributed">חץ שמאלה עם זנב</annotation>
@@ -243,27 +243,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↷" type="tts" draft="contributed">חץ מעגלי עליון עם כיוון השעון</annotation>
 		<annotation cp="↸" draft="contributed">חץ צפון מערב פס ארוך</annotation>
 		<annotation cp="↸" type="tts" draft="contributed">חץ צפון מערב פס ארוך</annotation>
-		<annotation cp="↹" draft="contributed">פסי חיצים שמאלה מעל ימינה</annotation>
+		<annotation cp="↹" draft="contributed">חץ | ימינה | פס | שמאלה, שמאלה מעל ימינה</annotation>
 		<annotation cp="↹" type="tts" draft="contributed">פסי חיצים שמאלה מעל ימינה</annotation>
 		<annotation cp="↺" draft="contributed">חץ מעגלי פתוח נגד כיוון השעון</annotation>
 		<annotation cp="↺" type="tts" draft="contributed">חץ מעגלי פתוח נגד כיוון השעון</annotation>
 		<annotation cp="↻" draft="contributed">חץ מעגלי פתוח עם כיוון השעון</annotation>
 		<annotation cp="↻" type="tts" draft="contributed">חץ מעגלי פתוח עם כיוון השעון</annotation>
-		<annotation cp="↼" draft="contributed">קוץ צלצל שמאלה למעלה</annotation>
+		<annotation cp="↼" draft="contributed">קוץ | קוץ צלצל שמאלה למעלה</annotation>
 		<annotation cp="↼" type="tts" draft="contributed">קוץ צלצל שמאלה למעלה</annotation>
 		<annotation cp="↽" draft="contributed">קוץ צלצל שמאלה למטה</annotation>
 		<annotation cp="↽" type="tts" draft="contributed">קוץ צלצל שמאלה למטה</annotation>
-		<annotation cp="↾" draft="contributed">קוץ צלצל ימינה למעלה</annotation>
+		<annotation cp="↾" draft="contributed">קוץ | קוץ צלצל ימינה למעלה</annotation>
 		<annotation cp="↾" type="tts" draft="contributed">קוץ צלצל ימינה למעלה</annotation>
-		<annotation cp="↿" draft="contributed">קוץ צלצל שמאלי למעלה</annotation>
+		<annotation cp="↿" draft="contributed">קוץ | קוץ צלצל שמאלי למעלה</annotation>
 		<annotation cp="↿" type="tts" draft="contributed">קוץ צלצל שמאלי למעלה</annotation>
-		<annotation cp="⇀" draft="contributed">קוץ צלצל ימני למעלה</annotation>
+		<annotation cp="⇀" draft="contributed">קוץ | קוץ צלצל ימני למעלה</annotation>
 		<annotation cp="⇀" type="tts" draft="contributed">קוץ צלצל ימני למעלה</annotation>
-		<annotation cp="⇁" draft="contributed">קוץ צלצל ימני למטה</annotation>
+		<annotation cp="⇁" draft="contributed">קוץ | קוץ צלצל ימני למטה</annotation>
 		<annotation cp="⇁" type="tts" draft="contributed">קוץ צלצל ימני למטה</annotation>
-		<annotation cp="⇂" draft="contributed">קוץ צלצל ימינה למטה</annotation>
+		<annotation cp="⇂" draft="contributed">קוץ | קוץ צלצל ימינה למטה</annotation>
 		<annotation cp="⇂" type="tts" draft="contributed">קוץ צלצל ימינה למטה</annotation>
-		<annotation cp="⇃" draft="contributed">קוץ צלצל שמאלי למטה</annotation>
+		<annotation cp="⇃" draft="contributed">קוץ | קוץ צלצל שמאלי למטה</annotation>
 		<annotation cp="⇃" type="tts" draft="contributed">קוץ צלצל שמאלי למטה</annotation>
 		<annotation cp="⇄" draft="contributed">חץ ימינה מעל חץ שמאלה</annotation>
 		<annotation cp="⇄" type="tts" draft="contributed">חץ ימינה מעל חץ שמאלה</annotation>
@@ -327,29 +327,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⇢" type="tts" draft="contributed">חץ מקווקו ימינה</annotation>
 		<annotation cp="⇣" draft="contributed">חץ מקווקו למטה</annotation>
 		<annotation cp="⇣" type="tts" draft="contributed">חץ מקווקו למטה</annotation>
-		<annotation cp="⇤" draft="contributed">חץ שמאלה אל פס</annotation>
+		<annotation cp="⇤" draft="contributed">חץ שמאלה | פס</annotation>
 		<annotation cp="⇤" type="tts" draft="contributed">חץ שמאלה אל פס</annotation>
-		<annotation cp="⇥" draft="contributed">חץ ימינה אל פס</annotation>
+		<annotation cp="⇥" draft="contributed">חץ ימינה | פס</annotation>
 		<annotation cp="⇥" type="tts" draft="contributed">חץ ימינה אל פס</annotation>
-		<annotation cp="⇦" draft="contributed">חץ חלול שמאלה</annotation>
+		<annotation cp="⇦" draft="contributed">חץ חלול | חץ שמאלה</annotation>
 		<annotation cp="⇦" type="tts" draft="contributed">חץ חלול שמאלה</annotation>
-		<annotation cp="⇧" draft="contributed">חץ חלול למעלה</annotation>
+		<annotation cp="⇧" draft="contributed">חץ חלול | חץ למעלה</annotation>
 		<annotation cp="⇧" type="tts" draft="contributed">חץ חלול למעלה</annotation>
-		<annotation cp="⇨" draft="contributed">חץ חלול ימינה</annotation>
+		<annotation cp="⇨" draft="contributed">חץ חלול | חץ ימינה</annotation>
 		<annotation cp="⇨" type="tts" draft="contributed">חץ חלול ימינה</annotation>
-		<annotation cp="⇩" draft="contributed">חץ חלול למטה</annotation>
+		<annotation cp="⇩" draft="contributed">חץ חלול | חץ למטה</annotation>
 		<annotation cp="⇩" type="tts" draft="contributed">חץ חלול למטה</annotation>
-		<annotation cp="⇪" draft="contributed">חץ חלול למעלה מפס</annotation>
+		<annotation cp="⇪" draft="contributed">חץ חלול | חץ למעלה | חץ מפס</annotation>
 		<annotation cp="⇪" type="tts" draft="contributed">חץ חלול למעלה מפס</annotation>
-		<annotation cp="⇵" draft="contributed">חץ למטה משמאל למעלה מימין</annotation>
+		<annotation cp="⇵" draft="contributed">חץ למטה | חץ למעלה</annotation>
 		<annotation cp="⇵" type="tts" draft="contributed">חץ למטה משמאל למעלה מימין</annotation>
-		<annotation cp="∀" draft="contributed">לכל</annotation>
+		<annotation cp="∀" draft="contributed">אוניברסלי | לכל | נתון</annotation>
 		<annotation cp="∀" type="tts" draft="contributed">לכל</annotation>
-		<annotation cp="∂" draft="contributed">נגזרת</annotation>
+		<annotation cp="∂" draft="contributed">דיפרנציאל | נגזרת | נגזרת חלקית</annotation>
 		<annotation cp="∂" type="tts" draft="contributed">נגזרת</annotation>
-		<annotation cp="∃" draft="contributed">קיים</annotation>
+		<annotation cp="∃" draft="contributed">קיים | קיימות</annotation>
 		<annotation cp="∃" type="tts" draft="contributed">קיים</annotation>
-		<annotation cp="∅" draft="contributed">קבוצה ריקה</annotation>
+		<annotation cp="∅" draft="contributed">אופרטור קבוצות | הקבוצה הריקה | מתמטיקה | קבוצה ריקה</annotation>
 		<annotation cp="∅" type="tts" draft="contributed">קבוצה ריקה</annotation>
 		<annotation cp="∆">דלתא | משולש | תוספת</annotation>
 		<annotation cp="∆" type="tts">תוספת</annotation>
@@ -357,15 +357,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∇" type="tts">משולש הפוך</annotation>
 		<annotation cp="∈">אלמנט | אלמנט של | חבר ב- | מערך | נכלל | רכיב | רכיב של</annotation>
 		<annotation cp="∈" type="tts">רכיב של</annotation>
-		<annotation cp="∉" draft="contributed">לא שייך ל-</annotation>
+		<annotation cp="∉" draft="contributed">אופרטור קבוצות | אי-שייכות | לא נמצא ב- | לא שייך ל-</annotation>
 		<annotation cp="∉" type="tts" draft="contributed">לא שייך ל-</annotation>
-		<annotation cp="∋" draft="contributed">שייך ל-</annotation>
+		<annotation cp="∋" draft="contributed">אופרטור קבוצות | נמצא ב- | שייך ל- | שייכות</annotation>
 		<annotation cp="∋" type="tts" draft="contributed">שייך ל-</annotation>
-		<annotation cp="∎" draft="contributed">מש״ל</annotation>
+		<annotation cp="∎" draft="contributed">Q.E.D. | QED | הלמוש | מ.ש.ל. | מש״ל</annotation>
 		<annotation cp="∎" type="tts" draft="contributed">מש״ל</annotation>
-		<annotation cp="∏" draft="contributed">מכפלת קבוצה</annotation>
+		<annotation cp="∏" draft="contributed">לוגיקה | מכפלה | מכפלת קבוצה</annotation>
 		<annotation cp="∏" type="tts" draft="contributed">מכפלת קבוצה</annotation>
-		<annotation cp="∑" draft="contributed">סכום קבוצה</annotation>
+		<annotation cp="∑" draft="contributed">מתמטיקה | סיגמה | סכום | סכום קבוצה</annotation>
 		<annotation cp="∑" type="tts" draft="contributed">סכום קבוצה</annotation>
 		<annotation cp="+">בנוסף | הוספה | סימן פלוס | פלוס</annotation>
 		<annotation cp="+" type="tts">סימן פלוס</annotation>
@@ -377,7 +377,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="×" type="tts">סימן הכפלה</annotation>
 		<annotation cp="&lt;">פחות | קטן מ- | תג | תג פותח</annotation>
 		<annotation cp="&lt;" type="tts">קטן מ-</annotation>
-		<annotation cp="≮" draft="contributed">לא קטן מ-</annotation>
+		<annotation cp="≮" draft="contributed">אי-שוויון | לא קטן מ- | מתמטיקה</annotation>
 		<annotation cp="≮" type="tts" draft="contributed">לא קטן מ-</annotation>
 		<annotation cp="=">שווה | שווה ל- | שוויון</annotation>
 		<annotation cp="=" type="tts">שווה</annotation>
@@ -385,7 +385,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="≠" type="tts">לא שווה</annotation>
 		<annotation cp="&gt;">גדול | גדול מ- | יותר | תג | תג סוגר</annotation>
 		<annotation cp="&gt;" type="tts">גדול מ-</annotation>
-		<annotation cp="≯" draft="contributed">לא גדול מ-</annotation>
+		<annotation cp="≯" draft="contributed">אי-שוויון | לא גדול מ- | מתמטיקה</annotation>
 		<annotation cp="≯" type="tts" draft="contributed">לא גדול מ-</annotation>
 		<annotation cp="¬">לא | שלילה</annotation>
 		<annotation cp="¬" type="tts">שלילה</annotation>
@@ -399,15 +399,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⁻" type="tts">סימן מינוס עילי</annotation>
 		<annotation cp="∓" draft="contributed">חיבור או חיסור</annotation>
 		<annotation cp="∓" type="tts">חיבור או חיסור</annotation>
-		<annotation cp="∕" draft="contributed">לוכסן חילוק</annotation>
+		<annotation cp="∕" draft="contributed">חלקי | לוכסן | לוכסן חילוק | קו נטוי</annotation>
 		<annotation cp="∕" type="tts" draft="contributed">לוכסן חילוק</annotation>
-		<annotation cp="⁄" draft="contributed">לוכסן שברים</annotation>
+		<annotation cp="⁄" draft="contributed">חלקי | לוכסן | לוכסן שברים | קו נטוי</annotation>
 		<annotation cp="⁄" type="tts" draft="contributed">לוכסן שברים</annotation>
-		<annotation cp="∗" draft="contributed">אופרטור כוכבית</annotation>
+		<annotation cp="∗">אופרטור כוכבית | כוכב | כוכבית</annotation>
 		<annotation cp="∗" type="tts" draft="contributed">אופרטור כוכבית</annotation>
-		<annotation cp="∘" draft="contributed">אופרטור טבעת</annotation>
+		<annotation cp="∘" draft="contributed">אופרטור | אופרטור טבעת | קומפוזיציה</annotation>
 		<annotation cp="∘" type="tts" draft="contributed">אופרטור טבעת</annotation>
-		<annotation cp="∙" draft="contributed">אופרטור תבליט</annotation>
+		<annotation cp="∙">אופרטור | אופרטור תבליט</annotation>
 		<annotation cp="∙" type="tts" draft="contributed">אופרטור תבליט</annotation>
 		<annotation cp="√">שורש | שורש מרובע | שורש ריבועי</annotation>
 		<annotation cp="√" type="tts">שורש ריבועי</annotation>
@@ -443,109 +443,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∶" type="tts">יחס</annotation>
 		<annotation cp="∷">פרופורציה | פרופורציונליות</annotation>
 		<annotation cp="∷" type="tts">פרופורציה</annotation>
-		<annotation cp="∼" draft="contributed">אופרטור טילדה</annotation>
+		<annotation cp="∼" draft="contributed">אופרטור | אופרטור טילדה</annotation>
 		<annotation cp="∼" type="tts" draft="contributed">אופרטור טילדה</annotation>
-		<annotation cp="∽" draft="contributed">טילדה הפוכה</annotation>
+		<annotation cp="∽" draft="contributed">טילדה | טילדה הפוכה</annotation>
 		<annotation cp="∽" type="tts" draft="contributed">טילדה הפוכה</annotation>
 		<annotation cp="∾" draft="contributed">s שכובה הפוכה</annotation>
 		<annotation cp="∾" type="tts" draft="contributed">s שכובה הפוכה</annotation>
-		<annotation cp="≃" draft="contributed">שוויון אסימפטוטי</annotation>
+		<annotation cp="≃" draft="contributed">אסימפטוטה | מתמטיקה | שוויון אסימפטוטי</annotation>
 		<annotation cp="≃" type="tts" draft="contributed">שוויון אסימפטוטי</annotation>
-		<annotation cp="≅" draft="contributed">איזומורפיות</annotation>
+		<annotation cp="≅" draft="contributed">איזומורפיות | בערך שווה | שוויון | שקול | שקילות</annotation>
 		<annotation cp="≅" type="tts" draft="contributed">איזומורפיות</annotation>
 		<annotation cp="≈">בערך | בקירוב | כמעט | כמעט שווה | קירוב</annotation>
 		<annotation cp="≈" type="tts">כמעט שווה</annotation>
-		<annotation cp="≌" draft="contributed">שוויון כולל</annotation>
+		<annotation cp="≌" draft="contributed">מתמטיקה | שוויון | שוויון כולל</annotation>
 		<annotation cp="≌" type="tts" draft="contributed">שוויון כולל</annotation>
 		<annotation cp="≒" draft="contributed">תמונת שוויון דומה</annotation>
 		<annotation cp="≒" type="tts" draft="contributed">תמונת שוויון דומה</annotation>
-		<annotation cp="≖" draft="contributed">שוויון טבעת</annotation>
+		<annotation cp="≖" draft="contributed">מתמטיקה | שוויון | שוויון טבעת</annotation>
 		<annotation cp="≖" type="tts" draft="contributed">שוויון טבעת</annotation>
 		<annotation cp="≡">בדיוק | זהה | זהה ל- | שווה ערך | שקול</annotation>
 		<annotation cp="≡" type="tts">זהה ל-</annotation>
-		<annotation cp="≣" draft="contributed">מוגדר בתור</annotation>
+		<annotation cp="≣" draft="contributed">מוגדר בתור | שווה תמיד ל- | שקול ל-</annotation>
 		<annotation cp="≣" type="tts" draft="contributed">מוגדר בתור</annotation>
 		<annotation cp="≤">פחות | קטן | קטן מ- או שווה ל- | שווה | שוויון</annotation>
 		<annotation cp="≤" type="tts">קטן מ- או שווה ל-</annotation>
 		<annotation cp="≥">גדול | גדול מ- או שווה ל- | יותר | שווה | שוויון</annotation>
 		<annotation cp="≥" type="tts">גדול מ- או שווה ל-</annotation>
-		<annotation cp="≦" draft="contributed">קטן מ- מעל שווה</annotation>
+		<annotation cp="≦" draft="contributed">אי-שוויון | מתמטיקה | קטן מ- מעל שווה</annotation>
 		<annotation cp="≦" type="tts" draft="contributed">קטן מ- מעל שווה</annotation>
-		<annotation cp="≧" draft="contributed">גדול מ- מעל שווה</annotation>
+		<annotation cp="≧" draft="contributed">אי-שוויון | גדול מ- מעל שווה | מתמטיקה</annotation>
 		<annotation cp="≧" type="tts" draft="contributed">גדול מ- מעל שווה</annotation>
-		<annotation cp="≪" draft="contributed">הרבה פחות מ-</annotation>
+		<annotation cp="≪" draft="contributed">אי-שוויון | הרבה פחות מ- | מתמטיקה</annotation>
 		<annotation cp="≪" type="tts" draft="contributed">הרבה פחות מ-</annotation>
-		<annotation cp="≫" draft="contributed">הרבה יותר מ-</annotation>
+		<annotation cp="≫" draft="contributed">אי-שוויון | הרבה יותר מ- | מתמטיקה</annotation>
 		<annotation cp="≫" type="tts" draft="contributed">הרבה יותר מ-</annotation>
 		<annotation cp="≬" draft="contributed">בין</annotation>
 		<annotation cp="≬" type="tts" draft="contributed">בין</annotation>
-		<annotation cp="≳" draft="contributed">גדול מ- שווה</annotation>
+		<annotation cp="≳" draft="contributed">אי-שוויון | גדול מ- או שווה ל- | מתמטיקה</annotation>
 		<annotation cp="≳" type="tts" draft="contributed">גדול מ- שווה</annotation>
-		<annotation cp="≺" draft="contributed">קודם ל-</annotation>
+		<annotation cp="≺" draft="contributed">אופרטור קבוצות | מתמטיקה | קודם ל-</annotation>
 		<annotation cp="≺" type="tts" draft="contributed">קודם ל-</annotation>
-		<annotation cp="≻" draft="contributed">עוקב</annotation>
+		<annotation cp="≻" draft="contributed">אופרטור קבוצות | מתמטיקה | עוקב</annotation>
 		<annotation cp="≻" type="tts" draft="contributed">עוקב</annotation>
-		<annotation cp="⊁" draft="contributed">לא עוקב</annotation>
+		<annotation cp="⊁" draft="contributed">אופרטור קבוצות | לא עוקב | מתמטיקה</annotation>
 		<annotation cp="⊁" type="tts" draft="contributed">לא עוקב</annotation>
 		<annotation cp="⊂">מוכל ב- | נכלל ב- | קבוצה | קבוצת משנה</annotation>
 		<annotation cp="⊂" type="tts">מוכל ב-</annotation>
-		<annotation cp="⊃" draft="contributed">מכיל</annotation>
+		<annotation cp="⊃" draft="contributed">אופרטור קבוצות | מכיל | מתמטיקה</annotation>
 		<annotation cp="⊃" type="tts" draft="contributed">מכיל</annotation>
-		<annotation cp="⊆" draft="contributed">מוכל או שווה ל-</annotation>
+		<annotation cp="⊆" draft="contributed">אופרטור קבוצות | מוכל או שווה ל- | מתמטיקה</annotation>
 		<annotation cp="⊆" type="tts" draft="contributed">מוכל או שווה ל-</annotation>
-		<annotation cp="⊇" draft="contributed">קבוצה מכילה</annotation>
+		<annotation cp="⊇" draft="contributed">אופרטור קבוצות | מכיל | מתמטיקה | קבוצה מכילה</annotation>
 		<annotation cp="⊇" type="tts" draft="contributed">קבוצה מכילה</annotation>
-		<annotation cp="⊕" draft="contributed">פלוס במעגל</annotation>
+		<annotation cp="⊕" draft="contributed">חיבור | סכום | סכום ישר | פלוס במעגל</annotation>
 		<annotation cp="⊕" type="tts" draft="contributed">פלוס במעגל</annotation>
-		<annotation cp="⊖" draft="contributed">מינוס במעגל</annotation>
+		<annotation cp="⊖" draft="contributed">הפרש סימטרי | מינוס | שחיקה</annotation>
 		<annotation cp="⊖" type="tts" draft="contributed">מינוס במעגל</annotation>
-		<annotation cp="⊗" draft="contributed">כפל במעגל</annotation>
+		<annotation cp="⊗" draft="contributed">כפל במעגל | מכפלה | מכפלה טנזורית</annotation>
 		<annotation cp="⊗" type="tts" draft="contributed">כפל במעגל</annotation>
-		<annotation cp="⊘" draft="contributed">לוכסן חילוק במעגל</annotation>
+		<annotation cp="⊘" draft="contributed">חילוק | לוכסן חילוק במעגל | מתמטיקה</annotation>
 		<annotation cp="⊘" type="tts" draft="contributed">לוכסן חילוק במעגל</annotation>
-		<annotation cp="⊙" draft="contributed">נקודה במעגל</annotation>
+		<annotation cp="⊙" draft="contributed">XNOR | אופרטור | נקודה במעגל</annotation>
 		<annotation cp="⊙" type="tts" draft="contributed">נקודה במעגל</annotation>
-		<annotation cp="⊚" draft="contributed">טבעת במעגל</annotation>
+		<annotation cp="⊚" draft="contributed">אופרטור טבעת במעגל | טבעת במעגל</annotation>
 		<annotation cp="⊚" type="tts" draft="contributed">טבעת במעגל</annotation>
-		<annotation cp="⊛" draft="contributed">כוכבית במעגל</annotation>
+		<annotation cp="⊛" draft="contributed">אופרטור | כוכבית | כוכבית במעגל</annotation>
 		<annotation cp="⊛" type="tts" draft="contributed">כוכבית במעגל</annotation>
-		<annotation cp="⊞" draft="contributed">פלוס בריבוע</annotation>
+		<annotation cp="⊞" draft="contributed">חיבור | מתמטיקה | פלוס בריבוע</annotation>
 		<annotation cp="⊞" type="tts" draft="contributed">פלוס בריבוע</annotation>
-		<annotation cp="⊟" draft="contributed">מינוס בריבוע</annotation>
+		<annotation cp="⊟" draft="contributed">מינוס | מינוס בריבוע | מתמטייקה</annotation>
 		<annotation cp="⊟" type="tts" draft="contributed">מינוס בריבוע</annotation>
-		<annotation cp="⊥" draft="contributed">ניצב</annotation>
+		<annotation cp="⊥" draft="contributed">זווית ישרה | מאונך | ניצב</annotation>
 		<annotation cp="⊥" type="tts" draft="contributed">ניצב</annotation>
 		<annotation cp="⊮" draft="contributed">לא אוכף</annotation>
 		<annotation cp="⊮" type="tts" draft="contributed">לא אוכף</annotation>
-		<annotation cp="⊰" draft="contributed">קודם ביחס</annotation>
+		<annotation cp="⊰" draft="contributed">אופרטור קבוצות | מתמטיקה | קודם ביחס</annotation>
 		<annotation cp="⊰" type="tts" draft="contributed">קודם ביחס</annotation>
-		<annotation cp="⊱" draft="contributed">עוקב ביחס</annotation>
+		<annotation cp="⊱" draft="contributed">אופרטור קבוצות | מתמטיקה | עוקב ביחס</annotation>
 		<annotation cp="⊱" type="tts" draft="contributed">עוקב ביחס</annotation>
-		<annotation cp="⋭" draft="contributed">לא מכיל כתת-קבוצה נורמלית שווה</annotation>
+		<annotation cp="⋭" draft="contributed">לא מכיל כתת-קבוצה נורמלית שווה | מתמטיקה | תורת הקבוצות</annotation>
 		<annotation cp="⋭" type="tts" draft="contributed">לא מכיל כתת-קבוצה נורמלית שווה</annotation>
 		<annotation cp="⊶" draft="contributed">מקורי</annotation>
 		<annotation cp="⊶" type="tts" draft="contributed">מקורי</annotation>
-		<annotation cp="⊹" draft="contributed">מטריצה הרמיטיאנית</annotation>
+		<annotation cp="⊹" draft="contributed">מטריצה הרמיטיאנית | מטריצה מרובעת | מתמטיקה</annotation>
 		<annotation cp="⊹" type="tts" draft="contributed">מטריצה הרמיטיאנית</annotation>
-		<annotation cp="⊿" draft="contributed">משולש זווית ישרה</annotation>
+		<annotation cp="⊿" draft="contributed">זווית ישרה | משולשת זווית ישרה | מתמטיקה</annotation>
 		<annotation cp="⊿" type="tts" draft="contributed">משולש זווית ישרה</annotation>
-		<annotation cp="⋁" draft="contributed">או קבוצה</annotation>
+		<annotation cp="⋁" draft="contributed">או קבוצה | לוגיקה | מתמטיקה</annotation>
 		<annotation cp="⋁" type="tts" draft="contributed">או קבוצה</annotation>
-		<annotation cp="⋂" draft="contributed">חיתוך קבוצות</annotation>
+		<annotation cp="⋂" draft="contributed">אופרטור קבוצות | חיתוך | חיתוך קבוצות | מתמטיקה</annotation>
 		<annotation cp="⋂" type="tts" draft="contributed">חיתוך קבוצות</annotation>
-		<annotation cp="⋃" draft="contributed">איחוד קבוצות</annotation>
+		<annotation cp="⋃" draft="contributed">אופרטור קבוצות | איחוד | איחוד קבוצות | מתמטיקה</annotation>
 		<annotation cp="⋃" type="tts" draft="contributed">איחוד קבוצות</annotation>
-		<annotation cp="⋅" draft="contributed">אופרטור נקודה</annotation>
+		<annotation cp="⋅" draft="contributed">אופרטור | אופרטור נקודה</annotation>
 		<annotation cp="⋅" type="tts" draft="contributed">אופרטור נקודה</annotation>
-		<annotation cp="⋆" draft="contributed">אופרטור של כוכבית</annotation>
+		<annotation cp="⋆" draft="contributed">אופרטור | אופרטור של כוכבית</annotation>
 		<annotation cp="⋆" type="tts" draft="contributed">אופרטור של כוכבית</annotation>
-		<annotation cp="⋈" draft="contributed">איחוד טבעי</annotation>
+		<annotation cp="⋈" draft="contributed">אופרטור בינארי | איחוד טבעי | עניבת פרפר</annotation>
 		<annotation cp="⋈" type="tts" draft="contributed">איחוד טבעי</annotation>
-		<annotation cp="⋒" draft="contributed">חיתוך כפול</annotation>
+		<annotation cp="⋒" draft="contributed">אופרטור קבוצות | חיתוך | חיתוך כפול | מתמטיקה</annotation>
 		<annotation cp="⋒" type="tts" draft="contributed">חיתוך כפול</annotation>
-		<annotation cp="⋘" draft="contributed">קטן בהרבה מ-</annotation>
+		<annotation cp="⋘" draft="contributed">אי-שוויון | מתמטיקה | קטן בהרבה מ-</annotation>
 		<annotation cp="⋘" type="tts" draft="contributed">קטן בהרבה מ-</annotation>
-		<annotation cp="⋙" draft="contributed">גדול בהרבה מ-</annotation>
+		<annotation cp="⋙" draft="contributed">אי-שוויון | גדול בהרבה מ- | מתמטיקה</annotation>
 		<annotation cp="⋙" type="tts" draft="contributed">גדול בהרבה מ-</annotation>
 		<annotation cp="⋮">מתמטיקה | שלוש נקודות | שלוש נקודות אנכיות</annotation>
 		<annotation cp="⋮" type="tts">שלוש נקודות אנכיות</annotation>
@@ -703,7 +703,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⩽" type="tts" draft="contributed">קטן מ- עם שוויון אלכסוני</annotation>
 		<annotation cp="⪍" draft="contributed">קטן מ- מעל שוויון דומה</annotation>
 		<annotation cp="⪍" type="tts" draft="contributed">קטן מ- מעל שוויון דומה</annotation>
-		<annotation cp="⪚" draft="contributed">שוויון דו-קווי גדול מ-</annotation>
+		<annotation cp="⪚" draft="contributed">אי-שוויון | מתמטיקה | שוויון דו-קווי גדול מ-</annotation>
 		<annotation cp="⪚" type="tts" draft="contributed">שוויון דו-קווי גדול מ-</annotation>
 		<annotation cp="⪺" draft="contributed">עוקב מעל לא כמעט שווה</annotation>
 		<annotation cp="⪺" type="tts" draft="contributed">עוקב מעל לא כמעט שווה</annotation>
@@ -773,7 +773,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🤗" type="tts">פרצוף מחבק</annotation>
 		<annotation cp="🤭">אוי | אופס | טעות | פרצוף עם יד על הפה</annotation>
 		<annotation cp="🤭" type="tts">פרצוף עם יד על הפה</annotation>
-		<annotation cp="🫢">הַפתָעָה | חוסר אמון | יראה | מביך | מפחד | פנים עם עיניים פקוחות ויד על הפה | פרצוף עם יד על הפה ועיניים פעורות | תדהמה</annotation>
+		<annotation cp="🫢">הַפתָעָה | חוסר אמון | יראה | מביך | מפחד | פנים עם עיניים פקוחות ויד על הפה | תדהמה</annotation>
 		<annotation cp="🫢" type="tts">פרצוף עם יד על הפה ועיניים פעורות</annotation>
 		<annotation cp="🫣">הצצה | פרצוף מציץ עם יד על העיניים | שקוע במשהו</annotation>
 		<annotation cp="🫣" type="tts">פרצוף מציץ עם יד על העיניים</annotation>
@@ -1117,7 +1117,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👏" type="tts">מחיאות כפיים</annotation>
 		<annotation cp="🙌">כפות ידיים | כפות ידיים מורמות | סימן | שמחה</annotation>
 		<annotation cp="🙌" type="tts">כפות ידיים מורמות</annotation>
-		<annotation cp="🫶">אהבה | ידיים לב | סימן לב עם הידיים</annotation>
+		<annotation cp="🫶">אהבה | ידיים לב</annotation>
 		<annotation cp="🫶" type="tts">סימן לב עם הידיים</annotation>
 		<annotation cp="👐">ידיים פתוחות | כפות ידיים פתוחות | קבלה</annotation>
 		<annotation cp="👐" type="tts">כפות ידיים פתוחות</annotation>
@@ -1185,13 +1185,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👨" type="tts">איש</annotation>
 		<annotation cp="🧔">אדם מזוקן | זקן | מזוקן</annotation>
 		<annotation cp="🧔" type="tts">אדם מזוקן</annotation>
-		<annotation cp="🧔‍♂">גבר | גבר עם זקן | גבר: זקן | זקן</annotation>
+		<annotation cp="🧔‍♂">גבר | גבר: זקן | זקן</annotation>
 		<annotation cp="🧔‍♂" type="tts">גבר עם זקן</annotation>
 		<annotation cp="👱‍♂">איש | בלונדיני | גבר</annotation>
 		<annotation cp="👱‍♂" type="tts">בלונדיני</annotation>
 		<annotation cp="👩">אישה | בחורה | בת</annotation>
 		<annotation cp="👩" type="tts">אישה</annotation>
-		<annotation cp="🧔‍♀">אישה | אישה עם זקן | אישה: זקן | זקן</annotation>
+		<annotation cp="🧔‍♀">אישה | אישה: זקן | זקן</annotation>
 		<annotation cp="🧔‍♀" type="tts">אישה עם זקן</annotation>
 		<annotation cp="👱‍♀">אישה | בלונדינית</annotation>
 		<annotation cp="👱‍♀" type="tts">בלונדינית</annotation>
@@ -1285,7 +1285,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👨‍⚖" type="tts">שופט</annotation>
 		<annotation cp="👩‍⚖">אישה | מאזניים | משפט | צדק | שופטת</annotation>
 		<annotation cp="👩‍⚖" type="tts">שופטת</annotation>
-		<annotation cp="🧑‍🌾">גנן | גננת | חווה | חקלאות | חקלאי | חקלאי/ת | חקלאית</annotation>
+		<annotation cp="🧑‍🌾">גנן | גננת | חווה | חקלאות | חקלאי | חקלאית</annotation>
 		<annotation cp="🧑‍🌾" type="tts">חקלאי/ת</annotation>
 		<annotation cp="👨‍🌾">איש | גנן | חוואי | חקלאי</annotation>
 		<annotation cp="👨‍🌾" type="tts">חקלאי</annotation>
@@ -1297,7 +1297,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👨‍🍳" type="tts">טבח</annotation>
 		<annotation cp="👩‍🍳">אישה | טבחית | מבשלת | שפית</annotation>
 		<annotation cp="👩‍🍳" type="tts">טבחית</annotation>
-		<annotation cp="🧑‍🔧">אינסטלטור | אינסטלטורית | חשמלאי | חשמלאית | מכונאי | מכונאי/ת | מכונאית | שרברב</annotation>
+		<annotation cp="🧑‍🔧">אינסטלטור | אינסטלטורית | חשמלאי | חשמלאית | מכונאי | מכונאית | שרברב</annotation>
 		<annotation cp="🧑‍🔧" type="tts">מכונאי/ת</annotation>
 		<annotation cp="👨‍🔧">איש | איש מקצוע | גבר | חשמלאי | טכנאי | מכונאי | שרברב</annotation>
 		<annotation cp="👨‍🔧" type="tts">מכונאי</annotation>
@@ -1309,31 +1309,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👨‍🏭" type="tts">פועל</annotation>
 		<annotation cp="👩‍🏭">אישה | מפעילה | מפעל | מרכיבה | עובדת | עובדת תעשייה | פועלת</annotation>
 		<annotation cp="👩‍🏭" type="tts">פועלת</annotation>
-		<annotation cp="🧑‍💼">אדריכל | אדריכלית | מנהל | מנהלת | עבודה משרדית | עובד/ת משרד | עסק | צווארון לבן</annotation>
+		<annotation cp="🧑‍💼">אדריכל | אדריכלית | מנהל | מנהלת | עבודה משרדית | עסק | צווארון לבן</annotation>
 		<annotation cp="🧑‍💼" type="tts">עובד/ת משרד</annotation>
 		<annotation cp="👨‍💼">אדריכל | איש עסקים | מנהל | משרד | עובד משרד | פקיד | צווארון לבן</annotation>
 		<annotation cp="👨‍💼" type="tts">עובד משרד</annotation>
 		<annotation cp="👩‍💼">אדריכלית | אשת עסקים | מנהלת | משרד | עובדת משרד | פקידה | צווארון לבן</annotation>
 		<annotation cp="👩‍💼" type="tts">עובדת משרד</annotation>
-		<annotation cp="🧑‍🔬">ביולוג | ביולוגית | מדען | מדען/ית | מדענית | מהנדס | מהנדסת</annotation>
+		<annotation cp="🧑‍🔬">ביולוג | ביולוגית | מדען | מדענית | מהנדס | מהנדסת</annotation>
 		<annotation cp="🧑‍🔬" type="tts">מדען/ית</annotation>
 		<annotation cp="👨‍🔬">איש | ביולוג | גבר | כימאי | מדען | מהנדס | פיזיקאי</annotation>
 		<annotation cp="👨‍🔬" type="tts">מדען</annotation>
 		<annotation cp="👩‍🔬">אישה | ביולוגית | כימאית | מדענית | מהנדסת | פיזיקאית</annotation>
 		<annotation cp="👩‍🔬" type="tts">מדענית</annotation>
-		<annotation cp="🧑‍💻">טכנולוג | טכנולוג/ית | טכנולוגית | ממציא | מפתח | מפתחת | מתכנת | מתכנתת</annotation>
+		<annotation cp="🧑‍💻">טכנולוג | טכנולוגית | ממציא | מפתח | מפתחת | מתכנת | מתכנתת</annotation>
 		<annotation cp="🧑‍💻" type="tts">טכנולוג/ית</annotation>
 		<annotation cp="👨‍💻">איש | גבר | חוקר | טכנולוג | מפתח | מתכנת | תוכנה</annotation>
 		<annotation cp="👨‍💻" type="tts">טכנולוג</annotation>
 		<annotation cp="👩‍💻">אישה | חוקרת | טכנולוגית | מפתחת | מתכנתת | תוכנה</annotation>
 		<annotation cp="👩‍💻" type="tts">טכנולוגית</annotation>
-		<annotation cp="🧑‍🎤">אומן | אמן | אמנית | זמר | זמר/ת | זמרת | שחקן | שחקנית</annotation>
+		<annotation cp="🧑‍🎤">אומן | אמן | אמנית | זמר | זמרת | שחקן | שחקנית</annotation>
 		<annotation cp="🧑‍🎤" type="tts">זמר/ת</annotation>
 		<annotation cp="👨‍🎤">איש | בדרן | גבר | זמר | כוכב | רוק | שחקן</annotation>
 		<annotation cp="👨‍🎤" type="tts">זמר</annotation>
 		<annotation cp="👩‍🎤">אישה | בדרנית | זמרת | כוכבת | רוק | שחקנית</annotation>
 		<annotation cp="👩‍🎤" type="tts">זמרת</annotation>
-		<annotation cp="🧑‍🎨">אומן | אומן/ית | אומנות | אומנית | אמן | אמנות | אמנית | צבעים</annotation>
+		<annotation cp="🧑‍🎨">אומן | אומנות | אומנית | אמן | אמנות | אמנית | צבעים</annotation>
 		<annotation cp="🧑‍🎨" type="tts">אומן/ית</annotation>
 		<annotation cp="👨‍🎨">איש | אמן | גבר | צבעים | צייר</annotation>
 		<annotation cp="👨‍🎨" type="tts">אמן</annotation>
@@ -1351,7 +1351,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👨‍🚀" type="tts">אסטרונאוט</annotation>
 		<annotation cp="👩‍🚀">אישה | אסטרונאוטית | חלל | חללית</annotation>
 		<annotation cp="👩‍🚀" type="tts">אסטרונאוטית</annotation>
-		<annotation cp="🧑‍🚒">כבאות | כבאי | כבאית | לוחם אש | לוחם/ת אש | לוחמת אש | מכבי אש</annotation>
+		<annotation cp="🧑‍🚒">כבאות | כבאי | כבאית | לוחם אש | לוחמת אש | מכבי אש</annotation>
 		<annotation cp="🧑‍🚒" type="tts">לוחם/ת אש</annotation>
 		<annotation cp="👨‍🚒">איש | גבר | כבאי | כיבוי | לוחם אש | מכבי אש</annotation>
 		<annotation cp="👨‍🚒" type="tts">לוחם אש</annotation>
@@ -1685,11 +1685,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫂" type="tts">אנשים מתחבקים</annotation>
 		<annotation cp="👪">אבא | אמא | הורים | ילד | ילדה | משפחה</annotation>
 		<annotation cp="👪" type="tts">משפחה</annotation>
-		<annotation cp="🧑‍🧑‍🧒">משפחה: הורה, הורה, ילד | משפחה: הורה, מבוגר, מבוגרת, ילד, ילדה</annotation>
+		<annotation cp="🧑‍🧑‍🧒">משפחה: הורה, מבוגר, מבוגרת, ילד, ילדה</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts">משפחה: הורה, הורה, ילד</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">משפחה: הורה, הורה, ילד, ילד | משפחה: הורה, מבוגר, ילד, ילדה</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒">משפחה: הורה, מבוגר, ילד, ילדה</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">משפחה: הורה, הורה, ילד, ילד</annotation>
-		<annotation cp="🧑‍🧒">משפחה: הורה, ילד | משפחה: מבוגר, מבוגרת, ילד, ילדה</annotation>
+		<annotation cp="🧑‍🧒">משפחה: מבוגר, מבוגרת, ילד, ילדה</annotation>
 		<annotation cp="🧑‍🧒" type="tts">משפחה: הורה, ילד</annotation>
 		<annotation cp="🧑‍🧒‍🧒">משפחה: מבוגר, מבוגרת, ילד, ילדה</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts">משפחה: מבוגר, מבוגרת, ילד, ילדה</annotation>
@@ -2153,7 +2153,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🧂" type="tts">מלח</annotation>
 		<annotation cp="🥫">קופסת שימורים | שימורים</annotation>
 		<annotation cp="🥫" type="tts">שימורים</annotation>
-		<annotation cp="🍱">בנטו | חמגשית עם אוכל | קופסה</annotation>
+		<annotation cp="🍱">בנטו | קופסה</annotation>
 		<annotation cp="🍱" type="tts">חמגשית עם אוכל</annotation>
 		<annotation cp="🍘">אורז | פריכיות | פריכית אורז</annotation>
 		<annotation cp="🍘" type="tts">פריכית אורז</annotation>
@@ -2925,7 +2925,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👙" type="tts">ביקיני</annotation>
 		<annotation cp="👚">אישה | בגד | חולצה | חולצת אישה</annotation>
 		<annotation cp="👚" type="tts">חולצת אישה</annotation>
-		<annotation cp="🪭">ביישן | חם | לרקוד | מאוורר | מאוורר יד מתקפל | מניפת יד מתקפלת | קירור | רפרוף</annotation>
+		<annotation cp="🪭">ביישן | חם | לרקוד | מאוורר | מאוורר יד מתקפל | קירור | רפרוף</annotation>
 		<annotation cp="🪭" type="tts">מניפת יד מתקפלת</annotation>
 		<annotation cp="👛">ארנק | כסף | מטבעות</annotation>
 		<annotation cp="👛" type="tts">ארנק</annotation>
@@ -3855,9 +3855,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="£" type="tts">פאונד</annotation>
 		<annotation cp="¥">ין | יפן | מטבע</annotation>
 		<annotation cp="¥" type="tts">ין</annotation>
-		<annotation cp="₢" draft="contributed">קרוזרו</annotation>
+		<annotation cp="₢" draft="contributed">BRB | מטבע | קרוזיארו | קרוזרו</annotation>
 		<annotation cp="₢" type="tts" draft="contributed">קרוזרו</annotation>
-		<annotation cp="₣" draft="contributed">פרנק צרפתי</annotation>
+		<annotation cp="₣" draft="contributed">מטבע | פרנק | פרנק צרפתי</annotation>
 		<annotation cp="₣" type="tts" draft="contributed">פרנק צרפתי</annotation>
 		<annotation cp="₤">לִירָה | מטבע</annotation>
 		<annotation cp="₤" type="tts">לִירָה</annotation>

--- a/common/annotations/hu.xml
+++ b/common/annotations/hu.xml
@@ -811,9 +811,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🤥" type="tts">hazudó arc</annotation>
 		<annotation cp="🫨">arc | földrengés | meglepődés | rázkódó | rezeg</annotation>
 		<annotation cp="🫨" type="tts">rázkódó arc</annotation>
-		<annotation cp="🙂‍↔" draft="contributed">vízszintesen rázkódó arc</annotation>
+		<annotation cp="🙂‍↔" draft="contributed">nem, fejrázás | vízszintesen rázkódó arc</annotation>
 		<annotation cp="🙂‍↔" type="tts" draft="contributed">vízszintesen rázkódó arc</annotation>
-		<annotation cp="🙂‍↕" draft="contributed">függőlegesen rázkódó arc</annotation>
+		<annotation cp="🙂‍↕" draft="contributed">bólintás, igen | függőlegesen rázkódó arc</annotation>
 		<annotation cp="🙂‍↕" type="tts" draft="contributed">függőlegesen rázkódó arc</annotation>
 		<annotation cp="😌">arc | megkönnyebbült</annotation>
 		<annotation cp="😌" type="tts">megkönnyebbült arc</annotation>
@@ -1873,7 +1873,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">papagáj</annotation>
 		<annotation cp="🪽">angyal | madár | mitológia | repül | repülés | szárny</annotation>
 		<annotation cp="🪽" type="tts">szárny</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">fekete madár</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">fekete | holló | madár | varjú | vetési varjú</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">fekete madár</annotation>
 		<annotation cp="🪿">bolondos | gágog | liba | madár | szárnyas</annotation>
 		<annotation cp="🪿" type="tts">liba</annotation>

--- a/common/annotations/is.xml
+++ b/common/annotations/is.xml
@@ -241,7 +241,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↶" type="tts">ör uppi í hálfhring rangsælis</annotation>
 		<annotation cp="↷">ör uppi í hálfhring réttsælis</annotation>
 		<annotation cp="↷" type="tts">ör uppi í hálfhring réttsælis</annotation>
-		<annotation cp="↸" draft="contributed">ör ská upp til vinstri að rönd</annotation>
+		<annotation cp="↸" draft="contributed">átt | norðvestur | ör | ör ská upp til vinstri að rönd</annotation>
 		<annotation cp="↸" type="tts" draft="contributed">ör ská upp til vinstri að rönd</annotation>
 		<annotation cp="↹">ör | örvar að striki vinstri yfir hægri | strik | til hægri | til vinstri</annotation>
 		<annotation cp="↹" type="tts">örvar að striki vinstri yfir hægri</annotation>
@@ -411,7 +411,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∙" type="tts" draft="contributed">virkir</annotation>
 		<annotation cp="√">annað veldi | kvaðratrót | óræð tala | rót | rótarstærð | stofntala</annotation>
 		<annotation cp="√" type="tts">kvaðratrót</annotation>
-		<annotation cp="∝" draft="contributed">hlutfallsmerki</annotation>
+		<annotation cp="∝">hlutfallsleiki | hlutfallsmerki</annotation>
 		<annotation cp="∝" type="tts" draft="contributed">hlutfallsmerki</annotation>
 		<annotation cp="∞">óendanlegt | óendanlegt-merki</annotation>
 		<annotation cp="∞" type="tts">óendanlegt-merki</annotation>
@@ -423,7 +423,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∣" type="tts" draft="contributed">deilir</annotation>
 		<annotation cp="∥">samsíða</annotation>
 		<annotation cp="∥" type="tts">samsíða</annotation>
-		<annotation cp="∧" draft="contributed">og-röktákn</annotation>
+		<annotation cp="∧" draft="contributed">og | og-röktákn | röktákn</annotation>
 		<annotation cp="∧" type="tts" draft="contributed">og-röktákn</annotation>
 		<annotation cp="∩">mengi | sniðmengi</annotation>
 		<annotation cp="∩" type="tts">sniðmengi</annotation>
@@ -449,9 +449,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∽" type="tts">öfug tilda</annotation>
 		<annotation cp="∾">öfugt s á hlið</annotation>
 		<annotation cp="∾" type="tts">öfugt s á hlið</annotation>
-		<annotation cp="≃" draft="contributed">undirstrikuð bugða</annotation>
+		<annotation cp="≃" draft="contributed">stærðfræði | um það bil | undirstrikuð bugða</annotation>
 		<annotation cp="≃" type="tts" draft="contributed">undirstrikuð bugða</annotation>
-		<annotation cp="≅" draft="contributed">tvíundirstrikuð bugða</annotation>
+		<annotation cp="≅" draft="contributed">einslögun | jafngildi | samsvörun | stærðfræði | tvíundirstrikuð bugða</annotation>
 		<annotation cp="≅" type="tts" draft="contributed">tvíundirstrikuð bugða</annotation>
 		<annotation cp="≈">næstum jafnt | nálgun | námundun</annotation>
 		<annotation cp="≈" type="tts">næstum jafnt</annotation>
@@ -463,7 +463,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="≖" type="tts">hringur í jafnaðarmerki</annotation>
 		<annotation cp="≡">nákvæmlega eins | nákvæmlega eins og | nákvæmur | þrefalt</annotation>
 		<annotation cp="≡" type="tts">nákvæmlega eins og</annotation>
-		<annotation cp="≣" draft="contributed">aljafnaðarmerki</annotation>
+		<annotation cp="≣">jöfnuður | stærðfræði</annotation>
 		<annotation cp="≣" type="tts" draft="contributed">aljafnaðarmerki</annotation>
 		<annotation cp="≤">jafnt | minna en | minna en eða jafnt | ójöfnuður | samasem</annotation>
 		<annotation cp="≤" type="tts">minna en eða jafnt</annotation>
@@ -489,41 +489,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⊁" type="tts">kemur ekki á eftir</annotation>
 		<annotation cp="⊂">hlutmengi | hlutmengi í | mengi</annotation>
 		<annotation cp="⊂" type="tts">hlutmengi í</annotation>
-		<annotation cp="⊃" draft="contributed">yfirmengistákn</annotation>
+		<annotation cp="⊃">mengjavirkir | stærðfræði | yfirmengistákn</annotation>
 		<annotation cp="⊃" type="tts" draft="contributed">yfirmengistákn</annotation>
-		<annotation cp="⊆" draft="contributed">hlutmengisjafnaðartákn</annotation>
+		<annotation cp="⊆" draft="contributed">mengjavirkir | stærðfræði</annotation>
 		<annotation cp="⊆" type="tts" draft="contributed">hlutmengisjafnaðartákn</annotation>
-		<annotation cp="⊇" draft="contributed">yfirmengisjafnaðartákn</annotation>
+		<annotation cp="⊇">jöfnuður | stærðfræði | yfirmengisjafnaðartákn</annotation>
 		<annotation cp="⊇" type="tts" draft="contributed">yfirmengisjafnaðartákn</annotation>
 		<annotation cp="⊕">plús | plús í hring</annotation>
 		<annotation cp="⊕" type="tts">plús í hring</annotation>
 		<annotation cp="⊖">mínus í hring | samhverfur mismunur | upplausn</annotation>
 		<annotation cp="⊖" type="tts">mínus í hring</annotation>
-		<annotation cp="⊗" draft="contributed">margföldun í hring</annotation>
+		<annotation cp="⊗" draft="contributed">margfeldi | margföldun í hring | þinill</annotation>
 		<annotation cp="⊗" type="tts" draft="contributed">margföldun í hring</annotation>
-		<annotation cp="⊘" draft="contributed">deilingarskástrik í hring</annotation>
+		<annotation cp="⊘" draft="contributed">deiling | deilingarskrástrik í hring | stærðfræði</annotation>
 		<annotation cp="⊘" type="tts" draft="contributed">deilingarskástrik í hring</annotation>
-		<annotation cp="⊙" draft="contributed">depill í hring virki</annotation>
+		<annotation cp="⊙" draft="contributed">depill í hring virki | virki | XNOR</annotation>
 		<annotation cp="⊙" type="tts" draft="contributed">depill í hring virki</annotation>
 		<annotation cp="⊚" draft="contributed">hringur í hring virki</annotation>
 		<annotation cp="⊚" type="tts" draft="contributed">hringur í hring virki</annotation>
-		<annotation cp="⊛" draft="contributed">stjarna í hring virki</annotation>
+		<annotation cp="⊛" draft="contributed">stjarna | stjarna í hring virki | virki</annotation>
 		<annotation cp="⊛" type="tts" draft="contributed">stjarna í hring virki</annotation>
-		<annotation cp="⊞" draft="contributed">plús í ferningi</annotation>
+		<annotation cp="⊞" draft="contributed">plús í ferningi | samlagning | stærðfræði</annotation>
 		<annotation cp="⊞" type="tts" draft="contributed">plús í ferningi</annotation>
-		<annotation cp="⊟" draft="contributed">mínus í ferningi</annotation>
+		<annotation cp="⊟" draft="contributed">frádráttur | mínus í ferningi | stærðfræði</annotation>
 		<annotation cp="⊟" type="tts" draft="contributed">mínus í ferningi</annotation>
-		<annotation cp="⊥" draft="contributed">hornrétt á</annotation>
+		<annotation cp="⊥" draft="contributed">hornrétt á | stærðfræði</annotation>
 		<annotation cp="⊥" type="tts" draft="contributed">hornrétt á</annotation>
-		<annotation cp="⊮" draft="contributed">þvingar ekki</annotation>
+		<annotation cp="⊮" draft="contributed">stærðfræði | þvingar ekki</annotation>
 		<annotation cp="⊮" type="tts" draft="contributed">þvingar ekki</annotation>
-		<annotation cp="⊰" draft="contributed">kemur á undan í venslum</annotation>
+		<annotation cp="⊰">kemur á undan í venslum | mengjavirkir | stærðfræði</annotation>
 		<annotation cp="⊰" type="tts" draft="contributed">kemur á undan í venslum</annotation>
-		<annotation cp="⊱" draft="contributed">kemur á eftir í venslum</annotation>
+		<annotation cp="⊱">kemur á eftir í venslum | mengjavirkir | stærðfræði</annotation>
 		<annotation cp="⊱" type="tts" draft="contributed">kemur á eftir í venslum</annotation>
 		<annotation cp="⋭">grúpufræði | inniheldur ekki sem normleg hlutgrúpa eða jafnt | stærðfræði</annotation>
 		<annotation cp="⋭" type="tts">inniheldur ekki sem normleg hlutgrúpa eða jafnt</annotation>
-		<annotation cp="⊶" draft="contributed">upprunaleg</annotation>
+		<annotation cp="⊶" draft="contributed">raðfræði | upprunaleg</annotation>
 		<annotation cp="⊶" type="tts" draft="contributed">upprunaleg</annotation>
 		<annotation cp="⊹">ferningsfylki | hermískt samoka fylki | sjálfoka fylki | stærðfræði</annotation>
 		<annotation cp="⊹" type="tts">hermískt samoka fylki</annotation>

--- a/common/annotations/kab.xml
+++ b/common/annotations/kab.xml
@@ -141,7 +141,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😶" type="tts" draft="unconfirmed">udem s war imi</annotation>
 		<annotation cp="🫥" draft="unconfirmed">udem s yizirig yettwagezmen</annotation>
 		<annotation cp="🫥" type="tts" draft="unconfirmed">udem s yizirig yettwagezmen</annotation>
-		<annotation cp="😶‍🌫" draft="unconfirmed">udem deg usigna</annotation>
+		<annotation cp="😶‍🌫" draft="unconfirmed">aqerru deg usigna | udem deg usigna</annotation>
 		<annotation cp="😶‍🌫" type="tts" draft="unconfirmed">udem deg usigna</annotation>
 		<annotation cp="😏" draft="unconfirmed">acmumeḥ n tiḥḥerci</annotation>
 		<annotation cp="😏" type="tts" draft="unconfirmed">acmumeḥ n tiḥḥerci</annotation>
@@ -151,7 +151,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙄" type="tts" draft="unconfirmed">udem s wallen ibellɣen</annotation>
 		<annotation cp="😬" draft="unconfirmed">udem yesmejgaren</annotation>
 		<annotation cp="😬" type="tts" draft="unconfirmed">udem yesmejgaren</annotation>
-		<annotation cp="😮‍💨" draft="unconfirmed">udem ittenferrihen</annotation>
+		<annotation cp="😮‍💨" draft="unconfirmed">udem ittenferrihen | udem yettseffiṛen</annotation>
 		<annotation cp="😮‍💨" type="tts" draft="unconfirmed">udem ittenferrihen</annotation>
 		<annotation cp="🤥" draft="unconfirmed">udem yeskiddiben</annotation>
 		<annotation cp="🤥" type="tts" draft="unconfirmed">udem yeskiddiben</annotation>
@@ -227,7 +227,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😳" type="tts" draft="unconfirmed">udem uzwiɣ</annotation>
 		<annotation cp="🥺" draft="unconfirmed">abaṛuṛec n wallen</annotation>
 		<annotation cp="🥺" type="tts" draft="unconfirmed">abaṛuṛec n wallen</annotation>
-		<annotation cp="🥹" draft="unconfirmed">udem yeṭṭfen imeṭṭawen</annotation>
+		<annotation cp="🥹" draft="unconfirmed">iḥeznen | udem yeṭṭfen imeṭṭawen | yerfan | yettrun</annotation>
 		<annotation cp="🥹" type="tts" draft="unconfirmed">udem yeṭṭfen imeṭṭawen</annotation>
 		<annotation cp="😦" draft="unconfirmed">udem yenneɣnan s yimi yeldin</annotation>
 		<annotation cp="😦" type="tts" draft="unconfirmed">udem yenneɣnan s yimi yeldin</annotation>
@@ -287,7 +287,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👻" type="tts" draft="unconfirmed">afunṭum</annotation>
 		<annotation cp="🤖" draft="unconfirmed">aṛubut</annotation>
 		<annotation cp="🤖" type="tts" draft="unconfirmed">aṛubut</annotation>
-		<annotation cp="😺" draft="unconfirmed">amcic yeḍsan</annotation>
+		<annotation cp="😺" draft="unconfirmed">acmumeḥ | amcic | imi | ldi | taḍsa | udem</annotation>
 		<annotation cp="😺" type="tts" draft="unconfirmed">amcic yeḍsan</annotation>
 		<annotation cp="😸" draft="unconfirmed">amcic yeḍsan s wallen yeḍsan</annotation>
 		<annotation cp="😸" type="tts" draft="unconfirmed">amcic yeḍsan s wallen yeḍsan</annotation>
@@ -301,13 +301,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙀" type="tts" draft="unconfirmed">amcic yeɛyan</annotation>
 		<annotation cp="😿" draft="unconfirmed">amcic yettrun</annotation>
 		<annotation cp="😿" type="tts" draft="unconfirmed">amcic yettrun</annotation>
-		<annotation cp="🙈" draft="unconfirmed">iddew ur nettwal adɣu</annotation>
+		<annotation cp="🙈" draft="unconfirmed">iddew ur nettwali adɣu</annotation>
 		<annotation cp="🙈" type="tts" draft="unconfirmed">iddew ur nettwal adɣu</annotation>
 		<annotation cp="🙉" draft="unconfirmed">iddew ur yettḥessisen i udeɣu</annotation>
 		<annotation cp="🙉" type="tts" draft="unconfirmed">iddew ur yettḥessisen i udeɣu</annotation>
 		<annotation cp="🙊" draft="unconfirmed">iddew ur nettmeslay ɣef udɣu</annotation>
 		<annotation cp="🙊" type="tts" draft="unconfirmed">iddew ur nettmeslay ɣef udɣu</annotation>
-		<annotation cp="💌" draft="unconfirmed">tabrat n wul</annotation>
+		<annotation cp="💌" draft="unconfirmed">tabrat n tayri | tabrat n wul</annotation>
 		<annotation cp="💌" type="tts" draft="unconfirmed">tabrat n wul</annotation>
 		<annotation cp="💘" draft="unconfirmed">ul tekka tneccabt</annotation>
 		<annotation cp="💘" type="tts" draft="unconfirmed">ul tekka tneccabt</annotation>
@@ -331,7 +331,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="💔" type="tts" draft="unconfirmed">ul yerẓen</annotation>
 		<annotation cp="❤‍🔥" draft="unconfirmed">ul tecɛel deg-s tmes</annotation>
 		<annotation cp="❤‍🔥" type="tts" draft="unconfirmed">ul tecɛel deg-s tmes</annotation>
-		<annotation cp="❤‍🩹" draft="unconfirmed">adi n wul</annotation>
+		<annotation cp="❤‍🩹" draft="unconfirmed">adawi n wul</annotation>
 		<annotation cp="❤‍🩹" type="tts" draft="unconfirmed">adi n wul</annotation>
 		<annotation cp="❤" draft="unconfirmed">ul azeggaɣ</annotation>
 		<annotation cp="❤" type="tts" draft="unconfirmed">ul azeggaɣ</annotation>
@@ -353,7 +353,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤎" type="tts" draft="unconfirmed">ul aqehwi</annotation>
 		<annotation cp="🖤" draft="unconfirmed">ul aberkan</annotation>
 		<annotation cp="🖤" type="tts" draft="unconfirmed">ul aberkan</annotation>
-		<annotation cp="🩶" draft="unconfirmed">ul idbar</annotation>
+		<annotation cp="🩶" draft="unconfirmed">u idbar</annotation>
 		<annotation cp="🩶" type="tts" draft="unconfirmed">ul idbar</annotation>
 		<annotation cp="🤍" draft="unconfirmed">ul amellal</annotation>
 		<annotation cp="🤍" type="tts" draft="unconfirmed">ul amellal</annotation>
@@ -387,7 +387,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤚" type="tts" draft="unconfirmed">talwaḥt n ufus irefden</annotation>
 		<annotation cp="🖐" draft="unconfirmed">afus s yiḍudan yeldin</annotation>
 		<annotation cp="🖐" type="tts" draft="unconfirmed">afus s yiḍudan yeldin</annotation>
-		<annotation cp="✋" draft="unconfirmed">argaz: acebbub awreɣ</annotation>
+		<annotation cp="✋" draft="unconfirmed">afus irefden</annotation>
 		<annotation cp="✋" type="tts" draft="unconfirmed">argaz: acebbub awreɣ</annotation>
 		<annotation cp="🖖" draft="unconfirmed">aburkan n tezmert</annotation>
 		<annotation cp="🖖" type="tts" draft="unconfirmed">aburkan n tezmert</annotation>
@@ -519,7 +519,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧔" type="tts" draft="unconfirmed">amdan: tamart</annotation>
 		<annotation cp="🧔‍♂" draft="unconfirmed">argaz: tamart</annotation>
 		<annotation cp="🧔‍♂" type="tts" draft="unconfirmed">argaz: tamart</annotation>
-		<annotation cp="👱‍♂" draft="unconfirmed">argaz: acebbub aceɛlla</annotation>
+		<annotation cp="👱‍♂" draft="unconfirmed">argaz: acebbub aceɛlal</annotation>
 		<annotation cp="👱‍♂" type="tts" draft="unconfirmed">argaz: acebbub aceɛlla</annotation>
 		<annotation cp="👩" draft="unconfirmed">tameṭṭut</annotation>
 		<annotation cp="👩" type="tts" draft="unconfirmed">tameṭṭut</annotation>
@@ -1029,7 +1029,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍳" type="tts" draft="unconfirmed">tamellalt yewwan</annotation>
 		<annotation cp="🍲" draft="unconfirmed">taqessult n tgella</annotation>
 		<annotation cp="🍲" type="tts" draft="unconfirmed">taqessult n tgella</annotation>
-		<annotation cp="🫕" draft="unconfirmed">taḥelwiḍt</annotation>
+		<annotation cp="🫕" draft="unconfirmed">taḥelwifḍt</annotation>
 		<annotation cp="🫕" type="tts" draft="unconfirmed">taḥelwiḍt</annotation>
 		<annotation cp="🥣" draft="unconfirmed">aḍebdi s tejɣelt</annotation>
 		<annotation cp="🥣" type="tts" draft="unconfirmed">aḍebdi s tejɣelt</annotation>
@@ -1055,7 +1055,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍝" type="tts" draft="unconfirmed">spagiti</annotation>
 		<annotation cp="🍠" draft="unconfirmed">baṭaṭa taẓidant ikenfen</annotation>
 		<annotation cp="🍠" type="tts" draft="unconfirmed">baṭaṭa taẓidant ikenfen</annotation>
-		<annotation cp="🍢" draft="unconfirmed">tifarrugt</annotation>
+		<annotation cp="🍢" draft="unconfirmed">tafarrugt</annotation>
 		<annotation cp="🍢" type="tts" draft="unconfirmed">tifarrugt</annotation>
 		<annotation cp="🍣" draft="unconfirmed">aṣuci</annotation>
 		<annotation cp="🍣" type="tts" draft="unconfirmed">aṣuci</annotation>
@@ -1239,7 +1239,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🚕" type="tts" draft="unconfirmed">Ataksi</annotation>
 		<annotation cp="🚗" draft="unconfirmed">Takerrust</annotation>
 		<annotation cp="🚗" type="tts" draft="unconfirmed">Takerrust</annotation>
-		<annotation cp="🛹" draft="unconfirmed">avilu</annotation>
+		<annotation cp="🛹">Avilu</annotation>
 		<annotation cp="🛹" type="tts" draft="unconfirmed">avilu</annotation>
 		<annotation cp="🚨" draft="unconfirmed">Taftilt n tkerrust n tmsulta</annotation>
 		<annotation cp="🚨" type="tts" draft="unconfirmed">Taftilt n tkerrust n tmsulta</annotation>
@@ -1313,7 +1313,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧨" type="tts" draft="unconfirmed">aḥerbi</annotation>
 		<annotation cp="✨">itran</annotation>
 		<annotation cp="✨" type="tts" draft="unconfirmed">itran</annotation>
-		<annotation cp="🎈" draft="unconfirmed">tacuffut</annotation>
+		<annotation cp="🎈">asfugel</annotation>
 		<annotation cp="🎈" type="tts" draft="unconfirmed">tacuffut</annotation>
 		<annotation cp="🧧" draft="unconfirmed">tabrat tazeggaɣt</annotation>
 		<annotation cp="🧧" type="tts" draft="unconfirmed">tabrat tazeggaɣt</annotation>
@@ -1343,7 +1343,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🎮" draft="unconfirmed">urar n tvidyut</annotation>
 		<annotation cp="🎮" type="tts" draft="unconfirmed">urar n tvidyut</annotation>
 		<annotation cp="🀄">azeggaɣ | mahjong | urar</annotation>
-		<annotation cp="🎴" draft="unconfirmed">tikarḍiwin n wurra n ujeǧǧig</annotation>
+		<annotation cp="🎴">takarḍa | urar</annotation>
 		<annotation cp="🎴" type="tts" draft="unconfirmed">tikarḍiwin n wurra n ujeǧǧig</annotation>
 		<annotation cp="🎭" draft="unconfirmed">igelmusen</annotation>
 		<annotation cp="🎭" type="tts" draft="unconfirmed">igelmusen</annotation>
@@ -1397,7 +1397,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👙" type="tts" draft="unconfirmed">abikini</annotation>
 		<annotation cp="👚" draft="unconfirmed">iceṭṭiḍen n tlawin</annotation>
 		<annotation cp="👚" type="tts" draft="unconfirmed">iceṭṭiḍen n tlawin</annotation>
-		<annotation cp="🪭" draft="unconfirmed">tasebuḥrut</annotation>
+		<annotation cp="🪭" draft="unconfirmed">tasbuḥrut</annotation>
 		<annotation cp="🪭" type="tts" draft="unconfirmed">tasebuḥrut</annotation>
 		<annotation cp="👛" draft="unconfirmed">ṣṣak</annotation>
 		<annotation cp="👛" type="tts" draft="unconfirmed">ṣṣak</annotation>
@@ -1614,7 +1614,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📦" type="tts" draft="unconfirmed">akemmus</annotation>
 		<annotation cp="🗳">asenduq</annotation>
 		<annotation cp="🗳" type="tts" draft="unconfirmed">asenduq</annotation>
-		<annotation cp="✏" draft="unconfirmed">aɣnib</annotation>
+		<annotation cp="✏">imru</annotation>
 		<annotation cp="✏" type="tts" draft="unconfirmed">aɣnib</annotation>
 		<annotation cp="✒">imru n tricet aberkan</annotation>
 		<annotation cp="✒" type="tts" draft="unconfirmed">imru n tricet aberkan</annotation>

--- a/common/annotations/kk.xml
+++ b/common/annotations/kk.xml
@@ -1685,13 +1685,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫂" type="tts">құшақтасқан адамдар</annotation>
 		<annotation cp="👪">ана | әке | бала | отбасы</annotation>
 		<annotation cp="👪" type="tts">отбасы</annotation>
-		<annotation cp="🧑‍🧑‍🧒" draft="contributed">отбасы: ересек, ересек, бала</annotation>
+		<annotation cp="🧑‍🧑‍🧒" draft="contributed">екі ересек пен бір бала</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts" draft="contributed">отбасы: ересек, ересек, бала</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒" draft="contributed">отбасы: ересек, ересек, бала, бала</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒" draft="contributed">екі ересек пен екі бала</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts" draft="contributed">отбасы: ересек, ересек, бала, бала</annotation>
-		<annotation cp="🧑‍🧒" draft="contributed">отбасы: ересек, бала</annotation>
+		<annotation cp="🧑‍🧒" draft="contributed">бір ересек пен бір бала</annotation>
 		<annotation cp="🧑‍🧒" type="tts" draft="contributed">отбасы: ересек, бала</annotation>
-		<annotation cp="🧑‍🧒‍🧒" draft="contributed">отбасы: ересек, бала, бала</annotation>
+		<annotation cp="🧑‍🧒‍🧒" draft="contributed">бір ересек пен екі бала</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts" draft="contributed">отбасы: ересек, бала, бала</annotation>
 		<annotation cp="👣">аяқ іздері | дене | ізі | киім</annotation>
 		<annotation cp="👣" type="tts">аяқ іздері</annotation>
@@ -1873,11 +1873,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">тотықұс</annotation>
 		<annotation cp="🪽" draft="contributed">қанат</annotation>
 		<annotation cp="🪽" type="tts" draft="contributed">қанат</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">ұзақ</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">қара | қарға | құзғын қарға | құс</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">ұзақ</annotation>
 		<annotation cp="🪿" draft="contributed">қаз</annotation>
 		<annotation cp="🪿" type="tts" draft="contributed">қаз</annotation>
-		<annotation cp="🐦‍🔥" draft="contributed">феникс</annotation>
+		<annotation cp="🐦‍🔥" draft="contributed">қиял, қиял құс, фантастика, қайта туу | феникс</annotation>
 		<annotation cp="🐦‍🔥" type="tts" draft="contributed">феникс</annotation>
 		<annotation cp="🐸">бақа | бақаның беті | бет</annotation>
 		<annotation cp="🐸" type="tts">бақаның беті</annotation>
@@ -2019,7 +2019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🍊" type="tts">мандарин</annotation>
 		<annotation cp="🍋">жеміс | лимон | өсімдік | цитрус</annotation>
 		<annotation cp="🍋" type="tts">лимон</annotation>
-		<annotation cp="🍋‍🟩" draft="contributed">лайм</annotation>
+		<annotation cp="🍋‍🟩" draft="contributed">лайм | цитрус, жеміс, тропикалық</annotation>
 		<annotation cp="🍋‍🟩" type="tts" draft="contributed">лайм</annotation>
 		<annotation cp="🍌">банан | жеміс | өсімдік</annotation>
 		<annotation cp="🍌" type="tts">банан</annotation>
@@ -2079,11 +2079,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫘" type="tts">бұршақ</annotation>
 		<annotation cp="🌰">каштан | өсімдік</annotation>
 		<annotation cp="🌰" type="tts">каштан</annotation>
-		<annotation cp="🫚" draft="contributed">зімбір тамыры</annotation>
+		<annotation cp="🫚">дәмдеуіш | зімбір тамыры | сыра | тамыр</annotation>
 		<annotation cp="🫚" type="tts" draft="contributed">зімбір тамыры</annotation>
-		<annotation cp="🫛" draft="contributed">бұршаққынды асбұршақ</annotation>
+		<annotation cp="🫛">асбұршақ | бұршақ | бұршаққынды асбұршақ | көкөніс</annotation>
 		<annotation cp="🫛" type="tts" draft="contributed">бұршаққынды асбұршақ</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">қоңыр саңырауқұлақ</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">қоңыр саңырауқұлақ | саңырауқұлақ | тамақ, саңырауқұлақ, табиғат, көкөніс</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">қоңыр саңырауқұлақ</annotation>
 		<annotation cp="🍞">бөлке | нан</annotation>
 		<annotation cp="🍞" type="tts">нан</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">таяқ</annotation>
 		<annotation cp="🔗">шынжыр</annotation>
 		<annotation cp="🔗" type="tts">шынжыр</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">үзілген шынжыр</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">үзілген шынжыр | үзу, үзілу, шынжыр, кісен, еркіндік, бостандық</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">үзілген шынжыр</annotation>
 		<annotation cp="⛓">бізбек | тізбек</annotation>
 		<annotation cp="⛓" type="tts">тізбек</annotation>
@@ -3601,7 +3601,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🔆" type="tts">жарықтандыру түймесі</annotation>
 		<annotation cp="📶">антенна | антенна таяқшалары | жолақ | мобильді | телефон | ұялы</annotation>
 		<annotation cp="📶" type="tts">антенна таяқшалары</annotation>
-		<annotation cp="🛜" draft="contributed">сымсыз желі</annotation>
+		<annotation cp="🛜">желі | интернет | компьютер | сымсыз</annotation>
 		<annotation cp="🛜" type="tts" draft="contributed">сымсыз желі</annotation>
 		<annotation cp="📳">дірілдеу | дірілдеу режимі | мобильді | режим | телефон | ұялы</annotation>
 		<annotation cp="📳" type="tts">дірілдеу режимі</annotation>

--- a/common/annotations/mr.xml
+++ b/common/annotations/mr.xml
@@ -1685,11 +1685,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫂" type="tts">मिठी मारणार्‍या व्यक्ती</annotation>
 		<annotation cp="👪">कुटुंब</annotation>
 		<annotation cp="👪" type="tts">कुटुंब</annotation>
-		<annotation cp="🧑‍🧑‍🧒" draft="contributed">कुटुंब: प्रौढ, प्रौढ, मूल</annotation>
+		<annotation cp="🧑‍🧑‍🧒" draft="contributed">कुटुंब: प्रौढ, सज्ञान, मूल</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts" draft="contributed">कुटुंब: प्रौढ, प्रौढ, मूल</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" draft="contributed">कुटुंब: प्रौढ, सज्ञान, मूल, लहान मूल</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts" draft="contributed">कुटुंब: प्रौढ, सज्ञान, मूल, लहान मूल</annotation>
-		<annotation cp="🧑‍🧒" draft="contributed">कुटुंब: प्रौढ, मूल</annotation>
+		<annotation cp="🧑‍🧒" draft="contributed">कुटुंब: प्रौढ, लहान मूल</annotation>
 		<annotation cp="🧑‍🧒" type="tts" draft="contributed">कुटुंब: प्रौढ, मूल</annotation>
 		<annotation cp="🧑‍🧒‍🧒" draft="contributed">कुटुंब: प्रौढ, मूल, लहान मूल</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts" draft="contributed">कुटुंब: प्रौढ, मूल, लहान मूल</annotation>
@@ -2019,7 +2019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🍊" type="tts">नारंगी</annotation>
 		<annotation cp="🍋">फळ | लिंबू | लिंबूवर्गीय फळ</annotation>
 		<annotation cp="🍋" type="tts">लिंबू</annotation>
-		<annotation cp="🍋‍🟩" draft="contributed">लिंबूवर्गीय फळ</annotation>
+		<annotation cp="🍋‍🟩" draft="contributed">चुना | लिंबूवर्गीय, फळे, उष्णकटिबंधीय</annotation>
 		<annotation cp="🍋‍🟩" type="tts" draft="contributed">लिंबूवर्गीय फळ</annotation>
 		<annotation cp="🍌">केळ | केळं | फळ</annotation>
 		<annotation cp="🍌" type="tts">केळ</annotation>
@@ -2083,7 +2083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫚" type="tts">आले</annotation>
 		<annotation cp="🫛">कडधान्ये | घेवडा | बिन्स | भाजी | मटार | शेंगा</annotation>
 		<annotation cp="🫛" type="tts">मटार</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">तपकिरी मशरूम</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">अन्न, बुरशी, निसर्ग, भाजीपाला | तपकिरी मशरूम</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">तपकिरी मशरूम</annotation>
 		<annotation cp="🍞">ब्रेड | ब्रेडचा तुकडा | वडी</annotation>
 		<annotation cp="🍞" type="tts">ब्रेड</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">अंधांची काठी</annotation>
 		<annotation cp="🔗">साखळी</annotation>
 		<annotation cp="🔗" type="tts">साखळी</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">तुटलेली साखळी</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">तुटलेली साखळी | तोडणे, तोडणे, साखळी, कफ, स्वातंत्र्य</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">तुटलेली साखळी</annotation>
 		<annotation cp="⛓">चेन</annotation>
 		<annotation cp="⛓" type="tts">चेन</annotation>

--- a/common/annotations/pa.xml
+++ b/common/annotations/pa.xml
@@ -1873,7 +1873,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">ਤੋਤਾ</annotation>
 		<annotation cp="🪽">ਉੱਡਣਾ | ਹਵਾਬਾਜ਼ੀ | ਦੈਵੀ | ਪੰਖ | ਪੰਛੀ | ਮਿਥਿਹਾਸ</annotation>
 		<annotation cp="🪽" type="tts">ਪੰਖ</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">ਕਾਲਾ ਪੰਛੀ</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">ਕਾਂ | ਕਾਲਾ ਪੰਛੀ | ਰੂਕ</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">ਕਾਲਾ ਪੰਛੀ</annotation>
 		<annotation cp="🪿">ਸ਼ਿਕਾਰ | ਜੰਗਲੀ ਬੱਤਖ ਦੀ ਅਵਾਜ਼ | ਪੰਛੀ | ਬੱਤਖ ਦੀ ਨਸਲ ਦਾ ਪੰਛੀ | ਮੂਰਖ</annotation>
 		<annotation cp="🪿" type="tts">ਬੱਤਖ ਦੀ ਨਸਲ ਦਾ ਪੰਛੀ</annotation>

--- a/common/annotations/pt_PT.xml
+++ b/common/annotations/pt_PT.xml
@@ -1874,7 +1874,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">↑↑↑</annotation>
 		<annotation cp="🪽">angelical | asa | ave | aviação | mitologia | pássaro | voar</annotation>
 		<annotation cp="🪽" type="tts">↑↑↑</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">pássaro preto</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">ave | corvo | gralha | pássaro | preto</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">↑↑↑</annotation>
 		<annotation cp="🪿">ave | ganso | grasnido | pássaro | pateta</annotation>
 		<annotation cp="🪿" type="tts">↑↑↑</annotation>

--- a/common/annotations/ru.xml
+++ b/common/annotations/ru.xml
@@ -407,17 +407,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∗" type="tts">оператор звездочки</annotation>
 		<annotation cp="∘" draft="contributed">кольцевой оператор</annotation>
 		<annotation cp="∘" type="tts">кольцевой оператор</annotation>
-		<annotation cp="∙" draft="contributed">оператор произведения</annotation>
+		<annotation cp="∙" draft="contributed">буллет-оператор | оператор | оператор произведения</annotation>
 		<annotation cp="∙" type="tts" draft="contributed">оператор произведения</annotation>
 		<annotation cp="√">знак корня | иррациональное число | квадратный | корень | радикал</annotation>
 		<annotation cp="√" type="tts">квадратный корень</annotation>
-		<annotation cp="∝" draft="contributed">пропорционально</annotation>
+		<annotation cp="∝" draft="contributed">пропорционально | пропорциональность</annotation>
 		<annotation cp="∝" type="tts" draft="contributed">пропорционально</annotation>
 		<annotation cp="∞">бесконечность | знак бесконечности</annotation>
 		<annotation cp="∞" type="tts">знак бесконечности</annotation>
-		<annotation cp="∟" draft="contributed">прямой угол</annotation>
+		<annotation cp="∟" draft="contributed">математика | правый угол | прямой угол</annotation>
 		<annotation cp="∟" type="tts" draft="contributed">прямой угол</annotation>
-		<annotation cp="∠" draft="contributed">острый угол</annotation>
+		<annotation cp="∠" draft="contributed">острый угол | угол</annotation>
 		<annotation cp="∠" type="tts" draft="contributed">острый угол</annotation>
 		<annotation cp="∣">вертикальная линия | разделительная черта | разделяет</annotation>
 		<annotation cp="∣" type="tts">разделяет</annotation>
@@ -429,9 +429,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∩" type="tts">пересечение</annotation>
 		<annotation cp="∪">множество | объединение | совокупность</annotation>
 		<annotation cp="∪" type="tts">объединение</annotation>
-		<annotation cp="∫" draft="contributed">интеграл</annotation>
+		<annotation cp="∫" draft="contributed">интеграл | математический анализ</annotation>
 		<annotation cp="∫" type="tts" draft="contributed">интеграл</annotation>
-		<annotation cp="∬" draft="contributed">двойной интеграл</annotation>
+		<annotation cp="∬" draft="contributed">двойной интеграл | математический анализ</annotation>
 		<annotation cp="∬" type="tts" draft="contributed">двойной интеграл</annotation>
 		<annotation cp="∮">интеграл по замкнутому контуру | интеграл по контуру | криволинейный интеграл</annotation>
 		<annotation cp="∮" type="tts">интеграл по замкнутому контуру</annotation>
@@ -457,7 +457,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="≈" type="tts">приблизительно равно</annotation>
 		<annotation cp="≌">все равны | математика | равенство</annotation>
 		<annotation cp="≌" type="tts">все равны</annotation>
-		<annotation cp="≒" draft="contributed">приблизительное равенство</annotation>
+		<annotation cp="≒" draft="contributed">знак приблизительного равенства | приблизительное равенство</annotation>
 		<annotation cp="≒" type="tts" draft="contributed">приблизительное равенство</annotation>
 		<annotation cp="≖">кольцо в равно | математика | равенство</annotation>
 		<annotation cp="≖" type="tts">кольцо в равно</annotation>
@@ -513,7 +513,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⊞" type="tts">плюс в квадрате</annotation>
 		<annotation cp="⊟">вычитание | знак минуса | математика | минус | минус в квадрате</annotation>
 		<annotation cp="⊟" type="tts">минус в квадрате</annotation>
-		<annotation cp="⊥" draft="contributed">вертикальный шип</annotation>
+		<annotation cp="⊥" draft="contributed">вертикальный шип | фальсум | шип</annotation>
 		<annotation cp="⊥" type="tts" draft="contributed">вертикальный шип</annotation>
 		<annotation cp="⊮">не влечет</annotation>
 		<annotation cp="⊮" type="tts">не влечет</annotation>
@@ -2019,7 +2019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🍊" type="tts">мандарин</annotation>
 		<annotation cp="🍋">лимон | фрукт | цитрус | цитрусовый</annotation>
 		<annotation cp="🍋" type="tts">лимон</annotation>
-		<annotation cp="🍋‍🟩" draft="contributed">лайм</annotation>
+		<annotation cp="🍋‍🟩" draft="contributed">лайм | тропический | фрукт | цитрус | цитрусовый</annotation>
 		<annotation cp="🍋‍🟩" type="tts" draft="contributed">лайм</annotation>
 		<annotation cp="🍌">банан | фрукт</annotation>
 		<annotation cp="🍌" type="tts">банан</annotation>
@@ -2083,7 +2083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫚" type="tts">корень имбиря</annotation>
 		<annotation cp="🫛">бобовые | бобы | горох | овощ | стручок | стручок гороха | эдамамэ</annotation>
 		<annotation cp="🫛" type="tts">стручок гороха</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">бурый гриб</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">бурый гриб | гриб | еда | овощ | природа</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">бурый гриб</annotation>
 		<annotation cp="🍞">батон | буханка | хлеб</annotation>
 		<annotation cp="🍞" type="tts">хлеб</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">белая трость</annotation>
 		<annotation cp="🔗">гиперссылка | звенья | связывание | связь | ссылка</annotation>
 		<annotation cp="🔗" type="tts">гиперссылка</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">разорванная цепь</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">оковы | разорванная цепь | разорвать | разрыв | свобода | цепь</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">разорванная цепь</annotation>
 		<annotation cp="⛓">звенья | цепочка | цепь</annotation>
 		<annotation cp="⛓" type="tts">цепь</annotation>

--- a/common/annotations/sq.xml
+++ b/common/annotations/sq.xml
@@ -2275,7 +2275,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🥄" type="tts">lugë</annotation>
 		<annotation cp="🔪">armë | gatim | thikë | thikë kuzhine | vegël</annotation>
 		<annotation cp="🔪" type="tts">thikë kuzhine</annotation>
-		<annotation cp="🫙" draft="contributed">kanë</annotation>
+		<annotation cp="🫙">erëza | kavanoz | rezervë | vazo</annotation>
 		<annotation cp="🫙" type="tts" draft="contributed">kanë</annotation>
 		<annotation cp="🏺">amforë | armë | ujori | vegël | zodiak</annotation>
 		<annotation cp="🏺" type="tts">amforë</annotation>
@@ -3601,7 +3601,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🔆" type="tts">butoni i ndriçimit</annotation>
 		<annotation cp="📶">antenë | celular | shirit | shiritat e antenës | sinjal</annotation>
 		<annotation cp="📶" type="tts">shiritat e antenës</annotation>
-		<annotation cp="🛜" draft="contributed">lidhje me valë</annotation>
+		<annotation cp="🛜">internet | kompjuter | pa tel | rrjet</annotation>
 		<annotation cp="🛜" type="tts" draft="contributed">lidhje me valë</annotation>
 		<annotation cp="📳">celular | dridhje | modalitet | modaliteti i dridhjeve | telefon</annotation>
 		<annotation cp="📳" type="tts">modaliteti i dridhjeve</annotation>
@@ -3621,7 +3621,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="➖" type="tts">shenja minus e trashë</annotation>
 		<annotation cp="➗">matematikë | ndarje | shenja e pjesëtimit e trashë</annotation>
 		<annotation cp="➗" type="tts">shenja e pjesëtimit e trashë</annotation>
-		<annotation cp="🟰" draft="contributed">shenjë e fortë barazie</annotation>
+		<annotation cp="🟰">barazi | matematikë | shenja e barazimit e trashë</annotation>
 		<annotation cp="🟰" type="tts" draft="contributed">shenjë e fortë barazie</annotation>
 		<annotation cp="♾">pafundësi | pakufi | përgjithmonë | universale</annotation>
 		<annotation cp="♾" type="tts">pafundësi</annotation>

--- a/common/annotations/sv.xml
+++ b/common/annotations/sv.xml
@@ -811,9 +811,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🤥" type="tts">ljugande ansikte</annotation>
 		<annotation cp="🫨">ansikte | jordbävning | shock | skakande | vibrera</annotation>
 		<annotation cp="🫨" type="tts">skakande ansikte</annotation>
-		<annotation cp="🙂‍↔" draft="contributed">huvud skakar horisontellt</annotation>
+		<annotation cp="🙂‍↔" draft="contributed">huvud skakar horisontellt | skakar nej</annotation>
 		<annotation cp="🙂‍↔" type="tts" draft="contributed">huvud skakar horisontellt</annotation>
-		<annotation cp="🙂‍↕" draft="contributed">huvud skakar vertikalt</annotation>
+		<annotation cp="🙂‍↕" draft="contributed">huvud skakar vertikalt | nickar ja</annotation>
 		<annotation cp="🙂‍↕" type="tts" draft="contributed">huvud skakar vertikalt</annotation>
 		<annotation cp="😌">lättat ansikte | lättnad</annotation>
 		<annotation cp="😌" type="tts">lättat ansikte</annotation>
@@ -2083,7 +2083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫚" type="tts">ingefära</annotation>
 		<annotation cp="🫛">ärta | ärtskida | bönor | edamame | grönsaker</annotation>
 		<annotation cp="🫛" type="tts">ärtskida</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">brun svamp</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">brun flugsvamp | brunsvamp | grönsaker | mat | natur | sopp</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">brun svamp</annotation>
 		<annotation cp="🍞">bröd | limpa</annotation>
 		<annotation cp="🍞" type="tts">bröd</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">blindkäpp</annotation>
 		<annotation cp="🔗">länk | länkar | länksymbol | två ringar</annotation>
 		<annotation cp="🔗" type="tts">länk</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">bruten länk</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">boja | bryta | frihet | kedja</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">bruten länk</annotation>
 		<annotation cp="⛓">kedja | kedjor</annotation>
 		<annotation cp="⛓" type="tts">kedjor</annotation>

--- a/common/annotations/sw.xml
+++ b/common/annotations/sw.xml
@@ -25,7 +25,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🏾" type="tts">ngozi nyeusi kiasi</annotation>
 		<annotation cp="🏿">kibadilisha emoji | ngozi nyeusi | nyeusi | sura</annotation>
 		<annotation cp="🏿" type="tts">ngozi nyeusi</annotation>
-		<annotation cp="‾" draft="contributed">kistari cha juu</annotation>
+		<annotation cp="‾" draft="contributed">kata juu | kistari cha juu | kiunganishi</annotation>
 		<annotation cp="‾" type="tts" draft="contributed">kistari cha juu</annotation>
 		<annotation cp="_">kistari | kistari chini | mstari | mstari chini | mstari wa chini</annotation>
 		<annotation cp="_" type="tts">mstari wa chini</annotation>
@@ -63,7 +63,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="¿" type="tts">alama ya kuuliza iliyopinduliwa</annotation>
 		<annotation cp="؟">alama ya kuuliza | alama ya kuuliza ya kiarabu | kiarabu | swali</annotation>
 		<annotation cp="؟" type="tts">alama ya kuuliza ya kiarabu</annotation>
-		<annotation cp="‽" draft="contributed">kibalagha</annotation>
+		<annotation cp="‽" draft="contributed">balagha | kinaya</annotation>
 		<annotation cp="‽" type="tts" draft="contributed">kibalagha</annotation>
 		<annotation cp=".">alama ya kikomo | kikomo | nukta</annotation>
 		<annotation cp="." type="tts">kikomo</annotation>
@@ -165,7 +165,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="‸" type="tts" draft="contributed">kareti</annotation>
 		<annotation cp="※">alama ya kurejelea</annotation>
 		<annotation cp="※" type="tts">alama ya kurejelea</annotation>
-		<annotation cp="⁂" draft="contributed">vinyota</annotation>
+		<annotation cp="⁂" draft="contributed">dinku | nyota | vinyota</annotation>
 		<annotation cp="⁂" type="tts" draft="contributed">vinyota</annotation>
 		<annotation cp="`">lafudhi | lafudhi ya kuu | toni</annotation>
 		<annotation cp="`" type="tts">lafudhi ya kuu</annotation>
@@ -223,7 +223,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↬" type="tts" draft="contributed">kishale kilichosokota kinachoelekea kulia</annotation>
 		<annotation cp="↭" draft="contributed">kishale cha kiwimbi chenye ncha pande mbili</annotation>
 		<annotation cp="↭" type="tts" draft="contributed">kishale cha kiwimbi chenye ncha pande mbili</annotation>
-		<annotation cp="↯" draft="contributed">zigizagi yenye kishale kinachoelekea chini</annotation>
+		<annotation cp="↯" draft="contributed">zigizagi | zigizagi yenye kishale kinachoelekea chini</annotation>
 		<annotation cp="↯" type="tts" draft="contributed">zigizagi yenye kishale kinachoelekea chini</annotation>
 		<annotation cp="↰" draft="contributed">kishale kinachoelekea juu chenye ncha iliyopinda kushoto</annotation>
 		<annotation cp="↰" type="tts" draft="contributed">kishale kinachoelekea juu chenye ncha iliyopinda kushoto</annotation>
@@ -241,29 +241,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↶" type="tts" draft="contributed">kishale nusu mviringo kinachoelekea kinyume saa</annotation>
 		<annotation cp="↷" draft="contributed">kishale nusu mviringo kinachoelekea kisaa</annotation>
 		<annotation cp="↷" type="tts" draft="contributed">kishale nusu mviringo kinachoelekea kisaa</annotation>
-		<annotation cp="↸" draft="contributed">kishale cha upau wa kasakazini magharibi</annotation>
+		<annotation cp="↸" draft="contributed">kishale cha kaskazini magharibi kinachoegemea upao</annotation>
 		<annotation cp="↸" type="tts" draft="contributed">kishale cha upau wa kasakazini magharibi</annotation>
-		<annotation cp="↹" draft="contributed">kishale kinachoelekea kushoto juu ya kishale kinachoelekea kulia</annotation>
+		<annotation cp="↹" draft="contributed">kishale | kushoto | upao | vishale vya upau wa kushoto juu ya kulia</annotation>
 		<annotation cp="↹" type="tts" draft="contributed">kishale kinachoelekea kushoto juu ya kishale kinachoelekea kulia</annotation>
 		<annotation cp="↺" draft="contributed">kishale cha mviringo wazi kinachoelekea kinyume cha saa</annotation>
 		<annotation cp="↺" type="tts" draft="contributed">kishale cha mviringo wazi kinachoelekea kinyume cha saa</annotation>
 		<annotation cp="↻" draft="contributed">kishale cha mviringo wazi kinachoelekea kisaa</annotation>
 		<annotation cp="↻" type="tts" draft="contributed">kishale cha mviringo wazi kinachoelekea kisaa</annotation>
-		<annotation cp="↼" draft="contributed">chusa chenye chembe inayoelekea juu kushoto</annotation>
+		<annotation cp="↼" draft="contributed">chembe | chusa chenye chembe inayoelekea juu kushoto</annotation>
 		<annotation cp="↼" type="tts" draft="contributed">chusa chenye chembe inayoelekea juu kushoto</annotation>
-		<annotation cp="↽" draft="contributed">chusa chenye chembe inayoelekea chini kushoto</annotation>
+		<annotation cp="↽" draft="contributed">chembe | chusa chenye chembe inayoelekea chini kushoto</annotation>
 		<annotation cp="↽" type="tts" draft="contributed">chusa chenye chembe inayoelekea chini kushoto</annotation>
-		<annotation cp="↾" draft="contributed">chusa kinachoelekea juu chenye chembe cha kulia</annotation>
+		<annotation cp="↾" draft="contributed">chembe | chusa kinachoelekea juu chenye chembe cha kulia</annotation>
 		<annotation cp="↾" type="tts" draft="contributed">chusa kinachoelekea juu chenye chembe cha kulia</annotation>
-		<annotation cp="↿" draft="contributed">chusa kinachoelekea juu chenye chembe cha kushoto</annotation>
+		<annotation cp="↿" draft="contributed">chembe | chembe cha chusa kinachoelekea juu</annotation>
 		<annotation cp="↿" type="tts" draft="contributed">chusa kinachoelekea juu chenye chembe cha kushoto</annotation>
-		<annotation cp="⇀" draft="contributed">chusa chenye chembe inayoelekea juu kulia</annotation>
+		<annotation cp="⇀" draft="contributed">chembe | chusa chenye chembe inayoelekea juu kulia</annotation>
 		<annotation cp="⇀" type="tts" draft="contributed">chusa chenye chembe inayoelekea juu kulia</annotation>
-		<annotation cp="⇁" draft="contributed">chusa chenye chembe inayoelekea chini kulia</annotation>
+		<annotation cp="⇁" draft="contributed">chembe | chusa chenye chembe inayoelekea chini kulia</annotation>
 		<annotation cp="⇁" type="tts" draft="contributed">chusa chenye chembe inayoelekea chini kulia</annotation>
-		<annotation cp="⇂" draft="contributed">chusa kinachoelekea chini chenye chembe cha kulia</annotation>
+		<annotation cp="⇂">chusa | chusa kinachoelekea chini chenye chembe cha kulia</annotation>
 		<annotation cp="⇂" type="tts" draft="contributed">chusa kinachoelekea chini chenye chembe cha kulia</annotation>
-		<annotation cp="⇃" draft="contributed">chusa kinachoelekea chini chenye chembe cha kushoto</annotation>
+		<annotation cp="⇃" draft="contributed">chembe | chusa kinachoelekea chini chenye chembe cha kushoto</annotation>
 		<annotation cp="⇃" type="tts" draft="contributed">chusa kinachoelekea chini chenye chembe cha kushoto</annotation>
 		<annotation cp="⇄" draft="contributed">kishale cha kulia juu ya kishale cha kushoto</annotation>
 		<annotation cp="⇄" type="tts" draft="contributed">kishale cha kulia juu ya kishale cha kushoto</annotation>
@@ -343,13 +343,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⇪" type="tts" draft="contributed">kishale wazi chenye mkato kinachoelekea juu</annotation>
 		<annotation cp="⇵" draft="contributed">kishale cha kushoto chini cha kulia juu</annotation>
 		<annotation cp="⇵" type="tts" draft="contributed">kishale cha kushoto chini cha kulia juu</annotation>
-		<annotation cp="∀" draft="contributed">kwa yote</annotation>
+		<annotation cp="∀" draft="contributed">ikiwa | jumla | kwa yote | yote | yoyote</annotation>
 		<annotation cp="∀" type="tts" draft="contributed">kwa yote</annotation>
-		<annotation cp="∂" draft="contributed">mgawango tenguo</annotation>
+		<annotation cp="∂" draft="contributed">mgawango tenguo | tenguo</annotation>
 		<annotation cp="∂" type="tts" draft="contributed">mgawango tenguo</annotation>
 		<annotation cp="∃" draft="contributed">kuna</annotation>
 		<annotation cp="∃" type="tts" draft="contributed">kuna</annotation>
-		<annotation cp="∅" draft="contributed">seti kapa</annotation>
+		<annotation cp="∅" draft="contributed">hesabu | seti kapa | ukokotoaji</annotation>
 		<annotation cp="∅" type="tts" draft="contributed">seti kapa</annotation>
 		<annotation cp="∆">nyongeza | pembetatu</annotation>
 		<annotation cp="∆" type="tts">nyongeza</annotation>
@@ -357,15 +357,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="∇" type="tts">nabla</annotation>
 		<annotation cp="∈">inajumuisha | memba | memba ya | seti | umemba</annotation>
 		<annotation cp="∈" type="tts">memba ya</annotation>
-		<annotation cp="∉" draft="contributed">si memba</annotation>
+		<annotation cp="∉" draft="contributed">memba | si memba</annotation>
 		<annotation cp="∉" type="tts" draft="contributed">si memba</annotation>
-		<annotation cp="∋" draft="contributed">ina kama memba</annotation>
+		<annotation cp="∋" draft="contributed">ina kama memba | memba</annotation>
 		<annotation cp="∋" type="tts" draft="contributed">ina kama memba</annotation>
-		<annotation cp="∎" draft="contributed">mwisho wa thibitisho</annotation>
+		<annotation cp="∎" draft="contributed">halmosi | mwisho wa thibitisho | q.e.d | qed</annotation>
 		<annotation cp="∎" type="tts" draft="contributed">mwisho wa thibitisho</annotation>
-		<annotation cp="∏" draft="contributed">zao la mpango wa n</annotation>
+		<annotation cp="∏" draft="contributed">mantiki | zao | zao la mpango wa n</annotation>
 		<annotation cp="∏" type="tts" draft="contributed">zao la mpango wa n</annotation>
-		<annotation cp="∑" draft="contributed">jumla ya mpango wa n</annotation>
+		<annotation cp="∑" draft="contributed">hisabati | jumla ya mpango wa n | ujumlishaji</annotation>
 		<annotation cp="∑" type="tts" draft="contributed">jumla ya mpango wa n</annotation>
 		<annotation cp="+">alama ya kujumlisha | jumlisha | ongeza</annotation>
 		<annotation cp="+" type="tts">alama ya kujumlisha</annotation>
@@ -377,7 +377,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="×" type="tts">alama ya kuzidisha</annotation>
 		<annotation cp="&lt;">chini ya | lebo | lebo ya kufungua</annotation>
 		<annotation cp="&lt;" type="tts">chini ya</annotation>
-		<annotation cp="≮" draft="contributed">si chini ya</annotation>
+		<annotation cp="≮" draft="contributed">hisabati | si chini ya | si sawa</annotation>
 		<annotation cp="≮" type="tts" draft="contributed">si chini ya</annotation>
 		<annotation cp="=">inalingana na | lingana</annotation>
 		<annotation cp="=" type="tts">lingana</annotation>
@@ -385,7 +385,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="≠" type="tts">hailingani</annotation>
 		<annotation cp="&gt;">lebo | lebo ya kufunga | zaidi ya</annotation>
 		<annotation cp="&gt;" type="tts">zaidi ya</annotation>
-		<annotation cp="≯" draft="contributed">si zaidi ya</annotation>
+		<annotation cp="≯" draft="contributed">hisabati | si sawa | si zaidi ya</annotation>
 		<annotation cp="≯" type="tts" draft="contributed">si zaidi ya</annotation>
 		<annotation cp="¬">sio | uhasi</annotation>
 		<annotation cp="¬" type="tts">uhasi</annotation>
@@ -397,163 +397,163 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="−" type="tts">alama ya kutoa</annotation>
 		<annotation cp="⁻">alama ya kutoa | alama ya kutoa ya juu | juu</annotation>
 		<annotation cp="⁻" type="tts">alama ya kutoa ya juu</annotation>
-		<annotation cp="∓" draft="contributed">jumlisha au toa</annotation>
+		<annotation cp="∓" draft="contributed">jumlisha au toa | jumlisha toa</annotation>
 		<annotation cp="∓" type="tts" draft="contributed">jumlisha au toa</annotation>
-		<annotation cp="∕" draft="contributed">deshi ya gawanya</annotation>
+		<annotation cp="∕" draft="contributed">deshi ya gawanya | mkato | sleshi</annotation>
 		<annotation cp="∕" type="tts" draft="contributed">deshi ya gawanya</annotation>
-		<annotation cp="⁄" draft="contributed">mkato wa sehemu</annotation>
+		<annotation cp="⁄" draft="contributed">mkato wa sehemu | mkwaju</annotation>
 		<annotation cp="⁄" type="tts" draft="contributed">mkato wa sehemu</annotation>
-		<annotation cp="∗" draft="contributed">kinyota cha kukokotoa</annotation>
+		<annotation cp="∗" draft="contributed">fomula ya kinyota | nyota</annotation>
 		<annotation cp="∗" type="tts" draft="contributed">kinyota cha kukokotoa</annotation>
-		<annotation cp="∘" draft="contributed">kiduara cha kukokotoa</annotation>
+		<annotation cp="∘" draft="contributed">kiduara cha kukokotoa | kikokotoo | kivungo</annotation>
 		<annotation cp="∘" type="tts" draft="contributed">kiduara cha kukokotoa</annotation>
-		<annotation cp="∙" draft="contributed">nukta ya kukokotoa</annotation>
+		<annotation cp="∙" draft="contributed">kikokotoo | nukta ya kukokotoa</annotation>
 		<annotation cp="∙" type="tts" draft="contributed">nukta ya kukokotoa</annotation>
 		<annotation cp="√">isiyoeleweka | kipeo | kipeo cha pili | mraba | mzizi</annotation>
 		<annotation cp="√" type="tts">kipeo cha pili</annotation>
-		<annotation cp="∝" draft="contributed">kadiri</annotation>
+		<annotation cp="∝" draft="contributed">kadiri | ulinganifu</annotation>
 		<annotation cp="∝" type="tts" draft="contributed">kadiri</annotation>
 		<annotation cp="∞">alama ya isiyokoma | isiyokoma</annotation>
 		<annotation cp="∞" type="tts">alama ya isiyokoma</annotation>
-		<annotation cp="∟" draft="contributed">pembe mraba</annotation>
+		<annotation cp="∟" draft="contributed">hesabati | pembe mraba</annotation>
 		<annotation cp="∟" type="tts" draft="contributed">pembe mraba</annotation>
-		<annotation cp="∠" draft="contributed">pembe</annotation>
+		<annotation cp="∠" draft="contributed">kali | pembe</annotation>
 		<annotation cp="∠" type="tts" draft="contributed">pembe</annotation>
-		<annotation cp="∣" draft="contributed">hugawanya</annotation>
+		<annotation cp="∣" draft="contributed">hugawanya | kigawanyi</annotation>
 		<annotation cp="∣" type="tts" draft="contributed">hugawanya</annotation>
 		<annotation cp="∥" draft="contributed">sambamba</annotation>
 		<annotation cp="∥" type="tts" draft="contributed">sambamba</annotation>
-		<annotation cp="∧" draft="contributed">mantiki na</annotation>
+		<annotation cp="∧" draft="contributed">kabari | mantiki</annotation>
 		<annotation cp="∧" type="tts" draft="contributed">mantiki na</annotation>
 		<annotation cp="∩">seti | ungano</annotation>
 		<annotation cp="∩" type="tts">ungano</annotation>
 		<annotation cp="∪">mkusanyiko | muungano | seti</annotation>
 		<annotation cp="∪" type="tts">muungano</annotation>
-		<annotation cp="∫" draft="contributed">rejeo</annotation>
+		<annotation cp="∫" draft="contributed">kalkulasi | rejeo</annotation>
 		<annotation cp="∫" type="tts" draft="contributed">rejeo</annotation>
-		<annotation cp="∬" draft="contributed">rejeo mbili</annotation>
+		<annotation cp="∬" draft="contributed">kalkulasi | rejeo mbili</annotation>
 		<annotation cp="∬" type="tts" draft="contributed">rejeo mbili</annotation>
 		<annotation cp="∮" draft="contributed">rejeo ya kontua</annotation>
 		<annotation cp="∮" type="tts" draft="contributed">rejeo ya kontua</annotation>
-		<annotation cp="∴" draft="contributed">hivyo basi</annotation>
+		<annotation cp="∴" draft="contributed">hivyo basi | mantiki</annotation>
 		<annotation cp="∴" type="tts" draft="contributed">hivyo basi</annotation>
-		<annotation cp="∵" draft="contributed">kwa sababu</annotation>
+		<annotation cp="∵" draft="contributed">kwa sababu | mantiki</annotation>
 		<annotation cp="∵" type="tts" draft="contributed">kwa sababu</annotation>
 		<annotation cp="∶" draft="contributed">uwiano</annotation>
 		<annotation cp="∶" type="tts" draft="contributed">uwiano</annotation>
-		<annotation cp="∷" draft="contributed">kiwango</annotation>
+		<annotation cp="∷" draft="contributed">kadiri | uwianisho</annotation>
 		<annotation cp="∷" type="tts" draft="contributed">kiwango</annotation>
-		<annotation cp="∼" draft="contributed">kiwimbi cha kikokotoo</annotation>
+		<annotation cp="∼" draft="contributed">fomula | kiwimbi cha kikokotoo</annotation>
 		<annotation cp="∼" type="tts" draft="contributed">kiwimbi cha kikokotoo</annotation>
-		<annotation cp="∽" draft="contributed">kiwimbi kinyume</annotation>
+		<annotation cp="∽" draft="contributed">kiwimbi | kiwimbi kinyume</annotation>
 		<annotation cp="∽" type="tts" draft="contributed">kiwimbi kinyume</annotation>
 		<annotation cp="∾" draft="contributed">s iliyopindwa kulala</annotation>
 		<annotation cp="∾" type="tts" draft="contributed">s iliyopindwa kulala</annotation>
-		<annotation cp="≃" draft="contributed">usawa usopacha</annotation>
+		<annotation cp="≃" draft="contributed">asimptoti | hesabu | usawa usopacha</annotation>
 		<annotation cp="≃" type="tts" draft="contributed">usawa usopacha</annotation>
-		<annotation cp="≅" draft="contributed">karibia sawa na</annotation>
+		<annotation cp="≅" draft="contributed">aisomofu | hesabu | karibu sawa na | usawa</annotation>
 		<annotation cp="≅" type="tts" draft="contributed">karibia sawa na</annotation>
 		<annotation cp="≈">kadirio | karibia | karibu inalingana</annotation>
 		<annotation cp="≈" type="tts">karibu inalingana</annotation>
-		<annotation cp="≌" draft="contributed">yote sawa</annotation>
+		<annotation cp="≌" draft="contributed">hesabu | usawa | yote sawa</annotation>
 		<annotation cp="≌" type="tts" draft="contributed">yote sawa</annotation>
 		<annotation cp="≒" draft="contributed">inakaribia kuwa sawa na picha</annotation>
 		<annotation cp="≒" type="tts" draft="contributed">inakaribia kuwa sawa na picha</annotation>
-		<annotation cp="≖" draft="contributed">usawa wa kujumlisha</annotation>
+		<annotation cp="≖" draft="contributed">hisabati | usawa | usawa wa kujumlisha</annotation>
 		<annotation cp="≖" type="tts" draft="contributed">usawa wa kujumlisha</annotation>
 		<annotation cp="≡">hasa | inafanana | inafanana na | mara tatu</annotation>
 		<annotation cp="≡" type="tts">inafanana na</annotation>
-		<annotation cp="≣" draft="contributed">ni sawa kabisa</annotation>
+		<annotation cp="≣" draft="contributed">hesabu | sawa kabisa | usawa</annotation>
 		<annotation cp="≣" type="tts" draft="contributed">ni sawa kabisa</annotation>
 		<annotation cp="≤">chini ya | chini ya au lingana | inalingana | kutokuwa sawa | lingana</annotation>
 		<annotation cp="≤" type="tts">chini ya au lingana</annotation>
 		<annotation cp="≥">inalingana | kutokuwa sawa | lingana | zaidi ya | zaidi ya au lingana</annotation>
 		<annotation cp="≥" type="tts">zaidi ya au lingana</annotation>
-		<annotation cp="≦" draft="contributed">chini ya juu ya sawa</annotation>
+		<annotation cp="≦" draft="contributed">chini ya juu ya sawa | hisabati | kukosa usawa</annotation>
 		<annotation cp="≦" type="tts" draft="contributed">chini ya juu ya sawa</annotation>
-		<annotation cp="≧" draft="contributed">zaidi ya juu ya sawa</annotation>
+		<annotation cp="≧" draft="contributed">hesabu | ukosefu wa usawa | zaidi ya juu ya sawa</annotation>
 		<annotation cp="≧" type="tts" draft="contributed">zaidi ya juu ya sawa</annotation>
-		<annotation cp="≪" draft="contributed">chache zaidi ya</annotation>
+		<annotation cp="≪" draft="contributed">chache zaidi ya | hesabu | ukosefu wa usawa</annotation>
 		<annotation cp="≪" type="tts" draft="contributed">chache zaidi ya</annotation>
-		<annotation cp="≫" draft="contributed">kubwa zaidi ya</annotation>
+		<annotation cp="≫" draft="contributed">hesabu | kubwa zaidi ya | ukosefu wa usawa</annotation>
 		<annotation cp="≫" type="tts" draft="contributed">kubwa zaidi ya</annotation>
 		<annotation cp="≬" draft="contributed">kati ya</annotation>
 		<annotation cp="≬" type="tts" draft="contributed">kati ya</annotation>
-		<annotation cp="≳" draft="contributed">kisawe cha kubwa kuliko</annotation>
+		<annotation cp="≳" draft="contributed">hisabati | kisawe cha kubwa kuliko | ukosefu wa usawa</annotation>
 		<annotation cp="≳" type="tts" draft="contributed">kisawe cha kubwa kuliko</annotation>
-		<annotation cp="≺" draft="contributed">inatangulia</annotation>
+		<annotation cp="≺" draft="contributed">hisabati | inatangulia | kigawanyaji cha seti</annotation>
 		<annotation cp="≺" type="tts" draft="contributed">inatangulia</annotation>
-		<annotation cp="≻" draft="contributed">inafuata</annotation>
+		<annotation cp="≻" draft="contributed">hisabati | inafuata | kigawanyaji cha seti</annotation>
 		<annotation cp="≻" type="tts" draft="contributed">inafuata</annotation>
-		<annotation cp="⊁" draft="contributed">haifuati</annotation>
+		<annotation cp="⊁" draft="contributed">haifuati | hisabati | kigawanyaji cha seti</annotation>
 		<annotation cp="⊁" type="tts" draft="contributed">haifuati</annotation>
 		<annotation cp="⊂">seti | seti ndogo | seti ndogo ya</annotation>
 		<annotation cp="⊂" type="tts">seti ndogo ya</annotation>
-		<annotation cp="⊃" draft="contributed">seti kuu</annotation>
+		<annotation cp="⊃" draft="contributed">hisabati | kigawanyaji cha seti | seti kuu</annotation>
 		<annotation cp="⊃" type="tts" draft="contributed">seti kuu</annotation>
 		<annotation cp="⊆" draft="contributed">sawa na seti ndogo</annotation>
 		<annotation cp="⊆" type="tts" draft="contributed">sawa na seti ndogo</annotation>
-		<annotation cp="⊇" draft="contributed">sawa na seti kuu</annotation>
+		<annotation cp="⊇" draft="contributed">hisabati | sawa na seti kuu | usawa</annotation>
 		<annotation cp="⊇" type="tts" draft="contributed">sawa na seti kuu</annotation>
-		<annotation cp="⊕" draft="contributed">jumlisha kwenye duara</annotation>
+		<annotation cp="⊕" draft="contributed">jumlisha | jumlisha kwenye duara</annotation>
 		<annotation cp="⊕" type="tts" draft="contributed">jumlisha kwenye duara</annotation>
-		<annotation cp="⊖" draft="contributed">ondoa kwenye duara</annotation>
+		<annotation cp="⊖" draft="contributed">mmomonyoko | ondoa kwenye duara | utofauti pacha</annotation>
 		<annotation cp="⊖" type="tts" draft="contributed">ondoa kwenye duara</annotation>
-		<annotation cp="⊗" draft="contributed">zidisha kwenye duara</annotation>
+		<annotation cp="⊗" draft="contributed">tokeo | uzidishaji | zidisha kwenye duara</annotation>
 		<annotation cp="⊗" type="tts" draft="contributed">zidisha kwenye duara</annotation>
-		<annotation cp="⊘" draft="contributed">gawanya kwenye duara</annotation>
+		<annotation cp="⊘" draft="contributed">gawanya kwenye duara | hisabati | kama kugawa</annotation>
 		<annotation cp="⊘" type="tts" draft="contributed">gawanya kwenye duara</annotation>
-		<annotation cp="⊙" draft="contributed">nukta ya kukokotoa kwenye duara</annotation>
+		<annotation cp="⊙" draft="contributed">kigawanyaji | nukta ya kukokotoa kwenye duara | XNOR</annotation>
 		<annotation cp="⊙" type="tts" draft="contributed">nukta ya kukokotoa kwenye duara</annotation>
 		<annotation cp="⊚" draft="contributed">ringi ya kugawanya kwenye duara</annotation>
 		<annotation cp="⊚" type="tts" draft="contributed">ringi ya kugawanya kwenye duara</annotation>
-		<annotation cp="⊛" draft="contributed">kinyota cha kugawanya kwenye duara</annotation>
+		<annotation cp="⊛" draft="contributed">kigawanyaji | kinyota | kinyota cha kugawanya kwenye duara</annotation>
 		<annotation cp="⊛" type="tts" draft="contributed">kinyota cha kugawanya kwenye duara</annotation>
-		<annotation cp="⊞" draft="contributed">jumlisha kwenye mraba</annotation>
+		<annotation cp="⊞" draft="contributed">hisabati | jumlisha kwenye mraba | kama jumlisha</annotation>
 		<annotation cp="⊞" type="tts" draft="contributed">jumlisha kwenye mraba</annotation>
-		<annotation cp="⊟" draft="contributed">ondoa kwenye mraba</annotation>
+		<annotation cp="⊟" draft="contributed">hisabati | kama alama ya ondoa | ondoa kwenye mraba</annotation>
 		<annotation cp="⊟" type="tts" draft="contributed">ondoa kwenye mraba</annotation>
-		<annotation cp="⊥" draft="contributed">taki wima</annotation>
+		<annotation cp="⊥" draft="contributed">taki | taki wima</annotation>
 		<annotation cp="⊥" type="tts" draft="contributed">taki wima</annotation>
 		<annotation cp="⊮" draft="contributed">hailazimishi</annotation>
 		<annotation cp="⊮" type="tts" draft="contributed">hailazimishi</annotation>
-		<annotation cp="⊰" draft="contributed">kutangulia kwenye uhusiano</annotation>
+		<annotation cp="⊰" draft="contributed">hisabati | kigawanyaji cha seti | kutangulia kwenye uhusiano</annotation>
 		<annotation cp="⊰" type="tts" draft="contributed">kutangulia kwenye uhusiano</annotation>
-		<annotation cp="⊱" draft="contributed">kufuata kwenye uhusiano</annotation>
+		<annotation cp="⊱" draft="contributed">hisabati | kigawanyaji cha seti | kufuata kwenye uhusiano</annotation>
 		<annotation cp="⊱" type="tts" draft="contributed">kufuata kwenye uhusiano</annotation>
-		<annotation cp="⋭" draft="contributed">haina kama kikundi kidogo kwenye sawa</annotation>
+		<annotation cp="⋭" draft="contributed">haina kama kikundi kidogo kwenye sawa | hisabati | nadharia ya kundi</annotation>
 		<annotation cp="⋭" type="tts" draft="contributed">haina kama kikundi kidogo kwenye sawa</annotation>
 		<annotation cp="⊶" draft="contributed">asili</annotation>
 		<annotation cp="⊶" type="tts" draft="contributed">asili</annotation>
-		<annotation cp="⊹" draft="contributed">solo la unyambuaji wa hermite</annotation>
+		<annotation cp="⊹" draft="contributed">hisabati | matriksi inayojiunganisha | solo la unyambuaji wa hermite | solo mraba</annotation>
 		<annotation cp="⊹" type="tts" draft="contributed">solo la unyambuaji wa hermite</annotation>
-		<annotation cp="⊿" draft="contributed">pembe tatu mraba</annotation>
+		<annotation cp="⊿" draft="contributed">hesabu | pembe tatu mraba</annotation>
 		<annotation cp="⊿" type="tts" draft="contributed">pembe tatu mraba</annotation>
-		<annotation cp="⋁" draft="contributed">mantiki ya n-ary au</annotation>
+		<annotation cp="⋁" draft="contributed">mantiki | mantiki ya n-ary au | utengano</annotation>
 		<annotation cp="⋁" type="tts" draft="contributed">mantiki ya n-ary au</annotation>
-		<annotation cp="⋂" draft="contributed">makutano ya n-ary</annotation>
+		<annotation cp="⋂" draft="contributed">hesabu | kikokotoo | makutano | makutano ya n-ary</annotation>
 		<annotation cp="⋂" type="tts" draft="contributed">makutano ya n-ary</annotation>
-		<annotation cp="⋃" draft="contributed">muunganiko wa n-ary</annotation>
+		<annotation cp="⋃" draft="contributed">hesabu | kikokotoo | muunganiko | muunganiko wa n-ary</annotation>
 		<annotation cp="⋃" type="tts" draft="contributed">muunganiko wa n-ary</annotation>
-		<annotation cp="⋅" draft="contributed">nukta ya kigawanyaji</annotation>
+		<annotation cp="⋅" draft="contributed">kigawanyaji | nukta ya kigawanyaji</annotation>
 		<annotation cp="⋅" type="tts" draft="contributed">nukta ya kigawanyaji</annotation>
-		<annotation cp="⋆" draft="contributed">nyota ya kigawanyaji</annotation>
+		<annotation cp="⋆" draft="contributed">kigawanyaji | nyota ya kigawanyaji</annotation>
 		<annotation cp="⋆" type="tts" draft="contributed">nyota ya kigawanyaji</annotation>
-		<annotation cp="⋈" draft="contributed">muunganiko asili</annotation>
+		<annotation cp="⋈" draft="contributed">kigawanyaji pacha | muunganiko asili</annotation>
 		<annotation cp="⋈" type="tts" draft="contributed">muunganiko asili</annotation>
-		<annotation cp="⋒" draft="contributed">makutano pacha</annotation>
+		<annotation cp="⋒" draft="contributed">hesabu | kigawanyaji | makutano | makutano pacha</annotation>
 		<annotation cp="⋒" type="tts" draft="contributed">makutano pacha</annotation>
-		<annotation cp="⋘" draft="contributed">chini zaidi ya</annotation>
+		<annotation cp="⋘" draft="contributed">chini zaidi ya | hisabati | ukosefu wa usawa</annotation>
 		<annotation cp="⋘" type="tts" draft="contributed">chini zaidi ya</annotation>
-		<annotation cp="⋙" draft="contributed">kubwa zidi ya</annotation>
+		<annotation cp="⋙" draft="contributed">hisabati | kubwa zidi ya | ukosefu wa usawa</annotation>
 		<annotation cp="⋙" type="tts" draft="contributed">kubwa zidi ya</annotation>
-		<annotation cp="⋮" draft="contributed">nukta tatu zilizo wima</annotation>
+		<annotation cp="⋮" draft="contributed">hisabati | nukta tatu zilizo wima | udondoshaji</annotation>
 		<annotation cp="⋮" type="tts" draft="contributed">nukta tatu zilizo wima</annotation>
-		<annotation cp="⋯" draft="contributed">nukta tatu katikati ya mstari</annotation>
+		<annotation cp="⋯" draft="contributed">nukta tatu katikati ya mstari | udondoshaji</annotation>
 		<annotation cp="⋯" type="tts" draft="contributed">nukta tatu katikati ya mstari</annotation>
-		<annotation cp="⋰" draft="contributed">nukta tatu za kimshazari kulia juu</annotation>
+		<annotation cp="⋰" draft="contributed">hisabati | nukta tatu za kimshazari kulia | udondoshaji</annotation>
 		<annotation cp="⋰" type="tts" draft="contributed">nukta tatu za kimshazari kulia juu</annotation>
-		<annotation cp="⋱" draft="contributed">nukta tatu za kimshazari kulia chini</annotation>
+		<annotation cp="⋱" draft="contributed">hisabati | nukta tatu za kimshazari kulia chini | udondoshaji</annotation>
 		<annotation cp="⋱" type="tts" draft="contributed">nukta tatu za kimshazari kulia chini</annotation>
 		<annotation cp="■" draft="contributed">mraba uliokolezwa</annotation>
 		<annotation cp="■" type="tts" draft="contributed">mraba uliokolezwa</annotation>
@@ -625,7 +625,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="◇" type="tts" draft="contributed">almasi iliyo wazi</annotation>
 		<annotation cp="◈" draft="contributed">almasi wazi iliyo na almasi iliyojazwa</annotation>
 		<annotation cp="◈" type="tts" draft="contributed">almasi wazi iliyo na almasi iliyojazwa</annotation>
-		<annotation cp="◉" draft="contributed">duara wazi iliyo na duara iliyojazwa</annotation>
+		<annotation cp="◉" draft="contributed">duara iliyo na duara ndani | duara iliyo na nukta | duara wazi iliyo na duara iliyojazwa</annotation>
 		<annotation cp="◉" type="tts" draft="contributed">duara wazi iliyo na duara iliyojazwa</annotation>
 		<annotation cp="◊">almasi | msambamba | msambamba sawa</annotation>
 		<annotation cp="◊" type="tts">msambamba</annotation>
@@ -635,7 +635,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="◌" type="tts" draft="contributed">nukta duara</annotation>
 		<annotation cp="◍" draft="contributed">duara iliyo na mistari ya wima</annotation>
 		<annotation cp="◍" type="tts" draft="contributed">duara iliyo na mistari ya wima</annotation>
-		<annotation cp="◎" draft="contributed">duara ndani ya duara</annotation>
+		<annotation cp="◎" draft="contributed">duara ndani ya duara | duara pacha | shabaha</annotation>
 		<annotation cp="◎" type="tts" draft="contributed">duara ndani ya duara</annotation>
 		<annotation cp="●">mduara | mduara uliojazwa</annotation>
 		<annotation cp="●" type="tts">mduara uliojazwa</annotation>
@@ -703,7 +703,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⩽" type="tts" draft="contributed">chini ya usawa ulio hanamu</annotation>
 		<annotation cp="⪍" draft="contributed">chini ya juu ya alama ya sawasawa</annotation>
 		<annotation cp="⪍" type="tts" draft="contributed">chini ya juu ya alama ya sawasawa</annotation>
-		<annotation cp="⪚" draft="contributed">laini mbili za sawa na juu ya zaidi ya</annotation>
+		<annotation cp="⪚" draft="contributed">hisabati | laini mbili za sawa na juu ya zaidi ya</annotation>
 		<annotation cp="⪚" type="tts" draft="contributed">laini mbili za sawa na juu ya zaidi ya</annotation>
 		<annotation cp="⪺" draft="contributed">inafuata juu ya karibu sawa na</annotation>
 		<annotation cp="⪺" type="tts" draft="contributed">inafuata juu ya karibu sawa na</annotation>
@@ -811,9 +811,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🤥" type="tts">uso unaodanganya</annotation>
 		<annotation cp="🫨">kutikisika | mtetemeko | shindo | tetema | uso | uso unaotikisika</annotation>
 		<annotation cp="🫨" type="tts">uso unaotikisika</annotation>
-		<annotation cp="🙂‍↔" draft="contributed">kutikisa kichwa kimlalo</annotation>
+		<annotation cp="🙂‍↔" draft="contributed">hapana, tikisa | kutikisa kichwa kimlalo</annotation>
 		<annotation cp="🙂‍↔" type="tts" draft="contributed">kutikisa kichwa kimlalo</annotation>
-		<annotation cp="🙂‍↕" draft="contributed">kutikisa kichwa juu chini</annotation>
+		<annotation cp="🙂‍↕" draft="contributed">kuitika, ndiyo | kutikisa kichwa juu chini</annotation>
 		<annotation cp="🙂‍↕" type="tts" draft="contributed">kutikisa kichwa juu chini</annotation>
 		<annotation cp="😌">farijika | uso | uso uliofarijika</annotation>
 		<annotation cp="😌" type="tts">uso uliofarijika</annotation>
@@ -1873,11 +1873,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">kasuku</annotation>
 		<annotation cp="🪽">angani | bawa | kuruka | malaika | mithiolojia | ndege</annotation>
 		<annotation cp="🪽" type="tts">bawa</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">ndege mweusi</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">kunguru | mweusi | ndege</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">ndege mweusi</annotation>
 		<annotation cp="🪿">bata | bata bukini | honi | ndege | puuzi</annotation>
 		<annotation cp="🪿" type="tts">bata bukini</annotation>
-		<annotation cp="🐦‍🔥" draft="contributed">finiksi</annotation>
+		<annotation cp="🐦‍🔥" draft="contributed">finiksi | njozi, ndege aliyejichoma, kufufuka, kuzaliwa upya</annotation>
 		<annotation cp="🐦‍🔥" type="tts" draft="contributed">finiksi</annotation>
 		<annotation cp="🐸">chura | uso | uso wa chura</annotation>
 		<annotation cp="🐸" type="tts">uso wa chura</annotation>
@@ -2019,7 +2019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🍊" type="tts">chenza</annotation>
 		<annotation cp="🍋">limau | mmea | tunda</annotation>
 		<annotation cp="🍋" type="tts">limau</annotation>
-		<annotation cp="🍋‍🟩" draft="contributed">ndimu</annotation>
+		<annotation cp="🍋‍🟩" draft="contributed">limau | ndimu, tunda, kitropiki</annotation>
 		<annotation cp="🍋‍🟩" type="tts" draft="contributed">ndimu</annotation>
 		<annotation cp="🍌">mmea | ndizi | tunda</annotation>
 		<annotation cp="🍌" type="tts">ndizi</annotation>
@@ -2083,7 +2083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫚" type="tts">tangawizi</annotation>
 		<annotation cp="🫛">ganda | ganda la njegere | kunde | maharage | mboga | njegere</annotation>
 		<annotation cp="🫛" type="tts">ganda la njegere</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">uyoga kahawia</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">chakula, ukungu, mboga, asili | uyoga kahawia</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">uyoga kahawia</annotation>
 		<annotation cp="🍞">mkate</annotation>
 		<annotation cp="🍞" type="tts">mkate</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">mkongojo wa vipofu</annotation>
 		<annotation cp="🔗">pete | pete ya mnyororo</annotation>
 		<annotation cp="🔗" type="tts">pete ya mnyororo</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">myororo uliokatika</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">kata, katika, myororo, pingu, uhuru | mnyororo uliokatika</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">myororo uliokatika</annotation>
 		<annotation cp="⛓">minyororo | mnyororo</annotation>
 		<annotation cp="⛓" type="tts">minyororo</annotation>
@@ -3855,11 +3855,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="£" type="tts">pauni</annotation>
 		<annotation cp="¥">CNY | JPY | sarafu | yeni | yuani</annotation>
 		<annotation cp="¥" type="tts">yeni</annotation>
-		<annotation cp="₢" draft="contributed">kruzeiro</annotation>
+		<annotation cp="₢" draft="contributed">BRB | kruzeiro | sarafu</annotation>
 		<annotation cp="₢" type="tts" draft="contributed">kruzeiro</annotation>
-		<annotation cp="₣" draft="contributed">faranga ya ufaransa</annotation>
+		<annotation cp="₣" draft="contributed">faranga | faranga ya ufaransa | sarafu</annotation>
 		<annotation cp="₣" type="tts" draft="contributed">faranga ya ufaransa</annotation>
-		<annotation cp="₤" draft="contributed">lira</annotation>
+		<annotation cp="₤" draft="contributed">lira | sarafu</annotation>
 		<annotation cp="₤" type="tts" draft="contributed">lira</annotation>
 		<annotation cp="₥">mil | mill</annotation>
 		<annotation cp="₥" type="tts">mill</annotation>
@@ -3867,15 +3867,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₩" type="tts">won</annotation>
 		<annotation cp="€">EUR | sarafu | yuro</annotation>
 		<annotation cp="€" type="tts">yuro</annotation>
-		<annotation cp="₰" draft="contributed">peni ya ujerumani</annotation>
+		<annotation cp="₰" draft="contributed">peni ya ujarumani | pfennig | sarafu</annotation>
 		<annotation cp="₰" type="tts" draft="contributed">peni ya ujerumani</annotation>
 		<annotation cp="₱">peso</annotation>
 		<annotation cp="₱" type="tts">peso</annotation>
-		<annotation cp="₳" draft="contributed">austral</annotation>
+		<annotation cp="₳" draft="contributed">ARA | austral | sarafu</annotation>
 		<annotation cp="₳" type="tts" draft="contributed">austral</annotation>
-		<annotation cp="₶" draft="contributed">livre tournois</annotation>
+		<annotation cp="₶" draft="contributed">livre tournois | sarafu</annotation>
 		<annotation cp="₶" type="tts" draft="contributed">livre tournois</annotation>
-		<annotation cp="₷" draft="contributed">spesmilo</annotation>
+		<annotation cp="₷" draft="contributed">sarafu | spesmilo</annotation>
 		<annotation cp="₷" type="tts" draft="contributed">spesmilo</annotation>
 		<annotation cp="₹">rupia | rupia ya india | sarafu</annotation>
 		<annotation cp="₹" type="tts">rupia ya india</annotation>
@@ -3883,9 +3883,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">rubo</annotation>
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
-		<annotation cp="₨" draft="contributed">rupii</annotation>
+		<annotation cp="₨" draft="contributed">rupii | sarafu</annotation>
 		<annotation cp="₨" type="tts" draft="contributed">rupii</annotation>
-		<annotation cp="﷼" draft="contributed">riale</annotation>
+		<annotation cp="﷼" draft="contributed">riale | sarafu</annotation>
 		<annotation cp="﷼" type="tts" draft="contributed">riale</annotation>
 		<annotation cp="¹">herufijuu | moja | weka moja juu</annotation>
 		<annotation cp="¹" type="tts">weka moja juu</annotation>

--- a/common/annotations/ta.xml
+++ b/common/annotations/ta.xml
@@ -253,9 +253,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="↼" type="tts">இடதுபுற ஹார்பூன் மேல்நோக்கிய பார்ப்</annotation>
 		<annotation cp="↽">இடதுபுற ஹார்பூன் கீழ்நோக்கிய பார்ப்</annotation>
 		<annotation cp="↽" type="tts">இடதுபுற ஹார்பூன் கீழ்நோக்கிய பார்ப்</annotation>
-		<annotation cp="↾" draft="contributed">இடதுபுற ஹார்பூன் வலதுநோக்கிய பார்ப்</annotation>
+		<annotation cp="↾">பார்ப் | மேல்நோக்கிய ஹார்பூன் வலதுபுற பார்ப்</annotation>
 		<annotation cp="↾" type="tts" draft="contributed">இடதுபுற ஹார்பூன் வலதுநோக்கிய பார்ப்</annotation>
-		<annotation cp="↿" draft="contributed">மேல்நோக்கிய ஹார்பூன் வலதுபுற பார்ப்</annotation>
+		<annotation cp="↿">பார்ப் | மேல்நோக்கிய ஹார்பூன் இடதுபுற பார்ப்</annotation>
 		<annotation cp="↿" type="tts" draft="contributed">மேல்நோக்கிய ஹார்பூன் வலதுபுற பார்ப்</annotation>
 		<annotation cp="⇀">பார்ப் | வலதுபுற ஹார்பூன் மேல்நோக்கிய பார்ப்</annotation>
 		<annotation cp="⇀" type="tts">வலதுபுற ஹார்பூன் மேல்நோக்கிய பார்ப்</annotation>
@@ -525,7 +525,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="⋭" type="tts">சாதாரணத் துணைக்குழுச் சமமின்மை</annotation>
 		<annotation cp="⊶">அசல்</annotation>
 		<annotation cp="⊶" type="tts">அசல்</annotation>
-		<annotation cp="⊹" draft="contributed">ஹெர்மைட் இணை அணி</annotation>
+		<annotation cp="⊹">கணிதம் | சதுர அணி | சுய-இணைந்த அணி | ஹெர்மிஷியன் கான்ஜுகேட் மேட்ரிக்ஸ்</annotation>
 		<annotation cp="⊹" type="tts" draft="contributed">ஹெர்மைட் இணை அணி</annotation>
 		<annotation cp="⊿">கணிதம் | வலது முக்கோணம் | வலதுபுற முக்கோணம்</annotation>
 		<annotation cp="⊿" type="tts">வலதுபுற முக்கோணம்</annotation>
@@ -1873,11 +1873,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦜" type="tts">கிளி</annotation>
 		<annotation cp="🪽">இறக்கை | தேவதை | தொன்மவியல் | பறப்பது | பறப்பியல் | பறவை</annotation>
 		<annotation cp="🪽" type="tts">இறக்கை</annotation>
-		<annotation cp="🐦‍⬛" draft="contributed">கருப்பு பறவை</annotation>
+		<annotation cp="🐦‍⬛" draft="contributed">அண்டங்காக்கை | கருப்பு | காகம் | காக்கைவகை | பறவை</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="contributed">கருப்பு பறவை</annotation>
 		<annotation cp="🪿">பறவை | பெரிய வாத்து | மடமை | வளர்ப்புப் பறவை | வாத்தின் கூச்சல்</annotation>
 		<annotation cp="🪿" type="tts">பெரிய வாத்து</annotation>
-		<annotation cp="🐦‍🔥" draft="contributed">ஃபீனிக்ஸ்</annotation>
+		<annotation cp="🐦‍🔥" draft="contributed">ஃபீனிக்ஸ் | கற்பனை, தீப்பறவை, மறுபிறப்பு, மறுபிறவி</annotation>
 		<annotation cp="🐦‍🔥" type="tts" draft="contributed">ஃபீனிக்ஸ்</annotation>
 		<annotation cp="🐸">தவளை | முகம் | விலங்கு</annotation>
 		<annotation cp="🐸" type="tts">தவளை முகம்</annotation>
@@ -2019,7 +2019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🍊" type="tts">ஆரஞ்சு</annotation>
 		<annotation cp="🍋">எலுமிச்சை | பழம் | புளிப்பு | மஞ்சள் வண்ணம்</annotation>
 		<annotation cp="🍋" type="tts">எலுமிச்சை</annotation>
-		<annotation cp="🍋‍🟩" draft="contributed">சாத்துக்குடி</annotation>
+		<annotation cp="🍋‍🟩" draft="contributed">சாத்துக்குடி | சிட்ரஸ், பழம், வெப்பமண்டலம்</annotation>
 		<annotation cp="🍋‍🟩" type="tts" draft="contributed">சாத்துக்குடி</annotation>
 		<annotation cp="🍌">உடல்நலம் | உணவு | பழம் | வாழைப்பழம்</annotation>
 		<annotation cp="🍌" type="tts">வாழைப்பழம்</annotation>
@@ -2083,7 +2083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫚" type="tts">இஞ்சி வேர்</annotation>
 		<annotation cp="🫛">எடமாம் | காய் | காய்கறி | பட்டாணி | பருப்பு வகை | பீன்ஸ்</annotation>
 		<annotation cp="🫛" type="tts">பட்டாணி காய்</annotation>
-		<annotation cp="🍄‍🟫" draft="contributed">பழுப்பு நிற காளான்</annotation>
+		<annotation cp="🍄‍🟫" draft="contributed">உணவு, பூஞ்சை, இயற்கை, காய்கறி | பழுப்பு நிற காளான்</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="contributed">பழுப்பு நிற காளான்</annotation>
 		<annotation cp="🍞">உணவகம் | உணவு | பிரெட் | ரொட்டி</annotation>
 		<annotation cp="🍞" type="tts">பிரெட்</annotation>
@@ -3301,7 +3301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🦯" type="tts">கைத்தடி</annotation>
 		<annotation cp="🔗">இணை | இரு வளையங்கள் | கட்டு | சேர்</annotation>
 		<annotation cp="🔗" type="tts">இரு வளையங்கள்</annotation>
-		<annotation cp="⛓‍💥" draft="contributed">உடைந்த சங்கிலி</annotation>
+		<annotation cp="⛓‍💥" draft="contributed">உடைந்த சங்கிலி | உடைப்பு, உடைத்தல், சங்கிலி, கஃப்ஸ், சுதந்திரம்</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="contributed">உடைந்த சங்கிலி</annotation>
 		<annotation cp="⛓">சங்கிலி | சங்கிலிகள் | செயின்</annotation>
 		<annotation cp="⛓" type="tts">சங்கிலிகள்</annotation>

--- a/common/annotations/th.xml
+++ b/common/annotations/th.xml
@@ -635,7 +635,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="◌" type="tts">วงกลมจุด</annotation>
 		<annotation cp="◍">วงกลมเติมเส้นแนวตั้ง</annotation>
 		<annotation cp="◍" type="tts">วงกลมเติมเส้นแนวตั้ง</annotation>
-		<annotation cp="◎" draft="contributed">จุดกลางเป้า</annotation>
+		<annotation cp="◎">เป้าหมาย | วงกลมซ้อน | วงกลมร่วมศูนย์กลาง</annotation>
 		<annotation cp="◎" type="tts" draft="contributed">จุดกลางเป้า</annotation>
 		<annotation cp="●">จุดกลม | จุดกลมทึบ</annotation>
 		<annotation cp="●" type="tts">จุดกลมทึบ</annotation>

--- a/common/annotations/to.xml
+++ b/common/annotations/to.xml
@@ -23,7 +23,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🏾" type="tts">kili melomelo-ʻuliʻuli</annotation>
 		<annotation cp="🏿">faʻahinga 6 | ʻuliʻuli | kili</annotation>
 		<annotation cp="🏿" type="tts">kili ʻuliʻuli</annotation>
-		<annotation cp="‾" draft="unconfirmed">kohi-hake</annotation>
+		<annotation cp="‾" draft="unconfirmed">hake | ʻolunga | kohi</annotation>
 		<annotation cp="‾" type="tts" draft="unconfirmed">kohi-hake</annotation>
 		<annotation cp="_">fakaʻilonga | hifo | kohi</annotation>
 		<annotation cp="_" type="tts">kohi hifo</annotation>
@@ -61,7 +61,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="¿" type="tts">fehuʻi fulihi</annotation>
 		<annotation cp="؟">fakaʻalepea | fakaʻilonga | fehuʻi</annotation>
 		<annotation cp="؟" type="tts">fehuʻi fakaʻalepea</annotation>
-		<annotation cp="‽" draft="unconfirmed">fehuʻikalanga</annotation>
+		<annotation cp="‽" draft="unconfirmed">fakaʻilonga | fehuʻi | fehuʻikalanga | kalanga</annotation>
 		<annotation cp="‽" type="tts" draft="unconfirmed">fehuʻikalanga</annotation>
 		<annotation cp=".">fakaʻilonga | piliote | toti</annotation>
 		<annotation cp="." type="tts">toti</annotation>
@@ -159,11 +159,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="″" type="tts">tiki lōua</annotation>
 		<annotation cp="‴">fakaʻilonga | lōtolu | tiki</annotation>
 		<annotation cp="‴" type="tts">tiki lōtolu</annotation>
-		<annotation cp="‸" draft="unconfirmed">liʻaki</annotation>
+		<annotation cp="‸" draft="unconfirmed">fakaʻilonga | liʻaki</annotation>
 		<annotation cp="‸" type="tts" draft="unconfirmed">liʻaki</annotation>
 		<annotation cp="※">fakaʻilonga | tukuatu</annotation>
 		<annotation cp="※" type="tts">tukuatu</annotation>
-		<annotation cp="⁂" draft="unconfirmed">ʻū fetuʻu</annotation>
+		<annotation cp="⁂" draft="unconfirmed">fakaʻilonga | fetuʻu</annotation>
 		<annotation cp="⁂" type="tts" draft="unconfirmed">ʻū fetuʻu</annotation>
 		<annotation cp="`">fakamamafa | kehe</annotation>
 		<annotation cp="`" type="tts">fakamamafa kehe</annotation>
@@ -179,175 +179,175 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="℗" type="tts">ongo mafai-pulusi</annotation>
 		<annotation cp="←">hema | ngahau | ngahau ki toʻohema | ngahau siʻi ki toʻohema</annotation>
 		<annotation cp="←" type="tts">ngahau siʻi ki toʻohema</annotation>
-		<annotation cp="↚" draft="unconfirmed">ngahau ki toʻohema moe kohi</annotation>
+		<annotation cp="↚" draft="unconfirmed">hema | kohi | ngahau</annotation>
 		<annotation cp="↚" type="tts" draft="unconfirmed">ngahau ki toʻohema moe kohi</annotation>
 		<annotation cp="→">mataʻu | ngahau | ngahau ki toʻomataʻu | ngahau siʻi ki toʻomataʻu</annotation>
 		<annotation cp="→" type="tts">ngahau siʻi ki toʻomataʻu</annotation>
-		<annotation cp="↛" draft="unconfirmed">ngahau ki toʻomataʻu moe kohi</annotation>
+		<annotation cp="↛" draft="unconfirmed">kohi | mataʻu | ngahau</annotation>
 		<annotation cp="↛" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu moe kohi</annotation>
 		<annotation cp="↑">hake | ʻolunga | ngahau | ngahau ki ʻolunga | ngahau siʻi ki ʻolunga</annotation>
 		<annotation cp="↑" type="tts">ngahau siʻi ki ʻolunga</annotation>
 		<annotation cp="↓">hifo | lalo | ngahau | ngahau ki lalo | ngahau siʻi ki lalo</annotation>
 		<annotation cp="↓" type="tts">ngahau siʻi ki lalo</annotation>
-		<annotation cp="↜" draft="unconfirmed">ngahau ki toʻohema fafasi</annotation>
+		<annotation cp="↜" draft="unconfirmed">fafasi | hema | ngahau</annotation>
 		<annotation cp="↜" type="tts" draft="unconfirmed">ngahau ki toʻohema fafasi</annotation>
-		<annotation cp="↝" draft="unconfirmed">ngahau ki toʻomataʻu fafasi</annotation>
+		<annotation cp="↝" draft="unconfirmed">fafasi | mataʻu | ngahau</annotation>
 		<annotation cp="↝" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu fafasi</annotation>
-		<annotation cp="↞" draft="unconfirmed">ngahau ʻuluua ki toʻohema</annotation>
+		<annotation cp="↞" draft="unconfirmed">2 | hema | ngahau</annotation>
 		<annotation cp="↞" type="tts" draft="unconfirmed">ngahau ʻuluua ki toʻohema</annotation>
-		<annotation cp="↟" draft="unconfirmed">ngahau ʻuluua ki ʻolunga</annotation>
+		<annotation cp="↟" draft="unconfirmed">2 | ʻolunga | ngahau</annotation>
 		<annotation cp="↟" type="tts" draft="unconfirmed">ngahau ʻuluua ki ʻolunga</annotation>
-		<annotation cp="↠" draft="unconfirmed">ngahau ʻuluua ki toʻomataʻu</annotation>
+		<annotation cp="↠" draft="unconfirmed">2 | mataʻu | ngahau</annotation>
 		<annotation cp="↠" type="tts" draft="unconfirmed">ngahau ʻuluua ki toʻomataʻu</annotation>
-		<annotation cp="↡" draft="unconfirmed">ngahau ʻuluua ki lalo</annotation>
+		<annotation cp="↡" draft="unconfirmed">2 | lalo | ngahau</annotation>
 		<annotation cp="↡" type="tts" draft="unconfirmed">ngahau ʻuluua ki lalo</annotation>
-		<annotation cp="↢" draft="unconfirmed">ngahau ki toʻohema moe hiku</annotation>
+		<annotation cp="↢" draft="unconfirmed">hema | hiku | ngahau</annotation>
 		<annotation cp="↢" type="tts" draft="unconfirmed">ngahau ki toʻohema moe hiku</annotation>
-		<annotation cp="↣" draft="unconfirmed">ngahau ki toʻomataʻu moe hiku</annotation>
+		<annotation cp="↣" draft="unconfirmed">hiku | mataʻu | ngahau</annotation>
 		<annotation cp="↣" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu moe hiku</annotation>
-		<annotation cp="↤" draft="unconfirmed">ngahau ki toʻohema meihe pā</annotation>
+		<annotation cp="↤" draft="unconfirmed">hema | ngahau | pā</annotation>
 		<annotation cp="↤" type="tts" draft="unconfirmed">ngahau ki toʻohema meihe pā</annotation>
-		<annotation cp="↥" draft="unconfirmed">ngahau ki ʻolunga meihe pā</annotation>
+		<annotation cp="↥" draft="unconfirmed">ʻolunga | ngahau | pā</annotation>
 		<annotation cp="↥" type="tts" draft="unconfirmed">ngahau ki ʻolunga meihe pā</annotation>
-		<annotation cp="↦" draft="unconfirmed">ngahau ki toʻomataʻu meihe pā</annotation>
+		<annotation cp="↦" draft="unconfirmed">mataʻu | ngahau | pā</annotation>
 		<annotation cp="↦" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu meihe pā</annotation>
-		<annotation cp="↧" draft="unconfirmed">ngahau ki lalo meihe pā</annotation>
+		<annotation cp="↧" draft="unconfirmed">lalo | ngahau | pā</annotation>
 		<annotation cp="↧" type="tts" draft="unconfirmed">ngahau ki lalo meihe pā</annotation>
-		<annotation cp="↨" draft="unconfirmed">ngahau ki ʻolunga mo lalo moe tuʻunga</annotation>
+		<annotation cp="↨" draft="unconfirmed">ʻolunga | lalo | ngahau | tuʻunga</annotation>
 		<annotation cp="↨" type="tts" draft="unconfirmed">ngahau ki ʻolunga mo lalo moe tuʻunga</annotation>
-		<annotation cp="↫" draft="unconfirmed">ngahau ki toʻohema fakakahoa</annotation>
+		<annotation cp="↫" draft="unconfirmed">fakakahoa | hema | ngahau</annotation>
 		<annotation cp="↫" type="tts" draft="unconfirmed">ngahau ki toʻohema fakakahoa</annotation>
-		<annotation cp="↬" draft="unconfirmed">ngahau ki toʻomataʻu fakakahoa</annotation>
+		<annotation cp="↬" draft="unconfirmed">fakakahoa | mataʻu | ngahau</annotation>
 		<annotation cp="↬" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu fakakahoa</annotation>
-		<annotation cp="↭" draft="unconfirmed">ngahau ki toʻohema-mataʻu fafasi</annotation>
+		<annotation cp="↭" draft="unconfirmed">fafasi | hema | mataʻu | ngahau</annotation>
 		<annotation cp="↭" type="tts" draft="unconfirmed">ngahau ki toʻohema-mataʻu fafasi</annotation>
-		<annotation cp="↯" draft="unconfirmed">ngahau ki lalo fepikopikoaki</annotation>
+		<annotation cp="↯" draft="unconfirmed">fepikopikoaki | lalo | ngahau</annotation>
 		<annotation cp="↯" type="tts" draft="unconfirmed">ngahau ki lalo fepikopikoaki</annotation>
-		<annotation cp="↰" draft="unconfirmed">ngahau ki ʻolunga afe ki toʻohema</annotation>
+		<annotation cp="↰" draft="unconfirmed">afe | hema | ʻolunga | ngahau</annotation>
 		<annotation cp="↰" type="tts" draft="unconfirmed">ngahau ki ʻolunga afe ki toʻohema</annotation>
-		<annotation cp="↱" draft="unconfirmed">ngahau ki ʻolunga afe ki toʻomataʻu</annotation>
+		<annotation cp="↱" draft="unconfirmed">afe | ʻolunga | mataʻu | ngahau</annotation>
 		<annotation cp="↱" type="tts" draft="unconfirmed">ngahau ki ʻolunga afe ki toʻomataʻu</annotation>
-		<annotation cp="↲" draft="unconfirmed">ngahau ki lalo afe ki toʻohema</annotation>
+		<annotation cp="↲" draft="unconfirmed">afe | hema | lalo | ngahau</annotation>
 		<annotation cp="↲" type="tts" draft="unconfirmed">ngahau ki lalo afe ki toʻohema</annotation>
-		<annotation cp="↳" draft="unconfirmed">ngahau ki lalo afe ki toʻomataʻu</annotation>
+		<annotation cp="↳" draft="unconfirmed">afe | lalo | mataʻu | ngahau</annotation>
 		<annotation cp="↳" type="tts" draft="unconfirmed">ngahau ki lalo afe ki toʻomataʻu</annotation>
-		<annotation cp="↴" draft="unconfirmed">ngahau ki toʻomataʻu tafihu ki lalo</annotation>
+		<annotation cp="↴" draft="unconfirmed">lalo | mataʻu | ngahau | tafihu</annotation>
 		<annotation cp="↴" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu tafihu ki lalo</annotation>
-		<annotation cp="↵" draft="unconfirmed">ngahau ki lalo tafihu ki toʻohema</annotation>
+		<annotation cp="↵" draft="unconfirmed">hema | lalo | ngahau | tafihu</annotation>
 		<annotation cp="↵" type="tts" draft="unconfirmed">ngahau ki lalo tafihu ki toʻohema</annotation>
-		<annotation cp="↶" draft="unconfirmed">ngahau vilovilo vaeuahake toʻohema</annotation>
+		<annotation cp="↶" draft="unconfirmed">hema | ngahau | vaeuahake | vilovilo</annotation>
 		<annotation cp="↶" type="tts" draft="unconfirmed">ngahau vilovilo vaeuahake toʻohema</annotation>
-		<annotation cp="↷" draft="unconfirmed">ngahau vilovilo vaeuahake toʻomataʻu</annotation>
+		<annotation cp="↷" draft="unconfirmed">mataʻu | ngahau | vaeuahake | vilovilo</annotation>
 		<annotation cp="↷" type="tts" draft="unconfirmed">ngahau vilovilo vaeuahake toʻomataʻu</annotation>
-		<annotation cp="↸" draft="unconfirmed">ngahau tokelauhihifo moe pā lōloa</annotation>
+		<annotation cp="↸" draft="unconfirmed">hihifo | lōloa | ngahau | pā | tokelau</annotation>
 		<annotation cp="↸" type="tts" draft="unconfirmed">ngahau tokelauhihifo moe pā lōloa</annotation>
-		<annotation cp="↹" draft="unconfirmed">ngahau ki toʻohema ʻi olunga ʻoe toʻomataʻu moe pā</annotation>
+		<annotation cp="↹" draft="unconfirmed">hema | mataʻu | ngahau | pā</annotation>
 		<annotation cp="↹" type="tts" draft="unconfirmed">ngahau ki toʻohema ʻi olunga ʻoe toʻomataʻu moe pā</annotation>
-		<annotation cp="↺" draft="unconfirmed">ngahau ava vilovilo toʻohema</annotation>
+		<annotation cp="↺" draft="unconfirmed">ava | hema | ngahau | vilovilo</annotation>
 		<annotation cp="↺" type="tts" draft="unconfirmed">ngahau ava vilovilo toʻohema</annotation>
-		<annotation cp="↻" draft="unconfirmed">ngahau ava vilovilo toʻomataʻu</annotation>
+		<annotation cp="↻" draft="unconfirmed">ava | mataʻu | ngahau | vilovilo</annotation>
 		<annotation cp="↻" type="tts" draft="unconfirmed">ngahau ava vilovilo toʻomataʻu</annotation>
-		<annotation cp="↼" draft="unconfirmed">taovelo talahake ki toʻohema</annotation>
+		<annotation cp="↼" draft="unconfirmed">hema | ʻolunga | taovelo</annotation>
 		<annotation cp="↼" type="tts" draft="unconfirmed">taovelo talahake ki toʻohema</annotation>
-		<annotation cp="↽" draft="unconfirmed">taovelo talahifo ki toʻohema</annotation>
+		<annotation cp="↽" draft="unconfirmed">hema | lalo | taovelo</annotation>
 		<annotation cp="↽" type="tts" draft="unconfirmed">taovelo talahifo ki toʻohema</annotation>
-		<annotation cp="↾" draft="unconfirmed">taovelo talamataʻu ki ʻolunga</annotation>
+		<annotation cp="↾" draft="unconfirmed">ʻolunga | mataʻu | taovelo</annotation>
 		<annotation cp="↾" type="tts" draft="unconfirmed">taovelo talamataʻu ki ʻolunga</annotation>
-		<annotation cp="↿" draft="unconfirmed">taovelo talahema ki ʻolunga</annotation>
+		<annotation cp="↿" draft="unconfirmed">hema | ʻolunga | taovelo</annotation>
 		<annotation cp="↿" type="tts" draft="unconfirmed">taovelo talahema ki ʻolunga</annotation>
-		<annotation cp="⇀" draft="unconfirmed">taovelo talahake ki toʻomataʻu</annotation>
+		<annotation cp="⇀" draft="unconfirmed">ʻolunga | mataʻu | taovelo</annotation>
 		<annotation cp="⇀" type="tts" draft="unconfirmed">taovelo talahake ki toʻomataʻu</annotation>
-		<annotation cp="⇁" draft="unconfirmed">taovelo talahifo ki toʻomataʻu</annotation>
+		<annotation cp="⇁" draft="unconfirmed">lalo | mataʻu | taovelo</annotation>
 		<annotation cp="⇁" type="tts" draft="unconfirmed">taovelo talahifo ki toʻomataʻu</annotation>
-		<annotation cp="⇂" draft="unconfirmed">taovelo talamataʻu ki lalo</annotation>
+		<annotation cp="⇂" draft="unconfirmed">lalo | mataʻu | taovelo</annotation>
 		<annotation cp="⇂" type="tts" draft="unconfirmed">taovelo talamataʻu ki lalo</annotation>
-		<annotation cp="⇃" draft="unconfirmed">taovelo talahema ki lalo</annotation>
+		<annotation cp="⇃" draft="unconfirmed">hema | lalo | taovelo</annotation>
 		<annotation cp="⇃" type="tts" draft="unconfirmed">taovelo talahema ki lalo</annotation>
-		<annotation cp="⇄" draft="unconfirmed">ngahau ki toʻomataʻu ʻi olunga ʻoe toʻohema</annotation>
+		<annotation cp="⇄" draft="unconfirmed">2 | hema | mataʻu | ngahau</annotation>
 		<annotation cp="⇄" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu ʻi olunga ʻoe toʻohema</annotation>
 		<annotation cp="⇅">hake | hifo | ʻolunga | lalo | ongo ngahau | ongo ngahau ki ʻolunga mo lalo</annotation>
 		<annotation cp="⇅" type="tts">ongo ngahau ki ʻolunga mo lalo</annotation>
 		<annotation cp="⇆">hema | mataʻu | ongo ngahau | ongo ngahau ki toʻomataʻu mo toʻohema</annotation>
 		<annotation cp="⇆" type="tts">ongo ngahau ki toʻomataʻu mo toʻohema</annotation>
-		<annotation cp="⇇" draft="unconfirmed">ngahau fakahoa ki toʻohema</annotation>
+		<annotation cp="⇇" draft="unconfirmed">2 | fakahoa | hema | ngahau</annotation>
 		<annotation cp="⇇" type="tts" draft="unconfirmed">ngahau fakahoa ki toʻohema</annotation>
-		<annotation cp="⇈" draft="unconfirmed">ngahau fakahoa ki ʻolunga</annotation>
+		<annotation cp="⇈" draft="unconfirmed">2 | fakahoa | ʻolunga | ngahau</annotation>
 		<annotation cp="⇈" type="tts" draft="unconfirmed">ngahau fakahoa ki ʻolunga</annotation>
-		<annotation cp="⇉" draft="unconfirmed">ngahau fakahoa ki toʻomataʻu</annotation>
+		<annotation cp="⇉" draft="unconfirmed">2 | fakahoa | mataʻu | ngahau</annotation>
 		<annotation cp="⇉" type="tts" draft="unconfirmed">ngahau fakahoa ki toʻomataʻu</annotation>
-		<annotation cp="⇊" draft="unconfirmed">ngahau fakahoa ki lalo</annotation>
+		<annotation cp="⇊" draft="unconfirmed">2 | fakahoa | lalo | ngahau</annotation>
 		<annotation cp="⇊" type="tts" draft="unconfirmed">ngahau fakahoa ki lalo</annotation>
-		<annotation cp="⇋" draft="unconfirmed">taovelo ki toʻohema ʻi olunga ʻoe toʻomataʻu</annotation>
+		<annotation cp="⇋" draft="unconfirmed">2 | hema | mataʻu | taovelo</annotation>
 		<annotation cp="⇋" type="tts" draft="unconfirmed">taovelo ki toʻohema ʻi olunga ʻoe toʻomataʻu</annotation>
-		<annotation cp="⇌" draft="unconfirmed">taovelo ki toʻomataʻu ʻi olunga ʻoe toʻohema</annotation>
+		<annotation cp="⇌" draft="unconfirmed">2 | hema | mataʻu | taovelo</annotation>
 		<annotation cp="⇌" type="tts" draft="unconfirmed">taovelo ki toʻomataʻu ʻi olunga ʻoe toʻohema</annotation>
-		<annotation cp="⇐" draft="unconfirmed">ngahau lōua ki toʻohema</annotation>
+		<annotation cp="⇐" draft="unconfirmed">2 | hema | lōua | ngahau</annotation>
 		<annotation cp="⇐" type="tts" draft="unconfirmed">ngahau lōua ki toʻohema</annotation>
-		<annotation cp="⇍" draft="unconfirmed">ngahau lōua ki toʻohema moe kohi</annotation>
+		<annotation cp="⇍" draft="unconfirmed">2 | hema | kohi | lōua | ngahau</annotation>
 		<annotation cp="⇍" type="tts" draft="unconfirmed">ngahau lōua ki toʻohema moe kohi</annotation>
-		<annotation cp="⇑" draft="unconfirmed">ngahau lōua ki ʻolunga</annotation>
+		<annotation cp="⇑" draft="unconfirmed">2 | ʻolunga | lōua | ngahau</annotation>
 		<annotation cp="⇑" type="tts" draft="unconfirmed">ngahau lōua ki ʻolunga</annotation>
-		<annotation cp="⇒" draft="unconfirmed">ngahau lōua ki toʻomataʻu</annotation>
+		<annotation cp="⇒" draft="unconfirmed">2 | lōua | mataʻu | ngahau</annotation>
 		<annotation cp="⇒" type="tts" draft="unconfirmed">ngahau lōua ki toʻomataʻu</annotation>
-		<annotation cp="⇏" draft="unconfirmed">ngahau lōua ki toʻomataʻu moe kohi</annotation>
+		<annotation cp="⇏" draft="unconfirmed">2 | kohi | lōua | mataʻu | ngahau</annotation>
 		<annotation cp="⇏" type="tts" draft="unconfirmed">ngahau lōua ki toʻomataʻu moe kohi</annotation>
-		<annotation cp="⇓" draft="unconfirmed">ngahau lōua ki lalo</annotation>
+		<annotation cp="⇓" draft="unconfirmed">2 | lalo | lōua | ngahau</annotation>
 		<annotation cp="⇓" type="tts" draft="unconfirmed">ngahau lōua ki lalo</annotation>
-		<annotation cp="⇔" draft="unconfirmed">ngahau lōua ki toʻohema-mataʻu</annotation>
+		<annotation cp="⇔" draft="unconfirmed">2 | hema | lōua | mataʻu | ngahau</annotation>
 		<annotation cp="⇔" type="tts" draft="unconfirmed">ngahau lōua ki toʻohema-mataʻu</annotation>
-		<annotation cp="⇎" draft="unconfirmed">ngahau lōua ki toʻohema-mataʻu moe kohi</annotation>
+		<annotation cp="⇎" draft="unconfirmed">2 | hema | kohi | lōua | mataʻu | ngahau</annotation>
 		<annotation cp="⇎" type="tts" draft="unconfirmed">ngahau lōua ki toʻohema-mataʻu moe kohi</annotation>
-		<annotation cp="⇖" draft="unconfirmed">ngahau lōua ki tokelauhihifo</annotation>
+		<annotation cp="⇖" draft="unconfirmed">2 | hihifo | lōua | ngahau | tokelau</annotation>
 		<annotation cp="⇖" type="tts" draft="unconfirmed">ngahau lōua ki tokelauhihifo</annotation>
-		<annotation cp="⇗" draft="unconfirmed">ngahau lōua ki tokelauhahake</annotation>
+		<annotation cp="⇗" draft="unconfirmed">2 | hahake | lōua | ngahau | tokelau</annotation>
 		<annotation cp="⇗" type="tts" draft="unconfirmed">ngahau lōua ki tokelauhahake</annotation>
-		<annotation cp="⇘" draft="unconfirmed">ngahau lōua ki tongahahake</annotation>
+		<annotation cp="⇘" draft="unconfirmed">2 | hahake | lōua | ngahau | tonga</annotation>
 		<annotation cp="⇘" type="tts" draft="unconfirmed">ngahau lōua ki tongahahake</annotation>
-		<annotation cp="⇙" draft="unconfirmed">ngahau lōua ki tongahihifo</annotation>
+		<annotation cp="⇙" draft="unconfirmed">2 | hihifo | lōua | ngahau | tonga</annotation>
 		<annotation cp="⇙" type="tts" draft="unconfirmed">ngahau lōua ki tongahihifo</annotation>
-		<annotation cp="⇚" draft="unconfirmed">ngahau lōtolu ki toʻohema</annotation>
+		<annotation cp="⇚" draft="unconfirmed">3 | hema | lōtolu | ngahau</annotation>
 		<annotation cp="⇚" type="tts" draft="unconfirmed">ngahau lōtolu ki toʻohema</annotation>
-		<annotation cp="⇛" draft="unconfirmed">ngahau lōtolu ki toʻomataʻu</annotation>
+		<annotation cp="⇛" draft="unconfirmed">3 | lōtolu | mataʻu | ngahau</annotation>
 		<annotation cp="⇛" type="tts" draft="unconfirmed">ngahau lōtolu ki toʻomataʻu</annotation>
-		<annotation cp="⇜" draft="unconfirmed">ngahau tafihifihu ki toʻohema</annotation>
+		<annotation cp="⇜" draft="unconfirmed">hema | ngahau | tafihifihu</annotation>
 		<annotation cp="⇜" type="tts" draft="unconfirmed">ngahau tafihifihu ki toʻohema</annotation>
-		<annotation cp="⇝" draft="unconfirmed">ngahau tafihifihu ki toʻomataʻu</annotation>
+		<annotation cp="⇝" draft="unconfirmed">mataʻu | ngahau | tafihifihu</annotation>
 		<annotation cp="⇝" type="tts" draft="unconfirmed">ngahau tafihifihu ki toʻomataʻu</annotation>
-		<annotation cp="⇞" draft="unconfirmed">ngahau ki ʻolunga moe kohi lōua</annotation>
+		<annotation cp="⇞" draft="unconfirmed">2 | ʻolunga | kohi | lōua | ngahau</annotation>
 		<annotation cp="⇞" type="tts" draft="unconfirmed">ngahau ki ʻolunga moe kohi lōua</annotation>
-		<annotation cp="⇟" draft="unconfirmed">ngahau ki lalo moe kohi lōua</annotation>
+		<annotation cp="⇟" draft="unconfirmed">2 | kohi | lalo | lōua | ngahau</annotation>
 		<annotation cp="⇟" type="tts" draft="unconfirmed">ngahau ki lalo moe kohi lōua</annotation>
-		<annotation cp="⇠" draft="unconfirmed">ngahau kohikohi ki toʻohema</annotation>
+		<annotation cp="⇠" draft="unconfirmed">hema | kohikohi | ngahau</annotation>
 		<annotation cp="⇠" type="tts" draft="unconfirmed">ngahau kohikohi ki toʻohema</annotation>
-		<annotation cp="⇡" draft="unconfirmed">ngahau kohikohi ki ʻolunga</annotation>
+		<annotation cp="⇡" draft="unconfirmed">ʻolunga | kohikohi | ngahau</annotation>
 		<annotation cp="⇡" type="tts" draft="unconfirmed">ngahau kohikohi ki ʻolunga</annotation>
-		<annotation cp="⇢" draft="unconfirmed">ngahau kohikohi ki toʻomataʻu</annotation>
+		<annotation cp="⇢" draft="unconfirmed">kohikohi | mataʻu | ngahau</annotation>
 		<annotation cp="⇢" type="tts" draft="unconfirmed">ngahau kohikohi ki toʻomataʻu</annotation>
-		<annotation cp="⇣" draft="unconfirmed">ngahau kohikohi ki lalo</annotation>
+		<annotation cp="⇣" draft="unconfirmed">kohikohi | lalo | ngahau</annotation>
 		<annotation cp="⇣" type="tts" draft="unconfirmed">ngahau kohikohi ki lalo</annotation>
-		<annotation cp="⇤" draft="unconfirmed">ngahau ki toʻohema moe pā</annotation>
+		<annotation cp="⇤" draft="unconfirmed">hema | ngahau | pā</annotation>
 		<annotation cp="⇤" type="tts" draft="unconfirmed">ngahau ki toʻohema moe pā</annotation>
-		<annotation cp="⇥" draft="unconfirmed">ngahau ki toʻomataʻu moe pā</annotation>
+		<annotation cp="⇥" draft="unconfirmed">mataʻu | ngahau | pā</annotation>
 		<annotation cp="⇥" type="tts" draft="unconfirmed">ngahau ki toʻomataʻu moe pā</annotation>
-		<annotation cp="⇦" draft="unconfirmed">ngeʻesi ngahau ki toʻohema</annotation>
+		<annotation cp="⇦" draft="unconfirmed">hema | ngahau | ngeʻesi</annotation>
 		<annotation cp="⇦" type="tts" draft="unconfirmed">ngeʻesi ngahau ki toʻohema</annotation>
-		<annotation cp="⇧" draft="unconfirmed">ngeʻesi ngahau ki ʻolunga</annotation>
+		<annotation cp="⇧" draft="unconfirmed">ʻolunga | ngahau | ngeʻesi</annotation>
 		<annotation cp="⇧" type="tts" draft="unconfirmed">ngeʻesi ngahau ki ʻolunga</annotation>
-		<annotation cp="⇨" draft="unconfirmed">ngeʻesi ngahau ki toʻomataʻu</annotation>
+		<annotation cp="⇨" draft="unconfirmed">mataʻu | ngahau | ngeʻesi</annotation>
 		<annotation cp="⇨" type="tts" draft="unconfirmed">ngeʻesi ngahau ki toʻomataʻu</annotation>
-		<annotation cp="⇩" draft="unconfirmed">ngeʻesi ngahau ki lalo</annotation>
+		<annotation cp="⇩" draft="unconfirmed">lalo | ngahau | ngeʻesi</annotation>
 		<annotation cp="⇩" type="tts" draft="unconfirmed">ngeʻesi ngahau ki lalo</annotation>
-		<annotation cp="⇪" draft="unconfirmed">ngeʻesi ngahau ki ʻolunga meihe pā</annotation>
+		<annotation cp="⇪" draft="unconfirmed">ʻolunga | ngahau | ngeʻesi | pā</annotation>
 		<annotation cp="⇪" type="tts" draft="unconfirmed">ngeʻesi ngahau ki ʻolunga meihe pā</annotation>
-		<annotation cp="⇵" draft="unconfirmed">ngahau ki lalo mo ki ʻolunga</annotation>
+		<annotation cp="⇵" draft="unconfirmed">ʻolunga | lalo | ngahau</annotation>
 		<annotation cp="⇵" type="tts" draft="unconfirmed">ngahau ki lalo mo ki ʻolunga</annotation>
-		<annotation cp="∀" draft="unconfirmed">kātoa</annotation>
+		<annotation cp="∀" draft="unconfirmed">kātoa | matematika</annotation>
 		<annotation cp="∀" type="tts" draft="unconfirmed">kātoa</annotation>
-		<annotation cp="∂" draft="unconfirmed">faikehekehe fakakonga</annotation>
+		<annotation cp="∂" draft="unconfirmed">faikehekehe | fakakonga | matematika</annotation>
 		<annotation cp="∂" type="tts" draft="unconfirmed">faikehekehe fakakonga</annotation>
-		<annotation cp="∃" draft="unconfirmed">ʻoku ʻi ai</annotation>
+		<annotation cp="∃" draft="unconfirmed">ʻoku ʻi ai | matematika</annotation>
 		<annotation cp="∃" type="tts" draft="unconfirmed">ʻoku ʻi ai</annotation>
-		<annotation cp="∅" draft="unconfirmed">ngeʻesi seti</annotation>
+		<annotation cp="∅" draft="unconfirmed">matematika | ngeʻesi | seti</annotation>
 		<annotation cp="∅" type="tts" draft="unconfirmed">ngeʻesi seti</annotation>
 		<annotation cp="∆">fakaʻilonga | tuputaha</annotation>
 		<annotation cp="∆" type="tts">tuputaha</annotation>
@@ -355,15 +355,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="∇" type="tts">tapatolu fulihi</annotation>
 		<annotation cp="∈">fakaʻilonga | ʻelemēniti | konga</annotation>
 		<annotation cp="∈" type="tts">ʻelemēniti</annotation>
-		<annotation cp="∉" draft="unconfirmed">ʻikai ha memipa</annotation>
+		<annotation cp="∉" draft="unconfirmed">ʻikai | matematika | memipa</annotation>
 		<annotation cp="∉" type="tts" draft="unconfirmed">ʻikai ha memipa</annotation>
-		<annotation cp="∋" draft="unconfirmed">memipa ʻoku faʻo</annotation>
+		<annotation cp="∋" draft="unconfirmed">faʻo | matematika | memipa</annotation>
 		<annotation cp="∋" type="tts" draft="unconfirmed">memipa ʻoku faʻo</annotation>
-		<annotation cp="∎" draft="unconfirmed">ngataʻanga ʻoe fakamoʻoni</annotation>
+		<annotation cp="∎" draft="unconfirmed">fakamoʻoni | matematika | ngataʻanga</annotation>
 		<annotation cp="∎" type="tts" draft="unconfirmed">ngataʻanga ʻoe fakamoʻoni</annotation>
-		<annotation cp="∏" draft="unconfirmed">liunga lōlahi</annotation>
+		<annotation cp="∏" draft="unconfirmed">liunga | lōlahi | matematika</annotation>
 		<annotation cp="∏" type="tts" draft="unconfirmed">liunga lōlahi</annotation>
-		<annotation cp="∑" draft="unconfirmed">tānaki lōlahi</annotation>
+		<annotation cp="∑" draft="unconfirmed">lōlahi | matematika | tānaki</annotation>
 		<annotation cp="∑" type="tts" draft="unconfirmed">tānaki lōlahi</annotation>
 		<annotation cp="+">fakaʻilonga | tānaki</annotation>
 		<annotation cp="+" type="tts">tānaki</annotation>
@@ -375,7 +375,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="×" type="tts">liunga</annotation>
 		<annotation cp="&lt;">fakaʻilonga | hifo | siʻi | siʻihifo</annotation>
 		<annotation cp="&lt;" type="tts">siʻihifo</annotation>
-		<annotation cp="≮" draft="unconfirmed">ʻikai siʻihifo</annotation>
+		<annotation cp="≮" draft="unconfirmed">ʻikai | matematika | siʻihifo</annotation>
 		<annotation cp="≮" type="tts" draft="unconfirmed">ʻikai siʻihifo</annotation>
 		<annotation cp="=">fakaʻilonga | tatau</annotation>
 		<annotation cp="=" type="tts">tatau</annotation>
@@ -383,7 +383,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="≠" type="tts">taʻetatau</annotation>
 		<annotation cp="&gt;">fakaʻilonga | hake | lahi | lahihake</annotation>
 		<annotation cp="&gt;" type="tts">lahihake</annotation>
-		<annotation cp="≯" draft="unconfirmed">ʻikai lahihake</annotation>
+		<annotation cp="≯" draft="unconfirmed">ʻikai | lahihake | matematika</annotation>
 		<annotation cp="≯" type="tts" draft="unconfirmed">ʻikai lahihake</annotation>
 		<annotation cp="¬">fakaʻikai | fakaʻilonga | ʻikai</annotation>
 		<annotation cp="¬" type="tts">fakaʻikai</annotation>
@@ -395,315 +395,315 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="−" type="tts">kole</annotation>
 		<annotation cp="⁻">fakaʻilonga | hake | kole</annotation>
 		<annotation cp="⁻" type="tts">kole hake</annotation>
-		<annotation cp="∓" draft="unconfirmed">kole pe tānaki</annotation>
+		<annotation cp="∓" draft="unconfirmed">kole | matematika | tānaki</annotation>
 		<annotation cp="∓" type="tts" draft="unconfirmed">kole pe tānaki</annotation>
-		<annotation cp="∕" draft="unconfirmed">kohi vahevahe</annotation>
+		<annotation cp="∕" draft="unconfirmed">kohi | matematika | vahevahe</annotation>
 		<annotation cp="∕" type="tts" draft="unconfirmed">kohi vahevahe</annotation>
-		<annotation cp="⁄" draft="unconfirmed">kohi fakakiseni</annotation>
+		<annotation cp="⁄" draft="unconfirmed">fakakiseni | kohi | matematika</annotation>
 		<annotation cp="⁄" type="tts" draft="unconfirmed">kohi fakakiseni</annotation>
-		<annotation cp="∗" draft="unconfirmed">fakafuofua fakafetuʻu</annotation>
+		<annotation cp="∗" draft="unconfirmed">fakafuofua | fetuʻu | matematika</annotation>
 		<annotation cp="∗" type="tts" draft="unconfirmed">fakafuofua fakafetuʻu</annotation>
-		<annotation cp="∘" draft="unconfirmed">fakafuofua mama</annotation>
+		<annotation cp="∘" draft="unconfirmed">fakafuofua | mama | matematika</annotation>
 		<annotation cp="∘" type="tts" draft="unconfirmed">fakafuofua mama</annotation>
-		<annotation cp="∙" draft="unconfirmed">fakafuofua pulukōkō</annotation>
+		<annotation cp="∙" draft="unconfirmed">fakafuofua | matematika | pulukōkō</annotation>
 		<annotation cp="∙" type="tts" draft="unconfirmed">fakafuofua pulukōkō</annotation>
 		<annotation cp="√">aka-tautakele | fakaʻilonga</annotation>
 		<annotation cp="√" type="tts">aka-tautakele</annotation>
-		<annotation cp="∝" draft="unconfirmed">fakahoatatau ki</annotation>
+		<annotation cp="∝" draft="unconfirmed">fakahoatatau | matematika</annotation>
 		<annotation cp="∝" type="tts" draft="unconfirmed">fakahoatatau ki</annotation>
 		<annotation cp="∞">fakaʻilonga | taʻengata</annotation>
 		<annotation cp="∞" type="tts">taʻengata</annotation>
-		<annotation cp="∟" draft="unconfirmed">tuliki totonu</annotation>
+		<annotation cp="∟" draft="unconfirmed">matematika | tuliki totonu</annotation>
 		<annotation cp="∟" type="tts" draft="unconfirmed">tuliki totonu</annotation>
-		<annotation cp="∠" draft="unconfirmed">tuliki</annotation>
+		<annotation cp="∠" draft="unconfirmed">masila | matematika | tuliki</annotation>
 		<annotation cp="∠" type="tts" draft="unconfirmed">tuliki</annotation>
-		<annotation cp="∣" draft="unconfirmed">vahe</annotation>
+		<annotation cp="∣" draft="unconfirmed">matematika | vahe</annotation>
 		<annotation cp="∣" type="tts" draft="unconfirmed">vahe</annotation>
-		<annotation cp="∥" draft="unconfirmed">palāleli</annotation>
+		<annotation cp="∥" draft="unconfirmed">matematika | palāleli</annotation>
 		<annotation cp="∥" type="tts" draft="unconfirmed">palāleli</annotation>
-		<annotation cp="∧" draft="unconfirmed">pea mo</annotation>
+		<annotation cp="∧" draft="unconfirmed">matematika | mo</annotation>
 		<annotation cp="∧" type="tts" draft="unconfirmed">pea mo</annotation>
 		<annotation cp="∩">fakaʻilonga | fehauaki</annotation>
 		<annotation cp="∩" type="tts">fehauaki</annotation>
 		<annotation cp="∪">fakaʻilonga | fekauʻaki</annotation>
 		<annotation cp="∪" type="tts">fekauʻaki</annotation>
-		<annotation cp="∫" draft="unconfirmed">ʻinitakolo</annotation>
+		<annotation cp="∫" draft="unconfirmed">ʻinitakolo | matematika</annotation>
 		<annotation cp="∫" type="tts" draft="unconfirmed">ʻinitakolo</annotation>
-		<annotation cp="∬" draft="unconfirmed">ʻinitakolo tuʻoua</annotation>
+		<annotation cp="∬" draft="unconfirmed">2 | ʻinitakolo | matematika</annotation>
 		<annotation cp="∬" type="tts" draft="unconfirmed">ʻinitakolo tuʻoua</annotation>
-		<annotation cp="∮" draft="unconfirmed">ʻinitakolo laine</annotation>
+		<annotation cp="∮" draft="unconfirmed">initakolo | laine | matematika</annotation>
 		<annotation cp="∮" type="tts" draft="unconfirmed">ʻinitakolo laine</annotation>
-		<annotation cp="∴" draft="unconfirmed">ko ia ai</annotation>
+		<annotation cp="∴" draft="unconfirmed">ko ia ai | matematika</annotation>
 		<annotation cp="∴" type="tts" draft="unconfirmed">ko ia ai</annotation>
-		<annotation cp="∵" draft="unconfirmed">koeʻuhi</annotation>
+		<annotation cp="∵" draft="unconfirmed">koeʻuhi | matematika</annotation>
 		<annotation cp="∵" type="tts" draft="unconfirmed">koeʻuhi</annotation>
-		<annotation cp="∶" draft="unconfirmed">lesiolo</annotation>
+		<annotation cp="∶" draft="unconfirmed">lesiolo | matematika</annotation>
 		<annotation cp="∶" type="tts" draft="unconfirmed">lesiolo</annotation>
-		<annotation cp="∷" draft="unconfirmed">hoatatau</annotation>
+		<annotation cp="∷" draft="unconfirmed">hoatatau | matematika</annotation>
 		<annotation cp="∷" type="tts" draft="unconfirmed">hoatatau</annotation>
-		<annotation cp="∼" draft="unconfirmed">fakafuofua fafasi</annotation>
+		<annotation cp="∼" draft="unconfirmed">fafasi | matematika</annotation>
 		<annotation cp="∼" type="tts" draft="unconfirmed">fakafuofua fafasi</annotation>
-		<annotation cp="∽" draft="unconfirmed">fakafuofua fafasi fulihi</annotation>
+		<annotation cp="∽" draft="unconfirmed">fafasi | fulihi | matematika</annotation>
 		<annotation cp="∽" type="tts" draft="unconfirmed">fakafuofua fafasi fulihi</annotation>
-		<annotation cp="∾" draft="unconfirmed">ʻesa fakapikopiko mo fulihi</annotation>
+		<annotation cp="∾" draft="unconfirmed">fakapikopiko | fulihi | ʻesa | matematika</annotation>
 		<annotation cp="∾" type="tts" draft="unconfirmed">ʻesa fakapikopiko mo fulihi</annotation>
-		<annotation cp="≃" draft="unconfirmed">tatau ʻihe taʻengata</annotation>
+		<annotation cp="≃" draft="unconfirmed">matematika | taʻengata | tatau</annotation>
 		<annotation cp="≃" type="tts" draft="unconfirmed">tatau ʻihe taʻengata</annotation>
-		<annotation cp="≅" draft="unconfirmed">ngali tatau</annotation>
+		<annotation cp="≅" draft="unconfirmed">matematika | ngali | tatau</annotation>
 		<annotation cp="≅" type="tts" draft="unconfirmed">ngali tatau</annotation>
 		<annotation cp="≈">fakaʻilonga | meimei | meimeitatau | tatau</annotation>
 		<annotation cp="≈" type="tts">meimeitatau</annotation>
-		<annotation cp="≌" draft="unconfirmed">tatau kātoa</annotation>
+		<annotation cp="≌" draft="unconfirmed">kātoa | matematika | tatau</annotation>
 		<annotation cp="≌" type="tts" draft="unconfirmed">tatau kātoa</annotation>
-		<annotation cp="≒" draft="unconfirmed">meimei tatau fakaʻesia</annotation>
+		<annotation cp="≒" draft="unconfirmed">fakaʻesia | matematika | tatau</annotation>
 		<annotation cp="≒" type="tts" draft="unconfirmed">meimei tatau fakaʻesia</annotation>
-		<annotation cp="≖" draft="unconfirmed">mama ʻi loto tatau</annotation>
+		<annotation cp="≖" draft="unconfirmed">mama | matematika | tatau</annotation>
 		<annotation cp="≖" type="tts" draft="unconfirmed">mama ʻi loto tatau</annotation>
 		<annotation cp="≡">fakaʻilonga | tatau | tuʻupau</annotation>
 		<annotation cp="≡" type="tts">tuʻupau</annotation>
-		<annotation cp="≣" draft="unconfirmed">tatau kātoa ʻaupito</annotation>
+		<annotation cp="≣" draft="unconfirmed">kātoa | matematika | tatau</annotation>
 		<annotation cp="≣" type="tts" draft="unconfirmed">tatau kātoa ʻaupito</annotation>
 		<annotation cp="≤">fakaʻilonga | hifo | siʻi | siʻihifo pe tatau | tatau</annotation>
 		<annotation cp="≤" type="tts">siʻihifo pe tatau</annotation>
 		<annotation cp="≥">fakaʻilonga | hake | lahi | lahihake pe tatau | tatau</annotation>
 		<annotation cp="≥" type="tts">lahihake pe tatau</annotation>
-		<annotation cp="≦" draft="unconfirmed">siʻihifo ʻihe tatau</annotation>
+		<annotation cp="≦" draft="unconfirmed">matematika | siʻihifo | tatau</annotation>
 		<annotation cp="≦" type="tts" draft="unconfirmed">siʻihifo ʻihe tatau</annotation>
-		<annotation cp="≧" draft="unconfirmed">lahihake ʻihe tatau</annotation>
+		<annotation cp="≧" draft="unconfirmed">lahihake | matematika | tatau</annotation>
 		<annotation cp="≧" type="tts" draft="unconfirmed">lahihake ʻihe tatau</annotation>
-		<annotation cp="≪" draft="unconfirmed">fuʻu siʻihifo</annotation>
+		<annotation cp="≪" draft="unconfirmed">matematika | siʻihifo</annotation>
 		<annotation cp="≪" type="tts" draft="unconfirmed">fuʻu siʻihifo</annotation>
-		<annotation cp="≫" draft="unconfirmed">fuʻu lahihake</annotation>
+		<annotation cp="≫" draft="unconfirmed">lahihake | matematika</annotation>
 		<annotation cp="≫" type="tts" draft="unconfirmed">fuʻu lahihake</annotation>
-		<annotation cp="≬" draft="unconfirmed">vahaʻa</annotation>
+		<annotation cp="≬" draft="unconfirmed">matematika | vahaʻa</annotation>
 		<annotation cp="≬" type="tts" draft="unconfirmed">vahaʻa</annotation>
-		<annotation cp="≳" draft="unconfirmed">lahihake fafasi</annotation>
+		<annotation cp="≳" draft="unconfirmed">fafasi | lahihake | matematika</annotation>
 		<annotation cp="≳" type="tts" draft="unconfirmed">lahihake fafasi</annotation>
-		<annotation cp="≺" draft="unconfirmed">tōmuʻa</annotation>
+		<annotation cp="≺" draft="unconfirmed">matematika | tōmuʻa</annotation>
 		<annotation cp="≺" type="tts" draft="unconfirmed">tōmuʻa</annotation>
-		<annotation cp="≻" draft="unconfirmed">tōmui</annotation>
+		<annotation cp="≻" draft="unconfirmed">hoko | matematika | tōmui</annotation>
 		<annotation cp="≻" type="tts" draft="unconfirmed">tōmui</annotation>
-		<annotation cp="⊁" draft="unconfirmed">ʻikai tōmui</annotation>
+		<annotation cp="⊁" draft="unconfirmed">ʻikai | matematika | tōmui</annotation>
 		<annotation cp="⊁" type="tts" draft="unconfirmed">ʻikai tōmui</annotation>
 		<annotation cp="⊂">fakaʻilonga | fakakonga | konga</annotation>
 		<annotation cp="⊂" type="tts">fakakonga</annotation>
-		<annotation cp="⊃" draft="unconfirmed">fakafano</annotation>
+		<annotation cp="⊃" draft="unconfirmed">fakafano | matematika</annotation>
 		<annotation cp="⊃" type="tts" draft="unconfirmed">fakafano</annotation>
-		<annotation cp="⊆" draft="unconfirmed">fakakonga tatau</annotation>
+		<annotation cp="⊆" draft="unconfirmed">fakakonga | matematika | tatau</annotation>
 		<annotation cp="⊆" type="tts" draft="unconfirmed">fakakonga tatau</annotation>
-		<annotation cp="⊇" draft="unconfirmed">fakafano tatau</annotation>
+		<annotation cp="⊇" draft="unconfirmed">fakafano | matematika | tatau</annotation>
 		<annotation cp="⊇" type="tts" draft="unconfirmed">fakafano tatau</annotation>
-		<annotation cp="⊕" draft="unconfirmed">tānaki fakafuopotopoto</annotation>
+		<annotation cp="⊕" draft="unconfirmed">fuopotopoto | matematika | tānaki</annotation>
 		<annotation cp="⊕" type="tts" draft="unconfirmed">tānaki fakafuopotopoto</annotation>
-		<annotation cp="⊖" draft="unconfirmed">kole fakafuopotopoto</annotation>
+		<annotation cp="⊖" draft="unconfirmed">fuopotopoto | kole | matematika</annotation>
 		<annotation cp="⊖" type="tts" draft="unconfirmed">kole fakafuopotopoto</annotation>
-		<annotation cp="⊗" draft="unconfirmed">liunga fakafuopotopoto</annotation>
+		<annotation cp="⊗" draft="unconfirmed">fuopotopoto | liunga | matematika</annotation>
 		<annotation cp="⊗" type="tts" draft="unconfirmed">liunga fakafuopotopoto</annotation>
-		<annotation cp="⊘" draft="unconfirmed">vahevahe fakafuopotopoto</annotation>
+		<annotation cp="⊘" draft="unconfirmed">fuopotopoto | matematika | vahevahe</annotation>
 		<annotation cp="⊘" type="tts" draft="unconfirmed">vahevahe fakafuopotopoto</annotation>
-		<annotation cp="⊙" draft="unconfirmed">toti fakafuopotopoto</annotation>
+		<annotation cp="⊙" draft="unconfirmed">fuopotopoto | matematika | toti</annotation>
 		<annotation cp="⊙" type="tts" draft="unconfirmed">toti fakafuopotopoto</annotation>
-		<annotation cp="⊚" draft="unconfirmed">mama fakafuopotopoto</annotation>
+		<annotation cp="⊚" draft="unconfirmed">fuopotopoto | mama | matematika</annotation>
 		<annotation cp="⊚" type="tts" draft="unconfirmed">mama fakafuopotopoto</annotation>
-		<annotation cp="⊛" draft="unconfirmed">fakafetuʻu fakafuopotopoto</annotation>
+		<annotation cp="⊛" draft="unconfirmed">fetuʻu | fuopotopoto | matematika</annotation>
 		<annotation cp="⊛" type="tts" draft="unconfirmed">fakafetuʻu fakafuopotopoto</annotation>
-		<annotation cp="⊞" draft="unconfirmed">tānaki fakatapafā</annotation>
+		<annotation cp="⊞" draft="unconfirmed">matematika | tānaki | tapafā</annotation>
 		<annotation cp="⊞" type="tts" draft="unconfirmed">tānaki fakatapafā</annotation>
-		<annotation cp="⊟" draft="unconfirmed">kole fakatapafā</annotation>
+		<annotation cp="⊟" draft="unconfirmed">kole | matematika | tapafā</annotation>
 		<annotation cp="⊟" type="tts" draft="unconfirmed">kole fakatapafā</annotation>
-		<annotation cp="⊥" draft="unconfirmed">foʻi tākisi hake</annotation>
+		<annotation cp="⊥" draft="unconfirmed">ʻolunga | matematika | tākisi</annotation>
 		<annotation cp="⊥" type="tts" draft="unconfirmed">foʻi tākisi hake</annotation>
-		<annotation cp="⊮" draft="unconfirmed">ʻikai fakamālohi</annotation>
+		<annotation cp="⊮" draft="unconfirmed">fakamālohi | ʻikai | matematika</annotation>
 		<annotation cp="⊮" type="tts" draft="unconfirmed">ʻikai fakamālohi</annotation>
-		<annotation cp="⊰" draft="unconfirmed">tōmuʻa felāveʻi</annotation>
+		<annotation cp="⊰" draft="unconfirmed">felāveʻi | matematika | tōmuʻa</annotation>
 		<annotation cp="⊰" type="tts" draft="unconfirmed">tōmuʻa felāveʻi</annotation>
-		<annotation cp="⊱" draft="unconfirmed">tōmui felāveʻi</annotation>
+		<annotation cp="⊱" draft="unconfirmed">felāveʻi | matematika | tōmui</annotation>
 		<annotation cp="⊱" type="tts" draft="unconfirmed">tōmui felāveʻi</annotation>
-		<annotation cp="⋭" draft="unconfirmed">ʻIkai ʻi ai ha pupunga fakakonga totonu tatau</annotation>
+		<annotation cp="⋭" draft="unconfirmed">ʻIkai | matematika | pupunga | tatau</annotation>
 		<annotation cp="⋭" type="tts" draft="unconfirmed">ʻIkai ʻi ai ha pupunga fakakonga totonu tatau</annotation>
-		<annotation cp="⊶" draft="unconfirmed">tupuʻi</annotation>
+		<annotation cp="⊶" draft="unconfirmed">matematika | tupuʻi</annotation>
 		<annotation cp="⊶" type="tts" draft="unconfirmed">tupuʻi</annotation>
-		<annotation cp="⊹" draft="unconfirmed">fakatokaʻanga fika fakahoa fakahēmitia</annotation>
+		<annotation cp="⊹" draft="unconfirmed">fika fakahoa | hēmitia | matematika</annotation>
 		<annotation cp="⊹" type="tts" draft="unconfirmed">fakatokaʻanga fika fakahoa fakahēmitia</annotation>
-		<annotation cp="⊿" draft="unconfirmed">tapatolu hangatonu</annotation>
+		<annotation cp="⊿" draft="unconfirmed">hangatonu | matematika | tapatolu</annotation>
 		<annotation cp="⊿" type="tts" draft="unconfirmed">tapatolu hangatonu</annotation>
-		<annotation cp="⋁" draft="unconfirmed">pe fakaʻuhingatotonu lōlahi</annotation>
+		<annotation cp="⋁" draft="unconfirmed">fakaʻuhingatotonu | matematika | pe</annotation>
 		<annotation cp="⋁" type="tts" draft="unconfirmed">pe fakaʻuhingatotonu lōlahi</annotation>
-		<annotation cp="⋂" draft="unconfirmed">fehauaki lōlahi</annotation>
+		<annotation cp="⋂" draft="unconfirmed">fehauaki | lōlahi | matematika</annotation>
 		<annotation cp="⋂" type="tts" draft="unconfirmed">fehauaki lōlahi</annotation>
-		<annotation cp="⋃" draft="unconfirmed">iunioni lōlahi</annotation>
+		<annotation cp="⋃" draft="unconfirmed">iunioni | lōlahi | matematika</annotation>
 		<annotation cp="⋃" type="tts" draft="unconfirmed">iunioni lōlahi</annotation>
-		<annotation cp="⋅" draft="unconfirmed">fakafuofua toti</annotation>
+		<annotation cp="⋅" draft="unconfirmed">matematika | toti</annotation>
 		<annotation cp="⋅" type="tts" draft="unconfirmed">fakafuofua toti</annotation>
-		<annotation cp="⋆" draft="unconfirmed">fakafuofua fetuʻu</annotation>
+		<annotation cp="⋆" draft="unconfirmed">fetuʻu | matematika</annotation>
 		<annotation cp="⋆" type="tts" draft="unconfirmed">fakafuofua fetuʻu</annotation>
-		<annotation cp="⋈" draft="unconfirmed">hoko totonu</annotation>
+		<annotation cp="⋈" draft="unconfirmed">hoko | matematika | totonu</annotation>
 		<annotation cp="⋈" type="tts" draft="unconfirmed">hoko totonu</annotation>
-		<annotation cp="⋒" draft="unconfirmed">fehauaki lōua</annotation>
+		<annotation cp="⋒" draft="unconfirmed">fehauaki | matematika | ua</annotation>
 		<annotation cp="⋒" type="tts" draft="unconfirmed">fehauaki lōua</annotation>
-		<annotation cp="⋘" draft="unconfirmed">siʻihifo ʻaupito</annotation>
+		<annotation cp="⋘" draft="unconfirmed">matematika | siʻihifo</annotation>
 		<annotation cp="⋘" type="tts" draft="unconfirmed">siʻihifo ʻaupito</annotation>
-		<annotation cp="⋙" draft="unconfirmed">lahihake ʻaupito</annotation>
+		<annotation cp="⋙" draft="unconfirmed">lahihake | matematika</annotation>
 		<annotation cp="⋙" type="tts" draft="unconfirmed">lahihake ʻaupito</annotation>
-		<annotation cp="⋮" draft="unconfirmed">totitolu tuʻutonu</annotation>
+		<annotation cp="⋮" draft="unconfirmed">3 | matematika | toti | tuʻutonu</annotation>
 		<annotation cp="⋮" type="tts" draft="unconfirmed">totitolu tuʻutonu</annotation>
-		<annotation cp="⋯" draft="unconfirmed">totitolu lotoloto fakalava</annotation>
+		<annotation cp="⋯" draft="unconfirmed">3 | fakalava | matematika | toti</annotation>
 		<annotation cp="⋯" type="tts" draft="unconfirmed">totitolu lotoloto fakalava</annotation>
-		<annotation cp="⋰" draft="unconfirmed">totitolu hemehema hake</annotation>
+		<annotation cp="⋰" draft="unconfirmed">3 | hemehema | matematika | toti</annotation>
 		<annotation cp="⋰" type="tts" draft="unconfirmed">totitolu hemehema hake</annotation>
-		<annotation cp="⋱" draft="unconfirmed">totitolu hemehema hifo</annotation>
+		<annotation cp="⋱" draft="unconfirmed">3 | hemehema | matematika | toti</annotation>
 		<annotation cp="⋱" type="tts" draft="unconfirmed">totitolu hemehema hifo</annotation>
-		<annotation cp="■" draft="unconfirmed">tapafā fonu</annotation>
+		<annotation cp="■" draft="unconfirmed">fonu | tapafā</annotation>
 		<annotation cp="■" type="tts" draft="unconfirmed">tapafā fonu</annotation>
-		<annotation cp="□" draft="unconfirmed">ngeʻesi tapafā</annotation>
+		<annotation cp="□" draft="unconfirmed">ngeʻesi | tapafā</annotation>
 		<annotation cp="□" type="tts" draft="unconfirmed">ngeʻesi tapafā</annotation>
-		<annotation cp="▢" draft="unconfirmed">ngeʻesi tapafā moe tuliki fuopotopoto</annotation>
+		<annotation cp="▢" draft="unconfirmed">fuopotopoto | ngeʻesi | tapafā | tuliki</annotation>
 		<annotation cp="▢" type="tts" draft="unconfirmed">ngeʻesi tapafā moe tuliki fuopotopoto</annotation>
-		<annotation cp="▣" draft="unconfirmed">tapafā fonu ʻi loto ʻoe ngeʻesi tapafā</annotation>
+		<annotation cp="▣" draft="unconfirmed">fonu | ngeʻesi | tapafā</annotation>
 		<annotation cp="▣" type="tts" draft="unconfirmed">tapafā fonu ʻi loto ʻoe ngeʻesi tapafā</annotation>
-		<annotation cp="▤" draft="unconfirmed">tapafā fonu he meʻa fakalava</annotation>
+		<annotation cp="▤" draft="unconfirmed">fakalava | fonu | tapafā</annotation>
 		<annotation cp="▤" type="tts" draft="unconfirmed">tapafā fonu he meʻa fakalava</annotation>
-		<annotation cp="▥" draft="unconfirmed">tapafā fonu he meʻa tuʻutonu</annotation>
+		<annotation cp="▥" draft="unconfirmed">fonu | tapafā | tuʻutonu</annotation>
 		<annotation cp="▥" type="tts" draft="unconfirmed">tapafā fonu he meʻa tuʻutonu</annotation>
-		<annotation cp="▦" draft="unconfirmed">tapafā fonu he lalava tuʻutonu</annotation>
+		<annotation cp="▦" draft="unconfirmed">fonu | lalava | tapafā</annotation>
 		<annotation cp="▦" type="tts" draft="unconfirmed">tapafā fonu he lalava tuʻutonu</annotation>
-		<annotation cp="▧" draft="unconfirmed">tapafā fonu he meʻa hemehema hifo</annotation>
+		<annotation cp="▧" draft="unconfirmed">fonu | hemehema | tapafā</annotation>
 		<annotation cp="▧" type="tts" draft="unconfirmed">tapafā fonu he meʻa hemehema hifo</annotation>
-		<annotation cp="▨" draft="unconfirmed">tapafā fonu he meʻa hemehema hake</annotation>
+		<annotation cp="▨" draft="unconfirmed">fonu | hemehema | tapafā</annotation>
 		<annotation cp="▨" type="tts" draft="unconfirmed">tapafā fonu he meʻa hemehema hake</annotation>
-		<annotation cp="▩" draft="unconfirmed">tapafā fonu he lalava hemehema</annotation>
+		<annotation cp="▩" draft="unconfirmed">fonu | lalava | tapafā</annotation>
 		<annotation cp="▩" type="tts" draft="unconfirmed">tapafā fonu he lalava hemehema</annotation>
-		<annotation cp="▬" draft="unconfirmed">tapafā tuliki-totonu fonu</annotation>
+		<annotation cp="▬" draft="unconfirmed">fonu | tapafā | tuliki-totonu</annotation>
 		<annotation cp="▬" type="tts" draft="unconfirmed">tapafā tuliki-totonu fonu</annotation>
-		<annotation cp="▭" draft="unconfirmed">ngeʻesi tapafā tuliki-totonu</annotation>
+		<annotation cp="▭" draft="unconfirmed">ngeʻesi | tapafā | tuliki-totonu</annotation>
 		<annotation cp="▭" type="tts" draft="unconfirmed">ngeʻesi tapafā tuliki-totonu</annotation>
-		<annotation cp="▮" draft="unconfirmed">tapafā tuliki-totonu fakatuʻu fonu</annotation>
+		<annotation cp="▮" draft="unconfirmed">fonu | tapafā | tuʻu | tuliki-totonu</annotation>
 		<annotation cp="▮" type="tts" draft="unconfirmed">tapafā tuliki-totonu fakatuʻu fonu</annotation>
-		<annotation cp="▰" draft="unconfirmed">tapafā palāleli fonu</annotation>
+		<annotation cp="▰" draft="unconfirmed">fonu | palāleli | tapafā</annotation>
 		<annotation cp="▰" type="tts" draft="unconfirmed">tapafā palāleli fonu</annotation>
 		<annotation cp="▲">fonu | hake | ʻolunga | tapatolu | tapatolu fonu ki ʻolunga</annotation>
 		<annotation cp="▲" type="tts">tapatolu fonu ki ʻolunga</annotation>
-		<annotation cp="△" draft="unconfirmed">ngeʻesi tapatolu ki ʻolunga</annotation>
+		<annotation cp="△" draft="unconfirmed">ʻolunga | ngeʻesi | tapatolu</annotation>
 		<annotation cp="△" type="tts" draft="unconfirmed">ngeʻesi tapatolu ki ʻolunga</annotation>
-		<annotation cp="▴" draft="unconfirmed">tapatolu siʻi fonu ki ʻolunga</annotation>
+		<annotation cp="▴" draft="unconfirmed">fonu | ʻolunga | tapatolu</annotation>
 		<annotation cp="▴" type="tts" draft="unconfirmed">tapatolu siʻi fonu ki ʻolunga</annotation>
-		<annotation cp="▵" draft="unconfirmed">ngeʻesi tapatolu siʻi ki ʻolunga</annotation>
+		<annotation cp="▵" draft="unconfirmed">ʻolunga | ngeʻesi | tapatolu</annotation>
 		<annotation cp="▵" type="tts" draft="unconfirmed">ngeʻesi tapatolu siʻi ki ʻolunga</annotation>
-		<annotation cp="▷" draft="unconfirmed">ngeʻesi tapatolu ki toʻomataʻu</annotation>
+		<annotation cp="▷" draft="unconfirmed">mataʻu | ngeʻesi | tapatolu</annotation>
 		<annotation cp="▷" type="tts" draft="unconfirmed">ngeʻesi tapatolu ki toʻomataʻu</annotation>
-		<annotation cp="▸" draft="unconfirmed">tapatolu siʻi fonu ki toʻomataʻu</annotation>
+		<annotation cp="▸" draft="unconfirmed">fonu | mataʻu | tapatolu</annotation>
 		<annotation cp="▸" type="tts" draft="unconfirmed">tapatolu siʻi fonu ki toʻomataʻu</annotation>
-		<annotation cp="▹" draft="unconfirmed">ngeʻesi tapatolu siʻi ki toʻomataʻu</annotation>
+		<annotation cp="▹" draft="unconfirmed">mataʻu | ngeʻesi | tapatolu</annotation>
 		<annotation cp="▹" type="tts" draft="unconfirmed">ngeʻesi tapatolu siʻi ki toʻomataʻu</annotation>
-		<annotation cp="►" draft="unconfirmed">hui fonu ki toʻomataʻu</annotation>
+		<annotation cp="►" draft="unconfirmed">fonu | hui | mataʻu | tapatolu</annotation>
 		<annotation cp="►" type="tts" draft="unconfirmed">hui fonu ki toʻomataʻu</annotation>
-		<annotation cp="▻" draft="unconfirmed">ngeʻesi hui ki toʻomataʻu</annotation>
+		<annotation cp="▻" draft="unconfirmed">hui | mataʻu | ngeʻesi | tapatolu</annotation>
 		<annotation cp="▻" type="tts" draft="unconfirmed">ngeʻesi hui ki toʻomataʻu</annotation>
 		<annotation cp="▼">fonu | hifo | lalo | tapatolu | tapatolu fonu ki lalo</annotation>
 		<annotation cp="▼" type="tts">tapatolu fonu ki lalo</annotation>
-		<annotation cp="▽" draft="unconfirmed">ngeʻesi tapatolu ki lalo</annotation>
+		<annotation cp="▽" draft="unconfirmed">lalo | ngeʻesi | tapatolu</annotation>
 		<annotation cp="▽" type="tts" draft="unconfirmed">ngeʻesi tapatolu ki lalo</annotation>
-		<annotation cp="▾" draft="unconfirmed">tapatolu siʻi fonu ki lalo</annotation>
+		<annotation cp="▾" draft="unconfirmed">fonu | lalo | tapatolu</annotation>
 		<annotation cp="▾" type="tts" draft="unconfirmed">tapatolu siʻi fonu ki lalo</annotation>
-		<annotation cp="▿" draft="unconfirmed">ngeʻesi tapatolu siʻi ki lalo</annotation>
+		<annotation cp="▿" draft="unconfirmed">lalo | ngeʻesi | tapatolu</annotation>
 		<annotation cp="▿" type="tts" draft="unconfirmed">ngeʻesi tapatolu siʻi ki lalo</annotation>
-		<annotation cp="◁" draft="unconfirmed">ngeʻesi tapatolu ki toʻohema</annotation>
+		<annotation cp="◁" draft="unconfirmed">hema | ngeʻesi | tapatolu</annotation>
 		<annotation cp="◁" type="tts" draft="unconfirmed">ngeʻesi tapatolu ki toʻohema</annotation>
-		<annotation cp="◂" draft="unconfirmed">tapatolu siʻi fonu ki toʻohema</annotation>
+		<annotation cp="◂" draft="unconfirmed">fonu | hema | tapatolu</annotation>
 		<annotation cp="◂" type="tts" draft="unconfirmed">tapatolu siʻi fonu ki toʻohema</annotation>
-		<annotation cp="◃" draft="unconfirmed">ngeʻesi tapatolu siʻi ki toʻohema</annotation>
+		<annotation cp="◃" draft="unconfirmed">hema | ngeʻesi | tapatolu</annotation>
 		<annotation cp="◃" type="tts" draft="unconfirmed">ngeʻesi tapatolu siʻi ki toʻohema</annotation>
-		<annotation cp="◄" draft="unconfirmed">hui fonu ki toʻohema</annotation>
+		<annotation cp="◄" draft="unconfirmed">fonu | hema | hui | tapatolu</annotation>
 		<annotation cp="◄" type="tts" draft="unconfirmed">hui fonu ki toʻohema</annotation>
-		<annotation cp="◅" draft="unconfirmed">ngeʻesi hui ki toʻohema</annotation>
+		<annotation cp="◅" draft="unconfirmed">hema | hui | ngeʻesi | tapatolu</annotation>
 		<annotation cp="◅" type="tts" draft="unconfirmed">ngeʻesi hui ki toʻohema</annotation>
-		<annotation cp="◆" draft="unconfirmed">taiamoni fonu</annotation>
+		<annotation cp="◆" draft="unconfirmed">fonu | taiamoni</annotation>
 		<annotation cp="◆" type="tts" draft="unconfirmed">taiamoni fonu</annotation>
-		<annotation cp="◇" draft="unconfirmed">ngeʻesi taiamoni</annotation>
+		<annotation cp="◇" draft="unconfirmed">ngeʻesi | taiamoni</annotation>
 		<annotation cp="◇" type="tts" draft="unconfirmed">ngeʻesi taiamoni</annotation>
-		<annotation cp="◈" draft="unconfirmed">taiamoni fonu ʻi loto ʻoe ngeʻesi taiamoni</annotation>
+		<annotation cp="◈" draft="unconfirmed">fonu | ngeʻesi | taiamoni</annotation>
 		<annotation cp="◈" type="tts" draft="unconfirmed">taiamoni fonu ʻi loto ʻoe ngeʻesi taiamoni</annotation>
-		<annotation cp="◉" draft="unconfirmed">fuopotopoto fonu ʻi loto ʻoe ngeʻesi fuopotopoto</annotation>
+		<annotation cp="◉" draft="unconfirmed">fonu | fuopotopoto | ngeʻesi</annotation>
 		<annotation cp="◉" type="tts" draft="unconfirmed">fuopotopoto fonu ʻi loto ʻoe ngeʻesi fuopotopoto</annotation>
 		<annotation cp="◊">mafao | taiamoni</annotation>
 		<annotation cp="◊" type="tts">taiamoni mafao</annotation>
 		<annotation cp="○">fuopotopoto | ngeʻesi</annotation>
 		<annotation cp="○" type="tts">ngeʻesi fuopotopoto</annotation>
-		<annotation cp="◌" draft="unconfirmed">fuopotopoto fakatoti</annotation>
+		<annotation cp="◌" draft="unconfirmed">fuopotopoto | toti</annotation>
 		<annotation cp="◌" type="tts" draft="unconfirmed">fuopotopoto fakatoti</annotation>
-		<annotation cp="◍" draft="unconfirmed">fuopotopoto fonu he meʻa tuʻutonu</annotation>
+		<annotation cp="◍" draft="unconfirmed">fonu | fuopotopoto | tuʻutonu</annotation>
 		<annotation cp="◍" type="tts" draft="unconfirmed">fuopotopoto fonu he meʻa tuʻutonu</annotation>
-		<annotation cp="◎" draft="unconfirmed">fuopotopoto fakatumuʻaki-taha</annotation>
+		<annotation cp="◎" draft="unconfirmed">2 | fuopotopoto</annotation>
 		<annotation cp="◎" type="tts" draft="unconfirmed">fuopotopoto fakatumuʻaki-taha</annotation>
 		<annotation cp="●">fonu | fuopotopoto</annotation>
 		<annotation cp="●" type="tts">fuopotopoto fonu</annotation>
-		<annotation cp="◐" draft="unconfirmed">fuopotopoto fonu ʻi toʻohema</annotation>
+		<annotation cp="◐" draft="unconfirmed">fonu | fuopotopoto | hema | vaeua</annotation>
 		<annotation cp="◐" type="tts" draft="unconfirmed">fuopotopoto fonu ʻi toʻohema</annotation>
-		<annotation cp="◑" draft="unconfirmed">fuopotopoto fonu ʻi toʻomataʻu</annotation>
+		<annotation cp="◑" draft="unconfirmed">fonu | fuopotopoto | mataʻu | vaeua</annotation>
 		<annotation cp="◑" type="tts" draft="unconfirmed">fuopotopoto fonu ʻi toʻomataʻu</annotation>
-		<annotation cp="◒" draft="unconfirmed">fuopotopoto fonu ʻi lalo</annotation>
+		<annotation cp="◒" draft="unconfirmed">fonu | fuopotopoto | lalo | vaeua</annotation>
 		<annotation cp="◒" type="tts" draft="unconfirmed">fuopotopoto fonu ʻi lalo</annotation>
-		<annotation cp="◓" draft="unconfirmed">fuopotopoto fonu ʻi ʻolunga</annotation>
+		<annotation cp="◓" draft="unconfirmed">fonu | fuopotopoto | ʻolunga | vaeua</annotation>
 		<annotation cp="◓" type="tts" draft="unconfirmed">fuopotopoto fonu ʻi ʻolunga</annotation>
-		<annotation cp="◔" draft="unconfirmed">fuopotopoto fonu ʻihe vahefā toʻomataʻu-ʻolunga</annotation>
+		<annotation cp="◔" draft="unconfirmed">fonu | fuopotopoto | ʻolunga | mataʻu | vahefā</annotation>
 		<annotation cp="◔" type="tts" draft="unconfirmed">fuopotopoto fonu ʻihe vahefā toʻomataʻu-ʻolunga</annotation>
-		<annotation cp="◕" draft="unconfirmed">fuopotopoto maha ʻihe vahefā toʻohema-ʻolunga</annotation>
+		<annotation cp="◕" draft="unconfirmed">fuopotopoto | hema | ʻolunga | maha | vahefā</annotation>
 		<annotation cp="◕" type="tts" draft="unconfirmed">fuopotopoto maha ʻihe vahefā toʻohema-ʻolunga</annotation>
-		<annotation cp="◖" draft="unconfirmed">fuopotopoto fonu vaeua toʻohema</annotation>
+		<annotation cp="◖" draft="unconfirmed">fonu | fuopotopoto | hema | vaeua</annotation>
 		<annotation cp="◖" type="tts" draft="unconfirmed">fuopotopoto fonu vaeua toʻohema</annotation>
-		<annotation cp="◗" draft="unconfirmed">fuopotopoto fonu vaeua toʻomataʻu</annotation>
+		<annotation cp="◗" draft="unconfirmed">fonu | fuopotopoto | mataʻu | vaeua</annotation>
 		<annotation cp="◗" type="tts" draft="unconfirmed">fuopotopoto fonu vaeua toʻomataʻu</annotation>
-		<annotation cp="◘" draft="unconfirmed">pulukōkō fulihi</annotation>
+		<annotation cp="◘" draft="unconfirmed">fulihi | pulukōkō</annotation>
 		<annotation cp="◘" type="tts" draft="unconfirmed">pulukōkō fulihi</annotation>
-		<annotation cp="◙" draft="unconfirmed">ngeʻesi fuopotopoto ʻi loto ʻoe tapafā fonu</annotation>
+		<annotation cp="◙" draft="unconfirmed">fonu | fuopotopoto | ngeʻesi | tapafā</annotation>
 		<annotation cp="◙" type="tts" draft="unconfirmed">ngeʻesi fuopotopoto ʻi loto ʻoe tapafā fonu</annotation>
-		<annotation cp="◜" draft="unconfirmed">fuopotopoto vahefā toʻohema-ʻolunga</annotation>
+		<annotation cp="◜" draft="unconfirmed">fuopotopoto | hema | ʻolunga | vahefā</annotation>
 		<annotation cp="◜" type="tts" draft="unconfirmed">fuopotopoto vahefā toʻohema-ʻolunga</annotation>
-		<annotation cp="◝" draft="unconfirmed">fuopotopoto vahefā toʻomataʻu-ʻolunga</annotation>
+		<annotation cp="◝" draft="unconfirmed">fuopotopoto | ʻolunga | mataʻu | vahefā</annotation>
 		<annotation cp="◝" type="tts" draft="unconfirmed">fuopotopoto vahefā toʻomataʻu-ʻolunga</annotation>
-		<annotation cp="◞" draft="unconfirmed">fuopotopoto vahefā toʻomataʻu-lalo</annotation>
+		<annotation cp="◞" draft="unconfirmed">fuopotopoto | lalo | mataʻu | vahefā</annotation>
 		<annotation cp="◞" type="tts" draft="unconfirmed">fuopotopoto vahefā toʻomataʻu-lalo</annotation>
-		<annotation cp="◟" draft="unconfirmed">fuopotopoto vahefā toʻohema-lalo</annotation>
+		<annotation cp="◟" draft="unconfirmed">fuopotopoto | hema | lalo | vahefā</annotation>
 		<annotation cp="◟" type="tts" draft="unconfirmed">fuopotopoto vahefā toʻohema-lalo</annotation>
-		<annotation cp="◠" draft="unconfirmed">fuopotopoto vaeua ʻi ʻolunga</annotation>
+		<annotation cp="◠" draft="unconfirmed">fuopotopoto | ʻolunga | vaeua</annotation>
 		<annotation cp="◠" type="tts" draft="unconfirmed">fuopotopoto vaeua ʻi ʻolunga</annotation>
-		<annotation cp="◡" draft="unconfirmed">fuopotopoto vaeua ʻi lalo</annotation>
+		<annotation cp="◡" draft="unconfirmed">fuopotopoto | lalo | vaeua</annotation>
 		<annotation cp="◡" type="tts" draft="unconfirmed">fuopotopoto vaeua ʻi lalo</annotation>
-		<annotation cp="◢" draft="unconfirmed">tapatolu fonu toʻomataʻu-lalo</annotation>
+		<annotation cp="◢" draft="unconfirmed">fonu | lalo | mataʻu | tapatolu</annotation>
 		<annotation cp="◢" type="tts" draft="unconfirmed">tapatolu fonu toʻomataʻu-lalo</annotation>
-		<annotation cp="◣" draft="unconfirmed">tapatolu fonu toʻohema-lalo</annotation>
+		<annotation cp="◣" draft="unconfirmed">fonu | hema | lalo | tapatolu</annotation>
 		<annotation cp="◣" type="tts" draft="unconfirmed">tapatolu fonu toʻohema-lalo</annotation>
-		<annotation cp="◤" draft="unconfirmed">tapatolu fonu toʻohema-ʻolunga</annotation>
+		<annotation cp="◤" draft="unconfirmed">fonu | hema | ʻolunga | tapatolu</annotation>
 		<annotation cp="◤" type="tts" draft="unconfirmed">tapatolu fonu toʻohema-ʻolunga</annotation>
-		<annotation cp="◥" draft="unconfirmed">tapatolu fonu toʻomataʻu-ʻolunga</annotation>
+		<annotation cp="◥" draft="unconfirmed">fonu | ʻolunga | mataʻu | tapatolu</annotation>
 		<annotation cp="◥" type="tts" draft="unconfirmed">tapatolu fonu toʻomataʻu-ʻolunga</annotation>
-		<annotation cp="◦" draft="unconfirmed">ngeʻesi pulukōkō</annotation>
+		<annotation cp="◦" draft="unconfirmed">ngeʻesi | pulukōkō</annotation>
 		<annotation cp="◦" type="tts" draft="unconfirmed">ngeʻesi pulukōkō</annotation>
 		<annotation cp="◯">fuopotopoto | ngeʻesi | ngeʻesi fuopotopoto lahi</annotation>
 		<annotation cp="◯" type="tts">ngeʻesi fuopotopoto lahi</annotation>
-		<annotation cp="◳" draft="unconfirmed">ngeʻesi tapafā vahefā toʻomataʻu-ʻolunga</annotation>
+		<annotation cp="◳" draft="unconfirmed">ʻolunga | mataʻu | ngeʻesi | tapafā | vahefā</annotation>
 		<annotation cp="◳" type="tts" draft="unconfirmed">ngeʻesi tapafā vahefā toʻomataʻu-ʻolunga</annotation>
-		<annotation cp="◷" draft="unconfirmed">ngeʻesi fuopotopoto vahefā toʻomataʻu-ʻolunga</annotation>
+		<annotation cp="◷" draft="unconfirmed">fuopotopoto | ʻolunga | mataʻu | ngeʻesi | vahefā</annotation>
 		<annotation cp="◷" type="tts" draft="unconfirmed">ngeʻesi fuopotopoto vahefā toʻomataʻu-ʻolunga</annotation>
-		<annotation cp="◿" draft="unconfirmed">tapatolu toʻomataʻu-lalo</annotation>
+		<annotation cp="◿" draft="unconfirmed">lalo | mataʻu | ngeʻesi | tapatolu</annotation>
 		<annotation cp="◿" type="tts" draft="unconfirmed">tapatolu toʻomataʻu-lalo</annotation>
 		<annotation cp="♪">nota vaevalu | tuʻungafasi</annotation>
 		<annotation cp="♪" type="tts">nota vaevalu</annotation>
-		<annotation cp="⨧" draft="unconfirmed">tānaki kohi ua</annotation>
+		<annotation cp="⨧" draft="unconfirmed">2 | kohi | tānaki</annotation>
 		<annotation cp="⨧" type="tts" draft="unconfirmed">tānaki kohi ua</annotation>
-		<annotation cp="⨯" draft="unconfirmed">liunga ʻotufika ʻi tuʻa</annotation>
+		<annotation cp="⨯" draft="unconfirmed">ʻotufika | liunga | matematika | tuʻa</annotation>
 		<annotation cp="⨯" type="tts" draft="unconfirmed">liunga ʻotufika ʻi tuʻa</annotation>
-		<annotation cp="⨼" draft="unconfirmed">liunga ʻotufika ʻi loto</annotation>
+		<annotation cp="⨼" draft="unconfirmed">ʻotufika | liunga | loto | matematika</annotation>
 		<annotation cp="⨼" type="tts" draft="unconfirmed">liunga ʻotufika ʻi loto</annotation>
-		<annotation cp="⩣" draft="unconfirmed">pe fakaʻuhingatotonu pā lōua hake</annotation>
+		<annotation cp="⩣" draft="unconfirmed">2 | matematika | pā | pe</annotation>
 		<annotation cp="⩣" type="tts" draft="unconfirmed">pe fakaʻuhingatotonu pā lōua hake</annotation>
-		<annotation cp="⩽" draft="unconfirmed">siʻihifo tatau fakahei</annotation>
+		<annotation cp="⩽" draft="unconfirmed">fakahei | matematika | siʻihifo | tatau</annotation>
 		<annotation cp="⩽" type="tts" draft="unconfirmed">siʻihifo tatau fakahei</annotation>
-		<annotation cp="⪍" draft="unconfirmed">siʻihifo moe meimei tatau</annotation>
+		<annotation cp="⪍" draft="unconfirmed">matematika | siʻihifo | tatau</annotation>
 		<annotation cp="⪍" type="tts" draft="unconfirmed">siʻihifo moe meimei tatau</annotation>
-		<annotation cp="⪚" draft="unconfirmed">laine lōua tatau lahihake</annotation>
+		<annotation cp="⪚" draft="unconfirmed">2 | lahihake | lōua | matematika | tatau</annotation>
 		<annotation cp="⪚" type="tts" draft="unconfirmed">laine lōua tatau lahihake</annotation>
-		<annotation cp="⪺" draft="unconfirmed">tōmui ʻikai meimei tatau hake</annotation>
+		<annotation cp="⪺" draft="unconfirmed">ʻikai | matematika | tatau | tōmui</annotation>
 		<annotation cp="⪺" type="tts" draft="unconfirmed">tōmui ʻikai meimei tatau hake</annotation>
 		<annotation cp="♭">falati | tuʻungafasi</annotation>
 		<annotation cp="♭" type="tts">falati</annotation>
@@ -711,21 +711,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="♯" type="tts">saapa</annotation>
 		<annotation cp="😀">fiefia | mata | ngutu</annotation>
 		<annotation cp="😀" type="tts">mata fiefia</annotation>
-		<annotation cp="😃">fiefia | kanoʻimata | mata | mata fiefia moe kanoʻimata lalahi | ngutu</annotation>
+		<annotation cp="😃">fiefia | kanoʻimata | mata | ngutu</annotation>
 		<annotation cp="😃" type="tts">mata fiefia moe kanoʻimata lalahi</annotation>
-		<annotation cp="😄">fiefia | kanoʻimata | mata | mata fiefia moe kanoʻimata malimali | ngutu</annotation>
+		<annotation cp="😄">fiefia | kanoʻimata | mata | ngutu</annotation>
 		<annotation cp="😄" type="tts">mata fiefia moe kanoʻimata malimali</annotation>
-		<annotation cp="😁">ina | kanoʻimata | mata | mata ina moe kanoʻimata malimali | ngutu</annotation>
+		<annotation cp="😁">ina | kanoʻimata | mata | ngutu</annotation>
 		<annotation cp="😁" type="tts">mata ina moe kanoʻimata malimali</annotation>
-		<annotation cp="😆">fiefia | mata | mata fiefia moe tetepa | ngutu | tetepa</annotation>
+		<annotation cp="😆">fiefia | mata | ngutu | tetepa</annotation>
 		<annotation cp="😆" type="tts">mata fiefia moe tetepa</annotation>
-		<annotation cp="😅">fiefia | mata | mata fiefia moe tautaʻa | ngutu | tautaʻa</annotation>
+		<annotation cp="😅">fiefia | mata | ngutu | tautaʻa</annotation>
 		<annotation cp="😅" type="tts">mata fiefia moe tautaʻa</annotation>
-		<annotation cp="🤣">kata | mata | mata kata moe teka faliki | ngutu | teka</annotation>
+		<annotation cp="🤣">kata | mata | ngutu | teka</annotation>
 		<annotation cp="🤣" type="tts">mata kata moe teka faliki</annotation>
-		<annotation cp="😂">fiefia | loʻimata | mata | mata moe loʻimata fiefia | ngutu</annotation>
+		<annotation cp="😂">fiefia | loʻimata | mata | ngutu</annotation>
 		<annotation cp="😂" type="tts">mata moe loʻimata fiefia</annotation>
-		<annotation cp="🙂">malimali | mata | mata kiʻi malimali</annotation>
+		<annotation cp="🙂">malimali | mata</annotation>
 		<annotation cp="🙂" type="tts">mata kiʻi malimali</annotation>
 		<annotation cp="🙃">fulihi | malimali | mata</annotation>
 		<annotation cp="🙃" type="tts">mata fulihi</annotation>
@@ -733,67 +733,67 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫠" type="tts">mata vaia</annotation>
 		<annotation cp="😉">fakakuitaha | malimali | mata</annotation>
 		<annotation cp="😉" type="tts">mata fakakuitaha</annotation>
-		<annotation cp="😊">kanoʻimata | malimali | mata | mata malimali moe kanoʻimata malimali</annotation>
+		<annotation cp="😊">kanoʻimata | malimali | mata</annotation>
 		<annotation cp="😊" type="tts">mata malimali moe kanoʻimata malimali</annotation>
-		<annotation cp="😇">malimali | mata | mata malimali moe takaniko | takaniko</annotation>
+		<annotation cp="😇">malimali | mata | takaniko</annotation>
 		<annotation cp="😇" type="tts">mata malimali moe takaniko</annotation>
-		<annotation cp="🥰">3 | mafu | malimali | mata | mata malimali moe mafu ʻe 3</annotation>
+		<annotation cp="🥰">3 | mafu | malimali | mata</annotation>
 		<annotation cp="🥰" type="tts">mata malimali moe mafu ʻe 3</annotation>
-		<annotation cp="😍">kanoʻimata | mafu | malimali | mata | mata malimali moe kanoʻimata mafu</annotation>
+		<annotation cp="😍">kanoʻimata | mafu | malimali | mata</annotation>
 		<annotation cp="😍" type="tts">mata malimali moe kanoʻimata mafu</annotation>
 		<annotation cp="🤩">fetuʻu | kanoʻimata | mata</annotation>
 		<annotation cp="🤩" type="tts">mata fetuʻu</annotation>
-		<annotation cp="😘">ʻuma | mafu | mata | mata ʻoku puhi ʻae ʻuma | puhi</annotation>
+		<annotation cp="😘">ʻuma | mafu | mata | puhi</annotation>
 		<annotation cp="😘" type="tts">mata ʻoku puhi ʻae ʻuma</annotation>
 		<annotation cp="😗">ʻuma | mata</annotation>
 		<annotation cp="😗" type="tts">mata ʻuma</annotation>
 		<annotation cp="☺">malimali | mata</annotation>
 		<annotation cp="☺" type="tts">mata malimali</annotation>
-		<annotation cp="😚">ʻuma | kanoʻimata | kuikui | mata | mata ʻuma moe kanoʻimata kuikui</annotation>
+		<annotation cp="😚">ʻuma | kanoʻimata | kuikui | mata</annotation>
 		<annotation cp="😚" type="tts">mata ʻuma moe kanoʻimata kuikui</annotation>
-		<annotation cp="😙">ʻuma | kanoʻimata | malimali | mata | mata ʻuma moe kanoʻimata malimali</annotation>
+		<annotation cp="😙">ʻuma | kanoʻimata | malimali | mata</annotation>
 		<annotation cp="😙" type="tts">mata ʻuma moe kanoʻimata malimali</annotation>
-		<annotation cp="🥲">loʻimata | malimali | mata | mata malimali moe loʻimata</annotation>
+		<annotation cp="🥲">loʻimata | malimali | mata</annotation>
 		<annotation cp="🥲" type="tts">mata malimali moe loʻimata</annotation>
-		<annotation cp="😋">ʻelelo | ʻuakai | ifo | mata | mataʻi ʻuakai</annotation>
+		<annotation cp="😋">ʻelelo | ʻuakai | ifo | mata</annotation>
 		<annotation cp="😋" type="tts">mataʻi ʻuakai</annotation>
-		<annotation cp="😛">ʻelelo | mata | mata moe ʻelelo | ngutu</annotation>
+		<annotation cp="😛">ʻelelo | mata | ngutu</annotation>
 		<annotation cp="😛" type="tts">mata moe ʻelelo</annotation>
-		<annotation cp="😜">ʻelelo | kuitaha | mata | mata kuitaha moe ʻelelo | ngutu</annotation>
+		<annotation cp="😜">ʻelelo | kuitaha | mata | ngutu</annotation>
 		<annotation cp="😜" type="tts">mata kuitaha moe ʻelelo</annotation>
 		<annotation cp="🤪">ʻelelo | kanoimata | masoli | mata | ngutu</annotation>
 		<annotation cp="🤪" type="tts">mata masoli</annotation>
-		<annotation cp="😝">ʻelelo | mata | mata tetepa moe ʻelelo | ngutu | tetepa</annotation>
+		<annotation cp="😝">ʻelelo | mata | ngutu | tetepa</annotation>
 		<annotation cp="😝" type="tts">mata tetepa moe ʻelelo</annotation>
-		<annotation cp="🤑">ʻelelo | mata | mata ngutu-paʻanga | ngutu | paʻanga</annotation>
+		<annotation cp="🤑">ʻelelo | mata | ngutu | paʻanga</annotation>
 		<annotation cp="🤑" type="tts">mata ngutu-paʻanga</annotation>
-		<annotation cp="🤗">fāʻufua | kula | mata | mata fāʻufua moe nima-homo | nima-homo</annotation>
+		<annotation cp="🤗">fāʻufua | kula | mata | nima-homo</annotation>
 		<annotation cp="🤗" type="tts">mata fāʻufua moe nima-homo</annotation>
-		<annotation cp="🤭">ʻufiʻufi | kula | mata | mata moe nima ʻi muʻa ʻoe ngutu | ngutu | nima</annotation>
+		<annotation cp="🤭">ʻufiʻufi | kula | mata | ngutu | nima</annotation>
 		<annotation cp="🤭" type="tts">mata moe nima ʻi muʻa ʻoe ngutu</annotation>
-		<annotation cp="🫢">ʻohovale | mata | mata matalahi moe nima ʻi muʻa ʻoe ngutu | ngutu | teteki</annotation>
+		<annotation cp="🫢">ʻohovale | mata | ngutu | teteki</annotation>
 		<annotation cp="🫢" type="tts">mata matalahi moe nima ʻi muʻa ʻoe ngutu</annotation>
-		<annotation cp="🫣">foʻimata | ilifia | mata | mata moe foʻimata tauasi | tauasi</annotation>
+		<annotation cp="🫣">foʻimata | ilifia | mata | tauasi</annotation>
 		<annotation cp="🫣" type="tts">mata moe foʻimata tauasi</annotation>
-		<annotation cp="🤫">fakalongolongo | mata | mata fiemaʻu fakalongolongo</annotation>
+		<annotation cp="🤫">fakalongolongo | mata</annotation>
 		<annotation cp="🤫" type="tts">mata fiemaʻu fakalongolongo</annotation>
-		<annotation cp="🤔">fakakaukau | mata | mataʻi fakakaukau</annotation>
+		<annotation cp="🤔">fakakaukau | mata</annotation>
 		<annotation cp="🤔" type="tts">mataʻi fakakaukau</annotation>
 		<annotation cp="🫡">fetapa | mata | salute</annotation>
 		<annotation cp="🫡" type="tts">mata fetapa</annotation>
-		<annotation cp="🤐">mata | mata moe ngutu meʻa-fakamaʻu-fusi | meʻa-fakamaʻu-fusi | ngutu</annotation>
+		<annotation cp="🤐">mata | meʻa-fakamaʻu-fusi | ngutu</annotation>
 		<annotation cp="🤐" type="tts">mata moe ngutu meʻa-fakamaʻu-fusi</annotation>
-		<annotation cp="🤨">kemo | mahiki | mata | mata moe kemo mahiki</annotation>
+		<annotation cp="🤨">kemo | mahiki | mata</annotation>
 		<annotation cp="🤨" type="tts">mata moe kemo mahiki</annotation>
-		<annotation cp="😐">ʻatā | mata | mata noa pē | noa</annotation>
+		<annotation cp="😐">ʻatā | mata | noa</annotation>
 		<annotation cp="😐" type="tts">mata noa pē</annotation>
 		<annotation cp="😑">mata | matanoa</annotation>
 		<annotation cp="😑" type="tts">mata matanoa</annotation>
 		<annotation cp="😶">mata | ngutu | taʻengutu</annotation>
 		<annotation cp="😶" type="tts">mata taʻengutu</annotation>
-		<annotation cp="🫥">mata | mata fakalaine toti | puli | taʻehāmai | toti</annotation>
+		<annotation cp="🫥">mata | puli | taʻehāmai | toti</annotation>
 		<annotation cp="🫥" type="tts">mata fakalaine toti</annotation>
-		<annotation cp="😶‍🌫">ʻao | lotoʻāvea | mata | mata ʻihe ʻao</annotation>
+		<annotation cp="😶‍🌫">ʻao | lotoʻāvea | mata</annotation>
 		<annotation cp="😶‍🌫" type="tts">mata ʻihe ʻao</annotation>
 		<annotation cp="😏">katakata | manuki | mata</annotation>
 		<annotation cp="😏" type="tts">mata katakata manuki</annotation>
@@ -801,17 +801,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😒" type="tts">mata taʻefiefia</annotation>
 		<annotation cp="🙄">kilokilo | mata</annotation>
 		<annotation cp="🙄" type="tts">mata kilokilo</annotation>
-		<annotation cp="😬">ina | mata | mata mioʻi | mio</annotation>
+		<annotation cp="😬">ina | mata | mio</annotation>
 		<annotation cp="😬" type="tts">mata mioʻi</annotation>
 		<annotation cp="😮‍💨">fiemālie | hō | mata</annotation>
 		<annotation cp="😮‍💨" type="tts">mata hō</annotation>
-		<annotation cp="🤥">ihu | lōloa | mata | mata moe ihu lōloa</annotation>
+		<annotation cp="🤥">ihu | lōloa | mata</annotation>
 		<annotation cp="🤥" type="tts">mata moe ihu lōloa</annotation>
-		<annotation cp="🫨">lulu | mafuike | mata tete | ngalulu | tete</annotation>
+		<annotation cp="🫨">lulu | mafuike | ngalulu | tete</annotation>
 		<annotation cp="🫨" type="tts">mata tete</annotation>
-		<annotation cp="🙂‍↔">kalo | mata | mata kalokalo | tete</annotation>
+		<annotation cp="🙂‍↔">kalo | mata | tete</annotation>
 		<annotation cp="🙂‍↔" type="tts">mata kalokalo</annotation>
-		<annotation cp="🙂‍↕">kamo | mata | mata kamokamo | tete</annotation>
+		<annotation cp="🙂‍↕">kamo | mata | tete</annotation>
 		<annotation cp="🙂‍↕" type="tts">mata kamokamo</annotation>
 		<annotation cp="😌">fakanongononga | mata</annotation>
 		<annotation cp="😌" type="tts">mata fakanongononga</annotation>
@@ -823,11 +823,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤤" type="tts">mata ngutu hafu fāvai</annotation>
 		<annotation cp="😴">mata | mohe</annotation>
 		<annotation cp="😴" type="tts">mata mohe</annotation>
-		<annotation cp="😷">fakafaitoʻo | mata | mata moe pūloa fakafaitoʻo | puke | pūloa</annotation>
+		<annotation cp="😷">fakafaitoʻo | mata | puke | pūloa</annotation>
 		<annotation cp="😷" type="tts">mata moe pūloa fakafaitoʻo</annotation>
-		<annotation cp="🤒">mata | mata moe meʻafuamafana | meʻafuamafana | puke</annotation>
+		<annotation cp="🤒">mata | meʻafuamafana | puke</annotation>
 		<annotation cp="🤒" type="tts">mata moe meʻafuamafana</annotation>
-		<annotation cp="🤕">haʻi lavea | mata | mata moe haʻi lavea | puke</annotation>
+		<annotation cp="🤕">haʻi lavea | mata | puke</annotation>
 		<annotation cp="🤕" type="tts">mata moe haʻi lavea</annotation>
 		<annotation cp="🤢">kavahia | mata | puke</annotation>
 		<annotation cp="🤢" type="tts">mata kavahia</annotation>
@@ -847,17 +847,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😵‍💫" type="tts">mata takatakai</annotation>
 		<annotation cp="🤯">mata | pahū</annotation>
 		<annotation cp="🤯" type="tts">mata pahū</annotation>
-		<annotation cp="🤠">kaupoe | mata | mata moe tatā fakakaupoe | tatā</annotation>
+		<annotation cp="🤠">kaupoe | mata | tatā</annotation>
 		<annotation cp="🤠" type="tts">mata moe tatā fakakaupoe</annotation>
 		<annotation cp="🥳">mata | paati</annotation>
 		<annotation cp="🥳" type="tts">mata paati</annotation>
 		<annotation cp="🥸">fakapuli | mata | matasioʻata</annotation>
 		<annotation cp="🥸" type="tts">mata fakapuli</annotation>
-		<annotation cp="😎">malimali | mata | mata malimali moe matasioʻatalaʻā | matasioʻatalaʻā</annotation>
+		<annotation cp="😎">malimali | mata | matasioʻatalaʻā</annotation>
 		<annotation cp="😎" type="tts">mata malimali moe matasioʻatalaʻā</annotation>
-		<annotation cp="🤓">mata | mata moe matasioʻata lahi | matasioʻata | ngutu</annotation>
+		<annotation cp="🤓">mata | matasioʻata | ngutu</annotation>
 		<annotation cp="🤓" type="tts">mata moe matasioʻata lahi</annotation>
-		<annotation cp="🧐">mata | mata moe matasioʻata tafaʻaki taha | matasioʻata | taha</annotation>
+		<annotation cp="🧐">mata | matasioʻata | taha</annotation>
 		<annotation cp="🧐" type="tts">mata moe matasioʻata tafaʻaki taha</annotation>
 		<annotation cp="😕">mata | puputuʻu</annotation>
 		<annotation cp="😕" type="tts">mata puputuʻu</annotation>
@@ -869,7 +869,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙁" type="tts">mata kiʻi fingo</annotation>
 		<annotation cp="☹">fingo | mata</annotation>
 		<annotation cp="☹" type="tts">mata fingo</annotation>
-		<annotation cp="😮">fakamanga | mata | mata moe ngutu fakamanga | ngutu</annotation>
+		<annotation cp="😮">fakamanga | mata | ngutu</annotation>
 		<annotation cp="😮" type="tts">mata moe ngutu fakamanga</annotation>
 		<annotation cp="😯">longo | mata</annotation>
 		<annotation cp="😯" type="tts">mata longo</annotation>
@@ -879,31 +879,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😳" type="tts">mata pahapaha</annotation>
 		<annotation cp="🥺">kole | mata</annotation>
 		<annotation cp="🥺" type="tts">mata kole</annotation>
-		<annotation cp="🥹">lotomamahi | mata | mata loʻimata maʻu | tuʻuaki</annotation>
+		<annotation cp="🥹">lotomamahi | mata | tuʻuaki</annotation>
 		<annotation cp="🥹" type="tts">mata loʻimata maʻu</annotation>
-		<annotation cp="😦">fakamanga | fingo | mata | mata fingo moe ngutu fakamanga | ngutu</annotation>
+		<annotation cp="😦">fakamanga | fingo | mata | ngutu</annotation>
 		<annotation cp="😦" type="tts">mata fingo moe ngutu fakamanga</annotation>
 		<annotation cp="😧">lotomamahi | mata</annotation>
 		<annotation cp="😧" type="tts">mata lotomamahi</annotation>
 		<annotation cp="😨">fakamanavahē | mata</annotation>
 		<annotation cp="😨" type="tts">mata fakamanavahē</annotation>
-		<annotation cp="😰">lotomoʻua | mata | mata lotomoʻua moe tautaʻa | pulū | tautaʻa</annotation>
+		<annotation cp="😰">lotomoʻua | mata | pulū | tautaʻa</annotation>
 		<annotation cp="😰" type="tts">mata lotomoʻua moe tautaʻa</annotation>
-		<annotation cp="😥">fakanongononga | lotomamahi | mata | mata lotomamahi kā fakanongononga</annotation>
+		<annotation cp="😥">fakanongononga | lotomamahi | mata</annotation>
 		<annotation cp="😥" type="tts">mata lotomamahi kā fakanongononga</annotation>
 		<annotation cp="😢">loʻimata | mata | tangi</annotation>
 		<annotation cp="😢" type="tts">mata loʻimata</annotation>
-		<annotation cp="😭">loʻimata | mata | mata loʻimata lahi | tangi</annotation>
+		<annotation cp="😭">loʻimata | mata | tangi</annotation>
 		<annotation cp="😭" type="tts">mata loʻimata lahi</annotation>
-		<annotation cp="😱">kekekeke | manavahē | mata | mata ʻoku kekekeke he manavahē</annotation>
+		<annotation cp="😱">kekekeke | manavahē | mata</annotation>
 		<annotation cp="😱" type="tts">mata ʻoku kekekeke he manavahē</annotation>
-		<annotation cp="😖">mata | mata fakapuputuʻu | puputuʻu</annotation>
+		<annotation cp="😖">mata | puputuʻu</annotation>
 		<annotation cp="😖" type="tts">mata fakapuputuʻu</annotation>
 		<annotation cp="😣">lotokītaki | mata</annotation>
 		<annotation cp="😣" type="tts">mata lotokītaki</annotation>
-		<annotation cp="😞">lotomamahi | mata | mata fakalotomamahi</annotation>
+		<annotation cp="😞">lotomamahi | mata</annotation>
 		<annotation cp="😞" type="tts">mata fakalotomamahi</annotation>
-		<annotation cp="😓">lototaʻotaʻomia | mata | mata lototaʻotaʻomia moe tautaʻa | tautaʻa</annotation>
+		<annotation cp="😓">lototaʻotaʻomia | mata | tautaʻa</annotation>
 		<annotation cp="😓" type="tts">mata lototaʻotaʻomia moe tautaʻa</annotation>
 		<annotation cp="😩">helaʻia | mata | ongosia</annotation>
 		<annotation cp="😩" type="tts">mata ongosia</annotation>
@@ -911,25 +911,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😫" type="tts">mata helaʻia</annotation>
 		<annotation cp="🥱">fakahela | mamao | mata</annotation>
 		<annotation cp="🥱" type="tts">mata mamao</annotation>
-		<annotation cp="😤">ihu | mao | mata | mata moe mao meihe ihu</annotation>
+		<annotation cp="😤">ihu | mao | mata</annotation>
 		<annotation cp="😤" type="tts">mata moe mao meihe ihu</annotation>
-		<annotation cp="😡">ʻita | kuolokula | mata | mata ʻita lahi</annotation>
+		<annotation cp="😡">ʻita | kuolokula | mata</annotation>
 		<annotation cp="😡" type="tts">mata ʻita lahi</annotation>
 		<annotation cp="😠">ʻita | mata</annotation>
 		<annotation cp="😠" type="tts">mata ʻita</annotation>
 		<annotation cp="🤬">kapekape | kulokula | mata</annotation>
 		<annotation cp="🤬" type="tts">mata kapekape</annotation>
-		<annotation cp="😈">lanufesiʻifekika | malimali | mata | mata malimali moe meʻatui | meʻatui</annotation>
+		<annotation cp="😈">lanufesiʻifekika | malimali | mata | meʻatui</annotation>
 		<annotation cp="😈" type="tts">mata malimali moe meʻatui</annotation>
-		<annotation cp="👿">ʻita | lanufesiʻifekika | mata | mata ʻita moe meʻatui | meʻatui</annotation>
+		<annotation cp="👿">ʻita | lanufesiʻifekika | mata | meʻatui</annotation>
 		<annotation cp="👿" type="tts">mata ʻita moe meʻatui</annotation>
 		<annotation cp="💀">ʻulupoko | mate</annotation>
 		<annotation cp="💀" type="tts">ʻulupoko</annotation>
-		<annotation cp="☠">2 | fehauaki | hui | ʻulupoko | ʻulupoko moe ongo hui fehauaki | kaihaʻa ʻi tahi</annotation>
+		<annotation cp="☠">2 | fehauaki | hui | ʻulupoko | kaihaʻa ʻi tahi</annotation>
 		<annotation cp="☠" type="tts">ʻulupoko moe ongo hui fehauaki</annotation>
 		<annotation cp="💩">meʻakovi | taʻe | tuʻunga</annotation>
 		<annotation cp="💩" type="tts">tuʻunga meʻakovi</annotation>
-		<annotation cp="🤡">fieoli | mata | mata tokotaha-fieoli</annotation>
+		<annotation cp="🤡">fieoli | mata</annotation>
 		<annotation cp="🤡" type="tts">mata tokotaha-fieoli</annotation>
 		<annotation cp="👹">faʻahikehe | nifoloa</annotation>
 		<annotation cp="👹" type="tts">nifoloa</annotation>
@@ -943,23 +943,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👾" type="tts">meʻamoʻuikehe fakamanavahē</annotation>
 		<annotation cp="🤖">mata | tangata-ukamea</annotation>
 		<annotation cp="🤖" type="tts">mata tangata-ukamea</annotation>
-		<annotation cp="😺">fiefia | mata | mataʻipusi fiefia | pusi</annotation>
+		<annotation cp="😺">fiefia | mata | pusi</annotation>
 		<annotation cp="😺" type="tts">mataʻipusi fiefia</annotation>
-		<annotation cp="😸">fiefia | kanoʻimata | malimali | mata | mataʻipusi fiefia moe kanoʻimata malimali | pusi</annotation>
+		<annotation cp="😸">fiefia | kanoʻimata | malimali | mata | pusi</annotation>
 		<annotation cp="😸" type="tts">mataʻipusi fiefia moe kanoʻimata malimali</annotation>
-		<annotation cp="😹">fiefia | loʻimata | mata | mataʻipusi moe loʻimata fiefia | pusi</annotation>
+		<annotation cp="😹">fiefia | loʻimata | mata | pusi</annotation>
 		<annotation cp="😹" type="tts">mataʻipusi moe loʻimata fiefia</annotation>
-		<annotation cp="😻">kanoʻimata | mafu | malimali | mata | mataʻipusi malimali moe kanoʻimata mafu | pusi</annotation>
+		<annotation cp="😻">kanoʻimata | mafu | malimali | mata | pusi</annotation>
 		<annotation cp="😻" type="tts">mataʻipusi malimali moe kanoʻimata mafu</annotation>
-		<annotation cp="😼">malimali feʻu | mata | mataʻipusi moe malimali feʻu | pusi</annotation>
+		<annotation cp="😼">malimali feʻu | mata | pusi</annotation>
 		<annotation cp="😼" type="tts">mataʻipusi moe malimali feʻu</annotation>
-		<annotation cp="😽">ʻuma | mata | mataʻipusi ʻuma | pusi</annotation>
+		<annotation cp="😽">ʻuma | mata | pusi</annotation>
 		<annotation cp="😽" type="tts">mataʻipusi ʻuma</annotation>
-		<annotation cp="🙀">mata | mataʻipusi ongosia | ongosia | pusi</annotation>
+		<annotation cp="🙀">mata | ongosia | pusi</annotation>
 		<annotation cp="🙀" type="tts">mataʻipusi ongosia</annotation>
-		<annotation cp="😿">loʻimata | mata | mataʻipusi loʻimata | pusi</annotation>
+		<annotation cp="😿">loʻimata | mata | pusi</annotation>
 		<annotation cp="😿" type="tts">mataʻipusi loʻimata</annotation>
-		<annotation cp="😾">mata | mataʻipusi taʻefiemālie | pusi | taʻefiemālie</annotation>
+		<annotation cp="😾">mata | pusi | taʻefiemālie</annotation>
 		<annotation cp="😾" type="tts">mataʻipusi taʻefiemālie</annotation>
 		<annotation cp="🙈">ʻikai | kovi | ngeli | sio</annotation>
 		<annotation cp="🙈" type="tts">ngeli ʻikai sio kovi</annotation>
@@ -969,15 +969,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙊" type="tts">ngeli ʻikai lea kovi</annotation>
 		<annotation cp="💌">ʻofa | mafu | tohi</annotation>
 		<annotation cp="💌" type="tts">tohi ʻofa</annotation>
-		<annotation cp="💘">ʻofa | mafu | mafu moe ngahau | ngahau</annotation>
+		<annotation cp="💘">ʻofa | mafu | ngahau</annotation>
 		<annotation cp="💘" type="tts">mafu moe ngahau</annotation>
-		<annotation cp="💝">lipine | mafu | mafu moe lipine | ofo</annotation>
+		<annotation cp="💝">lipine | mafu | ofo</annotation>
 		<annotation cp="💝" type="tts">mafu moe lipine</annotation>
 		<annotation cp="💖">mafu | ngingila</annotation>
 		<annotation cp="💖" type="tts">mafu ngingila</annotation>
 		<annotation cp="💗">mafu | tupu</annotation>
 		<annotation cp="💗" type="tts">mafu tupu</annotation>
-		<annotation cp="💓">mafu | mafu ʻoku tā | tā</annotation>
+		<annotation cp="💓">mafu | tā</annotation>
 		<annotation cp="💓" type="tts">mafu ʻoku tā</annotation>
 		<annotation cp="💞">mafu | ongo | takai</annotation>
 		<annotation cp="💞" type="tts">ongo mafu takai</annotation>
@@ -985,7 +985,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="💕" type="tts">ongo mafu</annotation>
 		<annotation cp="💟">lanufesiʻifekika | mafu | teuteuʻi</annotation>
 		<annotation cp="💟" type="tts">mafu teuteuʻi</annotation>
-		<annotation cp="❣">ʻilonga | kalanga | mafu | mafu fakaʻilonga kalanga</annotation>
+		<annotation cp="❣">ʻilonga | kalanga | mafu</annotation>
 		<annotation cp="❣" type="tts">mafu fakaʻilonga kalanga</annotation>
 		<annotation cp="💔">lavea | loto | mafu</annotation>
 		<annotation cp="💔" type="tts">loto lavea</annotation>
@@ -1035,9 +1035,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🕳" type="tts">ava</annotation>
 		<annotation cp="💬">lea | pulalea</annotation>
 		<annotation cp="💬" type="tts">pulalea</annotation>
-		<annotation cp="👁‍🗨">kanoʻimata | kanoʻimata ʻi ha pulalea | lea | pulalea</annotation>
+		<annotation cp="👁‍🗨">kanoʻimata | lea | pulalea</annotation>
 		<annotation cp="👁‍🗨" type="tts">kanoʻimata ʻi ha pulalea</annotation>
-		<annotation cp="🗨">hema | pulalea | pulalea ʻi hema</annotation>
+		<annotation cp="🗨">hema | pulalea</annotation>
 		<annotation cp="🗨" type="tts">pulalea ʻi hema</annotation>
 		<annotation cp="🗯">ʻita | pulalea</annotation>
 		<annotation cp="🗯" type="tts">pulalea ʻita</annotation>
@@ -1189,7 +1189,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👱‍♂" type="tts">tangata ʻulu kelo</annotation>
 		<annotation cp="👩">fefine</annotation>
 		<annotation cp="👩" type="tts">fefine</annotation>
-		<annotation cp="🧔‍♀" draft="unconfirmed">fefine kava</annotation>
+		<annotation cp="🧔‍♀" draft="unconfirmed">fefine | kava</annotation>
 		<annotation cp="🧔‍♀" type="tts" draft="unconfirmed">fefine kava</annotation>
 		<annotation cp="👱‍♀">fefine ʻulu kelo</annotation>
 		<annotation cp="👱‍♀" type="tts">fefine ʻulu kelo</annotation>
@@ -1401,11 +1401,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤵" type="tts">tokotaha vala kakato</annotation>
 		<annotation cp="🤵‍♂" draft="unconfirmed">kakato | tangata | vala</annotation>
 		<annotation cp="🤵‍♂" type="tts">tangata vala kakato</annotation>
-		<annotation cp="🤵‍♀" draft="unconfirmed">fefine vala kakato</annotation>
+		<annotation cp="🤵‍♀" draft="unconfirmed">fefine | kakato | vala</annotation>
 		<annotation cp="🤵‍♀" type="tts" draft="unconfirmed">fefine vala kakato</annotation>
 		<annotation cp="👰">tokotaha | tui | veili</annotation>
 		<annotation cp="👰" type="tts">tokotaha tui veili</annotation>
-		<annotation cp="👰‍♂" draft="unconfirmed">tangata tui veili</annotation>
+		<annotation cp="👰‍♂" draft="unconfirmed">tangata | tui | veili</annotation>
 		<annotation cp="👰‍♂" type="tts" draft="unconfirmed">tangata tui veili</annotation>
 		<annotation cp="👰‍♀" draft="unconfirmed">fefine | tui | veili</annotation>
 		<annotation cp="👰‍♀" type="tts">fefine tui veili</annotation>
@@ -1417,11 +1417,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫄" type="tts">tokotaha feitama</annotation>
 		<annotation cp="🤱">fakahuhu</annotation>
 		<annotation cp="🤱" type="tts">fakahuhu</annotation>
-		<annotation cp="👩‍🍼" draft="unconfirmed">fefine fakahuhu</annotation>
+		<annotation cp="👩‍🍼" draft="unconfirmed">fakahuhu | fefine</annotation>
 		<annotation cp="👩‍🍼" type="tts" draft="unconfirmed">fefine fakahuhu</annotation>
-		<annotation cp="👨‍🍼" draft="unconfirmed">tangata fakahuhu</annotation>
+		<annotation cp="👨‍🍼" draft="unconfirmed">fakahuhu | tangata</annotation>
 		<annotation cp="👨‍🍼" type="tts" draft="unconfirmed">tangata fakahuhu</annotation>
-		<annotation cp="🧑‍🍼" draft="unconfirmed">tokotaha fakahuhu</annotation>
+		<annotation cp="🧑‍🍼" draft="unconfirmed">fakahuhu | tokotaha</annotation>
 		<annotation cp="🧑‍🍼" type="tts" draft="unconfirmed">tokotaha fakahuhu</annotation>
 		<annotation cp="👼">ʻangelo | valevale</annotation>
 		<annotation cp="👼" type="tts">ʻangelo valevale</annotation>
@@ -1429,7 +1429,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🎅" type="tts">Sānita Kalausi</annotation>
 		<annotation cp="🤶">fefine | Sānita Kalausi | Sānita Kalausi fefine</annotation>
 		<annotation cp="🤶" type="tts">Sānita Kalausi fefine</annotation>
-		<annotation cp="🧑‍🎄" draft="unconfirmed">Sānita Kalausi tokotaha</annotation>
+		<annotation cp="🧑‍🎄" draft="unconfirmed">Sānita Kalausi | tokotaha</annotation>
 		<annotation cp="🧑‍🎄" type="tts" draft="unconfirmed">Sānita Kalausi tokotaha</annotation>
 		<annotation cp="🦸">ivimālohi | tokotaha ivimālohi</annotation>
 		<annotation cp="🦸" type="tts">tokotaha ivimālohi</annotation>
@@ -1683,13 +1683,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫂" type="tts">kakai fāʻufua</annotation>
 		<annotation cp="👪">fāmili</annotation>
 		<annotation cp="👪" type="tts">fāmili</annotation>
-		<annotation cp="🧑‍🧑‍🧒" draft="unconfirmed">fāmili: ongo motuʻa, fānau</annotation>
+		<annotation cp="🧑‍🧑‍🧒" draft="unconfirmed">fāmili | fānau | kāinga | motuʻa</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts" draft="unconfirmed">fāmili: ongo motuʻa, fānau</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒" draft="unconfirmed">fāmili: ongo motuʻa, ongo fānau</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒" draft="unconfirmed">fāmili | fānau | kāinga | motuʻa</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts" draft="unconfirmed">fāmili: ongo motuʻa, ongo fānau</annotation>
-		<annotation cp="🧑‍🧒" draft="unconfirmed">fāmili: motuʻa, fānau</annotation>
+		<annotation cp="🧑‍🧒" draft="unconfirmed">fāmili | fānau | kāinga | motuʻa</annotation>
 		<annotation cp="🧑‍🧒" type="tts" draft="unconfirmed">fāmili: motuʻa, fānau</annotation>
-		<annotation cp="🧑‍🧒‍🧒" draft="unconfirmed">fāmili: motuʻa, ongo fānau</annotation>
+		<annotation cp="🧑‍🧒‍🧒" draft="unconfirmed">fāmili | fānau | kāinga | motuʻa</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts" draft="unconfirmed">fāmili: motuʻa, ongo fānau</annotation>
 		<annotation cp="👣">topuvaʻe</annotation>
 		<annotation cp="👣" type="tts">topuvaʻe</annotation>
@@ -1729,7 +1729,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🐱" type="tts">mataʻi-pusi</annotation>
 		<annotation cp="🐈">pusi</annotation>
 		<annotation cp="🐈" type="tts">pusi</annotation>
-		<annotation cp="🐈‍⬛" draft="unconfirmed">pusi ʻuliʻuli</annotation>
+		<annotation cp="🐈‍⬛" draft="unconfirmed">ʻuliʻuli | malala | pusi</annotation>
 		<annotation cp="🐈‍⬛" type="tts" draft="unconfirmed">pusi ʻuliʻuli</annotation>
 		<annotation cp="🦁">laione | mata | mataʻi-laione</annotation>
 		<annotation cp="🦁" type="tts">mataʻi-laione</annotation>
@@ -1815,7 +1815,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦇" type="tts">peka</annotation>
 		<annotation cp="🐻">mata | mataʻi-pea | pea</annotation>
 		<annotation cp="🐻" type="tts">mataʻi-pea</annotation>
-		<annotation cp="🐻‍❄" draft="unconfirmed">pea hinehina</annotation>
+		<annotation cp="🐻‍❄" draft="unconfirmed">hinehina | pea | tea</annotation>
 		<annotation cp="🐻‍❄" type="tts" draft="unconfirmed">pea hinehina</annotation>
 		<annotation cp="🐨">ʻAositelēlia | koala | mata | pea</annotation>
 		<annotation cp="🐨" type="tts">koala</annotation>
@@ -1871,11 +1871,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦜" type="tts">kakā</annotation>
 		<annotation cp="🪽">ʻangelo | kapakau | talatupuʻa</annotation>
 		<annotation cp="🪽" type="tts">kapakau</annotation>
-		<annotation cp="🐦‍⬛" draft="unconfirmed">manupuna lanuʻuliʻuli</annotation>
+		<annotation cp="🐦‍⬛" draft="unconfirmed">ʻuliʻuli | kalou | leveni | manupuna</annotation>
 		<annotation cp="🐦‍⬛" type="tts" draft="unconfirmed">manupuna lanuʻuliʻuli</annotation>
 		<annotation cp="🪿">kuusi | manupuna</annotation>
 		<annotation cp="🪿" type="tts">kuusi</annotation>
-		<annotation cp="🐦‍🔥" draft="unconfirmed">feniki</annotation>
+		<annotation cp="🐦‍🔥" draft="unconfirmed">feniki | manupuna | taʻengata</annotation>
 		<annotation cp="🐦‍🔥" type="tts" draft="unconfirmed">feniki</annotation>
 		<annotation cp="🐸">mata | mataʻi-poto | poto</annotation>
 		<annotation cp="🐸" type="tts">mataʻi-poto</annotation>
@@ -2081,7 +2081,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫚" type="tts">sinisā</annotation>
 		<annotation cp="🫛">ngeʻesi | piini</annotation>
 		<annotation cp="🫛" type="tts">ngeʻesi piini</annotation>
-		<annotation cp="🍄‍🟫" draft="unconfirmed">fakamalu-ʻa-tēvolo kula</annotation>
+		<annotation cp="🍄‍🟫" draft="unconfirmed">fakamalu | kula | melomelo | tēvolo</annotation>
 		<annotation cp="🍄‍🟫" type="tts" draft="unconfirmed">fakamalu-ʻa-tēvolo kula</annotation>
 		<annotation cp="🍞">mā</annotation>
 		<annotation cp="🍞" type="tts">mā</annotation>
@@ -3299,7 +3299,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦯" type="tts">tokotoko fakaʻeke</annotation>
 		<annotation cp="🔗">kupu | kupuʻi sēini</annotation>
 		<annotation cp="🔗" type="tts">kupuʻi sēini</annotation>
-		<annotation cp="⛓‍💥" draft="unconfirmed">sēini motu</annotation>
+		<annotation cp="⛓‍💥" draft="unconfirmed">motu | sēini</annotation>
 		<annotation cp="⛓‍💥" type="tts" draft="unconfirmed">sēini motu</annotation>
 		<annotation cp="⛓">sēini</annotation>
 		<annotation cp="⛓" type="tts">sēini</annotation>
@@ -3479,7 +3479,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="↕" type="tts">ngahau ki ʻolunga mo lalo</annotation>
 		<annotation cp="↔">hema | mataʻu | ngahau | ngahau ki toʻohema mo toʻomataʻu</annotation>
 		<annotation cp="↔" type="tts">ngahau ki toʻohema mo toʻomataʻu</annotation>
-		<annotation cp="↮" draft="unconfirmed">ngahau ki toʻohema-mataʻu moe kohi</annotation>
+		<annotation cp="↮" draft="unconfirmed">hema | kohi | mataʻu | ngahau</annotation>
 		<annotation cp="↮" type="tts" draft="unconfirmed">ngahau ki toʻohema-mataʻu moe kohi</annotation>
 		<annotation cp="↩">afe | hema | ngahau | ngahau afe ki toʻohema</annotation>
 		<annotation cp="↩" type="tts">ngahau afe ki toʻohema</annotation>
@@ -3853,11 +3853,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="£" type="tts">sōvaleni</annotation>
 		<annotation cp="¥">ieni | paʻanga | Siapani</annotation>
 		<annotation cp="¥" type="tts">ieni</annotation>
-		<annotation cp="₢" draft="unconfirmed">kuluseilo</annotation>
+		<annotation cp="₢" draft="unconfirmed">kuluseilo | paʻanga | Palāsili</annotation>
 		<annotation cp="₢" type="tts" draft="unconfirmed">kuluseilo</annotation>
-		<annotation cp="₣" draft="unconfirmed">falanikē</annotation>
+		<annotation cp="₣" draft="unconfirmed">falanikē | Falanisē | paʻanga</annotation>
 		<annotation cp="₣" type="tts" draft="unconfirmed">falanikē</annotation>
-		<annotation cp="₤" draft="unconfirmed">lila</annotation>
+		<annotation cp="₤" draft="unconfirmed">ʻĪtali | lila | paʻanga</annotation>
 		<annotation cp="₤" type="tts" draft="unconfirmed">lila</annotation>
 		<annotation cp="₥">mili | paʻanga</annotation>
 		<annotation cp="₥" type="tts">mili</annotation>
@@ -3865,15 +3865,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₩" type="tts">uoni</annotation>
 		<annotation cp="€">ʻeulo | ʻEulope | paʻanga</annotation>
 		<annotation cp="€" type="tts">ʻeulo</annotation>
-		<annotation cp="₰" draft="unconfirmed">pifeni</annotation>
+		<annotation cp="₰" draft="unconfirmed">pifeni | sēniti | Siamane</annotation>
 		<annotation cp="₰" type="tts" draft="unconfirmed">pifeni</annotation>
 		<annotation cp="₱">paʻanga | peso | Sepeni</annotation>
 		<annotation cp="₱" type="tts">peso</annotation>
-		<annotation cp="₳" draft="unconfirmed">ʻōsitali</annotation>
+		<annotation cp="₳" draft="unconfirmed">ʻAsenitina | ʻōsitali | paʻanga</annotation>
 		<annotation cp="₳" type="tts" draft="unconfirmed">ʻōsitali</annotation>
-		<annotation cp="₶" draft="unconfirmed">līvele tūnua</annotation>
+		<annotation cp="₶" draft="unconfirmed">Falanisē | līvele tūnua | motuʻa | paʻanga</annotation>
 		<annotation cp="₶" type="tts" draft="unconfirmed">līvele tūnua</annotation>
-		<annotation cp="₷" draft="unconfirmed">sipesimilo</annotation>
+		<annotation cp="₷" draft="unconfirmed">ʻEsipulanito | paʻanga | sipesimilo</annotation>
 		<annotation cp="₷" type="tts" draft="unconfirmed">sipesimilo</annotation>
 		<annotation cp="₹">ʻInitia | lupi | lupi fakaʻinitia | paʻanga</annotation>
 		<annotation cp="₹" type="tts">lupi fakaʻinitia</annotation>
@@ -3881,9 +3881,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">lupi fakalūsia</annotation>
 		<annotation cp="₿">fakapulipuli | makapiti | paʻanga</annotation>
 		<annotation cp="₿" type="tts">makapiti</annotation>
-		<annotation cp="₨" draft="unconfirmed">lupi</annotation>
+		<annotation cp="₨" draft="unconfirmed">ʻInitia | lupi | paʻanga</annotation>
 		<annotation cp="₨" type="tts" draft="unconfirmed">lupi</annotation>
-		<annotation cp="﷼" draft="unconfirmed">liale</annotation>
+		<annotation cp="﷼" draft="unconfirmed">ʻAlepea | liale | paʻanga</annotation>
 		<annotation cp="﷼" type="tts" draft="unconfirmed">liale</annotation>
 		<annotation cp="¹">fakaʻilonga | hake | taha</annotation>
 		<annotation cp="¹" type="tts">taha hake</annotation>

--- a/common/annotations/uk.xml
+++ b/common/annotations/uk.xml
@@ -479,7 +479,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="≫" type="tts">набагато більше</annotation>
 		<annotation cp="≬">між</annotation>
 		<annotation cp="≬" type="tts">між</annotation>
-		<annotation cp="≳" draft="contributed">більше ніж або еквівалентний</annotation>
+		<annotation cp="≳">більше ніж або еквівалентно | математика | нерівність</annotation>
 		<annotation cp="≳" type="tts" draft="contributed">більше ніж або еквівалентний</annotation>
 		<annotation cp="≺" draft="contributed">передувати</annotation>
 		<annotation cp="≺" type="tts" draft="contributed">передувати</annotation>
@@ -3529,7 +3529,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🕎" type="tts">менора</annotation>
 		<annotation cp="🔯">зірка | удача | шестикутна зірка з крапкою</annotation>
 		<annotation cp="🔯" type="tts">шестикутна зірка з крапкою</annotation>
-		<annotation cp="🪯" draft="contributed">кханда</annotation>
+		<annotation cp="🪯">релігія | сикх | сикхізм</annotation>
 		<annotation cp="🪯" type="tts" draft="contributed">кханда</annotation>
 		<annotation cp="♈">баран | зодіак | Овен</annotation>
 		<annotation cp="♈" type="tts">Овен</annotation>


### PR DESCRIPTION
CLDR-16978

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Restore emoji keyword annotations (non tts) that were (seemingly improperly) deleted by the CLDRModify -fQ pass (commit [e8697986ac..](https://github.com/unicode-org/cldr/pull/3165/commits/e8697986ac626738ba3eb3d21a70bb57ac14674a)) in PR [#3165](https://github.com/unicode-org/cldr/pull/3165). In most cases this just involved reverting to the version of the file before that commit (nothing had changed these files since). In some cases there was a little hand editing where CLDRModify -fQ had deleted some annotations but added others.

There is a separate ticket [CLDR-16972](https://unicode-org.atlassian.net/browse/CLDR-16972)  to investigate why these deletions are happening, and fix.

ALLOW_MANY_COMMITS=true


[CLDR-16972]: https://unicode-org.atlassian.net/browse/CLDR-16972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ