### PR TITLE
CLDR-16929 ie and prg promotion

### DIFF
--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -397,7 +397,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="DZ" draft="unconfirmed">Algeria</territory>
 			<territory type="EA" draft="unconfirmed">Ceuta e Melilla</territory>
 			<territory type="EC" draft="unconfirmed">Ecuador</territory>
-			<territory type="EE" draft="unconfirmed">Estonia</territory>
+			<territory type="EE" draft="contributed">Estonia</territory>
 			<territory type="EG" draft="unconfirmed">Egiptia</territory>
 			<territory type="EH" draft="unconfirmed">West-Sahara</territory>
 			<territory type="ER" draft="unconfirmed">Eritrea</territory>

--- a/common/main/ie_EE.xml
+++ b/common/main/ie_EE.xml
@@ -8,7 +8,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <ldml>
 	<identity>
 		<version number="$Revision$"/>
-		<language type="prg"/>
-		<territory type="001"/>
+		<language type="ie"/>
+		<territory type="EE"/>
 	</identity>
 </ldml>

--- a/common/main/prg.xml
+++ b/common/main/prg.xml
@@ -144,7 +144,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NZ" draft="unconfirmed">Nawazēlandan</territory>
 			<territory type="PA" draft="unconfirmed">Panāma</territory>
 			<territory type="PE" draft="unconfirmed">Perū</territory>
-			<territory type="PL" draft="unconfirmed">Pōli</territory>
+			<territory type="PL" draft="contributed">Pōli</territory>
 			<territory type="PT" draft="unconfirmed">Pōrtugalin</territory>
 			<territory type="PW" draft="unconfirmed">Palau</territory>
 			<territory type="PY" draft="unconfirmed">Paragwājs</territory>

--- a/common/main/prg_PL.xml
+++ b/common/main/prg_PL.xml
@@ -8,7 +8,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <ldml>
 	<identity>
 		<version number="$Revision$"/>
-		<language type="ie"/>
-		<territory type="001"/>
+		<language type="prg"/>
+		<territory type="PL"/>
 	</identity>
 </ldml>

--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -61,6 +61,7 @@ hu ;	modern ;	Hungarian
 hy ;	modern ;	Armenian
 ia ;	moderate ;	Interlingua
 id ;	modern ;	Indonesian
+ie ;	basic ;	Interlingue
 ig ;	modern ;	Igbo
 is ;	modern ;	Icelandic
 it ;	modern ;	Italian
@@ -108,6 +109,7 @@ or ;	modern ;	Odia
 pa ;	modern ;	Punjabi
 pcm ;	moderate ;	Nigerian Pidgin
 pl ;	modern ;	Polish
+prg ;	basic ;	Prussian
 ps ;	modern ;	Pashto
 pt ;	modern ;	Portuguese
 qu ;	moderate ;	Quechua

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -1050,8 +1050,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Idi; ?; ? } => { Idi; Latin; Unknown Region }-->
 		<likelySubtag from="idu" to="idu_Latn_ZZ"/>
 		<!--{ Idoma; ?; ? } => { Idoma; Latin; Unknown Region }-->
-		<likelySubtag from="ie" to="ie_Latn_001"/>
-		<!--{ Interlingue; ?; ? } => { Interlingue; Latin; world }-->
+		<likelySubtag from="ie" to="ie_Latn_EE"/>
+		<!--{ Interlingue; ?; ? } => { Interlingue; Latin; Estonia }-->
 		<likelySubtag from="ife" to="ife_Latn_TG"/>
 		<!--{ Ifè; ?; ? } => { Ifè; Latin; Togo }-->
 		<likelySubtag from="ig" to="ig_Latn_NG"/>
@@ -2076,8 +2076,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<!--{ Prakrit languages; ?; ? } => { Prakrit languages; Kharoshthi; Pakistan }-->
 		<likelySubtag from="prd" to="prd_Arab_IR"/>
 		<!--{ Parsi-Dari; ?; ? } => { Parsi-Dari; Arabic; Iran }-->
-		<likelySubtag from="prg" to="prg_Latn_001"/>
-		<!--{ Prussian; ?; ? } => { Prussian; Latin; world }-->
+		<likelySubtag from="prg" to="prg_Latn_PL"/>
+		<!--{ Prussian; ?; ? } => { Prussian; Latin; Poland }-->
 		<likelySubtag from="ps" to="ps_Arab_AF"/>
 		<!--{ Pashto; ?; ? } => { Pashto; Arabic; Afghanistan }-->
 		<likelySubtag from="pss" to="pss_Latn_ZZ"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2920,6 +2920,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="en" populationPercent="50"/>	<!--English-->
 			<languagePopulation type="fi" populationPercent="21"/>	<!--Finnish-->
 			<languagePopulation type="vro" populationPercent="5.7"/>	<!--Võro-->
+			<languagePopulation type="ie" populationPercent="0.0001"/>	<!--Interlingue-->
 		</territory>
 		<territory type="EG" gdp="1204000000000" literacyPercent="73.9" population="104124000">	<!--Egypt-->
 			<languagePopulation type="ar" populationPercent="94" officialStatus="official"/>	<!--Arabic-->

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1813,7 +1813,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			ga_IE gaa_GH gd_GB gez_ET gl_ES gn_PY gsw_CH gu_IN guz_KE gv_IM
 			ha_Arab_NG ha_NG haw_US he_IL hi_IN hi_Latn_IN hnj_Hmnp hnj_Hmnp_US hr_HR
 			hsb_DE hu_HU hy_AM
