### PR TITLE
CLDR-17002 lang/script display names from ↑↑↑ -> code value if likely real name, did not have ↑↑↑ in 43

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -523,7 +523,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hebr">Hebreeus</script>
 			<script type="Hira">Hiragana</script>
 			<script type="Hrkt">Japannese lettergreepskrif</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Jpan">Japannees</script>
 			<script type="Kana">Katakana</script>
 			<script type="Khmr">Khmer</script>
@@ -547,7 +547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Telu">Teloegoe</script>
 			<script type="Tfng">Tifinagh</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibettaans</script>
 			<script type="Ugar" draft="unconfirmed">Ugaritieses</script>
 			<script type="Vaii">Vai</script>

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -186,7 +186,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fit">finlandés de Tornedalen</language>
 			<language type="fj">fixanu</language>
 			<language type="fo">feroés</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francés</language>
 			<language type="fr_CA">francés de Canadá</language>
 			<language type="fr_CH">francés de Suiza</language>
@@ -345,7 +345,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letón</language>
@@ -589,7 +589,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">llingua desconocida</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbequistanín</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">venecianu</language>
 			<language type="vep">vepsiu</language>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -175,7 +175,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filippin</language>
 			<language type="fj">fici</language>
 			<language type="fo">farer</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">fransız</language>
 			<language type="fr_CA">Kanada fransızcası</language>
 			<language type="fr_CH">İsveçrə fransızcası</language>
@@ -321,7 +321,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luyseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">latış</language>
@@ -542,7 +542,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">naməlum dil</language>
 			<language type="ur">urdu</language>
 			<language type="uz">özbək</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vyetnam</language>
 			<language type="vo">volapük</language>

--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -497,13 +497,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scripts>
 			<script type="Adlm" draft="unconfirmed">Adlam</script>
 			<script type="Aghb" draft="unconfirmed">Albani Kaukasus</script>
-			<script type="Ahom" draft="unconfirmed">↑↑↑</script>
-			<script type="Arab" draft="unconfirmed">↑↑↑</script>
+			<script type="Ahom" draft="unconfirmed">Ahom</script>
+			<script type="Arab" draft="unconfirmed">Arab</script>
 			<script type="Aran" draft="unconfirmed">Nasta’lik</script>
 			<script type="Armi" draft="unconfirmed">Aram Kekaèsaran</script>
 			<script type="Armn" draft="unconfirmed">Lemènder</script>
 			<script type="Avst" draft="unconfirmed">Awèstan</script>
-			<script type="Bali" draft="unconfirmed">↑↑↑</script>
+			<script type="Bali" draft="unconfirmed">Bali</script>
 			<script type="Bamu" draft="unconfirmed">Bamum</script>
 			<script type="Bass" draft="unconfirmed">Wah</script>
 			<script type="Batk" draft="unconfirmed">Batak</script>
@@ -592,7 +592,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Merc" draft="unconfirmed">Merowé Doyong</script>
 			<script type="Mero" draft="unconfirmed">Merowé</script>
 			<script type="Mlym" draft="unconfirmed">Malayalam</script>
-			<script type="Modi" draft="unconfirmed">↑↑↑</script>
+			<script type="Modi" draft="unconfirmed">Modi</script>
 			<script type="Mong" draft="unconfirmed">Monggoli</script>
 			<script type="Mroo" draft="unconfirmed">Meru</script>
 			<script type="Mtei" draft="unconfirmed">Manipur</script>
@@ -656,7 +656,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Tibt" draft="unconfirmed">Tibèt</script>
 			<script type="Tirh" draft="unconfirmed">Tirhuta</script>
 			<script type="Tnsa" draft="unconfirmed">Tangsa</script>
-			<script type="Toto" draft="unconfirmed">↑↑↑</script>
+			<script type="Toto" draft="unconfirmed">Toto</script>
 			<script type="Ugar" draft="unconfirmed">Ugarit</script>
 			<script type="Vaii" draft="unconfirmed">Wai</script>
 			<script type="Vith" draft="unconfirmed">Witkut</script>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -180,7 +180,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fit">finneg traoñienn an Torne</language>
 			<language type="fj">fidjieg</language>
 			<language type="fo">faeroeg</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">galleg</language>
 			<language type="fr_CA">galleg Kanada</language>
 			<language type="fr_CH">galleg Suis</language>
@@ -325,7 +325,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">luyia</language>
 			<language type="lv">latvieg</language>
@@ -554,7 +554,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">yezh dianav</language>
 			<language type="ur">ourdou</language>
 			<language type="uz">ouzbekeg</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">venezieg</language>
 			<language type="vep">vepseg</language>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -181,7 +181,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipino</language>
 			<language type="fj">fidžijski</language>
 			<language type="fo">farski</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francuski</language>
 			<language type="fr_CA">↑↑↑</language>
 			<language type="fr_CH">↑↑↑</language>
@@ -329,7 +329,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luhija</language>
 			<language type="lv">latvijski</language>
@@ -557,7 +557,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">nepoznati jezik</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbečki</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">venecijanski</language>
 			<language type="vi">vijetnamski</language>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -191,7 +191,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipí</language>
 			<language type="fj">fijià</language>
 			<language type="fo">feroès</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francès</language>
 			<language type="fr_CA">francès canadenc</language>
 			<language type="fr_CH">francès suís</language>
