### PR TITLE
CLDR-16972 CLDRModify -fQ is messing up some annotations

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -2118,7 +2118,8 @@ public class CLDRModify {
                         }
 
                         XPathParts keywordParts = parts.cloneAsThawed().removeAttribute(2, "type");
-                        String keywordPath = keywordParts.toString();
+                        String keywordPath =
+                                CLDRFile.getDistinguishingXPath(keywordParts.toString(), null);
                         String rawKeywordValue = cldrFileToFilter.getStringValue(keywordPath);
 
                         // skip if keywords AND name are inherited
@@ -2132,7 +2133,7 @@ public class CLDRModify {
 
                         // skip if the name is not above root
                         String nameSourceLocale = resolved.getSourceLocaleID(xpath, null);
-                        if ("root".equals(nameSourceLocale)
+                        if (XMLSource.ROOT_ID.equals(nameSourceLocale)
                                 || XMLSource.CODE_FALLBACK_ID.equals(nameSourceLocale)) {
                             return;
                         }
@@ -2142,6 +2143,7 @@ public class CLDRModify {
                         String sourceLocaleId = resolved.getSourceLocaleID(keywordPath, null);
                         sorted.clear();
                         sorted.add(name);
+
                         List<String> items;
                         if (!sourceLocaleId.equals(XMLSource.ROOT_ID)
                                 && !sourceLocaleId.equals(XMLSource.CODE_FALLBACK_ID)) {
@@ -2149,6 +2151,9 @@ public class CLDRModify {
                             sorted.addAll(items);
                         }
                         DisplayAndInputProcessor.filterCoveredKeywords(sorted);
+                        // TODO: Also filter items that are duplicates except for case
+                        // Reference: https://unicode-org.atlassian.net/browse/CLDR-16972
+                        // DisplayAndInputProcessor.filterKeywordsDifferingOnlyInCase(sorted);
                         String newKeywordValue = Joiner.on(" | ").join(sorted);
                         if (!newKeywordValue.equals(keywordValue)) {
                             replace(keywordPath, keywordPath, newKeywordValue);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -5,6 +5,7 @@ import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.util.Set;
+import java.util.TreeSet;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.DisplayAndInputProcessor.PathSpaceType;
 import org.unicode.cldr.util.CLDRConfig;
@@ -783,6 +784,37 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
                     count + ") processInput twice, " + path,
                     actualXmlFormat,
                     doubleInputProcessing);
+        }
+    }
+
+    public void TestFilterCoveredKeywords() {
+        TreeSet<String> set = new TreeSet<>();
+        set.add("bear");
+        set.add("panda");
+        set.add("panda bear");
+        DisplayAndInputProcessor.filterCoveredKeywords(set);
+        if (set.contains("panda bear")) {
+            errln("panda bear should be filtered out");
+        } else {
+            set.add("PANDA BEAR");
+            DisplayAndInputProcessor.filterCoveredKeywords(set);
+            if (set.contains("PANDA BEAR")) {
+                errln("PANDA BEAR should be filtered out");
+            }
+        }
+        set.clear();
+        set.add("bEAR");
+        set.add("Panda");
+        set.add("panda Bear");
+        DisplayAndInputProcessor.filterCoveredKeywords(set);
+        if (set.contains("panda Bear")) {
+            errln("panda Bear should be filtered out");
+        } else {
+            set.add("PandA beAR");
+            DisplayAndInputProcessor.filterCoveredKeywords(set);
+            if (set.contains("PandA beAR")) {
+                errln("PandA beAR should be filtered out");
+            }
         }
     }
 }


### PR DESCRIPTION
-Call getDistinguishingXPath in CLDRModify to avoid getting bogus code-fallback

-Enhance DisplayAndInputProcessor.filterCoveredKeywords so PANDA BEAR matches panda and bear

-Add a unit test TestFilterCoveredKeywords

-TODO comment, still need retroactive fix for japanse poskantoor | Japanse poskantoor

CLDR-16972

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