-			ia_001 id_ID ie_001 ife_TG ig_NG ii_CN io_001 is_IS it_IT iu_CA iu_Latn_CA
+			ia_001 id_ID ie_EE ife_TG ig_NG ii_CN io_001 is_IS it_IT iu_CA iu_Latn_CA
 			ja_JP jbo_001 jgo_CM jmc_TZ jv_ID
 			ka_GE kab_DZ kaj_NG kam_KE kcg_NG kde_TZ kea_CV ken_CM kgp_BR khq_ML ki_KE
 			kk_KZ kkj_CM kl_GL kln_KE km_KH kn_IN ko_KR kok_IN kpe_LR ks_Arab ks_Arab_IN
@@ -1827,14 +1827,14 @@ For terms of use, see http://www.unicode.org/copyright.html
 			naq_NA nb nb_NO nd_ZW nds_DE ne_NP nl_NL nmg_CM nn_NO nnh_CM nqo_GN nr_ZA
 			nso_ZA nus_SS nv_US ny_MW nyn_UG
 			oc_FR om_ET or_IN os_GE osa_US
-			pa_Arab_PK pa_Guru pa_Guru_IN pap_CW pcm_NG pis_SB pl_PL prg_001 ps_AF pt_BR
+			pa_Arab_PK pa_Guru pa_Guru_IN pap_CW pcm_NG pis_SB pl_PL prg_PL ps_AF pt_BR
 			qu_PE quc_GT
 			raj_IN rhg_Rohg rhg_Rohg_MM rif_MA rm_CH rn_BI ro_RO rof_TZ ru_RU rw_RW rwk_TZ
 			sa_IN sah_RU saq_KE sat_Deva_IN sat_Olck sat_Olck_IN sbp_TZ sc_IT scn_IT
 			sd_Arab sd_Arab_PK sd_Deva_IN sdh_IR se_NO seh_MZ ses_ML sg_CF shi_Latn_MA
-			shi_Tfng shi_Tfng_MA shn_MM si_LK sid_ET sk_SK skr_PK sl_SI sma_SE smj_SE smn_FI
-			sms_FI sn_ZW so_SO sq_AL sr_Cyrl sr_Cyrl_RS sr_Latn_RS ss_ZA ssy_ER st_ZA
-			su_Latn su_Latn_ID sv_SE sw_TZ syr_IQ szl_PL
+			shi_Tfng shi_Tfng_MA shn_MM si_LK sid_ET sk_SK skr_PK sl_SI sma_SE smj_SE
+			smn_FI sms_FI sn_ZW so_SO sq_AL sr_Cyrl sr_Cyrl_RS sr_Latn_RS ss_ZA ssy_ER
+			st_ZA su_Latn su_Latn_ID sv_SE sw_TZ syr_IQ szl_PL
 			ta_IN te_IN teo_UG tg_TJ th_TH ti_ET tig_ER tk_TM tn_ZA to_TO tok_001 tpi_PG
 			tr_TR trv_TW trw_PK ts_ZA tt_RU twq_NE tyv_RU tzm_MA
 			ug_CN uk_UA ur_PK uz_Arab_AF uz_Cyrl_UZ uz_Latn uz_Latn_UZ

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateMaximalLocales.java
@@ -166,6 +166,8 @@ public class GenerateMaximalLocales {
                 "hi_Latn_IN",
                 "no_Latn_NO",
                 "tok_Latn_001",
+                "prg_Latn_PL",
+                "ie_Latn_EE",
             };
 
     /**
@@ -194,8 +196,6 @@ public class GenerateMaximalLocales {
                         {"ff_Adlm", "ff_Adlm_GN"},
                         {"ia", "ia_Latn_001"},
                         {"ia_Latn", "ia_Latn_001"},
-                        {"ie", "ie_Latn_001"},
-                        {"ie_Latn", "ie_Latn_001"},
                         {"io", "io_Latn_001"},
                         {"io_Latn", "io_Latn_001"},
                         {"jbo", "jbo_Latn_001"},
@@ -214,8 +214,6 @@ public class GenerateMaximalLocales {
                         {"ms_Arab", "ms_Arab_MY"},
                         {"pap", "pap_Latn_CW"},
                         {"pap_Latn", "pap_Latn_CW"},
-                        {"prg", "prg_Latn_001"},
-                        {"prg_Latn", "prg_Latn_001"},
                         {
                             "rif", "rif_Latn_MA"
                         }, // https://unicode-org.atlassian.net/browse/CLDR-14962?focusedCommentId=165053

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -364,6 +364,7 @@ Estonia	EE	"1,244,288"	100%	"41,650,000,000"	official	Estonian	et	71%
 Estonia	EE	"1,244,288"	100%	"41,650,000,000"		Finnish	fi	21%
 Estonia	EE	"1,244,288"	100%	"41,650,000,000"		Russian	ru	56%
 Estonia	EE	"1,244,288"	100%	"41,650,000,000"		Võro	vro	5.7%
+Estonia	EE	"1,244,288"	0%	"41,650,000,000"		Interlingue	ie	1	99%
 Eswatini	SZ	"1,087,200"	88%	"11,600,000,000"	official	English	en	80%			https://www.cia.gov/cia/publications/factbook/geos/wz.html
 Eswatini	SZ	"1,087,200"	88%	"11,600,000,000"	official	Swati	ss	58%
 Eswatini	SZ	"1,087,200"	88%	"11,600,000,000"		Tsonga	ts	"18,500"


### PR DESCRIPTION
- default content and likely subtags are now: ie-EE and prg-PL
- promote the EE and PL territory translations respectively
- adds 'ie' and 'prg' at basic

CLDR-16929


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

supersedes #3178 