@@ -348,7 +348,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luisenyo</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letó</language>
@@ -592,7 +592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">idioma desconegut</language>
 			<language type="ur">urdú</language>
 			<language type="uz">uzbek</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">vènet</language>
 			<language type="vep">vepse</language>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -632,7 +632,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">neznámý jazyk</language>
 			<language type="ur">urdština</language>
 			<language type="uz">uzbečtina</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">benátština</language>
 			<language type="vep">vepština</language>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -633,7 +633,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hebr">Hebreig</script>
 			<script type="Hira">Hiragana</script>
 			<script type="Hrkt">Syllwyddor Japaneaidd</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Jpan">Japaneaidd</script>
 			<script type="Kana">Catacana</script>
 			<script type="Khmr">Chmeraidd</script>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -182,7 +182,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filippinsk</language>
 			<language type="fj">fijiansk</language>
 			<language type="fo">færøsk</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">fransk</language>
 			<language type="fr_CA">canadisk fransk</language>
 			<language type="fr_CH">schweizisk fransk</language>
@@ -330,7 +330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-Lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">luyana</language>
 			<language type="lv">lettisk</language>
@@ -560,7 +560,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">ukendt sprog</language>
 			<language type="ur">urdu</language>
 			<language type="uz">usbekisk</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vietnamesisk</language>
 			<language type="vo">volapyk</language>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -706,7 +706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Cakm">Chakma</script>
 			<script type="Cans">UCAS</script>
 			<script type="Cari">Karisch</script>
-			<script type="Cham" draft="contributed">↑↑↑</script>
+			<script type="Cham" draft="contributed">Cham</script>
 			<script type="Cher">Cherokee</script>
 			<script type="Cirt">Cirth</script>
 			<script type="Copt">Koptisch</script>
@@ -751,7 +751,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hung">Altungarisch</script>
 			<script type="Inds">Indus-Schrift</script>
 			<script type="Ital">Altitalisch</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java">Javanesisch</script>
 			<script type="Jpan">Japanisch</script>
 			<script type="Jurc" draft="contributed">Jurchen</script>
@@ -788,7 +788,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Merc" draft="contributed">Meroitisch kursiv</script>
 			<script type="Mero">Meroitisch</script>
 			<script type="Mlym">Malayalam</script>
-			<script type="Modi" draft="contributed">↑↑↑</script>
+			<script type="Modi" draft="contributed">Modi</script>
 			<script type="Mong">Mongolisch</script>
 			<script type="Moon">Moon</script>
 			<script type="Mroo" draft="contributed">Mro</script>
@@ -855,7 +855,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Tfng">Tifinagh</script>
 			<script type="Tglg">Tagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibetisch</script>
 			<script type="Tirh" draft="contributed">Tirhuta</script>
 			<script type="Ugar">Ugaritisch</script>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -260,7 +260,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">luba-katanga</language>
 			<language type="lua">luba-luluašćina</language>
 			<language type="lun">lundašćina</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizošćina</language>
 			<language type="luy">luhya</language>
 			<language type="lv">letišćina</language>
@@ -443,7 +443,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">njeznata rěc</language>
 			<language type="ur">urdušćina</language>
 			<language type="uz">usbekšćina</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">vendašćina</language>
 			<language type="vi">vietnamšćina</language>
 			<language type="vo">volapük</language>

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -144,7 +144,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fur" draft="unconfirmed">friula</language>
 			<language type="fy">frisa</language>
 			<language type="ga">irlanda</language>
-			<language type="gaa" draft="unconfirmed">↑↑↑</language>
+			<language type="gaa" draft="unconfirmed">gaa</language>
 			<language type="gd">gaela</language>
 			<language type="gez" draft="unconfirmed">geeza</language>
 			<language type="gil" draft="unconfirmed">kiribata</language>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -181,7 +181,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipino</language>
 			<language type="fj">fiyiano</language>
 			<language type="fo">feroés</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francés</language>
 			<language type="fr_CA">francés canadiense</language>
 			<language type="fr_CH">francés suizo</language>
@@ -330,7 +330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseño</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letón</language>
@@ -560,7 +560,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">lengua desconocida</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbeko</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vietnamita</language>
 			<language type="vo">volapük</language>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -220,7 +220,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fur">friuuli</language>
 			<language type="fy">läänefriisi</language>
 			<language type="ga">iiri</language>
-			<language type="gaa">↑↑↑</language>
+			<language type="gaa">gaa</language>
 			<language type="gag">gagauusi</language>
 			<language type="gan">kani</language>
 			<language type="gay">gajo</language>
@@ -372,7 +372,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">lulua</language>
 			<language type="lui">luisenjo</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lušei</language>
 			<language type="luy">luhja</language>
 			<language type="lv">läti</language>
@@ -632,7 +632,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">määramata keel</language>
 			<language type="ur">urdu</language>
 			<language type="uz">usbeki</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">veneti</language>
 			<language type="vep">vepsa</language>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -210,7 +210,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fit">meänkieli</language>
 			<language type="fj">fidži</language>
 			<language type="fo">fääri</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">ranska</language>
 			<language type="fr_CA">kanadanranska</language>
 			<language type="fr_CH">sveitsinranska</language>
@@ -382,7 +382,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luluanluba</language>
 			<language type="lui">luiseño</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lusai</language>
 			<language type="luy">luhya</language>
 			<language type="lv">latvia</language>
@@ -644,7 +644,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">tuntematon kieli</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbekki</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">venetsia</language>
 			<language type="vep">vepsä</language>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -513,7 +513,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hebr">Hebrew</script>
 			<script type="Hira">Hiragana</script>
 			<script type="Hrkt">Japanese syllabaries</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Jpan">Japanese</script>
 			<script type="Kana">Katakana</script>
 			<script type="Khmr">Khmer</script>
