### PR TITLE
CLDR-16995 Add space between variable $IPA_CONSONANT and combining mark

### DIFF
--- a/common/transforms/fa-fa_FONIPA.xml
+++ b/common/transforms/fa-fa_FONIPA.xml
@@ -86,7 +86,7 @@ $BOUNDARY {او} → uː;
 {و} ه $BOUNDARY → v;
 {و} هٔ $BOUNDARY → v;
 $IPA_CONSONANT {و} → uː;
-$IPA_CONSONANT\u0651 {و} → uː; # shadda after a consonant
+$IPA_CONSONANT \u0651 {و} → uː; # shadda after a consonant
 ُ{و} $IPA_CONSONANT → uː;
 
 $BOUNDARY {و} $BOUNDARY → va;


### PR DESCRIPTION
CLDR-16995

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16995)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In the new fa-fa_FONIPA transform, one usage of the new variable $IPA_CONSONANT was immediately followed by a combining mark U+0651, so that combination was interpreted as a single undefined variable name. Just added a space to separate the U+0651

ALLOW_MANY_COMMITS=true
