### PR TITLE
CLDR-16587 en_AT needs to override EUR-specific format inherited from en_150

### DIFF
--- a/common/main/en_AT.xml
+++ b/common/main/en_AT.xml
@@ -36,5 +36,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
+		<currencies>
+			<currency type="EUR">
+				<pattern>¤ #,##0.00</pattern>
+			</currency>
+		</currencies>
 	</numbers>
 </ldml>


### PR DESCRIPTION
CLDR-16587

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16587)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

en_AT needs to override the EUR-specific currency formatting inherited from en_150 (no space between leading symbol and amount) to match its standard currency format (space between leading symbol and amount), which also matches the standard de_AT currency format.