### PR TITLE
CLDR-17003 fix the currency formats unit pattern

### DIFF
--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -4030,7 +4030,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000000" count="other">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -4947,8 +4947,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -5985,8 +5985,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/an.xml
+++ b/common/main/an.xml
@@ -1405,8 +1405,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -6279,11 +6279,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="zero">↑↑↑</unitPattern>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
+			<unitPattern count="zero">{0} {1}</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
 			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
@@ -6375,12 +6375,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="zero">↑↑↑</unitPattern>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="zero">{0} {1}</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -4872,8 +4872,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -7284,8 +7284,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -5259,8 +5259,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -5292,10 +5292,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -4949,7 +4949,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="unconfirmed">¤ 000 T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -5213,8 +5213,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/bgn.xml
+++ b/common/main/bgn.xml
@@ -809,7 +809,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000000" count="other">¤00میلیارد</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AFN">

--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -3724,8 +3724,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="zero">↑↑↑</unitPattern>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="zero">{0} {1}</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{1} {0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -6315,8 +6315,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -9851,11 +9851,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">000 T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -5066,8 +5066,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -12770,9 +12770,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12798,9 +12798,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -12814,9 +12814,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -12830,9 +12830,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -12846,9 +12846,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -12862,9 +12862,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -12878,9 +12878,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -12894,9 +12894,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -12910,9 +12910,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -12926,9 +12926,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -12942,9 +12942,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -12958,9 +12958,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -12974,9 +12974,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -12990,9 +12990,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -13006,9 +13006,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -13022,9 +13022,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -13038,9 +13038,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -13054,9 +13054,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -13070,9 +13070,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -13086,9 +13086,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -13102,9 +13102,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -13158,9 +13158,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -13174,9 +13174,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -13190,9 +13190,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -13206,9 +13206,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -13222,9 +13222,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -13238,9 +13238,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -13254,9 +13254,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -13270,9 +13270,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -13286,9 +13286,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -13302,9 +13302,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -13318,9 +13318,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -13334,9 +13334,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -13350,9 +13350,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -13366,9 +13366,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -13382,9 +13382,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -13398,9 +13398,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -13414,9 +13414,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -13430,9 +13430,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -13446,9 +13446,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -13462,9 +13462,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -13478,9 +13478,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -13494,9 +13494,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -13510,9 +13510,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -13526,9 +13526,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -5772,9 +5772,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 бил ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -5828,8 +5828,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -4884,8 +4884,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##,##0.00;(#,##,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -3881,8 +3881,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 трлн ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -3565,7 +3565,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{1} {0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -4800,8 +4800,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ckb.xml
+++ b/common/main/ckb.xml
@@ -1644,8 +1644,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AFN">

--- a/common/main/co.xml
+++ b/common/main/co.xml
@@ -1150,7 +1150,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -10297,10 +10297,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/cu.xml
+++ b/common/main/cu.xml
@@ -904,7 +904,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -3531,7 +3531,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -5602,12 +5602,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="zero">↑↑↑</unitPattern>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="zero">{0} {1}</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -5558,8 +5558,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -6026,8 +6026,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/doi.xml
+++ b/common/main/doi.xml
@@ -922,8 +922,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -4727,10 +4727,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/dz.xml
+++ b/common/main/dz.xml
@@ -2406,7 +2406,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -4710,7 +4710,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{1} {0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -5871,8 +5871,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -4156,8 +4156,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AUD">

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -6020,8 +6020,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -5465,8 +5465,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -12597,8 +12597,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12624,8 +12624,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -12639,8 +12639,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -12654,8 +12654,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -12669,8 +12669,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -12684,8 +12684,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -12699,8 +12699,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -12714,8 +12714,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -12729,8 +12729,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -12744,8 +12744,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -12759,8 +12759,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -12774,8 +12774,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -12789,8 +12789,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -12804,8 +12804,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -12819,8 +12819,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -12834,8 +12834,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -12849,8 +12849,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -12864,8 +12864,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -12879,8 +12879,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -12894,8 +12894,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -12909,8 +12909,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12952,8 +12952,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -12967,8 +12967,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -12982,8 +12982,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -12997,8 +12997,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -13012,8 +13012,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -13027,8 +13027,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -13042,8 +13042,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -13057,8 +13057,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -13072,8 +13072,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -13087,8 +13087,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -13102,8 +13102,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -13117,8 +13117,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -13132,8 +13132,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -13147,8 +13147,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -13162,8 +13162,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -13177,8 +13177,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -13192,8 +13192,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -13207,8 +13207,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -13222,8 +13222,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -13237,8 +13237,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -13252,8 +13252,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -13267,8 +13267,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -13282,8 +13282,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -13297,8 +13297,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -6369,8 +6369,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -12088,8 +12088,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12115,8 +12115,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -12130,8 +12130,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -12145,8 +12145,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -12160,8 +12160,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -12175,8 +12175,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -12190,8 +12190,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -12205,8 +12205,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -12220,8 +12220,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -12235,8 +12235,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -12250,8 +12250,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -12265,8 +12265,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -12280,8 +12280,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -12295,8 +12295,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -12310,8 +12310,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -12325,8 +12325,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -12340,8 +12340,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -12355,8 +12355,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -12370,8 +12370,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -12385,8 +12385,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -12400,8 +12400,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12443,8 +12443,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -12458,8 +12458,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -12473,8 +12473,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -12488,8 +12488,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -12503,8 +12503,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -12518,8 +12518,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -12533,8 +12533,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -12548,8 +12548,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -12563,8 +12563,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -12578,8 +12578,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -12593,8 +12593,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -12608,8 +12608,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -12623,8 +12623,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -12638,8 +12638,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -12653,8 +12653,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -12668,8 +12668,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -12683,8 +12683,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -12698,8 +12698,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -12713,8 +12713,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -12728,8 +12728,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -12743,8 +12743,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -12758,8 +12758,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -12773,8 +12773,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -12788,8 +12788,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -6246,8 +6246,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -7063,8 +7063,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -4726,8 +4726,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 bió'.' ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -8100,8 +8100,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -4523,7 +4523,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/fur.xml
+++ b/common/main/fur.xml
@@ -1405,8 +1405,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AMD">

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -4761,8 +4761,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">¤ 000 bln'.'</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -5865,11 +5865,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/gaa.xml
+++ b/common/main/gaa.xml
@@ -2471,7 +2471,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ALL">

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -7771,10 +7771,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -7890,10 +7890,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -4938,8 +4938,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -2045,8 +2045,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 Bio'.' ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -5905,8 +5905,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -4882,8 +4882,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/haw.xml
+++ b/common/main/haw.xml
@@ -703,8 +703,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="USD">

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -7105,10 +7105,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -6576,8 +6576,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>¤¤ {0}</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -6183,9 +6183,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -4982,10 +4982,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -6100,8 +6100,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -4882,8 +4882,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -4692,8 +4692,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">¤ 000 bln</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -7220,7 +7220,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -3696,7 +3696,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="unconfirmed">0</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -4734,13 +4734,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -4784,7 +4784,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ii.xml
+++ b/common/main/ii.xml
@@ -593,7 +593,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="CNY">

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -7457,8 +7457,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -5391,8 +5391,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -4747,7 +4747,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -5346,8 +5346,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -4852,8 +4852,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -2656,7 +2656,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">000 Bi ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -5288,8 +5288,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000000" count="other">¤ 000 tri</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -5839,8 +5839,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/kl.xml
+++ b/common/main/kl.xml
@@ -1269,8 +1269,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000 bn</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="DKK">

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -4751,7 +4751,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -6561,8 +6561,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -6700,7 +6700,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -4739,7 +4739,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -4307,8 +4307,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ks_Deva.xml
+++ b/common/main/ks_Deva.xml
@@ -782,10 +782,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="ahom">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
@@ -793,79 +793,79 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bhks">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="diak">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hmng">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hmnp">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kawi">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -873,128 +873,128 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathbold">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathdbl">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathmono">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathsanb">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathsans">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="modi">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mroo">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrtlng">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nagm">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="newa">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="segment">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sind">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sinh">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tirh">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tnsa">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="wara">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="wcho">
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/ksh.xml
+++ b/common/main/ksh.xml
@@ -1956,9 +1956,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">000 Bio ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="zero" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -4434,8 +4434,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/kxv.xml
+++ b/common/main/kxv.xml
@@ -3300,7 +3300,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -4816,8 +4816,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -3717,8 +3717,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">000 Bio'.' ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -4738,8 +4738,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -6199,7 +6199,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/lrc.xml
+++ b/common/main/lrc.xml
@@ -849,7 +849,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -7316,10 +7316,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -5655,9 +5655,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="zero">↑↑↑</unitPattern>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="zero">{0} {1}</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -4256,7 +4256,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/mg.xml
+++ b/common/main/mg.xml
@@ -963,8 +963,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/mgo.xml
+++ b/common/main/mgo.xml
@@ -538,8 +538,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="XAF">

--- a/common/main/mi.xml
+++ b/common/main/mi.xml
@@ -4564,7 +4564,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -6444,8 +6444,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -6663,8 +6663,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -6272,8 +6272,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -6299,8 +6299,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -6314,8 +6314,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -6329,8 +6329,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -6344,8 +6344,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -6359,8 +6359,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -6374,8 +6374,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -6389,8 +6389,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -6404,8 +6404,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -6419,8 +6419,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -6434,8 +6434,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -6449,8 +6449,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -6464,8 +6464,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -6479,8 +6479,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -6494,8 +6494,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -6509,8 +6509,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -6524,8 +6524,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -6539,8 +6539,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -6554,8 +6554,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -6569,8 +6569,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -6584,8 +6584,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -6637,8 +6637,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -6652,8 +6652,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -6667,8 +6667,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -6682,8 +6682,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -6697,8 +6697,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -6712,8 +6712,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -6727,8 +6727,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -6742,8 +6742,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -6757,8 +6757,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -6771,8 +6771,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -6786,8 +6786,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -6801,8 +6801,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -6816,8 +6816,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -6831,8 +6831,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -6846,8 +6846,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -6861,8 +6861,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -6876,8 +6876,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -6891,8 +6891,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -6906,8 +6906,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -6921,8 +6921,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -6936,8 +6936,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -6951,8 +6951,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -6966,8 +6966,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -6981,8 +6981,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/mni.xml
+++ b/common/main/mni.xml
@@ -731,7 +731,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -5911,8 +5911,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -7068,7 +7068,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ms_Arab.xml
+++ b/common/main/ms_Arab.xml
@@ -931,7 +931,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BND">

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -3546,11 +3546,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/nds.xml
+++ b/common/main/nds.xml
@@ -1410,8 +1410,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="hm" draft="contributed">'Kl'. h.mm a</dateFormatItem>
 						<dateFormatItem id="Hm" draft="contributed">'Kl'. H.mm</dateFormatItem>
 						<dateFormatItem id="hms" draft="contributed">'Klock' h.mm:ss a</dateFormatItem>
-						<dateFormatItem id="hmsv" draft="contributed">'Klock' h.mm:ss a v</dateFormatItem>
 						<dateFormatItem id="Hms" draft="contributed">'Klock' H.mm:ss</dateFormatItem>
+						<dateFormatItem id="hmsv" draft="contributed">'Klock' h.mm:ss a v</dateFormatItem>
 						<dateFormatItem id="Hmsv" draft="contributed">'Klock' H.mm:ss v</dateFormatItem>
 						<dateFormatItem id="M" draft="unconfirmed">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Md" draft="unconfirmed">d. M.</dateFormatItem>
@@ -1921,7 +1921,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AUD">

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -5302,8 +5302,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -12820,8 +12820,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12847,8 +12847,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -12862,8 +12862,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -12877,8 +12877,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -12892,8 +12892,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -12907,8 +12907,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -12922,8 +12922,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -12937,8 +12937,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -12952,8 +12952,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -12967,8 +12967,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -12982,8 +12982,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -12997,8 +12997,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -13012,8 +13012,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -13027,8 +13027,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -13042,8 +13042,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -13057,8 +13057,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -13072,8 +13072,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -13087,8 +13087,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -13102,8 +13102,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -13117,8 +13117,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -13132,8 +13132,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -13175,8 +13175,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -13190,8 +13190,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -13205,8 +13205,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -13220,8 +13220,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -13235,8 +13235,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -13250,8 +13250,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -13265,8 +13265,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -13280,8 +13280,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -13295,8 +13295,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -13310,8 +13310,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -13325,8 +13325,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -13340,8 +13340,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -13355,8 +13355,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -13370,8 +13370,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -13385,8 +13385,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -13400,8 +13400,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -13415,8 +13415,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -13430,8 +13430,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -13445,8 +13445,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -13460,8 +13460,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -13475,8 +13475,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -13490,8 +13490,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -13505,8 +13505,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -13520,8 +13520,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -11459,8 +11459,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -11471,8 +11471,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -11483,8 +11483,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -11495,8 +11495,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -11507,8 +11507,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -11519,8 +11519,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -11531,8 +11531,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -11543,8 +11543,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -11555,8 +11555,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -11567,8 +11567,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -11579,8 +11579,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -11591,8 +11591,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -11603,8 +11603,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -11615,8 +11615,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -11627,8 +11627,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -11639,8 +11639,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -11651,8 +11651,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -11663,8 +11663,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -11705,8 +11705,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -11717,8 +11717,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -11729,8 +11729,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -11741,8 +11741,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -11753,8 +11753,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -11765,8 +11765,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -11777,8 +11777,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -11789,8 +11789,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -11801,8 +11801,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -11813,8 +11813,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -11825,8 +11825,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -11837,8 +11837,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -11849,8 +11849,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -11861,8 +11861,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -11873,8 +11873,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -11885,8 +11885,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -11897,8 +11897,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -11909,8 +11909,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -11921,8 +11921,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -11933,8 +11933,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -11945,8 +11945,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -11957,8 +11957,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -11969,8 +11969,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/nso.xml
+++ b/common/main/nso.xml
@@ -545,8 +545,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ZAR">

--- a/common/main/oc.xml
+++ b/common/main/oc.xml
@@ -5580,7 +5580,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -5606,7 +5606,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -5620,7 +5620,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -5634,7 +5634,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -5648,7 +5648,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -5662,7 +5662,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -5676,7 +5676,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -5690,7 +5690,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -5704,7 +5704,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -5718,7 +5718,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -5732,7 +5732,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -5746,7 +5746,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -5760,7 +5760,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -5774,7 +5774,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -5788,7 +5788,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -5802,7 +5802,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -5816,7 +5816,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -5830,7 +5830,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -5844,7 +5844,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -5858,7 +5858,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -5872,7 +5872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -5902,7 +5902,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -5916,7 +5916,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -5930,7 +5930,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -5944,7 +5944,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -5958,7 +5958,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -5972,7 +5972,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -5986,7 +5986,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -6000,7 +6000,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -6014,7 +6014,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -6028,7 +6028,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -6042,7 +6042,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -6056,7 +6056,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -6070,7 +6070,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -6084,7 +6084,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -6098,7 +6098,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -6112,7 +6112,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -6126,7 +6126,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -6140,7 +6140,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -6154,7 +6154,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -6168,7 +6168,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -6182,7 +6182,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -6196,7 +6196,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -6210,7 +6210,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -6224,7 +6224,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/om.xml
+++ b/common/main/om.xml
@@ -732,8 +732,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -5164,8 +5164,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>

--- a/common/main/os.xml
+++ b/common/main/os.xml
@@ -825,8 +825,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -5841,8 +5841,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -4721,8 +4721,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -6084,10 +6084,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/prg.xml
+++ b/common/main/prg.xml
@@ -881,9 +881,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="zero" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="zero" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -5134,8 +5134,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -6111,8 +6111,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -4594,7 +4594,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/rif.xml
+++ b/common/main/rif.xml
@@ -1691,7 +1691,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BMD">

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -2610,8 +2610,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -6602,10 +6602,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/rw.xml
+++ b/common/main/rw.xml
@@ -700,7 +700,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="RWF">

--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -954,7 +954,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/sah.xml
+++ b/common/main/sah.xml
@@ -1468,7 +1468,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 трлн ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AWG">

--- a/common/main/sat.xml
+++ b/common/main/sat.xml
@@ -2388,9 +2388,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000" count="other">¤ 000 ᱜᱮᱞᱥᱟᱭ</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BMD">

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -12414,8 +12414,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12441,8 +12441,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -12456,8 +12456,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -12471,8 +12471,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -12486,8 +12486,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -12501,8 +12501,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -12516,8 +12516,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -12531,8 +12531,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -12546,8 +12546,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -12561,8 +12561,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -12576,8 +12576,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -12591,8 +12591,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -12606,8 +12606,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -12621,8 +12621,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -12636,8 +12636,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -12651,8 +12651,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -12666,8 +12666,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -12681,8 +12681,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -12696,8 +12696,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -12711,8 +12711,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -12726,8 +12726,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12769,8 +12769,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -12784,8 +12784,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -12799,8 +12799,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -12814,8 +12814,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -12829,8 +12829,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -12844,8 +12844,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -12859,8 +12859,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -12874,8 +12874,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -12889,8 +12889,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -12904,8 +12904,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -12919,8 +12919,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -12934,8 +12934,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -12949,8 +12949,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -12964,8 +12964,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -12979,8 +12979,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -12994,8 +12994,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -13009,8 +13009,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -13024,8 +13024,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -13039,8 +13039,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -13054,8 +13054,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -13069,8 +13069,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -13084,8 +13084,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -13099,8 +13099,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -13114,8 +13114,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -5178,8 +5178,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/sd_Deva.xml
+++ b/common/main/sd_Deva.xml
@@ -721,12 +721,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/se.xml
+++ b/common/main/se.xml
@@ -1322,9 +1322,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">000 bn ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="DKK">

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -5103,7 +5103,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{1}{0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -5890,10 +5890,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -6070,10 +6070,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/smn.xml
+++ b/common/main/smn.xml
@@ -1459,9 +1459,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="DKK">

--- a/common/main/sn.xml
+++ b/common/main/sn.xml
@@ -978,8 +978,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -10877,8 +10877,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -10899,8 +10899,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -10911,8 +10911,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -10923,8 +10923,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -10935,8 +10935,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -10947,8 +10947,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -10959,8 +10959,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -10971,8 +10971,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -10983,8 +10983,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
@@ -10995,8 +10995,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -11007,8 +11007,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -11019,8 +11019,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -11031,8 +11031,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -11043,8 +11043,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -11055,8 +11055,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -11067,8 +11067,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -11079,8 +11079,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -11091,8 +11091,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -11103,8 +11103,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -11115,8 +11115,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -11127,8 +11127,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -11196,8 +11196,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -11208,8 +11208,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -11220,8 +11220,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -11232,8 +11232,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -11244,8 +11244,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -11256,8 +11256,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -11268,8 +11268,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -11280,8 +11280,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -11292,8 +11292,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -11304,8 +11304,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -11316,8 +11316,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -11328,8 +11328,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
@@ -11340,8 +11340,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -11352,8 +11352,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -11364,8 +11364,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -11376,8 +11376,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -11388,8 +11388,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -11400,8 +11400,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -11412,8 +11412,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -11424,8 +11424,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -11436,8 +11436,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -11448,8 +11448,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -11460,8 +11460,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -11472,8 +11472,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -5243,8 +5243,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -5872,9 +5872,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/st.xml
+++ b/common/main/st.xml
@@ -634,8 +634,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ZAR">

--- a/common/main/su.xml
+++ b/common/main/su.xml
@@ -781,7 +781,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -6897,8 +6897,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -4924,7 +4924,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{1} {0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -4492,8 +4492,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="SYP">

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -4270,7 +4270,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="unconfirmed">000 bln ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BMD">

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -5936,8 +5936,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -5889,8 +5889,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>

--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -2327,7 +2327,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other">000 трлн'.' ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -6998,7 +6998,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -4248,8 +4248,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000 ት</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BMD">

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -4952,8 +4952,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/tn.xml
+++ b/common/main/tn.xml
@@ -631,8 +631,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ZAR">

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -7307,7 +7307,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -7328,7 +7328,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -7339,7 +7339,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -7350,7 +7350,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -7361,7 +7361,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -7372,7 +7372,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -7383,7 +7383,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -7394,7 +7394,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -7405,7 +7405,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -7416,7 +7416,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -7427,7 +7427,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -7438,7 +7438,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -7449,7 +7449,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -7460,7 +7460,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -7471,7 +7471,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -7482,7 +7482,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -7493,7 +7493,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -7504,7 +7504,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -7515,7 +7515,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -7526,7 +7526,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -7567,7 +7567,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -7578,7 +7578,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -7589,7 +7589,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -7600,7 +7600,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -7611,7 +7611,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -7622,7 +7622,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -7633,7 +7633,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -7644,7 +7644,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -7655,7 +7655,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -7666,7 +7666,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -7677,7 +7677,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -7688,7 +7688,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -7699,7 +7699,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -7710,7 +7710,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -7721,7 +7721,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -7732,7 +7732,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -7743,7 +7743,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -7754,7 +7754,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -7765,7 +7765,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -7776,7 +7776,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -7787,7 +7787,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -7798,7 +7798,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AUD">

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -6039,8 +6039,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/trw.xml
+++ b/common/main/trw.xml
@@ -3945,7 +3945,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/ts.xml
+++ b/common/main/ts.xml
@@ -563,8 +563,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ZAR">

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -1915,7 +1915,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/ug.xml
+++ b/common/main/ug.xml
@@ -3266,8 +3266,8 @@ Reviewed by Waris Abdukerim Janbaz <oyghan@gmail.com> of the Uyghur Computer Sci
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -6280,10 +6280,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="many">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="many">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -5552,8 +5552,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -5067,8 +5067,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/uz_Cyrl.xml
+++ b/common/main/uz_Cyrl.xml
@@ -2688,8 +2688,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">¤ 000трлн</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ANG">

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -4233,7 +4233,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -7756,7 +7756,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/wae.xml
+++ b/common/main/wae.xml
@@ -1483,8 +1483,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -1947,7 +1947,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -3625,8 +3625,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/xnr.xml
+++ b/common/main/xnr.xml
@@ -2720,7 +2720,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -4604,7 +4604,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -5283,8 +5283,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000000" count="other">¤ 000 tiri</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -7012,7 +7012,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -7010,7 +7010,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/za.xml
+++ b/common/main/za.xml
@@ -606,7 +606,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="CNH">

--- a/common/main/zgh.xml
+++ b/common/main/zgh.xml
@@ -932,7 +932,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">000T¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -9264,7 +9264,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -9275,7 +9275,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -9286,7 +9286,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -9297,7 +9297,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -9308,7 +9308,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -9319,7 +9319,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -9330,7 +9330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -9341,7 +9341,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -9352,7 +9352,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -9363,7 +9363,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -9374,7 +9374,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -9389,7 +9389,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -9400,7 +9400,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -9411,7 +9411,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -9422,7 +9422,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -9433,7 +9433,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -9444,7 +9444,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -9455,7 +9455,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -9466,7 +9466,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -9509,7 +9509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -9520,7 +9520,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -9531,7 +9531,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -9542,7 +9542,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -9553,7 +9553,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -9564,7 +9564,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -9575,7 +9575,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -9586,7 +9586,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -9597,7 +9597,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -9608,7 +9608,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -9619,7 +9619,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -9630,7 +9630,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -9641,7 +9641,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -9652,7 +9652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -9663,7 +9663,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -9674,7 +9674,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -9685,7 +9685,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -9696,7 +9696,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -9707,7 +9707,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -9718,7 +9718,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -9729,7 +9729,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -9740,7 +9740,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -11881,7 +11881,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
@@ -11892,7 +11892,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
@@ -11903,7 +11903,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
@@ -11914,7 +11914,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
@@ -11925,7 +11925,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
@@ -11936,7 +11936,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
@@ -11947,7 +11947,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
@@ -11958,7 +11958,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
@@ -11969,7 +11969,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
@@ -11980,7 +11980,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
@@ -11991,7 +11991,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
@@ -12004,7 +12004,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
@@ -12015,7 +12015,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
@@ -12026,7 +12026,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
@@ -12037,7 +12037,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
@@ -12048,7 +12048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
@@ -12059,7 +12059,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
@@ -12070,7 +12070,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
@@ -12081,7 +12081,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12113,7 +12113,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
@@ -12124,7 +12124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
@@ -12135,7 +12135,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
@@ -12146,7 +12146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
@@ -12157,7 +12157,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
@@ -12168,7 +12168,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
@@ -12179,7 +12179,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
@@ -12190,7 +12190,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
@@ -12201,7 +12201,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
@@ -12212,7 +12212,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
@@ -12223,7 +12223,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
@@ -12234,7 +12234,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
@@ -12245,7 +12245,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
@@ -12256,7 +12256,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
@@ -12267,7 +12267,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
@@ -12278,7 +12278,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
@@ -12289,7 +12289,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
@@ -12300,7 +12300,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
@@ -12311,7 +12311,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
@@ -12322,7 +12322,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
@@ -12333,7 +12333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
@@ -12344,7 +12344,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
@@ -12355,7 +12355,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -5521,8 +5521,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.Option.Options;
+import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRTool;
 import org.unicode.cldr.util.Counter;
@@ -38,6 +39,7 @@ public class SearchXml {
 
     private static Matcher valueMatcher;
     private static Matcher levelMatcher;
+    private static Matcher iRankMatcher;
 
     private static boolean showFiles;
     private static boolean showValues = true;
@@ -50,6 +52,7 @@ public class SearchXml {
 
     private static boolean pathExclude = false;
     private static boolean levelExclude = false;
+    private static boolean iRankExclude = false;
     private static boolean valueExclude = false;
     private static boolean fileExclude = false;
     private static boolean unique = false;
@@ -105,7 +108,12 @@ public class SearchXml {
                     .add("Verbose", null, null, "verbose output")
                     .add("recursive", null, null, "recurse directories")
                     .add("Star", null, null, "get statistics on starred paths")
-                    .add("PathHeader", null, null, "show path header and string ID");
+                    .add("PathHeader", null, null, "show path header and string ID")
+                    .add(
+                            "iRank",
+                            ".*",
+                            null,
+                            "Filter by inheritance rank, where 0 = root, ow N = inherits directly from rank N-1");
 
     public static void main(String[] args) throws IOException {
         double startTime = System.currentTimeMillis();
@@ -127,6 +135,9 @@ public class SearchXml {
 
         levelMatcher = getMatcher(myOptions.get("level").getValue(), exclude);
         levelExclude = exclude.value;
+
+        iRankMatcher = getMatcher(myOptions.get("iRank").getValue(), exclude);
+        iRankExclude = exclude.value;
 
         valueMatcher = getMatcher(myOptions.get("value").getValue(), exclude);
         valueExclude = exclude.value;
@@ -249,7 +260,19 @@ public class SearchXml {
 
             if (fileMatcher != null && fileExclude == fileMatcher.reset(coreName).find()) {
                 if (verbose) {
-                    System.out.println("#" + "* Skipping " + canonicalFile);
+                    System.out.println("#" + "* -f Skipping " + canonicalFile);
+                }
+                continue;
+            }
+            if (iRankMatcher != null
+                    && iRankExclude
+                            == iRankMatcher
+                                    .reset(
+                                            String.valueOf(
+                                                    CLDRLocale.getInstance(coreName).getRank()))
+                                    .find()) {
+                if (verbose) {
+                    System.out.println("#" + "* -i Skipping " + canonicalFile);
                 }
                 continue;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -438,10 +438,10 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
      */
     public Iterable<CLDRLocale> getParentIterator() {
         final CLDRLocale newThis = this;
-        return new Iterable<CLDRLocale>() {
+        return new Iterable<>() {
             @Override
             public Iterator<CLDRLocale> iterator() {
-                return new Iterator<CLDRLocale>() {
+                return new Iterator<>() {
                     CLDRLocale what = newThis;
 
                     @Override
@@ -658,5 +658,13 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
     public boolean isParentRoot() {
         return CLDRLocale.ROOT == getParent();
+    }
+
+    public int getRank() {
+        if (this == CLDRLocale.ROOT) {
+            return 0;
+        } else {
+            return 1 + getParent().getRank();
+        }
     }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,374 +1,1342 @@
 # constructed line for modify_config.txt file		;		
 # https://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-passes/cldrmodify-using-config-file		;		
 
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="1"] ; new_value=1
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="10"] ; new_value=10
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="11"] ; new_value=11
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="12"] ; new_value=12
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="2"] ; new_value=2
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="3"] ; new_value=3
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="4"] ; new_value=4
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="5"] ; new_value=5
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="6"] ; new_value=6
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="7"] ; new_value=7
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="8"] ; new_value=8
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="9"] ; new_value=9
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Mo1
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Mo10
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Mo11
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Mo12
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Mo2
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Mo3
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Mo4
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=Mo5
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Mo6
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Mo7
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Mo8
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Mo9
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="1"] ; new_value=First Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="10"] ; new_value=Tenth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="11"] ; new_value=Eleventh Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="12"] ; new_value=Twelfth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="2"] ; new_value=Second Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="3"] ; new_value=Third Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="4"] ; new_value=Fourth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="5"] ; new_value=Fifth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="6"] ; new_value=Sixth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"] ; new_value=Seventh Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="8"] ; new_value=Eighth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="chinese"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="9"] ; new_value=Ninth Month
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/dateTimeFormatLength[@type="medium"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"] ; new_value={1}, {0}
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/dateTimeFormatLength[@type="short"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"] ; new_value={1}, {0}
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/dateTimeFormatLength[@type="medium"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"] ; new_value={1}, {0}
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/dateTimeFormatLength[@type="short"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"] ; new_value={1}, {0}
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="afternoon1"] ; new_value=afternoon
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="am"] ; new_value=AM
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="evening1"] ; new_value=evening
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="midnight"] ; new_value=midnight
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="morning1"] ; new_value=morning
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="night1"] ; new_value=night
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="noon"] ; new_value=noon
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="narrow"]/dayPeriod[@type="pm"] ; new_value=PM
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="fri"] ; new_value=F
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="mon"] ; new_value=M
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="sat"] ; new_value=S
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="sun"] ; new_value=S
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="thu"] ; new_value=T
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="tue"] ; new_value=T
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="format"]/dayWidth[@type="narrow"]/day[@type="wed"] ; new_value=W
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="fri"] ; new_value=Fri
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="mon"] ; new_value=Mon
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="sat"] ; new_value=Sat
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="sun"] ; new_value=Sun
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="thu"] ; new_value=Thu
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="tue"] ; new_value=Tue
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="wed"] ; new_value=Wed
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="fri"] ; new_value=Fr
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="mon"] ; new_value=Mo
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="sat"] ; new_value=Sa
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="sun"] ; new_value=Su
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="thu"] ; new_value=Th
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="tue"] ; new_value=Tu
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="short"]/day[@type="wed"] ; new_value=We
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="fri"] ; new_value=Friday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="mon"] ; new_value=Monday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="sat"] ; new_value=Saturday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="sun"] ; new_value=Sunday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="thu"] ; new_value=Thursday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="tue"] ; new_value=Tuesday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="wide"]/day[@type="wed"] ; new_value=Wednesday
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="1"] ; new_value=J
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="10"] ; new_value=O
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="11"] ; new_value=N
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="12"] ; new_value=D
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="2"] ; new_value=F
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="3"] ; new_value=M
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="4"] ; new_value=A
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="5"] ; new_value=M
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="6"] ; new_value=J
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="7"] ; new_value=J
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="8"] ; new_value=A
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="9"] ; new_value=S
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Jan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Oct
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Nov
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Dec
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Feb
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Mar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Apr
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=May
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Jun
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Jul
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Aug
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Sep
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="1"] ; new_value=January
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="10"] ; new_value=October
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="11"] ; new_value=November
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="12"] ; new_value=December
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="2"] ; new_value=February
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="3"] ; new_value=March
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="4"] ; new_value=April
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="5"] ; new_value=May
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="6"] ; new_value=June
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"] ; new_value=July
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="8"] ; new_value=August
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="9"] ; new_value=September
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="format"]/quarterWidth[@type="narrow"]/quarter[@type="1"] ; new_value=1
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="format"]/quarterWidth[@type="narrow"]/quarter[@type="2"] ; new_value=2
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="format"]/quarterWidth[@type="narrow"]/quarter[@type="3"] ; new_value=3
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="format"]/quarterWidth[@type="narrow"]/quarter[@type="4"] ; new_value=4
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="abbreviated"]/quarter[@type="1"] ; new_value=Q1
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="abbreviated"]/quarter[@type="2"] ; new_value=Q2
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="abbreviated"]/quarter[@type="3"] ; new_value=Q3
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="abbreviated"]/quarter[@type="4"] ; new_value=Q4
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="wide"]/quarter[@type="1"] ; new_value=1st quarter
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="wide"]/quarter[@type="2"] ; new_value=2nd quarter
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="wide"]/quarter[@type="3"] ; new_value=3rd quarter
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="wide"]/quarter[@type="4"] ; new_value=4th quarter
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Tishri
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Sivan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Tamuz
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Av
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="13"] ; new_value=Elul
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Heshvan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Kislev
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Tevet
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=Shevat
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Adar I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Adar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="7"][@yeartype="leap"] ; new_value=Adar II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Nisan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Iyar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Tishri
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Sivan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Tamuz
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Av
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="13"] ; new_value=Elul
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Heshvan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Kislev
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Tevet
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=Shevat
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Adar I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Adar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"][@yeartype="leap"] ; new_value=Adar II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Nisan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Iyar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="1"] ; new_value=Tishri
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="10"] ; new_value=Sivan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="11"] ; new_value=Tamuz
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="12"] ; new_value=Av
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="13"] ; new_value=Elul
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="2"] ; new_value=Heshvan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="3"] ; new_value=Kislev
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="4"] ; new_value=Tevet
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="5"] ; new_value=Shevat
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="6"] ; new_value=Adar I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"] ; new_value=Adar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"][@yeartype="leap"] ; new_value=Adar II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="8"] ; new_value=Nisan
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="hebrew"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="9"] ; new_value=Iyar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Chaitra
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Pausa
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Magha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Phalguna
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Vaisakha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Jyaistha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Asadha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=Sravana
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Bhadra
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Asvina
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Kartika
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Agrahayana
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="1"] ; new_value=1
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="10"] ; new_value=10
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="11"] ; new_value=11
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="12"] ; new_value=12
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="2"] ; new_value=2
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="3"] ; new_value=3
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="4"] ; new_value=4
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="5"] ; new_value=5
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="6"] ; new_value=6
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="7"] ; new_value=7
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="8"] ; new_value=8
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="9"] ; new_value=9
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Chaitra
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Pausa
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Magha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Phalguna
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Vaisakha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Jyaistha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Asadha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=Sravana
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Bhadra
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Asvina
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Kartika
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Agrahayana
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="1"] ; new_value=Chaitra
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="10"] ; new_value=Pausa
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="11"] ; new_value=Magha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="12"] ; new_value=Phalguna
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="2"] ; new_value=Vaisakha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="3"] ; new_value=Jyaistha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="4"] ; new_value=Asadha
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="5"] ; new_value=Sravana
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="6"] ; new_value=Bhadra
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"] ; new_value=Asvina
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="8"] ; new_value=Kartika
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="indian"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="9"] ; new_value=Agrahayana
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="full"]/dateFormat[@type="standard"]/pattern[@type="standard"] ; new_value=EEEE, MMMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="long"]/dateFormat[@type="standard"]/pattern[@type="standard"] ; new_value=MMMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="medium"]/dateFormat[@type="standard"]/pattern[@type="standard"] ; new_value=MMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateFormats/dateFormatLength[@type="short"]/dateFormat[@type="standard"]/pattern[@type="standard"] ; new_value=M/d/y GGGGG
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="E"] ; new_value=ccc
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Ed"] ; new_value=d E
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Gy"] ; new_value=y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMM"] ; new_value=MMM y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMEd"] ; new_value=E, MMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMMMd"] ; new_value=MMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="GyMd"] ; new_value=M/d/y GGGGG
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="M"] ; new_value=L
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MEd"] ; new_value=E, M/d
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMM"] ; new_value=LLL
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMEd"] ; new_value=E, MMM d
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMMd"] ; new_value=MMMM d
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="MMMd"] ; new_value=MMM d
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="Md"] ; new_value=M/d
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="d"] ; new_value=d
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="y"] ; new_value=y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyy"] ; new_value=y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyM"] ; new_value=M/y GGGGG
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMEd"] ; new_value=E, M/d/y GGGGG
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMM"] ; new_value=MMM y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMEd"] ; new_value=E, MMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMM"] ; new_value=MMMM y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMMMd"] ; new_value=MMM d, y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyMd"] ; new_value=M/d/y GGGGG
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyQQQ"] ; new_value=QQQ y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yyyyQQQQ"] ; new_value=QQQQ y G
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="1"] ; new_value=1
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="10"] ; new_value=10
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="11"] ; new_value=11
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="12"] ; new_value=12
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="2"] ; new_value=2
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="3"] ; new_value=3
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="4"] ; new_value=4
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="5"] ; new_value=5
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="6"] ; new_value=6
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="7"] ; new_value=7
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="8"] ; new_value=8
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="format"]/monthWidth[@type="narrow"]/month[@type="9"] ; new_value=9
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="1"] ; new_value=Muh.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="10"] ; new_value=Shaw.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="11"] ; new_value=Dhuʻl-Q.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="12"] ; new_value=Dhuʻl-H.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="2"] ; new_value=Saf.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="3"] ; new_value=Rab. I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="4"] ; new_value=Rab. II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="5"] ; new_value=Jum. I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="6"] ; new_value=Jum. II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="7"] ; new_value=Raj.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="8"] ; new_value=Sha.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="abbreviated"]/month[@type="9"] ; new_value=Ram.
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="1"] ; new_value=Muharram
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="10"] ; new_value=Shawwal
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="11"] ; new_value=Dhuʻl-Qiʻdah
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="12"] ; new_value=Dhuʻl-Hijjah
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="2"] ; new_value=Safar
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="3"] ; new_value=Rabiʻ I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="4"] ; new_value=Rabiʻ II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="5"] ; new_value=Jumada I
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="6"] ; new_value=Jumada II
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="7"] ; new_value=Rajab
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="8"] ; new_value=Shaʻban
-locale=en ; action=add ; new_path=//ldml/dates/calendars/calendar[@type="islamic"]/months/monthContext[@type="stand-alone"]/monthWidth[@type="wide"]/month[@type="9"] ; new_value=Ramadan
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="day-narrow"]/relative[@type="-1"] ; new_value=yesterday
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="day-narrow"]/relative[@type="0"] ; new_value=today
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="day-narrow"]/relative[@type="1"] ; new_value=tomorrow
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="day-short"]/relative[@type="-1"] ; new_value=yesterday
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="day-short"]/relative[@type="0"] ; new_value=today
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="day-short"]/relative[@type="1"] ; new_value=tomorrow
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="dayOfYear-narrow"]/displayName ; new_value=day of yr.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="dayperiod-narrow"]/displayName ; new_value=AM/PM
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="era-narrow"]/displayName ; new_value=era
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relative[@type="-1"] ; new_value=last mo.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relative[@type="0"] ; new_value=this mo.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="month-narrow"]/relative[@type="1"] ; new_value=next mo.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relativePeriod ; new_value=the week of {0}
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relative[@type="-1"] ; new_value=last wk.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relative[@type="0"] ; new_value=this wk.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="week-narrow"]/relative[@type="1"] ; new_value=next wk.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="week-short"]/relativePeriod ; new_value=the week of {0}
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="weekOfMonth-narrow"]/displayName ; new_value=wk. of mo.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="weekday-narrow"]/displayName ; new_value=day of wk.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="weekdayOfMonth-narrow"]/displayName ; new_value=wkday. of mo.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relative[@type="-1"] ; new_value=last yr.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relative[@type="0"] ; new_value=this yr.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="year-narrow"]/relative[@type="1"] ; new_value=next yr.
-locale=en ; action=add ; new_path=//ldml/dates/fields/field[@type="zone-narrow"]/displayName ; new_value=zone
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="2"] ; new_value={0} or {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="end"] ; new_value={0}, or {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="middle"] ; new_value={0}, {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="start"] ; new_value={0}, {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="2"] ; new_value={0} or {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="end"] ; new_value={0}, or {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="middle"] ; new_value={0}, {1}
-locale=en ; action=add ; new_path=//ldml/listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="start"] ; new_value={0}, {1}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-quarter"]/perUnitPattern ; new_value={0}/q
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p1"]/unitPrefixPattern ; new_value=Ki{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p2"]/unitPrefixPattern ; new_value=Mi{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p3"]/unitPrefixPattern ; new_value=Gi{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p4"]/unitPrefixPattern ; new_value=Ti{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p5"]/unitPrefixPattern ; new_value=Pi{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p6"]/unitPrefixPattern ; new_value=Ei{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p7"]/unitPrefixPattern ; new_value=Zi{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="1024p8"]/unitPrefixPattern ; new_value=Yi{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-1"]/unitPrefixPattern ; new_value=d{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-12"]/unitPrefixPattern ; new_value=p{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-15"]/unitPrefixPattern ; new_value=f{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-18"]/unitPrefixPattern ; new_value=a{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-2"]/unitPrefixPattern ; new_value=c{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-21"]/unitPrefixPattern ; new_value=z{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-24"]/unitPrefixPattern ; new_value=y{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-27"]/unitPrefixPattern ; new_value=r{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-3"]/unitPrefixPattern ; new_value=m{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-30"]/unitPrefixPattern ; new_value=q{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-6"]/unitPrefixPattern ; new_value=μ{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p-9"]/unitPrefixPattern ; new_value=n{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p1"]/unitPrefixPattern ; new_value=da{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p12"]/unitPrefixPattern ; new_value=T{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p15"]/unitPrefixPattern ; new_value=P{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p18"]/unitPrefixPattern ; new_value=E{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p2"]/unitPrefixPattern ; new_value=h{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p21"]/unitPrefixPattern ; new_value=Z{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p24"]/unitPrefixPattern ; new_value=Y{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p27"]/unitPrefixPattern ; new_value=R{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p3"]/unitPrefixPattern ; new_value=k{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p30"]/unitPrefixPattern ; new_value=Q{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p6"]/unitPrefixPattern ; new_value=M{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="10p9"]/unitPrefixPattern ; new_value=G{0}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="per"]/compoundUnitPattern ; new_value={0}/{1}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="power2"]/compoundUnitPattern1[@count="other"] ; new_value={0}²
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="power3"]/compoundUnitPattern1[@count="other"] ; new_value={0}³
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="times"]/compoundUnitPattern ; new_value={0}⋅{1}
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/coordinateUnit/displayName ; new_value=direction
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="area-square-centimeter"]/perUnitPattern ; new_value={0}/cm²
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="area-square-inch"]/perUnitPattern ; new_value={0}/in²
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-day"]/perUnitPattern ; new_value={0}/d
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-hour"]/perUnitPattern ; new_value={0}/h
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-minute"]/perUnitPattern ; new_value={0}/min
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-month"]/perUnitPattern ; new_value={0}/m
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-quarter"]/perUnitPattern ; new_value={0}/q
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-second"]/perUnitPattern ; new_value={0}/s
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-week"]/perUnitPattern ; new_value={0}/w
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/perUnitPattern ; new_value={0}/y
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="length-centimeter"]/perUnitPattern ; new_value={0}/cm
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="length-foot"]/perUnitPattern ; new_value={0}/ft
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="length-inch"]/perUnitPattern ; new_value={0}/in
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="length-kilometer"]/perUnitPattern ; new_value={0}/km
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="length-meter"]/perUnitPattern ; new_value={0}/m
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-gram"]/perUnitPattern ; new_value={0}/g
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-kilogram"]/perUnitPattern ; new_value={0}/kg
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-ounce"]/perUnitPattern ; new_value={0}/oz
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-pound"]/perUnitPattern ; new_value={0}/lb
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="temperature-generic"]/displayName ; new_value=°
-locale=en ; action=add ; new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="temperature-generic"]/unitPattern[@count="other"] ; new_value={0}°
+locale=ab;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=af;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=af;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=am;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=am;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=an;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=an;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arab"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arab"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arab"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arab"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arab"]/unitPattern[@count="zero"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=ar;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="zero"];	new_value={0} {1}
+locale=as;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=as;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ast;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ast;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=az;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=az;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=be;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=be;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=be;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=be;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bew;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=bg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bgn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=blo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=blo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="zero"];	new_value={0} {1}
+locale=bn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=br;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=br;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=br;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=br;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=br;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=brx;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=brx;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs_Cyrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs_Cyrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs_Cyrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=bs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ca;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ca;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ccp;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ccp;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ce;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ce;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ceb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=chr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=chr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ckb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ckb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=co;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=cs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=cs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=cs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=cs;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=cu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=cv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=cy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=cy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=cy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=cy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=cy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=cy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="zero"];	new_value={0} {1}
+locale=da;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=da;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=de;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=de;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=doi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=doi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=dsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=dsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=dsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=dsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=dz;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ee;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=el;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=el;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=eo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=es;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=es;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=et;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=et;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=eu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=fa;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=fa;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ff_Adlm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=fi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=fi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=fil;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=fil;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=fo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=fo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=fr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=fr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=frr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=fur;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=fur;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=fy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=fy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ga;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=ga;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=ga;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ga;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ga;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=gaa;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=gd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=gl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=gl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=gsw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=gsw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=gu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=gu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ha;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ha;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=haw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=haw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=he;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=he;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=he;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=he;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=hi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=hi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=hr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=hr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=hr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=hsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=hsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=hsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=hsb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=hu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=hu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=hy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=hy;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ia;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ia;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=id;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ie;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=ig;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ig;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ig;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ig;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ii;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=is;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=is;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=it;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=it;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=jv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ka;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ka;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kab;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=kab;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=kea;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kgp;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=kgp;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=kk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=kl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=km;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=kn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ko;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kok;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="ahom"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bhks"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="diak"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hmng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hmnp"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kawi"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mathbold"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mathdbl"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mathmono"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mathsanb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mathsans"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="modi"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mroo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrtlng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nagm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="newa"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="segment"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sind"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sinh"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tirh"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tnsa"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="wara"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="wcho"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ks;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ks;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ksh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=ksh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=ksh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="zero"][@draft="contributed"];	new_value={0} {1}
+locale=ku;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ku;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=kxv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ky;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ky;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=lb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=lb;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=lij;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=lij;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=lo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=lrc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=lt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=lt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=lt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=lt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=lv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=lv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=lv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="zero"];	new_value={0} {1}
+locale=mai;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mgo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mgo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ml;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ml;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mni;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ms_Arab;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ms;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=mt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=mt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=mt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=mt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=nds;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=ne;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ne;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=nl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=no;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=nso;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=nso;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=oc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=om;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=om;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=or;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=or;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=os;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=os;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=pa;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=pa;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=pcm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=pcm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=pl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=pl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=pl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=pl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=prg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=prg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=prg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="zero"][@draft="unconfirmed"];	new_value={0} {1}
+locale=ps;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ps;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=pt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=pt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=qu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=rif;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=rm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=rm;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ru;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=ru;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=ru;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ru;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=rw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sa;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sah;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sat;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sat;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sat;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sc;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sd_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sd_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sd_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sd_Deva;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sd;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=se;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=se;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=se;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=si;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=sk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=sk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=sl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=smn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=smn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=smn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="two"];	new_value={0} {1}
+locale=sn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="rohg"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=so;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sq;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sq;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=sr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=st;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=st;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=su;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=sv;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=sw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=syr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="unconfirmed"];	new_value={0} {1}
+locale=syr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=szl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=ta;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ta;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=te;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=te;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=tg;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=th;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ti;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ti;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=tk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=tk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=tn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=tn;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="adlm"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=to;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=tr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=tr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=trw;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=ts;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ts;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=tt;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ug;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ug;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=uk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="few"];	new_value={0} {1}
+locale=uk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="many"];	new_value={0} {1}
+locale=uk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=uk;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=ur;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=ur;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=uz_Cyrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=uz_Cyrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=uz;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=uz;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=vec;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=vi;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=wae;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"][@draft="contributed"];	new_value={0} {1}
+locale=wae;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=wo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=xh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=xh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=xnr;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=yo;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=yrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=yrl;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=yue_Hans;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=yue;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=za;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"][@draft="unconfirmed"];	new_value={0} {1}
+locale=zgh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh_Hant;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="arabext"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="bali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="beng"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="brah"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cakm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="cham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="deva"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="fullwide"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gonm"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="gujr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="guru"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="hanidec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="java"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="kali"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="khmr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="knda"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lana"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lanatham"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="laoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="lepc"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="limb"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mlym"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mong"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mtei"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="mymrshan"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="nkoo"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="olck"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="orya"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="osma"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="saur"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="shrd"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sora"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="sund"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="takr"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="talu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tamldec"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="telu"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="thai"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="tibt"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zh;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="vaii"]/unitPattern[@count="other"][@draft="contributed"];	new_value={0} {1}
+locale=zu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="one"];	new_value={0} {1}
+locale=zu;	action=add;	new_path=//ldml/numbers/currencyFormats[@numberSystem="latn"]/unitPattern[@count="other"];	new_value={0} {1}


### PR DESCRIPTION
CLDR-17003

Uses CLDRModify -fk to make the changes. There is also a minor tool change to SearchXML, so that the search can be restricted to only locales inheriting directly from root.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
