### PR TITLE
CLDR-16392 fi search collation should be based on fi default sort, not traditional sort

### DIFF
--- a/common/collation/fi.xml
+++ b/common/collation/fi.xml
@@ -16,7 +16,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 					[import und-u-co-search]
 					# Below are the rules specific to fi.
 					# Per Apple language group, V and W should match for search.
-					[import fi-u-co-trad]
+					[import fi-u-co-standard]
 				]]></cr>
 			</collation>
 			<collation type="traditional">


### PR DESCRIPTION
CLDR-16392

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16392)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Finnish search collation should be based on the Finnish _default_ sort order, not the _traditional_ sort order. See discussion in the ticket.