@@ -536,7 +536,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Telu">Telugu</script>
 			<script type="Tfng">Tifinagh</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibetan</script>
 			<script type="Vaii">Vai</script>
 			<script type="Yiii">Yi</script>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -126,7 +126,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fil">filipiniskt</language>
 			<language type="fj">fijimál</language>
 			<language type="fo">føroyskt</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">franskt</language>
 			<language type="fr_CA">↑↑↑</language>
 			<language type="fr_CH">↑↑↑</language>
@@ -237,7 +237,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">luba-katanga</language>
 			<language type="lua">luba-lulua</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">lettiskt</language>
@@ -405,7 +405,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">ókent mál</language>
 			<language type="ur">urdu</language>
 			<language type="uz">usbekiskt</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vjetnamesiskt</language>
 			<language type="vo">volapykk</language>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -204,7 +204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fit">finnois tornédalien</language>
 			<language type="fj">fidjien</language>
 			<language type="fo">féroïen</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">français</language>
 			<language type="fr_CA">français canadien</language>
 			<language type="fr_CH">français suisse</language>
@@ -372,7 +372,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-kasaï (ciluba)</language>
 			<language type="lui">luiseño</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushaï</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letton</language>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -484,7 +484,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hebr" draft="unconfirmed">Hebreews</script>
 			<script type="Hira" draft="unconfirmed">Hiragana</script>
 			<script type="Hrkt" draft="unconfirmed">Japaans Silwenskraft</script>
-			<script type="Jamo" draft="unconfirmed">↑↑↑</script>
+			<script type="Jamo" draft="unconfirmed">Jamo</script>
 			<script type="Jpan" draft="unconfirmed">Japaans</script>
 			<script type="Kana" draft="unconfirmed">Katakana</script>
 			<script type="Khmr" draft="unconfirmed">Khmer</script>
@@ -507,7 +507,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Telu" draft="unconfirmed">Telugu</script>
 			<script type="Tfng" draft="unconfirmed">Tifinagh</script>
 			<script type="Thaa" draft="unconfirmed">Thaana</script>
-			<script type="Thai" draft="unconfirmed">↑↑↑</script>
+			<script type="Thai" draft="unconfirmed">Thai</script>
 			<script type="Tibt" draft="unconfirmed">Tibeetisk</script>
 			<script type="Vaii" draft="unconfirmed">Vai</script>
 			<script type="Yiii" draft="unconfirmed">Yi</script>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -552,7 +552,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Cakm" draft="contributed">Chakma</script>
 			<script type="Cans" draft="contributed">Verenigde Canadese Aboriginal-symbolen</script>
 			<script type="Cari" draft="contributed">Karysk</script>
-			<script type="Cham" draft="contributed">↑↑↑</script>
+			<script type="Cham" draft="contributed">Cham</script>
 			<script type="Cher" draft="contributed">Cherokee</script>
 			<script type="Cirt" draft="contributed">Cirth</script>
 			<script type="Copt" draft="contributed">Koptysk</script>
@@ -589,7 +589,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hung" draft="contributed">Aldhongaars</script>
 			<script type="Inds" draft="contributed">Indus</script>
 			<script type="Ital" draft="contributed">Ald-italysk</script>
-			<script type="Jamo" draft="contributed">↑↑↑</script>
+			<script type="Jamo" draft="contributed">Jamo</script>
 			<script type="Java" draft="contributed">Javaansk</script>
 			<script type="Jpan" draft="contributed">Japans</script>
 			<script type="Jurc" draft="contributed">Jurchen</script>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -526,7 +526,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Adlm">Adlam</script>
 			<script type="Aghb">Albánach Cugasach</script>
-			<script type="Ahom">↑↑↑</script>
+			<script type="Ahom">Ahom</script>
 			<script type="Arab">Arabach</script>
 			<script type="Aran">Nastaliq</script>
 			<script type="Armi">Aramach Impiriúil</script>
@@ -622,7 +622,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Mymr">Maenmarach</script>
 			<script type="Narb">Sean-Arabach Thuaidh</script>
 			<script type="Nbat">↑↑↑</script>
-			<script type="Newa">↑↑↑</script>
+			<script type="Newa">Newa</script>
 			<script type="Nkoo">N-cóis</script>
 			<script type="Nshu">↑↑↑</script>
 			<script type="Ogam">Ogham</script>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -664,13 +664,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Adlm">Adlam</script>
 			<script type="Afak">Afaka</script>
 			<script type="Aghb">Albàinis Chabhcasach</script>
-			<script type="Ahom">↑↑↑</script>
+			<script type="Ahom">Ahom</script>
 			<script type="Arab">Arabais</script>
 			<script type="Aran">Nastaliq</script>
 			<script type="Armi">Aramais impireil</script>
 			<script type="Armn">Airmeinis</script>
 			<script type="Avst">Avestanais</script>
-			<script type="Bali">↑↑↑</script>
+			<script type="Bali">Bali</script>
 			<script type="Bamu">Bamum</script>
 			<script type="Bass">Bassa Vah</script>
 			<script type="Batk">Batak</script>
@@ -685,7 +685,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Cakm">Chakma</script>
 			<script type="Cans">Sgrìobhadh Lideach Aonaichte nan Tùsanach Canadach</script>
 			<script type="Cari">Carian</script>
-			<script type="Cham">↑↑↑</script>
+			<script type="Cham">Cham</script>
 			<script type="Cher">Cherokee</script>
 			<script type="Chrs">Khwarazm</script>
 			<script type="Cirt">Cirth</script>
@@ -729,13 +729,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hrkt">Katakana no Hiragana</script>
 			<script type="Hung">Seann-Ungarais</script>
 			<script type="Ital">Seann-Eadailtis</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java">Deàbhanais</script>
 			<script type="Jpan">Seapanais</script>
 			<script type="Jurc">Jurchen</script>
 			<script type="Kali">Kayah Li</script>
 			<script type="Kana">Katakana</script>
