### PR TITLE
CLDR-17018 fix firstVersion for ldmlKeyboard and ldmlKeyboardTest

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdType.java
@@ -30,8 +30,8 @@ public enum DtdType {
             "validity"),
     ldmlBCP47("common/dtd/ldmlBCP47.dtd", "1.7.2", null, "bcp47"),
     // keyboard 3.0
-    keyboard("keyboards/dtd/ldmlKeyboard.dtd", "42.0", null, "../keyboards/3.0"),
-    keyboardTest("keyboards/dtd/ldmlKeyboardTest.dtd", "42.0", null, "../keyboards/test");
+    keyboard("keyboards/dtd/ldmlKeyboard.dtd", "44.0", null, "../keyboards/3.0"),
+    keyboardTest("keyboards/dtd/ldmlKeyboardTest.dtd", "44.0", null, "../keyboards/test");
     public static final Set<DtdType> STANDARD_SET =
             ImmutableSet.of(ldmlBCP47, supplementalData, ldml, keyboard);
 


### PR DESCRIPTION
- This was an error in #3114 / CLDR-15034

CLDR-17018

- [X] This PR completes the ticket.

ALLOW_MANY_COMMITS=true

-----
Two things:
- Keyboard updates were originally going to land in v42, we obvously missed that.
- cldr-archive is present but not enabled in exhaustive tests, CLDR-16393 should have caught this.