### PR TITLE
CLDR-16929 promote Esperanto to basic level

### DIFF
--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -37,6 +37,7 @@ doi ;	basic ;	Dogri
 dsb ;	modern ;	Lower Sorbian
 el ;	modern ;	Greek
 en ;	modern ;	English
+eo ;	basic ;	Esperanto
 es ;	modern ;	Spanish
 et ;	modern ;	Estonian
 eu ;	modern ;	Basque


### PR DESCRIPTION
CLDR-16929

- [ ] This PR completes the ticket.

This pull request promotes Esperanto (eo) to basic coverage level. All needed values are present, however with "unconfirmed" status.

ALLOW_MANY_COMMITS=true