-			<script type="Kawi">↑↑↑</script>
+			<script type="Kawi">Kawi</script>
 			<script type="Khar">Kharoshthi</script>
 			<script type="Khmr">Cmèar</script>
 			<script type="Khoj">Khojki</script>
@@ -753,7 +753,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Limb">Limbu</script>
 			<script type="Lina">Linear A</script>
 			<script type="Linb">Linear B</script>
-			<script type="Lisu">↑↑↑</script>
+			<script type="Lisu">Lisu</script>
 			<script type="Loma">Loma</script>
 			<script type="Lyci">Lycian</script>
 			<script type="Lydi">Lydian</script>
@@ -768,7 +768,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Merc">Meroiticeach ceangailte</script>
 			<script type="Mero">Meroiticeach</script>
 			<script type="Mlym">Malayalam</script>
-			<script type="Modi">↑↑↑</script>
+			<script type="Modi">Modi</script>
 			<script type="Mong">Mongolais</script>
 			<script type="Mroo">Mro</script>
 			<script type="Mtei">Meitei Mayek</script>
@@ -778,7 +778,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Nand">Nandinagari</script>
 			<script type="Narb">Seann-Arabach Thuathach</script>
 			<script type="Nbat">Nabataean</script>
-			<script type="Newa">↑↑↑</script>
+			<script type="Newa">Newa</script>
 			<script type="Nkgb">Naxi Geba</script>
 			<script type="Nkoo">N’ko</script>
 			<script type="Nshu">Nüshu</script>
@@ -838,7 +838,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Tibt">Tibeitis</script>
 			<script type="Tirh">Tirhuta</script>
 			<script type="Tnsa">Tangsa</script>
-			<script type="Toto">↑↑↑</script>
+			<script type="Toto">Toto</script>
 			<script type="Ugar">Ugariticeach</script>
 			<script type="Vaii">Vai</script>
 			<script type="Vith">Vithkuqi</script>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -145,7 +145,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipino</language>
 			<language type="fj">fixiano</language>
 			<language type="fo">feroés</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francés</language>
 			<language type="fr_CA">francés canadense</language>
 			<language type="fr_CH">francés suízo</language>
@@ -264,7 +264,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lu">luba-katanga</language>
 			<language type="lua">luba-lulua</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letón</language>
@@ -449,7 +449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">lingua descoñecida</language>
 			<language type="ur">urdú</language>
 			<language type="uz">uzbeko</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vietnamita</language>
 			<language type="vo">volapuk</language>

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -570,7 +570,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Tfng">Tifinagh</script>
 			<script type="Tglg">Tagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibeetisch</script>
 			<script type="Ugar">Ugaritisch</script>
 			<script type="Vaii">Vai</script>

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -490,7 +490,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hebr">Ibrananci</script>
 			<script type="Hira">Tsarin Rubutun Hiragana</script>
 			<script type="Hrkt">kalaman Jafananci</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Jpan">Jafanis</script>
 			<script type="Kana">Tsarin Rubutun Katakana</script>
 			<script type="Khmr">Yaren Khmer</script>
@@ -513,7 +513,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Telu">Yaren Telugu</script>
 			<script type="Tfng">Tifinagh</script>
 			<script type="Thaa">Yaren Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Yaren Tibet</script>
 			<script type="Vaii">Vai</script>
 			<script type="Yiii">Yi</script>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -183,7 +183,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipinski</language>
 			<language type="fj">fidžijski</language>
 			<language type="fo">ferojski</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francuski</language>
 			<language type="fr_CA">kanadski francuski</language>
 			<language type="fr_CH">švicarski francuski</language>
@@ -331,7 +331,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">luyia</language>
 			<language type="lv">latvijski</language>
@@ -560,7 +560,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">nepoznati jezik</language>
 			<language type="ur">urdski</language>
 			<language type="uz">uzbečki</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vijetnamski</language>
 			<language type="vo">volapük</language>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -260,7 +260,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">luba-katanga</language>
 			<language type="lua">luba-luluašćina</language>
 			<language type="lun">lundašćina</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizošćina</language>
 			<language type="luy">luhya</language>
 			<language type="lv">letišćina</language>
@@ -443,7 +443,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">njeznata rěč</language>
 			<language type="ur">urdušćina</language>
 			<language type="uz">uzbekšćina</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">vendašćina</language>
 			<language type="vi">vietnamšćina</language>
 			<language type="vo">volapük</language>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -183,7 +183,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filippínó</language>
 			<language type="fj">fidzsi</language>
 			<language type="fo">feröeri</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francia</language>
 			<language type="fr_CA">kanadai francia</language>
 			<language type="fr_CH">svájci francia</language>
@@ -333,7 +333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">lujia</language>
 			<language type="lv">lett</language>
@@ -562,7 +562,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">ismeretlen nyelv</language>
 			<language type="ur">urdu</language>
 			<language type="uz">üzbég</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec" draft="contributed">velencei</language>
 			<language type="vi">vietnámi</language>
@@ -608,7 +608,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scripts>
 			<script type="Adlm">Adlam</script>
 			<script type="Aghb" draft="contributed">Kaukázusi albaniai</script>
-			<script type="Arab">↑↑↑</script>
+			<script type="Arab">Arab</script>
 			<script type="Arab" alt="variant">Perzsa-arab</script>
 			<script type="Aran">Nasztalik</script>
 			<script type="Armi">Birodalmi arámi</script>
@@ -662,7 +662,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hung">Ómagyar</script>
 			<script type="Inds">Indus</script>
 			<script type="Ital">Régi olasz</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java">Jávai</script>
 			<script type="Jpan">Japán</script>
 			<script type="Kali">Kajah li</script>
