### PR TITLE
CLDR-17001 en, add display name for locale vmw Makhuwa

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -661,6 +661,7 @@ annotations.
 			<language type="vi">Vietnamese</language>
 			<language type="vls">West Flemish</language>
 			<language type="vmf">Main-Franconian</language>
+			<language type="vmw">Makhuwa</language>
 			<language type="vo">Volapük</language>
 			<language type="vot">Votic</language>
 			<language type="vro">Võro</language>


### PR DESCRIPTION
CLDR-17001

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17001)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add English name "Makhuwa" for locale `vmw` now that it is at basic and being converted for ICU.

ALLOW_MANY_COMMITS=true
