### PR TITLE
CLDR-16888 Regenerate unitPreferencesTest.txt due to IN prefs change

### DIFF
--- a/common/testData/units/unitPreferencesTest.txt
+++ b/common/testData/units/unitPreferencesTest.txt
@@ -330,9 +330,9 @@ pressure;	baromtrc;	001;	110;	110.0;	kilogram-per-meter-square-second;	11/10;	1.
 pressure;	baromtrc;	001;	100;	100.0;	kilogram-per-meter-square-second;	1;	1.0;	hectopascal
 pressure;	baromtrc;	001;	90;	90.0;	kilogram-per-meter-square-second;	9/10;	0.9;	hectopascal
 
-pressure;	baromtrc;	IN;	37250275043751/10000000000;	3725.0275043751;	kilogram-per-meter-square-second;	11/10;	1.1;	inch-ofhg
-pressure;	baromtrc;	IN;	3386388640341/1000000000;	3386.388640341;	kilogram-per-meter-square-second;	1;	1.0;	inch-ofhg
-pressure;	baromtrc;	IN;	30477497763069/10000000000;	3047.7497763069;	kilogram-per-meter-square-second;	9/10;	0.9;	inch-ofhg
+pressure;	baromtrc;	US;	37250275043751/10000000000;	3725.0275043751;	kilogram-per-meter-square-second;	11/10;	1.1;	inch-ofhg
+pressure;	baromtrc;	US;	3386388640341/1000000000;	3386.388640341;	kilogram-per-meter-square-second;	1;	1.0;	inch-ofhg
+pressure;	baromtrc;	US;	30477497763069/10000000000;	3047.7497763069;	kilogram-per-meter-square-second;	9/10;	0.9;	inch-ofhg
 
 pressure;	baromtrc;	BR;	110;	110.0;	kilogram-per-meter-square-second;	11/10;	1.1;	millibar
 pressure;	baromtrc;	BR;	100;	100.0;	kilogram-per-meter-square-second;	1;	1.0;	millibar
@@ -388,9 +388,9 @@ speed;	wind;	FI;	11/10;	1.1;	meter-per-second;	11/10;	1.1;	meter-per-second
 speed;	wind;	FI;	1;	1.0;	meter-per-second;	1;	1.0;	meter-per-second
 speed;	wind;	FI;	9/10;	0.9;	meter-per-second;	9/10;	0.9;	meter-per-second
 
-speed;	wind;	US;	15367/31250;	0.491744;	meter-per-second;	11/10;	1.1;	mile-per-hour
-speed;	wind;	US;	1397/3125;	0.44704;	meter-per-second;	1;	1.0;	mile-per-hour
-speed;	wind;	US;	12573/31250;	0.402336;	meter-per-second;	9/10;	0.9;	mile-per-hour
+speed;	wind;	GB;	15367/31250;	0.491744;	meter-per-second;	11/10;	1.1;	mile-per-hour
+speed;	wind;	GB;	1397/3125;	0.44704;	meter-per-second;	1;	1.0;	mile-per-hour
+speed;	wind;	GB;	12573/31250;	0.402336;	meter-per-second;	9/10;	0.9;	mile-per-hour
 
 temperature;	default;	001;	1097/4;	274.25;	kelvin;	11/10;	1.1;	celsius
 temperature;	default;	001;	5483/20;	274.15;	kelvin;	1;	1.0;	celsius


### PR DESCRIPTION
CLDR-16888

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16888)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Regenerate unitPreferencesTest.txt due to the change in unitPreferences for IN (barometric pressure); also takes into account GB pref change for windspeed (in CLDR-16892).

ALLOW_MANY_COMMITS=true