@@ -737,7 +737,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Tfng">Berber</script>
 			<script type="Tglg">Tagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibeti</script>
 			<script type="Ugar">Ugari</script>
 			<script type="Vaii">Vai</script>

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -138,7 +138,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fil">filipino</language>
 			<language type="fj">fijiano</language>
 			<language type="fo">feroese</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francese</language>
 			<language type="fr_CA">francese canadian</language>
 			<language type="fr_CH">francese suisse</language>
@@ -254,7 +254,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">luba-katanga</language>
 			<language type="lua">luba-lulua</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letton</language>
@@ -436,7 +436,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">lingua incognite</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbeko</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">venetiano</language>
 			<language type="vi">vietnamese</language>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -631,7 +631,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Afak">Afaka</script>
 			<script type="Aghb">Albania Kaukasia</script>
 			<script type="Ahom" draft="contributed">↑↑↑</script>
-			<script type="Arab">↑↑↑</script>
+			<script type="Arab">Arab</script>
 			<script type="Arab" alt="variant">Arab Persia</script>
 			<script type="Aran">Nastaliq</script>
 			<script type="Armi">Aram Imperial</script>
@@ -700,7 +700,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hung">Hungaria Kuno</script>
 			<script type="Inds">Indus</script>
 			<script type="Ital">Italia Lama</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java">Jawa</script>
 			<script type="Jpan">Jepang</script>
 			<script type="Jurc">Jurchen</script>
@@ -806,7 +806,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Tfng">Tifinagh</script>
 			<script type="Tglg">Tagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibet</script>
 			<script type="Tirh">Tirhuta</script>
 			<script type="Tnsa" draft="contributed">Tangsa</script>

--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -141,7 +141,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lou" draft="unconfirmed">creol de Louisiana</language>
 			<language type="lrc" draft="unconfirmed">nord-lurian</language>
 			<language type="lt" draft="unconfirmed">lituan</language>
-			<language type="luo" draft="unconfirmed">↑↑↑</language>
+			<language type="luo" draft="unconfirmed">luo</language>
 			<language type="lv" draft="unconfirmed">lettonian</language>
 			<language type="mad" draft="unconfirmed">maduran</language>
 			<language type="mak" draft="unconfirmed">macassaresi</language>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -204,7 +204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fit">finlandese del Tornedalen</language>
 			<language type="fj">figiano</language>
 			<language type="fo">faroese</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francese</language>
 			<language type="fr_CA">francese canadese</language>
 			<language type="fr_CH">francese svizzero</language>
@@ -368,7 +368,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">luyia</language>
 			<language type="lv">lettone</language>
@@ -627,7 +627,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">lingua imprecisata</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbeco</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">veneto</language>
 			<language type="vep">vepso</language>

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -156,7 +156,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lo">lausianu</language>
 			<language type="lt">lituanu</language>
 			<language type="lu">luba-katanga</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letãu</language>
 			<language type="mg">malgaxi</language>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -739,7 +739,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Tfng">Tifinagh</script>
 			<script type="Tglg">Dagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibetesch</script>
 			<script type="Ugar">Ugaritesch</script>
 			<script type="Vaii">Vai</script>

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -255,7 +255,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lu" draft="unconfirmed">luba-katanga</language>
 			<language type="lua" draft="unconfirmed">luba-lulua</language>
 			<language type="lun" draft="unconfirmed">lunda</language>
-			<language type="luo" draft="unconfirmed">↑↑↑</language>
+			<language type="luo" draft="unconfirmed">luo</language>
 			<language type="lus" draft="unconfirmed">lushai</language>
 			<language type="luy" draft="unconfirmed">luyia</language>
 			<language type="lv" draft="unconfirmed">letton</language>
@@ -427,7 +427,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und" draft="unconfirmed">lengua desconosciua</language>
 			<language type="ur" draft="unconfirmed">urdu</language>
 			<language type="uz" draft="unconfirmed">uzbeco</language>
-			<language type="vai" draft="unconfirmed">↑↑↑</language>
+			<language type="vai" draft="unconfirmed">vai</language>
 			<language type="ve" draft="unconfirmed">venda</language>
 			<language type="vi" draft="unconfirmed">vietnamita</language>
 			<language type="vun" draft="unconfirmed">vunjo</language>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -204,7 +204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fit">suomių kalbos Tornedalio tarmė</language>
 			<language type="fj">fidžių</language>
 			<language type="fo">farerų</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">prancūzų</language>
 			<language type="fr_CA">Kanados prancūzų</language>
 			<language type="fr_CH">Šveicarijos prancūzų</language>
@@ -372,7 +372,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">Lundos</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luja</language>
 			<language type="lv">latvių</language>
@@ -632,7 +632,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">nežinoma kalba</language>
 			<language type="ur">urdų</language>
 			<language type="uz">uzbekų</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">vendų</language>
 			<language type="vec">venetų</language>
 			<language type="vep">vepsų</language>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -327,7 +327,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">lubalulva</language>
 			<language type="lui">luisenu</language>
 			<language type="lun">lundu</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lušeju</language>
 			<language type="luy">luhju</language>
 			<language type="lv">latviešu</language>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -522,13 +522,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Adlm">Adlam</script>
 			<script type="Aghb" draft="contributed">Kaukasia Albania</script>
 			<script type="Ahom" draft="contributed">↑↑↑</script>
-			<script type="Arab">↑↑↑</script>
+			<script type="Arab">Arab</script>
 			<script type="Arab" alt="variant">Perso-Arab</script>
 			<script type="Aran">Nastaliq</script>
 			<script type="Armi" draft="contributed">Aramia Imperial</script>
 			<script type="Armn">Armenia</script>
 			<script type="Avst" draft="contributed">Avestan</script>
