### PR TITLE
CLDR-17030 Update ICU4J libs #3; update date in readme

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -12,7 +12,7 @@
   <body>
     <h2>Unicode Common Locale Data Repository (CLDR)</h2>
     <h3>ReadMe for Unicode <abbr title="Common Locale Data Repository">CLDR</abbr> version 44</h3>
-    <p>Last updated: 2023-Aug-09</p>
+    <p>Last updated: 2023-Aug-22</p>
 
     <!--<p><b>Note:</b> CLDR 44 is in development and not recommended for use at this stage.</p>-->
     <!--<p><b>Note:</b> This is the milestone 1 version of CLDR 44, intended for those wishing to do pre-release testing.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/411079/versions
 			for the icu4j.version tag to use -->
-		<icu4j.version>74.0.1-SNAPSHOT-cldr-2023-08-08</icu4j.version>
+		<icu4j.version>74.0.1-SNAPSHOT-cldr-2023-08-22</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.1.0</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-17030

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17030)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Update ICU4J libs in CLDR to ICU version of 2023-08-22, after CLDR release-44-alpha0 integration, after integration of Unicode 15.1 to ICU, and after ICU fees for likelySubtags and PersonNameFormatter.
