### PR TITLE
CLDR-16997 Update supplementalData.xml: AQ (Antarctica) is a continent, not a subregion of QO (Outlying Oceania)

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1224,7 +1224,7 @@ XXX Code for transations where no currency is involved
 -->
     </currencyData>
     <territoryContainment> <!-- based on UN data, at http://unstats.un.org/unsd/methods/m49/m49regin.htm -->
-        <group type="001" contains="019 002 150 142 009"/> <!--World -->
+        <group type="001" contains="019 002 150 142 009 AQ"/> <!--World -->
         <group type="001" contains="EU EZ UN" status="grouping"/> <!--European Union, Eurozone, United Nations -->
         <group type="001" contains="QU" status="deprecated"/> <!--European Union -->
         <group type="011" contains="BF BJ CI CV GH GM GN GW LR ML MR NE NG SH SL SN TG"/> <!--Western Africa -->
@@ -1266,7 +1266,7 @@ XXX Code for transations where no currency is involved
         <group type="061" contains="AS CK NU PF PN TK TO TV WF WS"/> <!--Polynesia -->
         <group type="034" contains="AF BD BT IN IR LK MV NP PK"/> <!--Southern Asia -->
         <group type="009" contains="053 054 057 061 QO"/> <!--Oceania -->
-        <group type="QO" contains="AQ AC CP DG TA"/> <!--Outlying Oceania -->
+        <group type="QO" contains="AC CP DG TA"/> <!--Outlying Oceania -->
         <group type="EU" contains="AT BE CY CZ DE DK EE ES FI FR GR HR HU IE IT LT LU LV MT NL PL PT SE SI SK BG RO" grouping="true"/> <!-- European Union, see http://europa.eu/abc/european_countries/index_en.htm -->
         <group type="EZ" contains="AT BE CY DE EE ES FI FR GR IE IT LT LU LV MT NL PT SI SK" grouping="true"/> <!-- Eurozone, see https://en.wikipedia.org/wiki/Eurozone -->
         <group type="UN" contains="AD AE AF AG AL AM AO AR AT AU AZ BA BB BD BE BF BG BH BI BJ BN BO BR BS BT BW BY BZ CA CD CF CG CH CI CL CM CN CO CR CU CV CY CZ DE DJ DK DM DO DZ EC EE EG ER ES ET FI FJ FM FR GA GB GD GE GH GM GN GQ GR GT GW GY HN HR HT HU ID IE IL IN IQ IR IS IT JM JO JP KE KG KH KI KM KN KP KR KW KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MG MH MK ML MM MN MR MT MU MV MX MW MY MZ NA NE NG NI NL NO NR NP NZ OM PA PE PG PH PK PL PT PW PY QA RO RS RU RW SA SB SC SD SE SG SI SK SL SM SN SO SR SS ST SV SY SZ TD TG TH TJ TL TM TN TO TR TT TV TZ UA UG US UY UZ VC VE VN VU WS YE ZA ZM ZW" grouping="true"/> <!-- United Nations, see https://en.wikipedia.org/wiki/Member_states_of_the_United_Nations -->


### PR DESCRIPTION
[CLDR-16997](https://unicode-org.atlassian.net/browse/CLDR-16997)

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

---

In the current CLDR, AQ (Antarctica) is placed as a child node of QO (Outlying Oceania) in supplementalData.xml . But it shouldn't be.

The standard used here should be UN M49.
In the UN M49 standard, AQ (Antarctica) is a continent, juxtaposed with Asia, Africa, America, Europe, and Oceania.

https://unstats.un.org/unsd/methodology/m49/

![m49_continents](https://github.com/unicode-org/cldr/assets/3896345/e803a29a-2931-4590-96e9-531e506d46ca)

[CLDR-16997]: https://unicode-org.atlassian.net/browse/CLDR-16997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