-			<script type="Bali" draft="contributed">↑↑↑</script>
+			<script type="Bali" draft="contributed">Bali</script>
 			<script type="Bass" draft="contributed">Bassa Vah</script>
 			<script type="Batk" draft="contributed">Batak</script>
 			<script type="Beng">Benggala</script>
@@ -541,7 +541,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Cakm">Chakma</script>
 			<script type="Cans">Suku Kata Orang Asli Kanada Bersatu</script>
 			<script type="Cari" draft="contributed">Carian</script>
-			<script type="Cham" draft="contributed">↑↑↑</script>
+			<script type="Cham" draft="contributed">Cham</script>
 			<script type="Cher">Cherokee</script>
 			<script type="Copt" draft="contributed">Coptic</script>
 			<script type="Cprt" draft="contributed">Cypriot</script>
@@ -580,7 +580,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hrkt">Ejaan sukuan Jepun</script>
 			<script type="Hung" draft="contributed">Hungary Lama</script>
 			<script type="Ital" draft="contributed">Italik Lama</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java" draft="contributed">Jawa</script>
 			<script type="Jpan">Jepun</script>
 			<script type="Kali" draft="contributed">Kayah Li</script>
@@ -611,7 +611,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Merc" draft="contributed">Kursif Meroitic</script>
 			<script type="Mero" draft="contributed">Meroitic</script>
 			<script type="Mlym">Malayalam</script>
-			<script type="Modi" draft="contributed">↑↑↑</script>
+			<script type="Modi" draft="contributed">Modi</script>
 			<script type="Mong">Mongolia</script>
 			<script type="Mroo" draft="contributed">Mro</script>
 			<script type="Mtei">Meitei Mayek</script>
@@ -620,7 +620,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Nand" draft="contributed">Nandinagari</script>
 			<script type="Narb" draft="contributed">Arab Utara Lama</script>
 			<script type="Nbat" draft="contributed">Nabataean</script>
-			<script type="Newa" draft="contributed">↑↑↑</script>
+			<script type="Newa" draft="contributed">Newa</script>
 			<script type="Nkoo">N’ko</script>
 			<script type="Nshu" draft="contributed">Nushu</script>
 			<script type="Ogam" draft="contributed">Ogham</script>
@@ -669,7 +669,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Tfng">Tifinagh</script>
 			<script type="Tglg" draft="contributed">Tagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibet</script>
 			<script type="Tirh" draft="contributed">Tirhuta</script>
 			<script type="Ugar" draft="contributed">Ugaritic</script>

--- a/common/main/nds.xml
+++ b/common/main/nds.xml
@@ -480,7 +480,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Cakm" draft="unconfirmed">Chakma</script>
 			<script type="Cans" draft="unconfirmed">Vereenheidlicht Kanaadsch Sülvenschrift</script>
 			<script type="Cari" draft="unconfirmed">Kaarsch</script>
-			<script type="Cham" draft="unconfirmed">↑↑↑</script>
+			<script type="Cham" draft="unconfirmed">Cham</script>
 			<script type="Cher" draft="unconfirmed">Cherokee</script>
 			<script type="Cirt" draft="unconfirmed">Cirth</script>
 			<script type="Copt" draft="unconfirmed">Koptsch</script>
@@ -582,7 +582,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Tfng" draft="unconfirmed">Tifinagh</script>
 			<script type="Tglg" draft="unconfirmed">Tagalog</script>
 			<script type="Thaa" draft="unconfirmed">Thaana</script>
-			<script type="Thai" draft="unconfirmed">↑↑↑</script>
+			<script type="Thai" draft="unconfirmed">Thai</script>
 			<script type="Tibt" draft="unconfirmed">Tibeetsch</script>
 			<script type="Ugar" draft="unconfirmed">Ugarietsch</script>
 			<script type="Vaii" draft="unconfirmed">Vai</script>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -689,7 +689,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Adlm">Adlam</script>
 			<script type="Afak" draft="contributed">Defaka</script>
 			<script type="Aghb" draft="contributed">Kaukasisch Albanees</script>
-			<script type="Ahom" draft="contributed">↑↑↑</script>
+			<script type="Ahom" draft="contributed">Ahom</script>
 			<script type="Arab">Arabisch</script>
 			<script type="Arab" alt="variant">Perso-Arabisch</script>
 			<script type="Aran">Nastaliq</script>
@@ -711,7 +711,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Cakm">Chakma</script>
 			<script type="Cans">Verenigde Canadese Aboriginal-symbolen</script>
 			<script type="Cari">Carisch</script>
-			<script type="Cham" draft="contributed">↑↑↑</script>
+			<script type="Cham" draft="contributed">Cham</script>
 			<script type="Cher">Cherokee</script>
 			<script type="Chrs" draft="contributed">Chorasmisch</script>
 			<script type="Cirt">Cirth</script>
@@ -759,7 +759,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hung">Oudhongaars</script>
 			<script type="Inds">Indus</script>
 			<script type="Ital">Oud-italisch</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java">Javaans</script>
 			<script type="Jpan">Japans</script>
 			<script type="Jurc" draft="contributed">Jurchen</script>
@@ -798,7 +798,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Merc" draft="contributed">Meroitisch cursief</script>
 			<script type="Mero">Meroïtisch</script>
 			<script type="Mlym">Malayalam</script>
-			<script type="Modi" draft="contributed">↑↑↑</script>
+			<script type="Modi" draft="contributed">Modi</script>
 			<script type="Mong">Mongools</script>
 			<script type="Moon">Moon</script>
 			<script type="Mroo" draft="contributed">Mro</script>
