### PR TITLE
CLDR-16929 Add missing basic items for Yakut (sah)

### DIFF
--- a/common/main/sah.xml
+++ b/common/main/sah.xml
@@ -1059,6 +1059,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 		</fields>
 		<timeZoneNames>
+			<hourFormat draft="contributed">↑↑↑</hourFormat>
+			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
+			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
+			<regionFormat draft="contributed">↑↑↑</regionFormat>
+			<regionFormat type="daylight" draft="contributed">↑↑↑</regionFormat>
+			<regionFormat type="standard" draft="contributed">↑↑↑</regionFormat>
+			<fallbackFormat draft="contributed">↑↑↑</fallbackFormat>
 			<zone type="Etc/Unknown">
 				<exemplarCity draft="contributed">Биллибэт</exemplarCity>
 			</zone>
@@ -1221,6 +1228,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic>Курусуун кэмэ</generic>
 					<standard>Курусуун сүрүн кэмэ</standard>
 					<daylight>Курусуун сайыҥҥы кэмэ</daylight>
+				</long>
+			</metazone>
+			<metazone type="GMT">
+				<long>
+					<standard draft="contributed">GMT</standard>
 				</long>
 			</metazone>
 			<metazone type="India">


### PR DESCRIPTION
CLDR-16929

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16929)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add 8 missing items for basic coverage to Yakut (`sah`, a language of `RU`) with status draft="contributed"; all are for `<timeZoneNames>`. Seven of these just use ↑↑↑ to fall back to root (as does Russian for 5 of these items, including gmtFormat and gmtZeroFormat which use "GMT{0}" and "GMT" respectively). For  the eighth item timeZoneNames/metazone[@type="GMT"]/long/standard, we just use "GMT" (there is no explicit root value) since that is also what would be used here (and in Russian) for gmtFormat and gmtZeroFormat.

ALLOW_MANY_COMMITS=true