@@ -867,7 +867,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Tfng">Tifinagh</script>
 			<script type="Tglg">Tagalog</script>
 			<script type="Thaa">Thaana</script>
-			<script type="Thai">↑↑↑</script>
+			<script type="Thai">Thai</script>
 			<script type="Tibt">Tibetaans</script>
 			<script type="Tirh" draft="contributed">Tirhuta</script>
 			<script type="Tnsa" draft="contributed">Tangsa</script>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -205,7 +205,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fit">tornedalsfinsk</language>
 			<language type="fj">fijiansk</language>
 			<language type="fo">færøysk</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">fransk</language>
 			<language type="fr_CA">↑↑↑</language>
 			<language type="fr_CH">↑↑↑</language>
@@ -373,7 +373,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luhya</language>
 			<language type="lv">latvisk</language>
@@ -634,7 +634,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">ukjent språk</language>
 			<language type="ur">urdu</language>
 			<language type="uz">usbekisk</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">venetiansk</language>
 			<language type="vep">vepsisk</language>

--- a/common/main/oc.xml
+++ b/common/main/oc.xml
@@ -183,7 +183,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und" draft="unconfirmed">lenga desconeguda</language>
 			<language type="ur" draft="unconfirmed">ordó</language>
 			<language type="uz" draft="unconfirmed">ozbèc</language>
-			<language type="vai" draft="unconfirmed">↑↑↑</language>
+			<language type="vai" draft="unconfirmed">vai</language>
 			<language type="ve" draft="unconfirmed">venda</language>
 			<language type="vi" draft="unconfirmed">vietnamian</language>
 			<language type="vo" draft="unconfirmed">volapuc</language>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -204,7 +204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fit">meänkieli</language>
 			<language type="fj">fidżijski</language>
 			<language type="fo">farerski</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">francuski</language>
 			<language type="fr_CA">francuski kanadyjski</language>
 			<language type="fr_CH">francuski szwajcarski</language>
@@ -372,7 +372,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luhya</language>
 			<language type="lv">łotewski</language>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -331,7 +331,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letão</language>
@@ -560,7 +560,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">idioma desconhecido</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbeque</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vietnamita</language>
 			<language type="vo">volapuque</language>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -491,7 +491,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hebr">Hebreo Simi</script>
 			<script type="Hira">Hiragana</script>
 			<script type="Hrkt">Japones silabico sananpakuna</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Jpan">Japones Simi</script>
 			<script type="Kana">Katakana</script>
 			<script type="Khmr">Khmer</script>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -156,7 +156,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fil" draft="contributed">filippino</language>
 			<language type="fj" draft="contributed">fidschian</language>
 			<language type="fo">feroais</language>
-			<language type="fon" draft="contributed">↑↑↑</language>
+			<language type="fon" draft="contributed">fon</language>
 			<language type="fr" draft="contributed">franzos</language>
 			<language type="fr_CA" draft="contributed">franzos canadais</language>
 			<language type="fr_CH" draft="contributed">franzos svizzer</language>
@@ -286,7 +286,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lua" draft="contributed">luba-lulua</language>
 			<language type="lui" draft="contributed">luiseno</language>
 			<language type="lun" draft="contributed">lunda</language>
-			<language type="luo" draft="contributed">↑↑↑</language>
+			<language type="luo" draft="contributed">luo</language>
 			<language type="lus" draft="contributed">lushai</language>
 			<language type="luy">luyia</language>
 			<language type="lv" draft="contributed">letton</language>
@@ -485,7 +485,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">lingua nunenconuschenta</language>
 			<language type="ur" draft="contributed">urdu</language>
 			<language type="uz" draft="contributed">usbec</language>
-			<language type="vai" draft="contributed">↑↑↑</language>
+			<language type="vai" draft="contributed">vai</language>
 			<language type="ve" draft="contributed">venda</language>
 			<language type="vi" draft="contributed">vietnamais</language>
 			<language type="vo" draft="contributed">volapuk</language>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -181,7 +181,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipineză</language>
 			<language type="fj">fijiană</language>
 			<language type="fo">feroeză</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">franceză</language>
 			<language type="fr_CA">↑↑↑</language>
 			<language type="fr_CH">↑↑↑</language>
@@ -330,7 +330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseno</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">letonă</language>
@@ -559,7 +559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">limbă necunoscută</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbecă</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec" draft="contributed">venetă</language>
 			<language type="vi">vietnameză</language>

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -138,7 +138,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fil">filipinu</language>
 			<language type="fj">fijianu</language>
 			<language type="fo">faroesu</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">frantzesu</language>
 			<language type="fr_CA">frantzesu canadesu</language>
 			<language type="fr_CH">frantzesu isvìtzeru</language>
@@ -255,7 +255,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">luba-katanga</language>
 			<language type="lua">tshiluba</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luyia</language>
 			<language type="lv">lètone</language>
@@ -433,7 +433,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">limba disconnota</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbecu</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">vènetu</language>
 			<language type="vi">vietnamita</language>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -326,7 +326,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">lubčina (luluánska)</language>
 			<language type="lui">luiseňo</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizorámčina</language>
 			<language type="luy">luhja</language>
 			<language type="lv">lotyština</language>
@@ -553,7 +553,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">neznámy jazyk</language>
 			<language type="ur">urdčina</language>
 			<language type="uz">uzbečtina</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">vendčina</language>
 			<language type="vi">vietnamčina</language>
 			<language type="vo">volapük</language>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -317,7 +317,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luisenščina</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizojščina</language>
 			<language type="luy">luhijščina</language>
 			<language type="lv">latvijščina</language>

--- a/common/main/smn.xml
+++ b/common/main/smn.xml
@@ -221,7 +221,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">katangaluba</language>
 			<language type="lua">lulualuba</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lusai</language>
 			<language type="luy">luhya</language>
 			<language type="lv">latviakielâ</language>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -570,7 +570,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Nand">Nandinagari</script>
 			<script type="Narb">Carabiyadii Hore ee Wuqooye</script>
 			<script type="Nbat">Nabataean</script>
-			<script type="Newa">↑↑↑</script>
+			<script type="Newa">Newa</script>
 			<script type="Nkoo">N’Ko</script>
 			<script type="Nshu">Nüshu</script>
 			<script type="Ogam">Ogham</script>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -373,7 +373,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lua">luba-lulua</language>
 			<language type="lui">luiseño</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushai</language>
 			<language type="luy">luhya</language>
 			<language type="lv">lettiska</language>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -541,7 +541,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hebr">Kiebrania</script>
 			<script type="Hira">Hiragana</script>
 			<script type="Hrkt">Hati za Kijapani</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Jpan">Kijapani</script>
 			<script type="Kana">Kikatakana</script>
 			<script type="Khmr">Kikambodia</script>

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -151,7 +151,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lrc" draft="unconfirmed">luryjski pōłnocny</language>
 			<language type="lt" draft="unconfirmed">litewski</language>
 			<language type="lu" draft="unconfirmed">luba-katanga</language>
-			<language type="luo" draft="unconfirmed">↑↑↑</language>
+			<language type="luo" draft="unconfirmed">luo</language>
 			<language type="luy" draft="unconfirmed">luhya</language>
 			<language type="lv" draft="unconfirmed">łotewski</language>
 			<language type="mas" draft="unconfirmed">masajski</language>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -707,7 +707,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Cakm">Chakma</script>
 			<script type="Cans">UCAS</script>
 			<script type="Cari">Karya</script>
-			<script type="Cham">↑↑↑</script>
+			<script type="Cham">Cham</script>
 			<script type="Cher">Çeroki</script>
 			<script type="Cirt">Cirth</script>
 			<script type="Copt">Kıpti</script>
@@ -746,7 +746,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hung">Eski Macar</script>
 			<script type="Inds">Indus</script>
 			<script type="Ital">Eski İtalyan</script>
-			<script type="Jamo">↑↑↑</script>
+			<script type="Jamo">Jamo</script>
 			<script type="Java">Cava Dili</script>
 			<script type="Jpan">Japon</script>
 			<script type="Jurc">Jurchen</script>
@@ -780,7 +780,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Merc">Meroitik El Yazısı</script>
 			<script type="Mero">Meroitik</script>
 			<script type="Mlym">Malayalam</script>
-			<script type="Modi">↑↑↑</script>
+			<script type="Modi">Modi</script>
 			<script type="Mong">Moğol</script>
 			<script type="Moon">Moon</script>
 			<script type="Mroo">Mro</script>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -142,7 +142,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="fil">filipincha</language>
 			<language type="fj">fiji</language>
 			<language type="fo">farercha</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">fransuzcha</language>
 			<language type="fr_CA">fransuz (Kanada)</language>
 			<language type="fr_CH">fransuz (Shveytsariya)</language>
@@ -260,7 +260,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="lu">luba-katanga</language>
 			<language type="lua">luba-lulua</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">lushay</language>
 			<language type="luy">luhya</language>
 			<language type="lv">latishcha</language>
@@ -442,7 +442,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="und">noma’lum til</language>
 			<language type="ur">urdu</language>
 			<language type="uz">o‘zbek</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vi">vyetnam</language>
 			<language type="vo">volapyuk</language>

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -138,7 +138,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fil">filipin</language>
 			<language type="fj">fijan</language>
 			<language type="fo">faroeze</language>
-			<language type="fon">↑↑↑</language>
+			<language type="fon">fon</language>
 			<language type="fr">franseze</language>
 			<language type="fr_CA">franseze canadeze</language>
 			<language type="fr_CH">franseze zvìsaro</language>
@@ -255,7 +255,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lu">luba katanga</language>
 			<language type="lua">luba lulua</language>
 			<language type="lun">lunda</language>
-			<language type="luo">↑↑↑</language>
+			<language type="luo">luo</language>
 			<language type="lus">mizo</language>
 			<language type="luy">luja</language>
 			<language type="lv">lètone</language>
@@ -433,7 +433,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="und">lengua desconoscùa</language>
 			<language type="ur">urdu</language>
 			<language type="uz">uzbego</language>
-			<language type="vai">↑↑↑</language>
+			<language type="vai">vai</language>
 			<language type="ve">venda</language>
 			<language type="vec">veneto</language>
 			<language type="vi">vietnameze</language>

--- a/common/main/wae.xml
+++ b/common/main/wae.xml
@@ -187,7 +187,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Taml" draft="contributed">Tamiliš</script>
 			<script type="Telu" draft="contributed">Telugu</script>
 			<script type="Thaa" draft="contributed">Thána</script>
-			<script type="Thai" draft="contributed">↑↑↑</script>
+			<script type="Thai" draft="contributed">Thai</script>
 			<script type="Zxxx" draft="contributed">Schriftlos</script>
 			<script type="Zzzz" draft="contributed">Unkodierti Schrift</script>
 		</scripts>


### PR DESCRIPTION
CLDR-17002

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Revert language/script display names from ↑↑↑ in current v44 data back to the explicit value if (1) it seems valid for the locale (e.g. fon, luo, vai, Jamo and Thai are valid display names in many locales), and (2) CLDR v43 did not have ↑↑↑ for the value.

The ticket covering this is for the data fix only, have a separate ticket for a tooling fix to prevent this.

ALLOW_MANY_COMMITS=true
